### PR TITLE
Export all keepalive data for a longer-running backup

### DIFF
--- a/lib/resources/backup.js
+++ b/lib/resources/backup.js
@@ -71,6 +71,7 @@ const trickler = () => {
     if ((ptr + 128) >= out.length) {
       transform.push(out.slice(ptr));
       chunks.shift();
+      ptr = 0;
     } else {
       transform.push(out.slice(ptr, ptr + 128));
       ptr += 128;


### PR DESCRIPTION
This code is only run if the end of the first chunk is reached, which will happen for a longer-running backup. In that case, we reset `ptr` so that all data after the first chunk is exported.