### PR TITLE
bug: account for possible trailing ; in geotrace and geoshape

### DIFF
--- a/lib/data/json.js
+++ b/lib/data/json.js
@@ -244,7 +244,7 @@ const submissionToOData = (fields, table, { xml, encHasData, submission, submitt
               dataPtr[name].properties = { accuracy };
           }
         } else if ((type === 'geotrace') || (type === 'geoshape')) {
-          const pointStrs = text.trim().replace(/;$/, '').split(';');
+          const pointStrs = text.split(';');
 
           // we pay the code cost of writing this loop twice so we gain a tighter
           // and more cpu-cache-friendly loop:
@@ -255,6 +255,8 @@ const submissionToOData = (fields, table, { xml, encHasData, submission, submitt
               const [ lat, lon, altitude/*, accuracy*/ ] = str.split(/\s+/g).map(parseFloat);
               // if we have an empty xml node the split won't yield a point:
               if (((lat == null) || (lon == null)) && (pointStrs.length === 1)) return;
+              // if we didn't get a coordinate, skip. this almost certainly only happens on trailing ;
+              if (Number.isNaN(lat) || Number.isNaN(lon)) continue;
 
               let point = `${lon} ${lat}`;
               if ((altitude != null) && !Number.isNaN(altitude)) point += ' ' + altitude;
@@ -271,6 +273,8 @@ const submissionToOData = (fields, table, { xml, encHasData, submission, submitt
               const [ lat, lon, altitude, accuracy ] = str.split(/\s+/g).map(parseFloat);
               // if we have an empty xml node the split won't yield a point:
               if (((lat == null) || (lon == null)) && (pointStrs.length === 1)) return;
+              // if we didn't get a coordinate, skip. this almost certainly only happens on trailing ;
+              if (Number.isNaN(lat) || Number.isNaN(lon)) continue;
 
               const point = [ lon, lat ];
               if ((altitude != null) && !Number.isNaN(altitude)) point.push(altitude);

--- a/lib/data/json.js
+++ b/lib/data/json.js
@@ -244,7 +244,7 @@ const submissionToOData = (fields, table, { xml, encHasData, submission, submitt
               dataPtr[name].properties = { accuracy };
           }
         } else if ((type === 'geotrace') || (type === 'geoshape')) {
-          const pointStrs = text.split(';');
+          const pointStrs = text.trim().replace(/;$/, '').split(';');
 
           // we pay the code cost of writing this loop twice so we gain a tighter
           // and more cpu-cache-friendly loop:

--- a/test/unit/data/json.js
+++ b/test/unit/data/json.js
@@ -259,8 +259,8 @@ describe('submissionToOData', () => {
       new MockField({ path: '/geotraceNoAlt', name: 'geotraceNoAlt', type: 'geotrace' })
     ];
     const submission = mockSubmission('geojson', `<data>
-        <geotrace>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8</geotrace>
-        <geotraceNoAlt>11.1 22.2;33.3 44.4;55.5 66.6</geotraceNoAlt>
+        <geotrace>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8;</geotrace>
+        <geotraceNoAlt>11.1 22.2;33.3 44.4;55.5 66.6;</geotraceNoAlt>
       </data>`);
     return submissionToOData(fields, 'Submissions', submission).then((result) => {
       result.should.eql([{
@@ -287,8 +287,8 @@ describe('submissionToOData', () => {
       new MockField({ path: '/geotraceNoAlt', name: 'geotraceNoAlt', type: 'geotrace' })
     ];
     const submission = mockSubmission('wkt', `<data>
-        <geotrace>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8</geotrace>
-        <geotraceNoAlt>11.1 22.2;33.3 44.4;55.5 66.6</geotraceNoAlt>
+        <geotrace>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8;</geotrace>
+        <geotraceNoAlt>11.1 22.2;33.3 44.4;55.5 66.6;</geotraceNoAlt>
       </data>`);
     return submissionToOData(fields, 'Submissions', submission, { wkt: true }).then((result) => {
       result.should.eql([{
@@ -306,8 +306,8 @@ describe('submissionToOData', () => {
       new MockField({ path: '/polygonNoAlt', name: 'polygonNoAlt', type: 'geoshape' })
     ];
     const submission = mockSubmission('geojson', `<data>
-        <polygon>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8;10.0 20.0 30.0 40.0;1.1 2.2 3.3 4.4</polygon>
-        <polygonNoAlt>11.1 22.2;33.3 44.4;55.5 66.6;11.1 22.2</polygonNoAlt>
+        <polygon>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8;10.0 20.0 30.0 40.0;1.1 2.2 3.3 4.4;</polygon>
+        <polygonNoAlt>11.1 22.2;33.3 44.4;55.5 66.6;11.1 22.2;</polygonNoAlt>
       </data>`);
     return submissionToOData(fields, 'Submissions', submission).then((result) => {
       result.should.eql([{
@@ -334,8 +334,8 @@ describe('submissionToOData', () => {
       new MockField({ path: '/polygonNoAlt', name: 'polygonNoAlt', type: 'geoshape' })
     ];
     const submission = mockSubmission('wkt', `<data>
-        <polygon>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8;10.0 20.0 30.0 40.0;1.1 2.2 3.3 4.4</polygon>
-        <polygonNoAlt>11.1 22.2;33.3 44.4;55.5 66.6;11.1 22.2</polygonNoAlt>
+        <polygon>1.1 2.2 3.3 4.4;5.5 6.6 7.7 8.8;10.0 20.0 30.0 40.0;1.1 2.2 3.3 4.4;</polygon>
+        <polygonNoAlt>11.1 22.2;33.3 44.4;55.5 66.6;11.1 22.2;</polygonNoAlt>
       </data>`);
     return submissionToOData(fields, 'Submissions', submission, { wkt: true }).then((result) => {
       result.should.eql([{


### PR DESCRIPTION
Closes #282 

Clients may add trailing semicolons to the end of geotrace or geoshape values.