### PR TITLE
new: add minimal Enketo integration to support form previews

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,22 @@ run: base
 	node lib/bin/run-server.js
 
 debug: base
-	node --debug --inspect lib/bin/run-server.js
+	./node_modules/nodemon/bin/nodemon.js --debug --inspect=0.0.0.0:9229 lib/bin/run-server.js
+
+# the default test timeout of 2000 ms is too short for some dev. machines.
+# consider increasing it more if you experience sporadic failures.
+mocha_command  = node node_modules/mocha/bin/mocha --recursive --timeout 5000
 
 test: node_modules
-	env BCRYPT=no node node_modules/mocha/bin/mocha --recursive
+	env BCRYPT=no $(mocha_command)
 test-full: node_modules
-	node node_modules/mocha/bin/mocha --recursive
+	$(mocha_command)
 
 test-integration: node_modules
-	node node_modules/mocha/bin/mocha --recursive test/integration
+	$(mocha_command) test/integration
 
 test-unit: node_modules
-	node node_modules/mocha/bin/mocha --recursive test/unit
+	$(mocha_command) test/unit
 
 test-coverage: node_modules
 	node node_modules/.bin/nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --exit --recursive test

--- a/config/default.json
+++ b/config/default.json
@@ -17,6 +17,7 @@
       "host": "localhost",
       "port": 5000
     },
+    "enketo": {},
     "env": {
       "domain": "http://localhost:8989"
     },

--- a/docs/api.md
+++ b/docs/api.md
@@ -1107,6 +1107,23 @@ To get only the XML of the `Form` rather than all of the details with the XML as
 + Response 403 (application/json)
     + Attributes (Error 403)
 
+#### Generating a Form Preview [POST /v1/projects/{projectId}/forms/{xmlFormId}/preview]
+
+When ODK Central is configured to use an Enketo service, add `/preview` to the end of the `Form` URL and `POST` without parameters to create a preview of the `Form`. The URL of the new preview is returned as `preview_url` in the response; see https://apidocs.enketo.org/v2/#/post-survey-preview.
+
+Creating a preview grants Enketo temporary, read-only access to the individual `Form` and its [Form Attachments](/reference/forms-and-submissions/'-form-attachments) for 15 minutes. After that period elapes, the preview may no longer load correctly.
+
++ Response 201 (application/json)
+    + Body
+
+            {
+              preview_url: 'https://enke.to/preview/::abcd1234',
+              code: 201
+            }
+
++ Response 403 (application/json)
+    + Attributes (Error 403)
+
 #### Retrieving Form Schema JSON [GET /v1/projects/{projectId}/forms/{xmlFormId}.schema.json{?flatten,odata}]
 
 _(introduced: version 0.2)_

--- a/lib/bin/reap-preview_keys.js
+++ b/lib/bin/reap-preview_keys.js
@@ -1,0 +1,17 @@
+// Copyright 2019 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+//
+// This task tidies up the database by deleting expired preview_key actors,
+// which are generated each time a form is previewed with Enketo, along with
+// their sessions and assignments.
+
+const { run } = require('../task/task');
+const { reapPreviewKeys } = require('../task/reap-preview_keys');
+run(reapPreviewKeys());
+

--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -35,12 +35,15 @@ const Sentry = require('../util/sentry').init(config.get('default.external.sentr
 const xlsform = require('../util/xlsform').init(config.get('default.xlsform'));
 const crypto = require('../util/crypto');
 
+// get an Enketo client
+const enketo = require('../util/enketo').init(config.get('default.enketo'));
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // START HTTP SERVICE
 
 // initialize our container, then generate an http service out of it.
-const container = require('../model/package').withDefaults({ db, mail, env, google, Sentry, crypto, xlsform });
+const container = require('../model/package').withDefaults({ db, mail, env, google, Sentry, crypto, xlsform, enketo });
 const service = require('../http/service')(container);
 
 // insert the graceful exit middleware.

--- a/lib/http/middleware.js
+++ b/lib/http/middleware.js
@@ -36,6 +36,8 @@ const versionParser = (request, response, next) => {
 // Similarly, we need to process fieldkey URLs and rewrite them before routing
 // occurs. if found, we just rewrite and store the value on request.
 const fieldKeyParser = (request, response, next) => {
+  // TODO: move this URL decoding somewhere more generic, if it's even desirable?
+  request.url = decodeURIComponent(request.url);
   const match = /^\/key\/([a-z0-9!$]{64})\//i.exec(request.url);
 
   request.fieldKey = Option.of(match).map((m) => m[1]);

--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -123,8 +123,8 @@ const sessionHandler = ({ Session, User, Auth, crypto }, context) => {
 // the token does not belong to a field key, as only field keys may be used in
 // this manner. (TODO: we should not explain in-situ for security reasons, but we
 // should explain /somewhere/.)
-const fieldKeyHandler = ({ Session, Auth }, context) => {
-  if (context.fieldKey.isEmpty()) return;
+const fieldKeyHandler = ({ Session, Auth, Actor }, context) => {
+  if (context.fieldKey.isEmpty()) return
 
   if ((context.auth != null) && (context.auth.isAuthenticated()))
     // fail if the user attempts multiple authentication schemes:
@@ -133,7 +133,8 @@ const fieldKeyHandler = ({ Session, Auth }, context) => {
   return Session.getByBearerToken(context.fieldKey.get())
     .then(getOrReject(Problem.user.authenticationFailed()))
     .then((session) => {
-      if (session.actor.type !== 'field_key') return reject(Problem.user.authenticationFailed());
+      if (session.actor.type !== Actor.types().fieldKey && session.actor.type !== Actor.types().previewKey)
+        return reject(Problem.user.authenticationFailed());
       return context.with({ auth: new Auth({ _session: session }) });
     });
 };

--- a/lib/model/instance/actor.js
+++ b/lib/model/instance/actor.js
@@ -25,7 +25,10 @@ const Problem = require('../../util/problem');
 const { resolve, getOrReject } = require('../../util/promise');
 const { withCreateTime, withUpdateTime } = require('../../util/instance');
 
-const actorTypes = { system: 'system', user: 'user', group: 'group', proxy: 'proxy', singleUse: 'singleUse', fieldKey: 'fieldKey' };
+const actorTypes = {
+  system: 'system', user: 'user', group: 'group', proxy: 'proxy',
+  singleUse: 'singleUse', fieldKey: 'field_key', previewKey: 'preview_key'
+};
 Object.freeze(actorTypes);
 
 module.exports = Instance('actors', {
@@ -109,5 +112,7 @@ module.exports = Instance('actors', {
   static getById(id) { return actors.getById(id); }
 
   static types() { return actorTypes; }
+
+  static reapPreviewKeys() { return actors.reapPreviewKeys(); }
 });
 

--- a/lib/model/instance/session.js
+++ b/lib/model/instance/session.js
@@ -1,4 +1,4 @@
-// Copyright 2017 ODK Central Developers
+// Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
 // https://github.com/opendatakit/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
@@ -28,6 +28,10 @@ module.exports = Instance('sessions', {
   static fromActor(actor) {
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + 1);
+    if (actor.expiresAt !== null && actor.expiresAt !== undefined) {
+      // Don't let the session extend beyond the actor's lifetime
+      expiresAt.setTime(Math.min(expiresAt.getTime(), actor.expiresAt.getTime()));
+    }
     return new Session({ actorId: actor.id, token: generateToken(), csrf: generateToken(), expiresAt });
   }
 

--- a/lib/model/migrations/20191206-01-add-form-viewer-role.js
+++ b/lib/model/migrations/20191206-01-add-form-viewer-role.js
@@ -1,0 +1,27 @@
+// Copyright 2019 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const verbs = [
+  'form.read'
+];
+
+const up = (db) =>
+  db.schema
+    .alterTable('roles', (roles) => roles.string('system', 15).alter())
+    .then(() =>
+      db
+        .insert({ name: 'Form Viewer', system: 'form-viewer', verbs: JSON.stringify(verbs) })
+        .into('roles'));
+
+const down = (db) =>
+  db.delete().from('roles').where({ system: 'form-viewer' })
+    .then(() => db.schema.alterTable('roles', (roles) => roles.string('system', 8).alter()));
+
+module.exports = { up, down };
+

--- a/lib/model/query/actors.js
+++ b/lib/model/query/actors.js
@@ -27,6 +27,25 @@ module.exports = {
   getById: (id) => ({ simply, Actor }) =>
     simply.getOneWhere('actors', { id, deletedAt: null }, Actor),
 
+  // clean up temporary preview key actors:
+  reapPreviewKeys: () => ({ db, Actor }) => {
+    const deleteRelated = (table) =>
+      db(table)
+        .where('actorId', 'in',
+          db.select('id')
+            .from('actors')
+            .where('type', Actor.types().previewKey)
+            .andWhere('expiresAt', '<', new Date()))
+        .delete();
+
+    return deleteRelated('assignments').then(() =>
+      deleteRelated('sessions').then(() =>
+        db('actors')
+          .delete()
+          .where('type', Actor.types().previewKey)
+          .andWhere('expiresAt', '<', new Date())));
+  },
+
   // permissions queries:
   assignRole: (actorId, roleId, acteeId) => ({ db }) =>
     db.insert({ actorId, roleId, acteeId }).into('assignments').then(() => true),

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -59,6 +59,26 @@ module.exports = (service, endpoint) => {
       .then((form) => auth.canOrReject('form.read', form))
       .then((form) => xml(form.def.xml))));
 
+  // create an Enketo preview of the form by creating a 15-minute, read-only token for OpenRosa access,
+  // POSTing to Enketo's `/api/v2/survey/preview`, and returning the response
+  service.post('/projects/:projectId/forms/:id/preview', endpoint(({ Actor, Form, Session, enketo, env }, { params, auth }, request, response) =>
+    Form.getByProjectAndXmlFormId(params.projectId, params.id)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('form.read', form))
+      .then((form) => {
+        const expiresAt = new Date();
+        expiresAt.setMinutes(expiresAt.getMinutes() + 15);
+        const displayName = 'Form preview token';
+        return (new Actor({ type: Actor.types().previewKey, expiresAt, displayName }))
+          .create()
+          .then((actor) => actor.assignSystemRole('form-viewer', form)
+            .then(() => Session.fromActor(actor).create()
+              .then((session) => {
+                const openRosaUrl = `${env.domain}/v1/key/${session.token}/projects/${params.projectId}`;
+                return enketo.preview(openRosaUrl, form.xmlFormId, response);
+              })));
+      })));
+
   service.get('/projects/:projectId/forms/:id.schema.json', endpoint(({ Form }, { params, query, auth }) =>
     Form.getByProjectAndXmlFormId(params.projectId, params.id)
       .then(getOrNotFound)

--- a/lib/task/reap-preview_keys.js
+++ b/lib/task/reap-preview_keys.js
@@ -1,0 +1,17 @@
+// Copyright 2019 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+//
+// This task tidies up the database by deleting expired preview_key actors,
+// which are generated each time a form is previewed with Enketo, along with
+// their sessions and assignments.
+
+const { task } = require('./task');
+const reapPreviewKeys = task.withContainer(({ Actor }) => Actor.reapPreviewKeys);
+module.exports = { reapPreviewKeys };
+

--- a/lib/util/enketo.js
+++ b/lib/util/enketo.js
@@ -1,0 +1,77 @@
+// Copyright 2019 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+// here we support previewing forms (and hopefully other things in the future)
+// by providing a very thin wrapper around node http requests to Enketo. given
+// an OpenRosa endpoint to access a form's xml and its media, Enketo should
+// return a preview url, which we then pass untouched to the client.
+
+const http = require('http');
+const https = require('https');
+const path = require('path');
+const querystring = require('querystring');
+const { isBlank } = require('./util');
+const Problem = require('./problem');
+
+const mock = {
+  preview: () => Promise.reject(Problem.internal.enketoNotConfigured())
+};
+
+const enketo = (hostname, pathname, port, protocol, apiKey) => ({
+  preview: (openRosaUrl, xmlFormId, response) => new Promise((resolve, reject) => {
+    const previewPath = path.posix.join(pathname, 'api/v2/survey/preview');
+    const auth = `${apiKey}:`;
+    const postData = querystring.stringify({ server_url: openRosaUrl, form_id: xmlFormId });
+    const headers = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(postData)
+    };
+
+    const request = protocol === 'https:' ? https.request : http.request;
+    const req = request({ hostname, port, headers, method: 'POST', path: previewPath, auth }, (res) => {
+      const resData = [];
+      res.on('data', (d) => { resData.push(d); });
+      res.on('error', reject);
+      res.on('end', () => {
+        let body;
+        try { body = JSON.parse(Buffer.concat(resData)); } catch (ex) {
+          reject(Problem.internal.enketoUnexpectedResponse('invalid JSON'));
+        }
+        if (res.statusCode === 200 || res.statusCode === 201) {
+          response.statusCode = res.statusCode;
+          resolve(body);
+        } else reject(Problem.internal.enketoUnexpectedResponse('wrong status code'));
+      });
+    });
+
+    req.on('error', (error) => { reject(Problem.internal.enketoNotAvailable({ error })); });
+
+    req.write(postData);
+    req.end();
+  })
+});
+
+// sorts through config and returns an object containing stubs or real functions for Enketo integration.
+// (okay, right now it's just one function)
+const init = (config) => {
+  if (config == null) return mock;
+  if (isBlank(config.url) || isBlank(config.apiKey)) return mock;
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(config.url);
+  } catch (ex) {
+    if (ex instanceof TypeError) return mock; // configuration has an invalid Enketo URL
+    else throw ex;
+  }
+  const { hostname, pathname, port, protocol } = parsedUrl;
+  return enketo(hostname, pathname, port, protocol, config.apiKey);
+};
+
+module.exports = { init };
+

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -136,7 +136,16 @@ const problems = {
     timeout: problem(502.1, () => 'The task took too long to run.'),
 
     // returned if an xlsform service is configured but it cannot be contacted.
-    xlsformNotAvailable: problem(502.2, () => 'The XLSForm conversion service could not be contacted.')
+    xlsformNotAvailable: problem(502.2, () => 'The XLSForm conversion service could not be contacted.'),
+
+    // returned in case no Enketo service is configured.
+    enketoNotConfigured: problem(501.4, () => 'This ODK Central has not been configured to use Enketo. Please contact your server administrator.'),
+
+    // returned if Enketo is configured but it cannot be contacted.
+    enketoNotAvailable: problem(502.3, () => 'Enketo could not be contacted.'),
+
+    // returned if Enketo returns an unexpected response.
+    enketoUnexpectedResponse: problem(500.4, () => 'The Enketo service returned an unexpected response.')
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -493,6 +493,12 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -802,6 +808,20 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
@@ -817,6 +837,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chownr": {
@@ -1195,6 +1221,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-equal": {
       "version": "0.2.2",
@@ -2393,6 +2428,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -3224,6 +3265,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "json5": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
@@ -3784,6 +3831,37 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.0.tgz",
+      "integrity": "sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.0",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -4382,6 +4460,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -4533,6 +4617,12 @@
         "utile": "0.3.x",
         "winston": "2.1.x"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -5605,6 +5695,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint": "~6",
     "eslint-config-airbnb-base": "~13",
     "eslint-plugin-import": "~2.18",
+    "nock": "~11",
     "nyc": "~14",
     "mocha": "~5",
     "node-mocks-http": "~1.6",

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -512,6 +512,31 @@ describe('api: /projects/:id/forms', () => {
             ]))))));
   });
 
+  describe('/:id/preview POST', () => {
+    it('should reject unless the user can read', testService((service) =>
+      service.login('chelsea', (asChelsea) =>
+        asChelsea.post('/v1/projects/1/forms/simple/preview').expect(403))));
+
+    it('should return json with preview url and code', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/preview')
+          .expect(201)
+          .then(({ body }) =>
+            body.should.eql({ preview_url: 'http://enke.to/preview/::abcdefgh', code: 201 })
+          ))));
+
+    it('should fail if Enketo returns an unexpected response', testService((service) => {
+      global.enketoPreviewTest = 'error'; // set up the mock service to fail.
+      return service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/preview')
+          .expect(500)
+          .then(({ body }) => {
+            body.code.should.equal(500.4);
+            body.message.should.equal('The Enketo service returned an unexpected response.');
+          }))
+    }));
+  });
+
   describe('/:id/manifest GET', () => {
     it('should reject unless the user can read', testService((service) =>
       service.login('chelsea', (asChelsea) =>

--- a/test/integration/other/roles-form-viewer.js
+++ b/test/integration/other/roles-form-viewer.js
@@ -1,0 +1,118 @@
+const should = require('should');
+const { testService } = require('../setup');
+const testData = require('../../data/xml');
+
+const viewer = (f) => (service) =>
+  service.login('chelsea', (asChelsea) =>
+    asChelsea.get('/v1/users/current')
+      .expect(200)
+      .then(({ body }) => body)
+      .then((chelsea) => service.login('alice', (asAlice) =>
+        asAlice.post(`/v1/projects/1/forms/simple/assignments/form-viewer/${chelsea.id}`)
+          .expect(200)
+          .then(() => f(asChelsea, chelsea)))));
+
+const withSubmissions = (f) => (service) =>
+  service.login('alice', (asAlice) =>
+    asAlice.post('/v1/projects/1/forms/simple/submissions')
+      .send(testData.instances.simple.one)
+      .set('Content-Type', 'application/xml')
+      .expect(200)
+      .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions')
+        .send(testData.instances.simple.two)
+        .set('Content-Type', 'application/xml')
+        .expect(200))
+      .then(() => asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.binaryType)
+        .set('Content-Type', 'application/xml')
+        .expect(200))
+      .then(() => service.login('chelsea', (asChelsea) =>
+        asChelsea.get('/v1/users/current')
+        .expect(200)
+        .then(({ body }) => body)
+        .then((chelsea) => asAlice.post(`/v1/projects/1/forms/binaryType/assignments/form-viewer/${chelsea.id}`)
+          .expect(200))))
+      .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+        .send(testData.instances.binaryType.one)
+        .set('Content-Type', 'application/xml')
+        .expect(200))
+      .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions/one/attachments/my_file1.mp4')
+        .send('content')
+        .expect(200))
+      .then(() => f(service)));
+
+describe('form viewer role', () => {
+  it('should not be able to list project containing form', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects')
+        .send({ name: 'Project Two' })
+        .expect(200)
+        .then(() => service)
+        .then(viewer((asViewer) => asViewer.get('/v1/projects')
+          .expect(200)
+          .then(({ body }) => body.length.should.equal(0)))))));
+
+  it('should not be able to get basic project details', testService(viewer((asViewer) =>
+    asViewer.get('/v1/projects/1')
+      .expect(403))));
+
+  it('should not be able to update project details', testService(viewer((asViewer) =>
+    asViewer.patch('/v1/projects/1')
+      .send({ name: 'New Name' })
+      .expect(403))));
+
+  it('should not be able to list all forms in a project', testService(viewer((asViewer) =>
+    asViewer.get('/v1/projects/1/forms')
+      .expect(403))));
+
+  it('should be able to get form detail', testService(withSubmissions(viewer((asViewer) =>
+    Promise.all(['simple', 'binaryType'].map((form) =>
+      asViewer.get(`/v1/projects/1/forms/${form}`)
+        .expect(200)
+        .then(({ body }) => { body.should.be.a.Form(); })))))));
+
+  it('should not be able to update form details', testService(viewer((asViewer) =>
+    asViewer.patch('/v1/projects/1/forms/simple')
+      .send({ name: 'New Name' })
+      .expect(403))));
+
+  it('should not be able to create new forms', testService(viewer((asViewer) =>
+    asViewer.post('/v1/projects/1/forms')
+      .send(testData.forms.withAttachments)
+      .set('Content-Type', 'text/xml')
+      .expect(403))));
+
+  it('should not be able to get detail of a form to which it has no assignment', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simple2)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => service)
+        .then(viewer((asViewer) => asViewer.get('/v1/projects/1/forms/simple2')
+          .expect(403))))));
+
+  it('should not be able to list form submissions', testService(withSubmissions(viewer((asViewer) =>
+    asViewer.get('/v1/projects/1/forms/simple/submissions')
+      .expect(403)))));
+
+  it('should not be able to create new submissions', testService(viewer((asViewer) =>
+    asViewer.post('/v1/projects/1/forms/simple/submissions')
+      .send(testData.instances.simple.one)
+      .set('Content-Type', 'text/xml')
+      .expect(403))));
+
+  it('should not be able to download submissions', testService(withSubmissions(viewer((asViewer) =>
+    asViewer.get('/v1/projects/1/forms/simple/submissions.csv.zip')
+      .expect(403)))));
+
+  it('should not be able to get submission detail', testService(withSubmissions(viewer((asViewer) =>
+    asViewer.get('/v1/projects/1/forms/simple/submissions/one')
+      .expect(403)))));
+
+  it('should not be able to fetch a submission attachment', testService(withSubmissions(viewer((asViewer) =>
+    asViewer.get('/v1/projects/1/forms/binaryType/submissions/one/attachments/my_file1.mp4')
+      .expect(403)))));
+
+});
+

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -41,6 +41,9 @@ const crypto = (process.env.BCRYPT === 'no')
   ? require('../util/crypto-mock')
   : require(appRoot + '/lib/util/crypto');
 
+// set up our enketo mock.
+const enketo = require(appRoot + '/test/util/enketo');
+
 // application things.
 const injector = require(appRoot + '/lib/model/package');
 const service = require(appRoot + '/lib/http/service');
@@ -96,7 +99,7 @@ const augment = (service) => {
 ////////////////////////////////////////////////////////////////////////////////
 // FINAL TEST WRAPPERS
 
-const baseContainer = injector.withDefaults({ db, mail, env, xlsform, google, crypto, Sentry });
+const baseContainer = injector.withDefaults({ db, mail, env, xlsform, google, crypto, enketo, Sentry });
 
 // called to get a service context per request. we do some work to hijack the
 // transaction system so that each test runs in a single transaction that then

--- a/test/integration/task/reap-preview_keys.js
+++ b/test/integration/task/reap-preview_keys.js
@@ -1,0 +1,21 @@
+const appRoot = require('app-root-path');
+const should = require('should');
+const { testTask } = require('../setup');
+const { reapSessions } = require(appRoot + '/lib/task/account');
+
+describe('task: reap-preview_keys', () => {
+  it('should remove expired preview keys', testTask(({ simply, Actor }) => {
+    const fifteenMinutesAgo = new Date();
+    fifteenMinutesAgo.setMinutes(fifteenMinutesAgo.getMinutes() - 15);
+    return Promise.all([
+      (new Actor({ displayName: 'expired', type: Actor.types().previewKey, expiresAt: fifteenMinutesAgo })).create(),
+      (new Actor({ displayName: 'current', type: Actor.types().previewKey })).create()
+    ])
+      .then(() => Actor.reapPreviewKeys())
+      .then(() => simply.countWhere('actors', { type: Actor.types().previewKey }))
+      .then((count) => { count.should.equal(1); })
+      .then(() => simply.getOneWhere('actors', { type: Actor.types().previewKey }, Actor))
+      .then((actor) => actor.get().displayName.should.equal('current'));
+  }));
+});
+

--- a/test/unit/http/middleware.js
+++ b/test/unit/http/middleware.js
@@ -73,6 +73,15 @@ describe('middleware', () => {
         done();
       });
     });
+
+    it('should decode percent-encoded keys', (done) => {
+      const request = createRequest({ url: '/key/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa%24aa!aaaaaaaaaaaaaaaaaa/users/23' });
+      fieldKeyParser(request, null, () => {
+        request.fieldKey.should.eql(Option.of('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa$aa!aaaaaaaaaaaaaaaaaa'));
+        request.url.should.equal('/users/23');
+        done();
+      });
+    });
   });
 });
 

--- a/test/unit/util/enketo.js
+++ b/test/unit/util/enketo.js
@@ -1,0 +1,62 @@
+const appRoot = require('app-root-path');
+const nock = require('nock');
+const querystring = require('querystring');
+const should = require('should');
+const enketo_ = require(appRoot + '/lib/util/enketo');
+const Problem = require(appRoot + '/lib/util/problem');
+
+describe('util/enketo', () => {
+  const enketoConfig = {
+    url: 'http://enketoHost:1234/enketoPath',
+    apiKey: 'enketoApiKey'
+  };
+  const enketo = enketo_.init(enketoConfig);
+  const enketoNock = nock('http://enketoHost:1234');
+  const openRosaUrl = 'http://openRosaHost:5678/somePath';
+  const xmlFormId = 'wellPumps';
+
+  describe('preview', () => {
+    it('should send a properly constructed request to Enketo', () => {
+      enketoNock
+        .post('/enketoPath/api/v2/survey/preview')
+        .reply(201, function(uri, requestBody) {
+          const base64Auth = Buffer.from('enketoApiKey:').toString('base64');
+          const expectedQueryString = querystring.stringify({ server_url: openRosaUrl, form_id: xmlFormId });
+          this.req.headers.authorization.should.equal(`Basic ${base64Auth}`);
+          requestBody.should.equal(expectedQueryString);
+          return JSON.stringify({ preview_url: 'http://enke.to/preview/::stuvwxyz', code: 201 });
+        });
+      const response = {};
+      return enketo.preview(openRosaUrl, xmlFormId, response);
+    });
+
+    it('should pass through the intact Enketo response', () => {
+      enketoNock
+        .post('/enketoPath/api/v2/survey/preview')
+        .reply(201, { preview_url: 'http://enke.to/preview/::stuvwxyz', code: 201 });
+      const response = {};
+      return enketo.preview(openRosaUrl, xmlFormId, response)
+        .then((result) => result.should.eql({ preview_url: 'http://enke.to/preview/::stuvwxyz', code: 201 }))
+        .then(() => response.statusCode.should.equal(201));
+    });
+
+    it('should throw a Problem if the Enketo response is not valid json', () => {
+      enketoNock
+        .post('/enketoPath/api/v2/survey/preview')
+        .reply(201, 'no json for you!');
+      const response = {};
+      return enketo.preview(openRosaUrl, xmlFormId, response)
+        .should.be.rejectedWith(Problem.internal.enketoUnexpectedResponse('invalid JSON'));
+    });
+
+    it('should throw a Problem if the Enketo response code is unexpected', () => {
+      enketoNock
+        .post('/enketoPath/api/v2/survey/preview')
+        .reply(204, {});
+      const response = {};
+      return enketo.preview(openRosaUrl, xmlFormId, response)
+        .should.be.rejectedWith(Problem.internal.enketoUnexpectedResponse('wrong status code'));
+    });
+  });
+});
+

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -1,0 +1,18 @@
+const appRoot = require('app-root-path');
+const Problem = require(appRoot + '/lib/util/problem');
+
+module.exports = {
+  preview: (openRosaUrl, xmlFormId, response) => new Promise((resolve, reject) => {
+    const state = global.enketoPreviewTest;
+    global.enketoPreviewTest = null;
+
+    if (state === 'error') {
+      // pretend that Enketo has misbehaved
+      reject(Problem.internal.enketoUnexpectedResponse('wrong status code'));
+    } else {
+      response.statusCode = 201;
+      resolve({ 'preview_url': 'http://enke.to/preview/::abcdefgh','code': 201 });
+    }
+  })
+};
+


### PR DESCRIPTION
See https://github.com/opendatakit/central-frontend/pull/272. This:

* Adds a new `form-viewer` role for read-only access to a single form only, without access to any submissions;
* Adds a `preview_key` actor type whose session tokens are accepted by `fieldKeyHandler`. Actors of this type are reaped once their `expiresAt` time has passed (PR to [central](https://github.com/opendatakit/central) with cron task is forthcoming);
* Adds an Enketo client wrapper (currently with just one function, `preview`) based on the [XLSForm conversion service client](https://github.com/opendatakit/central-backend/blob/master/lib/util/xlsform.js);
* Adds the `/v1/projects/{projectId}/forms/{xmlFormId}/preview` endpoint, which accepts an empty `POST` and then:
    * Creates a `preview_key` that's valid for 15 minutes;
    * Assigns the `preview_key` to the `form-viewer` role for this particular form;
    * `POST`s the OpenRosa `/v1/key/{previewKey}/projects/{projectId}` location and the `xmlFormId` to Enketo's [`/survey/preview`](https://apidocs.enketo.org/v2/#/post-survey-preview) endpoint;
    * returns Enketo's response to the client.