### PR TITLE
Ignore keepalive file when restoring backup

### DIFF
--- a/lib/task/fs.js
+++ b/lib/task/fs.js
@@ -93,6 +93,11 @@ const decryptFromArchive = (archivePath, directory, passphrase = '') =>
       // first we read all the records in the zipfile central directory. we check
       // for various zipbomb redflags and reject if we see any.
       zipfile.on('entry', (entry) => {
+        if (entry.fileName === 'keepalive') {
+          zipfile.readEntry();
+          return;
+        }
+
         entries.push(entry);
         totalBytes += entry.uncompressedSize;
         if (entries.length > 100)


### PR DESCRIPTION
Right now `lib/bin/restore.js` quits with the following error message when restoring a backup downloaded from `/v1/backup`:

```
Required parameter undefined missing.
'keepalive local key'
```

This PR modifies the restore process so that it ignores `keepalive`.

I had trouble writing a test for this change. Ideally, we would test the result of calling `decryptFromArchive()` on a .zip file that contains both encrypted files and a `keepalive` file. `encryptToArchive()` returns a .zip files with encrypted files, but I didn't see an easy way to insert a `keepalive` file into it. Instead, I verified this change as follows:

- I downloaded a .zip file locally using the "Download backup now" button.
- I modified `restore.js` so that it expands the zip into a persistent directory and decrypts encrypted files, but doesn't run `pgrestore()`.
- I ran `restore.js`. It did not show the error message and expanded a number of files.
- I committed those files to a Git repo.
- Next, I ran `lib/bin/backup.js`, uploading a backup to Google Drive.
- I downloaded that file and ran the modified `restore.js` on it. I moved the resulting files into the Git repo, comparing to the immediate backup.
- The only file that was different was `toc.dat`, a binary file.