### PR TITLE
improve: explicit <a> tags for links in emails.

### DIFF
--- a/lib/outbound/mail.js
+++ b/lib/outbound/mail.js
@@ -31,7 +31,7 @@ const messages = {
   // Notifies a user that an account has been provisioned at this address; gives
   // them the link required to set their password.
   // * {{token}} is the auth token that grants access to this operation.
-  accountCreated: message('ODK Central account created', '<html>Hello!<p>An account has been provisioned for you on an ODK Central data collection server.</p><p>If this message is unexpected, simply ignore it. Otherwise, please visit the following link to set your password and claim your account:</p><p>{{domain}}/#/account/claim?token={{token}}</p><p>The link is valid for 24 hours. After that, you will have to request a new one using the Reset Password tool.</p></html>'),
+  accountCreated: message('ODK Central account created', '<html>Hello!<p>An account has been provisioned for you on an ODK Central data collection server.</p><p>If this message is unexpected, simply ignore it. Otherwise, please visit the following link to set your password and claim your account:</p><p><a href="{{{domain}}}/#/account/claim?token={{token}}">{{{domain}}}/#/account/claim?token={{token}}</a></p><p>The link is valid for 24 hours. After that, you will have to request a new one using the Reset Password tool.</p></html>'),
 
   // Notifies a user that their account's email has been changed
   accountEmailChanged: message('ODK Central account email changed', '<html>Hello!<p><p>We are emailing because you have an ODK Central data collection account, and somebody has just changed the email address associated with the account from this one you are reading right now ({{oldEmail}}) to a new address ({{newEmail}}).</p><p>If this was you, please feel free to ignore this email. Otherwise, please contact your local ODK system administrator immediately.</p></html>'),
@@ -39,7 +39,7 @@ const messages = {
   // Notifies a user that a password reset has been initialted for their email;
   // gives them the link required to set their password.
   // * {{token}} is the auth token that grants access to this operation.
-  accountReset: message('ODK Central account password reset', '<html>Hello!<p>A password reset has been requested for this email address.</p><p>If this message is unexpected, simply ignore it. Otherwise, please visit the following link to set your password and claim your account:</p><p>{{domain}}/#/account/claim?token={{token}}</p><p>The link is valid for 24 hours. After that, you will have to request a new one using the Reset Password tool.</p></html>'),
+  accountReset: message('ODK Central account password reset', '<html>Hello!<p>A password reset has been requested for this email address.</p><p>If this message is unexpected, simply ignore it. Otherwise, please visit the following link to set your password and claim your account:</p><p><a href="{{{domain}}}/#/account/claim?token={{token}}">{{{domain}}}/#/account/claim?token={{token}}</a></p><p>The link is valid for 24 hours. After that, you will have to request a new one using the Reset Password tool.</p></html>'),
 
   // Notifies an email address that a password reset has been initiated, but that
   // no account exists at this address.

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -117,7 +117,7 @@ describe('api: /users', () => {
           .send({ email: 'david@opendatakit.org' })
           .expect(200)
           .then(() => {
-            const token = /token=([^<]+)<\/p>/.exec(global.inbox.pop().html)[1];
+            const token = /token=([a-z0-9!$]+)/i.exec(global.inbox.pop().html)[1];
             return service.post('/v1/users/reset/verify')
               .send({ new: 'testreset' })
               .set('Authorization', 'Bearer ' + token)
@@ -196,7 +196,7 @@ describe('api: /users', () => {
           global.inbox.length.should.equal(0);
           email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
           email.subject.should.equal('ODK Central account password reset');
-          const token = /token=([^<]+)<\/p>/.exec(email.html)[1];
+          const token = /token=([a-z0-9!$]+)/i.exec(email.html)[1];
 
           return service.post('/v1/users/reset/verify')
             .send({ new: 'reset!' })
@@ -210,7 +210,7 @@ describe('api: /users', () => {
       service.post('/v1/users/reset/initiate')
         .send({ email: 'alice@opendatakit.org' })
         .expect(200)
-        .then(() => /token=([^<]+)<\/p>/.exec(global.inbox.pop().html)[1])
+        .then(() => /token=([a-z0-9!$]+)/i.exec(global.inbox.pop().html)[1])
         .then((token) => service.post('/v1/users/reset/verify')
           .send({ new: 'reset!' })
           .set('Authorization', 'Bearer ' + token)


### PR DESCRIPTION
* so tokens don't get accidentally truncated in client autolinks.