### PR TITLE
bug: could sometimes fail to export all repeat rows. depends on chunks.

### DIFF
--- a/lib/data/briefcase.js
+++ b/lib/data/briefcase.js
@@ -7,7 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { Transform, PassThrough, pipeline } = require('stream');
+const { Transform, pipeline } = require('stream');
 const hparser = require('htmlparser2');
 const { identity, last } = require('ramda');
 const csv = require('csv-stringify');
@@ -284,7 +284,7 @@ const streamBriefcaseCsvs = (inStream, inFields, xmlFormId, decryptor) => {
       if (rootHeaderSent === false) this.push(rootHeader);
 
       // close all our substreams when the root stream closes.
-      for (const repeat of repeats) { repeat.stream.push(null); }
+      for (const repeat of repeats) { repeat.stream.end(); }
       done();
     }
   });
@@ -316,19 +316,12 @@ const streamBriefcaseCsvs = (inStream, inFields, xmlFormId, decryptor) => {
     for (const repeat of repeats) {
       const fieldName = repeat.name;
 
-      // so we have to wrap the csv() stream here that's produced above as we
-      // output it to the zipfile. for whatever reason the implementation of
-      // the csv streamer doesn't always wait til it's done to flush out, so
-      // repeat rows can go missing. but if we wrap it with a PassThrough stream,
-      // it provides the correct behavior.
-      const out = PartialPipe.of(repeat.stream, new PassThrough());
-
       if (totals[fieldName] > 1) {
         const count = (counts[fieldName] == null) ? 1 : (counts[fieldName] + 1);
         counts[fieldName] = count;
-        archive.append(out, { name: sanitize(`${xmlFormId}-${fieldName}~${count}.csv`) });
+        archive.append(repeat.stream, { name: sanitize(`${xmlFormId}-${fieldName}~${count}.csv`) });
       } else {
-        archive.append(out, { name: sanitize(`${xmlFormId}-${fieldName}.csv`) });
+        archive.append(repeat.stream, { name: sanitize(`${xmlFormId}-${fieldName}.csv`) });
       }
     }
   }

--- a/lib/data/briefcase.js
+++ b/lib/data/briefcase.js
@@ -7,7 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { Transform, pipeline } = require('stream');
+const { Transform, PassThrough, pipeline } = require('stream');
 const hparser = require('htmlparser2');
 const { identity, last } = require('ramda');
 const csv = require('csv-stringify');
@@ -315,12 +315,20 @@ const streamBriefcaseCsvs = (inStream, inFields, xmlFormId, decryptor) => {
     const counts = {};
     for (const repeat of repeats) {
       const fieldName = repeat.name;
+
+      // so we have to wrap the csv() stream here that's produced above as we
+      // output it to the zipfile. for whatever reason the implementation of
+      // the csv streamer doesn't always wait til it's done to flush out, so
+      // repeat rows can go missing. but if we wrap it with a PassThrough stream,
+      // it provides the correct behavior.
+      const out = PartialPipe.of(repeat.stream, new PassThrough());
+
       if (totals[fieldName] > 1) {
         const count = (counts[fieldName] == null) ? 1 : (counts[fieldName] + 1);
         counts[fieldName] = count;
-        archive.append(repeat.stream, { name: sanitize(`${xmlFormId}-${fieldName}~${count}.csv`) });
+        archive.append(out, { name: sanitize(`${xmlFormId}-${fieldName}~${count}.csv`) });
       } else {
-        archive.append(repeat.stream, { name: sanitize(`${xmlFormId}-${fieldName}.csv`) });
+        archive.append(out, { name: sanitize(`${xmlFormId}-${fieldName}.csv`) });
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -635,36 +635,23 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "archiver": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.0.3.tgz",
-      "integrity": "sha512-d0W7NUyXoLklozHHfvWnHoHS3dvQk8eB22pv5tBwcu1jEO5eZY8W+gHytkAaJ0R8fU2TnNThrWYxjvFlKvRxpw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.2.tgz",
+      "integrity": "sha512-Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==",
       "requires": {
         "archiver-utils": "^2.1.0",
-        "async": "^2.6.3",
+        "async": "^3.2.0",
         "buffer-crc32": "^0.2.1",
-        "glob": "^7.1.4",
-        "readable-stream": "^3.4.0",
-        "tar-stream": "^2.1.0",
-        "zip-stream": "^2.1.0"
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.1.4",
+        "zip-stream": "^4.0.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -691,9 +678,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -704,9 +691,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-          "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         }
       }
     },
@@ -796,12 +783,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -903,17 +887,24 @@
       "dev": true
     },
     "bl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
-        "readable-stream": "^3.0.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       },
       "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -982,9 +973,9 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -1353,14 +1344,26 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compress-commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.0.0.tgz",
-      "integrity": "sha512-gnETNngrfsAoLBENM8M0DoiCDJkHwz3OfIg4mBtqKDcRgE4oXNwHxHxgHvwKKlrcD7eZ7BVTy4l8t9xVF7q3FQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
+      "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
       "requires": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^2.0.0",
+        "crc32-stream": "^4.0.0",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^2.3.6"
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "concat-map": {
@@ -1459,12 +1462,24 @@
       }
     },
     "crc32-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
+      "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
       "requires": {
         "crc": "^3.4.4",
-        "readable-stream": "^2.0.0"
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -1497,12 +1512,9 @@
       }
     },
     "csv-stringify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
-      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
-      "requires": {
-        "lodash.get": "~4.4.2"
-      }
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.1.tgz",
+      "integrity": "sha512-HM0/86Ks8OwFbaYLd495tqTs1NhscZL52dC4ieKYumy8+nawQYC0xZ63w1NqLf0M148T2YLYqowoImc1giPn0g=="
     },
     "cycle": {
       "version": "1.0.3",
@@ -1769,9 +1781,9 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -3906,7 +3918,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -3928,11 +3941,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -5480,6 +5488,14 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdir-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.0.0.tgz",
+      "integrity": "sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "readdirp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -6476,11 +6492,11 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
       "requires": {
-        "bl": "^3.0.0",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
@@ -6488,9 +6504,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -7250,19 +7266,19 @@
       }
     },
     "zip-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.0.tgz",
-      "integrity": "sha512-F/xoLqlQShgvn1BzHQCNiYIoo2R93GQIMH+tA6JC3ckMDkme4bnhEEXSferZcG5ea/6bZNx3GqSUHqT8TUO6uQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
+      "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^2.0.0",
-        "readable-stream": "^3.4.0"
+        "compress-commons": "^4.0.0",
+        "readable-stream": "^3.6.0"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "node": ">=8"
   },
   "dependencies": {
-    "archiver": "~3",
+    "archiver": "~5",
     "bcrypt": "~3",
     "body-parser": "~1.18",
     "cli": "~1",
     "cloneable-readable": "~2",
     "config": "~1.26",
     "csv-parse": "~4",
-    "csv-stringify": "~1",
+    "csv-stringify": "~5",
     "digest-stream": "~2",
     "entities": "~2",
     "express": "~4.16",

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1,5 +1,6 @@
 const appRoot = require('app-root-path');
 const should = require('should');
+const uuid = require('uuid/v4');
 const { createReadStream, readFileSync } = require('fs');
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
@@ -807,6 +808,36 @@ describe('api: /forms/:id/submissions', () => {
               result['simple.csv'].should.be.a.SimpleCsv();
               done();
             }))))));
+
+    it('should include all repeat rows @slow', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(`
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:head><h:title>single-repeat-1-instance-10qs</h:title><model odk:xforms-version="1.0.0">
+<instance><data id="single-repeat-1-instance-10qs"><q1/><q2/><q3/><q4/><q5/><q6/><q7/><q8/><q9/><q10/><q11/><q12/><q13/><q14/><q15/><q16/><q17/><q18/><q19/><q20/><q21/><repeat jr:template=""><q22/><q23/><q24/><q25/><q26/><q27/><q28/><q29/><q30/><q31/><q32/><q33/><q34/><q35/><q36/><q37/><q38/><q39/><q40/><q41/></repeat><repeat><q22/><q23/><q24/><q25/><q26/><q27/><q28/><q29/><q30/><q31/><q32/><q33/><q34/><q35/><q36/><q37/><q38/><q39/><q40/><q41/></repeat><q42/><q43/><q44/><q45/><q46/><q47/><q48/><q49/><q50/><meta><instanceID/></meta></data></instance>
+<bind nodeset="/data/q1" type="string"/><bind nodeset="/data/q2" type="string"/><bind nodeset="/data/q3" type="string"/><bind nodeset="/data/q4" type="string"/><bind nodeset="/data/q5" type="string"/><bind nodeset="/data/q6" type="string"/><bind nodeset="/data/q7" type="string"/><bind nodeset="/data/q8" type="string"/><bind nodeset="/data/q9" type="string"/><bind nodeset="/data/q10" type="string"/><bind nodeset="/data/q11" type="string"/><bind nodeset="/data/q12" type="string"/><bind nodeset="/data/q13" type="string"/><bind nodeset="/data/q14" type="string"/><bind nodeset="/data/q15" type="string"/><bind nodeset="/data/q16" type="string"/><bind nodeset="/data/q17" type="string"/><bind nodeset="/data/q18" type="string"/><bind nodeset="/data/q19" type="string"/><bind nodeset="/data/q20" type="string"/><bind nodeset="/data/q21" type="string"/><bind nodeset="/data/repeat/q22" type="string"/><bind nodeset="/data/repeat/q23" type="string"/><bind nodeset="/data/repeat/q24" type="string"/><bind nodeset="/data/repeat/q25" type="string"/><bind nodeset="/data/repeat/q26" type="string"/><bind nodeset="/data/repeat/q27" type="string"/><bind nodeset="/data/repeat/q28" type="string"/><bind nodeset="/data/repeat/q29" type="string"/><bind nodeset="/data/repeat/q30" type="string"/><bind nodeset="/data/repeat/q31" type="string"/><bind nodeset="/data/repeat/q32" type="string"/><bind nodeset="/data/repeat/q33" type="string"/><bind nodeset="/data/repeat/q34" type="string"/><bind nodeset="/data/repeat/q35" type="string"/><bind nodeset="/data/repeat/q36" type="string"/><bind nodeset="/data/repeat/q37" type="string"/><bind nodeset="/data/repeat/q38" type="string"/><bind nodeset="/data/repeat/q39" type="string"/><bind nodeset="/data/repeat/q40" type="string"/><bind nodeset="/data/repeat/q41" type="string"/><bind nodeset="/data/q42" type="string"/><bind nodeset="/data/q43" type="string"/><bind nodeset="/data/q44" type="string"/><bind nodeset="/data/q45" type="string"/><bind nodeset="/data/q46" type="string"/><bind nodeset="/data/q47" type="string"/><bind nodeset="/data/q48" type="string"/><bind nodeset="/data/q49" type="string"/><bind nodeset="/data/q50" type="string"/><bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/></model></h:head>
+<h:body><input ref="/data/q1"><label>Q1</label></input><input ref="/data/q2"><label>Q2</label></input><input ref="/data/q3"><label>Q3</label></input><input ref="/data/q4"><label>Q4</label></input><input ref="/data/q5"><label>Q5</label></input><input ref="/data/q6"><label>Q6</label></input><input ref="/data/q7"><label>Q7</label></input><input ref="/data/q8"><label>Q8</label></input><input ref="/data/q9"><label>Q9</label></input><input ref="/data/q10"><label>Q10</label></input><input ref="/data/q11"><label>Q11</label></input><input ref="/data/q12"><label>Q12</label></input><input ref="/data/q13"><label>Q13</label></input><input ref="/data/q14"><label>Q14</label></input><input ref="/data/q15"><label>Q15</label></input><input ref="/data/q16"><label>Q16</label></input><input ref="/data/q17"><label>Q17</label></input><input ref="/data/q18"><label>Q18</label></input><input ref="/data/q19"><label>Q19</label></input><input ref="/data/q20"><label>Q20</label></input><input ref="/data/q21"><label>Q21</label></input><group ref="/data/repeat"><label>Repeat</label><repeat nodeset="/data/repeat"><input ref="/data/repeat/q22"><label>Q22</label></input><input ref="/data/repeat/q23"><label>Q23</label></input><input ref="/data/repeat/q24"><label>Q24</label></input><input ref="/data/repeat/q25"><label>Q25</label></input><input ref="/data/repeat/q26"><label>Q26</label></input><input ref="/data/repeat/q27"><label>Q27</label></input><input ref="/data/repeat/q28"><label>Q28</label></input><input ref="/data/repeat/q29"><label>Q29</label></input><input ref="/data/repeat/q30"><label>Q30</label></input><input ref="/data/repeat/q31"><label>Q31</label></input><input ref="/data/repeat/q32"><label>Q32</label></input><input ref="/data/repeat/q33"><label>Q33</label></input><input ref="/data/repeat/q34"><label>Q34</label></input><input ref="/data/repeat/q35"><label>Q35</label></input><input ref="/data/repeat/q36"><label>Q36</label></input><input ref="/data/repeat/q37"><label>Q37</label></input><input ref="/data/repeat/q38"><label>Q38</label></input><input ref="/data/repeat/q39"><label>Q39</label></input><input ref="/data/repeat/q40"><label>Q40</label></input><input ref="/data/repeat/q41"><label>Q41</label></input></repeat></group><input ref="/data/q42"><label>Q42</label></input><input ref="/data/q43"><label>Q43</label></input><input ref="/data/q44"><label>Q44</label></input><input ref="/data/q45"><label>Q45</label></input><input ref="/data/q46"><label>Q46</label></input><input ref="/data/q47"><label>Q47</label></input><input ref="/data/q48"><label>Q48</label></input><input ref="/data/q49"><label>Q49</label></input><input ref="/data/q50"><label>Q50</label></input></h:body></h:html>`)
+          .set('Content-Type', 'text/xml')
+          .expect(200)
+          .then(() => Promise.all((new Array(50)).fill(null).map(_ =>
+            asAlice.post('/v1/projects/1/forms/single-repeat-1-instance-10qs/submissions')
+              .send(`<data id="single-repeat-1-instance-10qs">
+  <meta><instanceID>${uuid()}</instanceID></meta>
+  ${[ 1, 2, 3, 4, 5, 6, 7, 8, 9 ].map((q) => `<q${q}>${uuid()}</q${q}>`).join('')}
+  <repeat>${[ 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 ].map((q) => `<q${q}>${uuid()}</q${q}>`).join('')}</repeat>
+  ${[ 42, 43, 44, 45, 46, 47, 48, 49, 50 ].map((q) => `<q${q}>${uuid()}</q${q}>`).join('')}
+  </data>`)
+              .set('Content-Type', 'text/xml')
+              .expect(200)))
+            .then(() => new Promise((done) =>
+              zipStreamToFiles(asAlice.get('/v1/projects/1/forms/single-repeat-1-instance-10qs/submissions.csv.zip'), (result) => {
+                result.filenames.should.eql([ 'single-repeat-1-instance-10qs.csv', 'single-repeat-1-instance-10qs-repeat.csv' ]);
+                result['single-repeat-1-instance-10qs.csv'].split('\n').length.should.equal(52);
+                result['single-repeat-1-instance-10qs-repeat.csv'].split('\n').length.should.equal(52);
+                done();
+              })))))));
 
     it('should not include data from other forms', testService((service) =>
       service.login('alice', (asAlice) => Promise.all([

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -395,7 +395,7 @@ Candace,2,three,three/children/child[1]
       </h:html>`;
 
     const inStream = streamTest.fromObjects(
-      (new Array(50)).fill(null).map(_ => instance(uuid(), `<orx:meta><orx:instanceID>${uuid()}</orx:instanceID></orx:meta><name>${uuid()}</name><children><child>${uuid()}</child></children>`)));
+      (new Array(50)).fill(null).map(_ => instance(uuid(), `<orx:meta><orx:instanceID>${uuid()}</orx:instanceID></orx:meta><name>${uuid()}</name><children><child><name>${uuid()}</name></child></children>`)));
 
     callAndParse(inStream, formXml, 'singlerepeat', (result) => {
       result.filenames.should.containDeep([ 'singlerepeat.csv', 'singlerepeat-child.csv' ]);

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -1,5 +1,6 @@
 const appRoot = require('app-root-path');
 const should = require('should');
+const uuid = require('uuid/v4');
 const { construct } = require('ramda');
 const streamTest = require('streamtest').v2;
 const testData = require(appRoot + '/test/data/xml');
@@ -348,6 +349,59 @@ Billy,4,two,two/children/child[1]
 Blaine,6,two,two/children/child[2]
 Candace,2,three,three/children/child[1]
 `);
+      done();
+    });
+  });
+
+  it('should output all rows', (done) => {
+    const formXml = `
+      <?xml version="1.0"?>
+      <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+        <h:head>
+          <model>
+            <instance>
+              <data id="singlerepeat">
+                <orx:meta>
+                  <orx:instanceID/>
+                </orx:meta>
+                <name/>
+                <age/>
+                <children>
+                  <child>
+                    <name/>
+                    <age/>
+                  </child>
+                </children>
+              </data>
+            </instance>
+            <bind nodeset="/data/orx:meta/orx:instanceID" preload="uid" type="string"/>
+            <bind nodeset="/data/name" type="string"/>
+            <bind nodeset="/data/children/child/name" type="string"/>
+          </model>
+        </h:head>
+        <h:body>
+          <input ref="/data/name">
+            <label>What is your name?</label>
+          </input>
+          <group ref="/data/children">
+            <label>Child</label>
+            <repeat nodeset="/data/children/child">
+              <input ref="/data/children/child/name">
+                <label>What is the child's name?</label>
+              </input>
+            </repeat>
+          </group>
+        </h:body>
+      </h:html>`;
+
+    const inStream = streamTest.fromObjects(
+      (new Array(50)).fill(null).map(_ => instance(uuid(), `<orx:meta><orx:instanceID>${uuid()}</orx:instanceID></orx:meta><name>${uuid()}</name><children><child>${uuid()}</child></children>`)));
+
+    callAndParse(inStream, formXml, 'singlerepeat', (result) => {
+      result.filenames.should.containDeep([ 'singlerepeat.csv', 'singlerepeat-child.csv' ]);
+      result['singlerepeat.csv'].split('\n').length.should.equal(52);
+      result['singlerepeat-child.csv'].split('\n').length.should.equal(52);
+      console.log('aoeuaoeu');
       done();
     });
   });

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -395,13 +395,12 @@ Candace,2,three,three/children/child[1]
       </h:html>`;
 
     const inStream = streamTest.fromObjects(
-      (new Array(50)).fill(null).map(_ => instance(uuid(), `<orx:meta><orx:instanceID>${uuid()}</orx:instanceID></orx:meta><name>${uuid()}</name><children><child><name>${uuid()}</name></child></children>`)));
+      (new Array(127)).fill(null).map(_ => instance(uuid(), `<orx:meta><orx:instanceID>${uuid()}</orx:instanceID></orx:meta><name>${uuid()}</name><children><child><name>${uuid()}</name></child></children>`)));
 
     callAndParse(inStream, formXml, 'singlerepeat', (result) => {
       result.filenames.should.containDeep([ 'singlerepeat.csv', 'singlerepeat-child.csv' ]);
-      result['singlerepeat.csv'].split('\n').length.should.equal(52);
-      result['singlerepeat-child.csv'].split('\n').length.should.equal(52);
-      console.log('aoeuaoeu');
+      result['singlerepeat.csv'].split('\n').length.should.equal(129);
+      result['singlerepeat-child.csv'].split('\n').length.should.equal(129);
       done();
     });
   });


### PR DESCRIPTION
* this can be a hard bug to reproduce. the number of bytes of csv
  produced per row of data, as well as the size of the rows coming from
  the database.
* whatever the conditions, the issue is that for whatever reason the csv
  stringify stream doesn't always wait to flush out, so it erroneously
  reports to the zip archive that it's done.
* if we wrap it in a PassThrough it works perfectly.
* there is probably a different solution that involves patching
  csv-stringify, but that's a far more expensive operation than we have
  time for rn.