### PR TITLE
bug: need to filter attachments and client audits by the odata filter.

### DIFF
--- a/lib/model/instance/client-audit.js
+++ b/lib/model/instance/client-audit.js
@@ -15,7 +15,7 @@ module.exports = Instance('client_audits', {
   all: [ 'blobId', 'remainder' ].concat(headers),
   readable: [] // not available over API anyway.
 })(({ clientAudits }) => class {
-  static streamForExport(formId, draft) { return clientAudits.streamForExport(formId, draft); }
+  static streamForExport(formId, draft, options) { return clientAudits.streamForExport(formId, draft, options); }
   static existsForBlob(blobId) { return clientAudits.existsForBlob(blobId); }
 });
 

--- a/lib/model/instance/submission-attachment.js
+++ b/lib/model/instance/submission-attachment.js
@@ -26,6 +26,6 @@ module.exports = Instance('submission_attachments', {
   static getBySubmissionDefIdAndName(submissionDefId, name) {
     return simply.getOneWhere('submission_attachments', { submissionDefId, name }, SubmissionAttachment);
   }
-  static streamForExport(formId, draft, keyIds) { return submissionAttachments.streamForExport(formId, draft, keyIds); }
+  static streamForExport(formId, draft, keyIds, options) { return submissionAttachments.streamForExport(formId, draft, keyIds, options); }
 });
 

--- a/lib/model/query/client-audits.js
+++ b/lib/model/query/client-audits.js
@@ -7,6 +7,9 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
+const { QueryOptions } = require('../../util/db');
+const { applyODataFilter } = require('../../data/odata-filter');
+
 module.exports = {
   existsForBlob: (blobId) => ({ db }) =>
     db.count('*').from('client_audits')
@@ -14,9 +17,10 @@ module.exports = {
       .limit(1)
       .then(([{ count }]) => Number(count) > 0),
 
-  streamForExport: (formId, draft) => ({ db }) =>
+  streamForExport: (formId, draft, options = QueryOptions.none) => ({ db }) =>
     db.select('client_audits.*', 'blobs.content')
       .from('submission_defs')
+      .modify(applyODataFilter(options.filter))
       .innerJoin(
         db.select(db.raw('max(id) as id'))
           .from('submission_defs')
@@ -25,7 +29,7 @@ module.exports = {
         'submission_defs.id', 'latest.id'
       )
       .innerJoin(
-        db.select('id').from('submissions').where({ formId, draft, deletedAt: null })
+        db.select('id', 'submitterId', 'createdAt').from('submissions').where({ formId, draft, deletedAt: null })
           .as('submissions'),
         'submissions.id', 'submission_defs.submissionId'
       )

--- a/lib/model/query/submission-attachments.js
+++ b/lib/model/query/submission-attachments.js
@@ -10,7 +10,8 @@
 // Submission Attachments are files that are expected to exist given the submission
 // xml data and the form XForms xml definition.
 
-const { wasUpdateSuccessful, rowsToInstances } = require('../../util/db');
+const { wasUpdateSuccessful, rowsToInstances, QueryOptions } = require('../../util/db');
+const { applyODataFilter } = require('../../data/odata-filter');
 
 module.exports = {
   // we want to enforce a consistent ordering so we don't use simply.
@@ -36,7 +37,7 @@ module.exports = {
       .then(wasUpdateSuccessful),
 
   // Returns a hybrid set of information from the Attachments and Blobs tables.
-  streamForExport: (formId, draft, keyIds = []) => ({ db }) =>
+  streamForExport: (formId, draft, keyIds = [], options = QueryOptions.none) => ({ db }) =>
     db
       .select('submission_attachments.name', 'blobs.content', 'submission_attachments.index', 'form_defs.keyId', 'submissions.instanceId', 'submission_defs.localKey')
       .from('submission_defs')
@@ -55,6 +56,7 @@ module.exports = {
       .innerJoin('form_defs', 'submission_defs.formDefId', 'form_defs.id')
       .innerJoin('submission_attachments', 'submission_attachments.submissionDefId', 'latest.id')
       .innerJoin('blobs', 'blobs.id', 'submission_attachments.blobId')
+      .modify(applyODataFilter(options.filter))
       .whereRaw('submission_attachments.name is distinct from submission_defs."encDataAttachmentName"')
       .where((where) => where
         .whereNull('form_defs.keyId')

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -196,22 +196,26 @@ module.exports = (service, endpoint) => {
       auth, params, query, passphrases, response) =>
       getForm(params, Form)
         .then((form) => auth.canOrReject('submission.read', form))
-        .then((form) => Promise.all([
-          form.def.getFields(),
-          SubmissionDef.streamForExport(form.id, draft, Object.keys(passphrases), QueryOptions.fromSubmissionCsvRequest(query)),
-          SubmissionAttachment.streamForExport(form.id, draft, Object.keys(passphrases)), // TODO: repetitive
-          ClientAudit.streamForExport(form.id, draft),
-          Key.getDecryptor(passphrases)
-        ]).then(([ fields, rows, attachments, clientAudits, decryptor ]) => {
-          const filename = sanitize(form.xmlFormId);
-          response.append('Content-Disposition', `attachment; filename="${filename}.zip"`);
-          response.append('Content-Type', 'application/zip');
-          return zipStreamFromParts(
-            streamBriefcaseCsvs(rows, fields, form.xmlFormId, decryptor),
-            streamAttachments(attachments, decryptor),
-            streamClientAudits(clientAudits, form)
-          );
-        }));
+        .then((form) => {
+          const keys = Object.keys(passphrases);
+          const options = QueryOptions.fromSubmissionCsvRequest(query);
+          return Promise.all([
+            form.def.getFields(),
+            SubmissionDef.streamForExport(form.id, draft, keys, options),
+            SubmissionAttachment.streamForExport(form.id, draft, keys, options),
+            ClientAudit.streamForExport(form.id, draft, options),
+            Key.getDecryptor(passphrases)
+          ]).then(([ fields, rows, attachments, clientAudits, decryptor ]) => {
+            const filename = sanitize(form.xmlFormId);
+            response.append('Content-Disposition', `attachment; filename="${filename}.zip"`);
+            response.append('Content-Type', 'application/zip');
+            return zipStreamFromParts(
+              streamBriefcaseCsvs(rows, fields, form.xmlFormId, decryptor),
+              streamAttachments(attachments, decryptor),
+              streamClientAudits(clientAudits, form)
+            );
+          });
+        });
 
     const csv = ({ Key, Form, SubmissionDef }, auth, params, query, passphrases, response, rootOnly) =>
       getForm(params, Form)


### PR DESCRIPTION
* on the /submissions.csv.zip endpoint.
* reviewers: ignore whitespace for an easier time.