### PR TITLE
Replace opendatakit with getodk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ If you override the default `forApi` and `fromApi`, it will be up to you to main
 
 ### Form Encryption
 
-We implement the [ODK XForms Encryption Specification](http://opendatakit.github.io/xforms-spec/encryption) to enable form encryption in transit from the device (in cases where HTTPS is not possible) and at rest on the Central server. In these cases, the XML stored in the `xml` column on the submission is actually the encryption manifest, which lists the files and keys that would be needed to decrypt the data in that submission successfully. The actual encrypted form data is stored as a separate attachment, typically named `submission.xml.enc` (but the name is up to the client).
+We implement the [ODK XForms Encryption Specification](http://getodk.github.io/xforms-spec/encryption) to enable form encryption in transit from the device (in cases where HTTPS is not possible) and at rest on the Central server. In these cases, the XML stored in the `xml` column on the submission is actually the encryption manifest, which lists the files and keys that would be needed to decrypt the data in that submission successfully. The actual encrypted form data is stored as a separate attachment, typically named `submission.xml.enc` (but the name is up to the client).
 
 Within this specification, we also create our own Managed Encryption system, so that with the use of a passphrase the Central server can create and manage the encryption keypair on behalf of the user, rather than make users learn things like OpenSSL and how to store keys securely.
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,27 @@
 
 ![Platform](https://img.shields.io/badge/platform-Node.js-blue.svg)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Build status](https://circleci.com/gh/opendatakit/central-backend.svg?style=shield)](https://circleci.com/gh/opendatakit/central-backend)
+[![Build status](https://circleci.com/gh/getodk/central-backend.svg?style=shield)](https://circleci.com/gh/getodk/central-backend)
 
-ODK Central Backend is a minimal [Open Data Kit](https://opendatakit.org/) server based on Node.js and Postgres. It is currently under development.
+ODK Central Backend is a minimal [ODK](https://getodk.org/) server based on Node.js and Postgres. It is currently under development.
 
-This repository contains only the code for the backend API server: [Central Frontend](https://github.com/opendatakit/central-frontend) holds frontend code, and [Central](https://github.com/opendatakit/central) contains both the Docker-based production deployment infrastructure for the combined frontend/backend, as well as project management and issue tickets.
+This repository contains only the code for the backend API server: [Central Frontend](https://github.com/getodk/central-frontend) holds frontend code, and [Central](https://github.com/getodk/central) contains both the Docker-based production deployment infrastructure for the combined frontend/backend, as well as project management and issue tickets.
 
 ## Contributing
 
-We need your help to make this project as useful as possible! Please see the [Contribution Guide](https://github.com/opendatakit/central-backend/blob/master/CONTRIBUTING.md) for detailed information on discussion forums, project policies, code guidelines, and an overview of the software architecture.
+We need your help to make this project as useful as possible! Please see the [Contribution Guide](https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md) for detailed information on discussion forums, project policies, code guidelines, and an overview of the software architecture.
 
 ## Using ODK Central Backend
 
-For information on how to install and deploy ODK Central Backend for use as an ODK server, please see [these instructions](https://github.com/opendatakit/central) on the ODK Central repository. For information on how to set up a development environment for this server to help contribute to it, please skip to the next section.
+For information on how to install and deploy ODK Central Backend for use as an ODK server, please see [these instructions](https://github.com/getodk/central) on the ODK Central repository. For information on how to set up a development environment for this server to help contribute to it, please skip to the next section.
 
 ### Command line scripts
 
-A number of operational tasks (creating accounts, setting passwords, etc) may be accomplished directly via local command line. These may be accessed by running `node lib/bin/cli.js` from the project root. If you run that script without arguments, it will provide the full list of available commands. For an overview of using Central command line tools in a production environment, see the [Central docs](https://docs.opendatakit.org/central-command-line/).
+A number of operational tasks (creating accounts, setting passwords, etc) may be accomplished directly via local command line. These may be accessed by running `node lib/bin/cli.js` from the project root. If you run that script without arguments, it will provide the full list of available commands. For an overview of using Central command line tools in a production environment, see the [Central docs](https://docs.getodk.org/central-command-line/).
 
 ### Accessing the API
 
-ODK Central Backend is, first and foremost, a RESTful HTTP API server that manages Users, Forms, Submissions, and other objects necessary to run an ODK data collection campaign. This API is used by the bundled frontend web interface to form a complete user-installable server solution, but that API can also be used on its own with or without the frontend to programmatically manage a data collection project. We provide a full documentation of the API in the standard [API Blueprint](https://apiblueprint.org/) format: you can find a plain version of that documentation [here](https://github.com/opendatakit/central-backend/blob/master/docs/api.md) in the repository, or you can access the [Apiary version](https://odkcentral.docs.apiary.io/) for a friendlier version of the same material with neat features like an interactive query tool.
+ODK Central Backend is, first and foremost, a RESTful HTTP API server that manages Users, Forms, Submissions, and other objects necessary to run an ODK data collection campaign. This API is used by the bundled frontend web interface to form a complete user-installable server solution, but that API can also be used on its own with or without the frontend to programmatically manage a data collection project. We provide a full documentation of the API in the standard [API Blueprint](https://apiblueprint.org/) format: you can find a plain version of that documentation [here](https://github.com/getodk/central-backend/blob/master/docs/api.md) in the repository, or you can access the [Apiary version](https://odkcentral.docs.apiary.io/) for a friendlier version of the same material with neat features like an interactive query tool.
 
 ## Setting up a development environment
 
@@ -59,11 +59,11 @@ Even so, often mail messages will go at first to spam, so be sure to check that.
 
 ## Testing
 
-Please see the [Contribution Guide](https://github.com/opendatakit/central-backend/blob/master/CONTRIBUTING.md) for complete information and guidelines on our tests.
+Please see the [Contribution Guide](https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md) for complete information and guidelines on our tests.
 
 This project is tested with both unit and integration tests. The unit tests (`/test/unit`) check, in isolation, the complicated parts of the core framework code. The integration tests (`/test/integration`) focus on verifying the correct behaviour of the API itself and the business logic that relies on the core framework code.
 
-To run all tests (both unit and integration), run `make test` in the project root. [CircleCI](https://circleci.com/gh/opendatakit/central-backend) is configured to run all tests for verification.
+To run all tests (both unit and integration), run `make test` in the project root. [CircleCI](https://circleci.com/gh/getodk/central-backend) is configured to run all tests for verification.
 
 Various other commands are available:
 
@@ -74,7 +74,7 @@ Various other commands are available:
 
 ## Style Guidelines
 
-Please see the [Contribution Guide](https://github.com/opendatakit/central-backend/blob/master/CONTRIBUTING.md) for complete information on our coding style.
+Please see the [Contribution Guide](https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md) for complete information on our coding style.
 
 In general, follow the existing conventions in the project. We use linting as _a part of_ coding style verification. To run the linter, run `make lint` from the repository root. We use [rules](.eslintrc.json) based on the [Airbnb JavaScript style guide](https://github.com/airbnb/javascript). The linter is not perfect; we will make exceptions when we have a consensus to do so.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 
 # ODK Central API
-[ODK Central Backend](https://github.com/opendatakit/central-backend) is a RESTful API server that provides key functionality for creating and managing Open Data Kit data collection campaigns. It couples with [Central Frontend](https://github.com/opendatakit/central-frontend), an independent frontend interface, to form [ODK Central](https://github.com/opendatakit/central), a complete user-installable ODK server solution. While Central Frontend is the primary consumer of the ODK Central API, the API this server provides is fully public and generic: anything that can be done in the user interface can be done directly via the API.
+[ODK Central Backend](https://github.com/getodk/central-backend) is a RESTful API server that provides key functionality for creating and managing ODK data collection campaigns. It couples with [Central Frontend](https://github.com/getodk/central-frontend), an independent frontend interface, to form [ODK Central](https://github.com/getodk/central), a complete user-installable ODK server solution. While Central Frontend is the primary consumer of the ODK Central API, the API this server provides is fully public and generic: anything that can be done in the user interface can be done directly via the API.
 
 You can read on for a brief overview of the main concepts and how they fit together, or jump to one of the sections for a more in-depth description.
 
@@ -23,7 +23,7 @@ The `/projects/:id/forms` resource and its subresource `/projects/:id/forms/…/
 
 Forms and their submissions are also accessible through two **open standards specifications** that we follow:
 
-* The [OpenRosa](https://docs.opendatakit.org/openrosa/) standard allows standard integration with tools like the [ODK Collect](https://docs.opendatakit.org/collect-intro/) mobile data collection app, or various other compatible tools like [Enketo](https://enketo.org/). It allows them to see the forms available on the server, and to send new submissions to them.
+* The [OpenRosa](https://docs.getodk.org/openrosa/) standard allows standard integration with tools like the [ODK Collect](https://docs.getodk.org/collect-intro/) mobile data collection app, or various other compatible tools like [Enketo](https://enketo.org/). It allows them to see the forms available on the server, and to send new submissions to them.
 * The [OData](http://odata.org/) standard allows data to be shared between platforms for analysis and reporting. Tools like [Microsoft Power BI](https://powerbi.microsoft.com/en-us/) and [Tableau](https://public.tableau.com/en-us/s/) are examples of clients that consume the standard OData format and provide advanced features beyond what we offer. If you are looking for a straightforward JSON output of your data, or you are considering building a visualization or reporting tool, this is your best option.
 
 Finally, **system information and configuration** is available via a set of specialized resources. Currently, you may set the Backups configuration, and retrieve Server Audit Logs.
@@ -218,7 +218,7 @@ Successful responses will come with an HTTP-Only, Secure-Only cookie. This cooki
     + Body
 
             {
-                "email": "my.email.address@opendatakit.org",
+                "email": "my.email.address@getodk.org",
                 "password": "my.super.secure.password"
             }
 
@@ -272,7 +272,7 @@ To use HTTPS Basic Authentication, attach an `Authorization` header formatted so
 
     `Authorization: Basic bXkuZW1haWwuYWRkcmVzc0BvcGVuZGF0YWtpdC5vcmc6bXkucGFzc3dvcmQ=`
 
-As given by [the standard](https://en.wikipedia.org/wiki/Basic_access_authentication), the text following the `Basic` marker here is a base64 encoding of the credentials, provided in the form `email:password` (in this example `my.email.address@opendatakit.org:my.password`).
+As given by [the standard](https://en.wikipedia.org/wiki/Basic_access_authentication), the text following the `Basic` marker here is a base64 encoding of the credentials, provided in the form `email:password` (in this example `my.email.address@getodk.org:my.password`).
 
 Unlike the standard, we do not require the client to first send an unauthenticated request and retry the request only after receiving a `WWW-Authenticate` response, and in fact we will never send the `WWW-Authenticate` header. This is mostly because, as noted above, we generally discourage the use of this authentication method, and would rather not advertise its use openly. As a result, if you wish to use Basic Authentication, directly supply the header on any request that needs it.
 
@@ -369,12 +369,12 @@ Users are not able to do anything upon creation besides log in and change their 
 
 + Request (application/json)
     + Attributes
-        + email: `my.email.address@opendatakit.org` (string, required) - The email address of the User account to be created.
+        + email: `my.email.address@getodk.org` (string, required) - The email address of the User account to be created.
         + password: `my.super.secure.password` (string, optional) - If provided, the User account will be created with this password. Otherwise, the user will still be able set their own password later.
 
     + Body
 
-            { "email": "my.email.address@opendatakit.org" }
+            { "email": "my.email.address@getodk.org" }
 
 + Response 200 (application/json)
     + Attributes (User)
@@ -437,13 +437,13 @@ When user details are updated, the `updatedAt` field will be automatically updat
 + Request (application/json)
     + Attributes
         + displayName: `New Name` (string, optional) - The friendly display name that should be associated with this User.
-        + email: `new.email.address@opendatakit.org` (string, optional) - The email address that should be associated with this User.
+        + email: `new.email.address@getodk.org` (string, optional) - The email address that should be associated with this User.
 
     + Body
 
             {
               "displayName": "New Name",
-              "email": "new.email.address@opendatakit.org"
+              "email": "new.email.address@getodk.org"
             }
 
 + Response 200 (application/json)
@@ -493,11 +493,11 @@ If the email address provided does not match any user in the system, that addres
 
 + Request (application/json)
     + Attributes
-        + email: `my.email.address@opendatakit.org` (string, required) - The email address of the User account whose password is to be reset.
+        + email: `my.email.address@getodk.org` (string, required) - The email address of the User account whose password is to be reset.
 
     + Body
 
-            { "email": "my.email.address@opendatakit.org" }
+            { "email": "my.email.address@getodk.org" }
 
 + Response 200 (application/json)
     + Attributes (Success)
@@ -1004,7 +1004,7 @@ This endpoint supports retrieving extended metadata; provide a header `X-Extende
 
 # Group Forms and Submissions
 
-`Form`s are the heart of ODK. They are created out of XML documents in the [ODK XForms](https://opendatakit.github.io/xforms-spec/) specification format. The [Intro to Forms](https://docs.opendatakit.org/form-design-intro/) on the ODK Documentation website is a good resource if you are unsure what this means. Once created, Forms can be retrieved in a variety of ways, their state can be managed, and they can be deleted.
+`Form`s are the heart of ODK. They are created out of XML documents in the [ODK XForms](https://getodk.github.io/xforms-spec/) specification format. The [Intro to Forms](https://docs.getodk.org/form-design-intro/) on the ODK Documentation website is a good resource if you are unsure what this means. Once created, Forms can be retrieved in a variety of ways, their state can be managed, and they can be deleted.
 
 `Submission`s are filled-out forms (also called `Instance`s in some other ODK documentation). Each is associated with a particular Form (and in many cases with a particular _version_ of a Form), and is also created out of a standard XML format based on the Form itself. Submissions can be sent with many accompanying multimedia attachments, such as photos taken in the course of the survey. Once created, the Submissions themselves as well as their attachments can be retrieved through this API.
 
@@ -1012,7 +1012,7 @@ These subsections cover only the modern RESTful API resources involving Forms an
 
 ## Forms [/v1/projects/{projectId}/forms]
 
-In this API, `Form`s are distinguished by their [`formId`](https://opendatakit.github.io/xforms-spec/#primary-instance)s, which are a part of the XForms XML that defines each Form. In fact, as you will see below, many of the properties of a Form are extracted automatically from the XML: `hash`, `name`, `version`, as well as the `formId` itself (which to reduce confusion internally is known as `xmlFormId` in ODK Central).
+In this API, `Form`s are distinguished by their [`formId`](https://getodk.github.io/xforms-spec/#primary-instance)s, which are a part of the XForms XML that defines each Form. In fact, as you will see below, many of the properties of a Form are extracted automatically from the XML: `hash`, `name`, `version`, as well as the `formId` itself (which to reduce confusion internally is known as `xmlFormId` in ODK Central).
 
 The only other property Forms currently have is `state`, which can be used to control whether Forms show up in mobile clients like ODK Collect for download, as well as whether they accept new `Submission`s or not.
 
@@ -1050,7 +1050,7 @@ For XLSForm upload, either `.xls` or `.xlsx` are accepted. You must provide the 
 
 By default, any XLSForm conversion Warnings will fail this request and return the warnings rather than use the converted XML to create a form. To override this behaviour, provide a querystring flag `?ignoreWarnings=true`. Conversion Errors will always fail this request.
 
-The API will currently check the XML's structure in order to extract the information we need about it, but ODK Central does _not_ run comprehensive validation on the full contents of the XML to ensure compliance with the ODK specification. Future versions will likely do this, but in the meantime you will have to use a tool like [ODK Validate](https://opendatakit.org/use/validate/) to be sure your Forms are correct.
+The API will currently check the XML's structure in order to extract the information we need about it, but ODK Central does _not_ run comprehensive validation on the full contents of the XML to ensure compliance with the ODK specification. Future versions will likely do this, but in the meantime you will have to use a tool like [ODK Validate](https://getodk.org/use/validate/) to be sure your Forms are correct.
 
 + Parameters
     + ignoreWarnings: `false` (boolean, optional) - Defaults to `false`. Set to `true` if you want the Form to be created even if the XLSForm conversion results in warnings.
@@ -3278,7 +3278,7 @@ Server Audit Logs entries are created for the following `action`s:
 
 This resource allows access to those log entries, with some paging and filtering options. These are provided by querystring parameters: `action` allows filtering by the action types listed above, `start` and `end` allow filtering by log timestamp (see below), and `limit` and `offset` control paging. If no paging parameters are given, the server will attempt to return every audit log entry that it has.
 
-The `start` and `end` parameters work based on exact timestamps, given in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. It is possible to provide just a datestring (eg `2000-01-01`), in which case midnight will be inferred. But this value alone leaves the timezone unspecified. When no timezone is given, the server's local time will be used: the standard [Docker deployment](https://docs.opendatakit.org/central-install/) will always set server local time to UTC, but installations may have been customized, and there is no guarantee the UTC default hasn't been overridden.
+The `start` and `end` parameters work based on exact timestamps, given in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. It is possible to provide just a datestring (eg `2000-01-01`), in which case midnight will be inferred. But this value alone leaves the timezone unspecified. When no timezone is given, the server's local time will be used: the standard [Docker deployment](https://docs.getodk.org/central-install/) will always set server local time to UTC, but installations may have been customized, and there is no guarantee the UTC default hasn't been overridden.
 
 For this reason, **we recommend always setting a timezone** when querying based on `start` and `end`: either by appending a `z` to indicate UTC (eg `2000-01-01z`) or by explicitly specifying a timezone per ISO 8601 (eg `2000-01-01+08`). The same applies for full timestamps (eg `2000-01-01T12:12:12z`, `2000-01-01T12:12:12+08`).
 
@@ -3309,7 +3309,7 @@ This endpoint supports retrieving extended metadata; provide a header `X-Extende
 
 ODK Central supports two types of encryption:
 
-1. The [old methodology](https://docs.opendatakit.org/encrypted-forms/), where you generate an RSA keypair and use it with locally-downloaded encrypted data to decrypt submissions. We refer to these sorts of keys in this documentation as "self-supplied keys."
+1. The [old methodology](https://docs.getodk.org/encrypted-forms/), where you generate an RSA keypair and use it with locally-downloaded encrypted data to decrypt submissions. We refer to these sorts of keys in this documentation as "self-supplied keys."
 2. Managed Encryption, where Central will generate and store an RSA keypair for you, secured under a passphrase that Central does not save. The CSV export path can then decrypt all records on the fly given the passphrase.
 
 Given the self-supplied key case, Central does not understand how to decrypt records, and the CSV export will export only metadata fields (and no binary attachments) for encrypted records. You may retrieve each data resource over the REST API and decrypt them yourself, or use ODK Briefcase to do this.
@@ -3476,7 +3476,7 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 + hint: `it was a secret` (string, optional) - The hint, if given, related to a managed encryption key.
 
 ## User (Actor)
-+ email: `my.email.address@opendatakit.org` (string, required) - Only `User`s have email addresses associated with them
++ email: `my.email.address@getodk.org` (string, required) - Only `User`s have email addresses associated with them
 
 ## Role (object)
 + id: `4` (number, required) - The numerical ID of the Role.

--- a/lib/bin/backup.js
+++ b/lib/bin/backup.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/bin/reap-sessions.js
+++ b/lib/bin/reap-sessions.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/bin/restore.js
+++ b/lib/bin/restore.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/data/attachments.js
+++ b/lib/data/attachments.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/data/briefcase.js
+++ b/lib/data/briefcase.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/data/client-audits.js
+++ b/lib/data/client-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/data/json.js
+++ b/lib/data/json.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/data/odata-filter.js
+++ b/lib/data/odata-filter.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/http/middleware.js
+++ b/lib/http/middleware.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/database.js
+++ b/lib/model/database.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/actee.js
+++ b/lib/model/instance/actee.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/actor.js
+++ b/lib/model/instance/actor.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/assignment.js
+++ b/lib/model/instance/assignment.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/audit.js
+++ b/lib/model/instance/audit.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/auth.js
+++ b/lib/model/instance/auth.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/blob.js
+++ b/lib/model/instance/blob.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/client-audit.js
+++ b/lib/model/instance/client-audit.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/config.js
+++ b/lib/model/instance/config.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/field-key.js
+++ b/lib/model/instance/field-key.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/form-attachment.js
+++ b/lib/model/instance/form-attachment.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/form-def.js
+++ b/lib/model/instance/form-def.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/form-field.js
+++ b/lib/model/instance/form-field.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/form-partial.js
+++ b/lib/model/instance/form-partial.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/form.js
+++ b/lib/model/instance/form.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/instance.js
+++ b/lib/model/instance/instance.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/key.js
+++ b/lib/model/instance/key.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/project.js
+++ b/lib/model/instance/project.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/public-link.js
+++ b/lib/model/instance/public-link.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/role.js
+++ b/lib/model/instance/role.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/session.js
+++ b/lib/model/instance/session.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/submission-attachment.js
+++ b/lib/model/instance/submission-attachment.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/submission-def.js
+++ b/lib/model/instance/submission-def.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/submission-partial.js
+++ b/lib/model/instance/submission-partial.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/instance/user.js
+++ b/lib/model/instance/user.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20170920-01-initial.js
+++ b/lib/model/migrations/20170920-01-initial.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20171010-01-auth.js
+++ b/lib/model/migrations/20171010-01-auth.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20171023-01-authz-forms.js
+++ b/lib/model/migrations/20171023-01-authz-forms.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20171030-01-add-default-authz-records.js
+++ b/lib/model/migrations/20171030-01-add-default-authz-records.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20171106-01-remove-user-update-timestamp.js
+++ b/lib/model/migrations/20171106-01-remove-user-update-timestamp.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20171121-01-add-submissions-constraint.js
+++ b/lib/model/migrations/20171121-01-add-submissions-constraint.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20171121-02-add-submitter.js
+++ b/lib/model/migrations/20171121-02-add-submitter.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20171213-01-unrequire-display-name.js
+++ b/lib/model/migrations/20171213-01-unrequire-display-name.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180108-01-expiring-actors.js
+++ b/lib/model/migrations/20180108-01-expiring-actors.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180108-02-enum-to-varchar.js
+++ b/lib/model/migrations/20180108-02-enum-to-varchar.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180112-01-audit-table.js
+++ b/lib/model/migrations/20180112-01-audit-table.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180112-02-add-field-keys.js
+++ b/lib/model/migrations/20180112-02-add-field-keys.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180118-01-rerequire-display-name.js
+++ b/lib/model/migrations/20180118-01-rerequire-display-name.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180125-01-add-form-detail-fields.js
+++ b/lib/model/migrations/20180125-01-add-form-detail-fields.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180125-02-more-field-key-grants.js
+++ b/lib/model/migrations/20180125-02-more-field-key-grants.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180125-03-add-blob-tables.js
+++ b/lib/model/migrations/20180125-03-add-blob-tables.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180301-01-configuration.js
+++ b/lib/model/migrations/20180301-01-configuration.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180322-01-additional-form-options.js
+++ b/lib/model/migrations/20180322-01-additional-form-options.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180327-01-update-form-constraints.js
+++ b/lib/model/migrations/20180327-01-update-form-constraints.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180501-01-add-configs-timestamp.js
+++ b/lib/model/migrations/20180501-01-add-configs-timestamp.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180501-02-fix-date-columns.js
+++ b/lib/model/migrations/20180501-02-fix-date-columns.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180515-01-enforce-nonnull-form-version.js
+++ b/lib/model/migrations/20180515-01-enforce-nonnull-form-version.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180727-01-rename-attachments-table.js
+++ b/lib/model/migrations/20180727-01-rename-attachments-table.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180727-02-add-md5-to-blobs.js
+++ b/lib/model/migrations/20180727-02-add-md5-to-blobs.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20180727-03-add-form-attachments-table.js
+++ b/lib/model/migrations/20180727-03-add-form-attachments-table.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181012-01-add-submissions-createdat-index.js
+++ b/lib/model/migrations/20181012-01-add-submissions-createdat-index.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181206-01-add-projects.js
+++ b/lib/model/migrations/20181206-01-add-projects.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181207-01-grant-verbs-to-text.js
+++ b/lib/model/migrations/20181207-01-grant-verbs-to-text.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181207-02-rename-grant-verbs.js
+++ b/lib/model/migrations/20181207-02-rename-grant-verbs.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181211-01-audit-verbs-to-text.js
+++ b/lib/model/migrations/20181211-01-audit-verbs-to-text.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181211-02-rename-audit-actions.js
+++ b/lib/model/migrations/20181211-02-rename-audit-actions.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181212-00-fix-user-type.js
+++ b/lib/model/migrations/20181212-00-fix-user-type.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181212-01-add-roles.js
+++ b/lib/model/migrations/20181212-01-add-roles.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181212-02-remove-groups.js
+++ b/lib/model/migrations/20181212-02-remove-groups.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181212-03-add-single-use-roles.js
+++ b/lib/model/migrations/20181212-03-add-single-use-roles.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181219-01-add-submission-update-verb.js
+++ b/lib/model/migrations/20181219-01-add-submission-update-verb.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181221-01-nullable-submission-blobs.js
+++ b/lib/model/migrations/20181221-01-nullable-submission-blobs.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20181230-01-add-device-id-to-submission.js
+++ b/lib/model/migrations/20181230-01-add-device-id-to-submission.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190225-01-add-actor-trigram-indices.js
+++ b/lib/model/migrations/20190225-01-add-actor-trigram-indices.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190225-02-add-role-grants.js
+++ b/lib/model/migrations/20190225-02-add-role-grants.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190226-01-convert-verbs-to-jsonb.js
+++ b/lib/model/migrations/20190226-01-convert-verbs-to-jsonb.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190226-02-add-role-actee-species.js
+++ b/lib/model/migrations/20190226-02-add-role-actee-species.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190226-03-add-assignment-verbs.js
+++ b/lib/model/migrations/20190226-03-add-assignment-verbs.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190226-04-add-assignment-actee-species.js
+++ b/lib/model/migrations/20190226-04-add-assignment-actee-species.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190227-01-add-project-manager-role.js
+++ b/lib/model/migrations/20190227-01-add-project-manager-role.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190405-01-add-project-archival-flag.js
+++ b/lib/model/migrations/20190405-01-add-project-archival-flag.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190416-01-email-uniqueness.js
+++ b/lib/model/migrations/20190416-01-email-uniqueness.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190416-02-add-user-delete-verb.js
+++ b/lib/model/migrations/20190416-02-add-user-delete-verb.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190520-01-add-form-versioning.js
+++ b/lib/model/migrations/20190520-01-add-form-versioning.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190523-01-add-form-state-constraint.js
+++ b/lib/model/migrations/20190523-01-add-form-state-constraint.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190605-01-reformat-audits.js
+++ b/lib/model/migrations/20190605-01-reformat-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190607-01-convert-audit-details-to-jsonb.js
+++ b/lib/model/migrations/20190607-01-convert-audit-details-to-jsonb.js
@@ -1,5 +1,5 @@
 // Copyright 2019 ODK Central Developers
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190607-02-standardize-attachment-actees.js
+++ b/lib/model/migrations/20190607-02-standardize-attachment-actees.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190607-03-rename-sub-attachment-audits.js
+++ b/lib/model/migrations/20190607-03-rename-sub-attachment-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190610-01-add-audits-verbs.js
+++ b/lib/model/migrations/20190610-01-add-audits-verbs.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190610-02-backfill-submission-audit-instanceids.js
+++ b/lib/model/migrations/20190610-02-backfill-submission-audit-instanceids.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190611-01-add-updatedat-to-form-attachments.js
+++ b/lib/model/migrations/20190611-01-add-updatedat-to-form-attachments.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190618-01-add-csrf-token.js
+++ b/lib/model/migrations/20190618-01-add-csrf-token.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190618-01-add-encryption-tracking.js
+++ b/lib/model/migrations/20190618-01-add-encryption-tracking.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190701-01-add-managed-encryption-key-check.js
+++ b/lib/model/migrations/20190701-01-add-managed-encryption-key-check.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190916-01-granularize-app-user-permissions.js
+++ b/lib/model/migrations/20190916-01-granularize-app-user-permissions.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190917-01-cleanup-app-user-role.js
+++ b/lib/model/migrations/20190917-01-cleanup-app-user-role.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190923-01-add-project-viewer-role.js
+++ b/lib/model/migrations/20190923-01-add-project-viewer-role.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20190925-01-add-client-audits.js
+++ b/lib/model/migrations/20190925-01-add-client-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20191007-01-backfill-client-audits.js
+++ b/lib/model/migrations/20191007-01-backfill-client-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20191010-01-add-excel-blob-reference.js
+++ b/lib/model/migrations/20191010-01-add-excel-blob-reference.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20191023-01-add-worker-columns-to-audits.js
+++ b/lib/model/migrations/20191023-01-add-worker-columns-to-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20191025-01-add-id-to-audits.js
+++ b/lib/model/migrations/20191025-01-add-id-to-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20191106-01-remove-deleted-actor-assignments.js
+++ b/lib/model/migrations/20191106-01-remove-deleted-actor-assignments.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20191231-01-remove-transformations.js
+++ b/lib/model/migrations/20191231-01-remove-transformations.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20191231-02-add-schema-storage.js
+++ b/lib/model/migrations/20191231-02-add-schema-storage.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200110-01-add-drafts.js
+++ b/lib/model/migrations/20200110-01-add-drafts.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200112-01-check-field-collisions.js
+++ b/lib/model/migrations/20200112-01-check-field-collisions.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200114-01-remove-formid-sha256-constraint.js
+++ b/lib/model/migrations/20200114-01-remove-formid-sha256-constraint.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200117-01-draft-test-submissions.js
+++ b/lib/model/migrations/20200117-01-draft-test-submissions.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200121-01-add-draft-keys.js
+++ b/lib/model/migrations/20200121-01-add-draft-keys.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200122-01-remove-draft-form-state.js
+++ b/lib/model/migrations/20200122-01-remove-draft-form-state.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200129-01-cascade-submission-deletes.js
+++ b/lib/model/migrations/20200129-01-cascade-submission-deletes.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200220-01-repair-submission-parsing.js
+++ b/lib/model/migrations/20200220-01-repair-submission-parsing.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200403-01-add-performance-indices.js
+++ b/lib/model/migrations/20200403-01-add-performance-indices.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200407-01-allow-actorless-submission-defs.js
+++ b/lib/model/migrations/20200407-01-allow-actorless-submission-defs.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200423-01-fix-field-insert-performance.js
+++ b/lib/model/migrations/20200423-01-fix-field-insert-performance.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200428-01-allow-string-downcast.js
+++ b/lib/model/migrations/20200428-01-allow-string-downcast.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200519-01-add-enketo-id.js
+++ b/lib/model/migrations/20200519-01-add-enketo-id.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200519-02-add-form-viewer-role.js
+++ b/lib/model/migrations/20200519-02-add-form-viewer-role.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200520-01-backfill-enketo.js
+++ b/lib/model/migrations/20200520-01-backfill-enketo.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200715-01-add-data-collector-role.js
+++ b/lib/model/migrations/20200715-01-add-data-collector-role.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200721-01-add-public-links.js
+++ b/lib/model/migrations/20200721-01-add-public-links.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200728-01-add-enketo-single-token-to-forms.js
+++ b/lib/model/migrations/20200728-01-add-enketo-single-token-to-forms.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200731-01-allow-project-managers-to-end-sessions.js
+++ b/lib/model/migrations/20200731-01-allow-project-managers-to-end-sessions.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200810-01-reschedule-enketo-processing.js
+++ b/lib/model/migrations/20200810-01-reschedule-enketo-processing.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200918-01-repair-publishedat-dates.js
+++ b/lib/model/migrations/20200918-01-repair-publishedat-dates.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20200930-01-add-backup-run-verb.js
+++ b/lib/model/migrations/20200930-01-add-backup-run-verb.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20201117-01-remove-deleted-actor-assignments-again.js
+++ b/lib/model/migrations/20201117-01-remove-deleted-actor-assignments-again.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20201207-01-harmonize-submitter-id-columns.js
+++ b/lib/model/migrations/20201207-01-harmonize-submitter-id-columns.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/package.js
+++ b/lib/model/package.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/actees.js
+++ b/lib/model/query/actees.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/actors.js
+++ b/lib/model/query/actors.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/all.js
+++ b/lib/model/query/all.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/assignments.js
+++ b/lib/model/query/assignments.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/builder.js
+++ b/lib/model/query/builder.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/client-audits.js
+++ b/lib/model/query/client-audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/configs.js
+++ b/lib/model/query/configs.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/field-keys.js
+++ b/lib/model/query/field-keys.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/form-defs.js
+++ b/lib/model/query/form-defs.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/keys.js
+++ b/lib/model/query/keys.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/public-links.js
+++ b/lib/model/query/public-links.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/roles.js
+++ b/lib/model/query/roles.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/sessions.js
+++ b/lib/model/query/sessions.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/simply.js
+++ b/lib/model/query/simply.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/submission-attachments.js
+++ b/lib/model/query/submission-attachments.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/submission-defs.js
+++ b/lib/model/query/submission-defs.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/trait/actee.js
+++ b/lib/model/trait/actee.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/trait/child.js
+++ b/lib/model/trait/child.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/trait/extended.js
+++ b/lib/model/trait/extended.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/outbound/google.js
+++ b/lib/outbound/google.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/outbound/mail.js
+++ b/lib/outbound/mail.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/outbound/odata.js
+++ b/lib/outbound/odata.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/outbound/openrosa.js
+++ b/lib/outbound/openrosa.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/assignments.js
+++ b/lib/resources/assignments.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/audits.js
+++ b/lib/resources/audits.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/backup.js
+++ b/lib/resources/backup.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/config.js
+++ b/lib/resources/config.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/public-links.js
+++ b/lib/resources/public-links.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/roles.js
+++ b/lib/resources/roles.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/sessions.js
+++ b/lib/resources/sessions.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/task/account.js
+++ b/lib/task/account.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/task/config.js
+++ b/lib/task/config.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/task/db.js
+++ b/lib/task/db.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/task/fs.js
+++ b/lib/task/fs.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/task/google.js
+++ b/lib/task/google.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/task/reap-sessions.js
+++ b/lib/task/reap-sessions.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/crypto.js
+++ b/lib/util/crypto.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
@@ -164,7 +164,7 @@ const getLocalDecipherer = (keys, passphrase = '') =>
 
 ////////////////////////////////////////////////////////////////////////////////
 // ODK SUBMISSION DECRYPTION UTIL
-// implements https://opendatakit.github.io/xforms-spec/encryption
+// implements https://getodk.github.io/xforms-spec/encryption
 
 // priv: Buffer, encAes: String containing base64
 // returns Buffer

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/enketo.js
+++ b/lib/util/enketo.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
@@ -77,7 +77,7 @@ const json = contentType('application/json');
 // the parameters to be set, except that if the value is null/undefined the parameter
 // will be _unset_ even if it already existed on the input URL.
 const urlWithQueryParams = (urlStr, set = {}) => {
-  const obj = new url.URL(urlStr, 'http://opendatakit.org');
+  const obj = new url.URL(urlStr, 'http://getodk.org');
   const params = obj.searchParams;
   for (const key of Object.keys(set))
     if (set[key] == null)

--- a/lib/util/instance.js
+++ b/lib/util/instance.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/promise.js
+++ b/lib/util/promise.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/quarantine/oaep.js
+++ b/lib/util/quarantine/oaep.js
@@ -2,7 +2,7 @@
 
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/stream.js
+++ b/lib/util/stream.js
@@ -1,6 +1,6 @@
 // Copyright 2018 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/xlsform.js
+++ b/lib/util/xlsform.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/xml.js
+++ b/lib/util/xml.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/util/zip.js
+++ b/lib/util/zip.js
@@ -1,6 +1,6 @@
 // Copyright 2017 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/worker/submission.attachment.update.js
+++ b/lib/worker/submission.attachment.update.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -1,6 +1,6 @@
 // Copyright 2019 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -214,7 +214,7 @@ describe('api: /key/:key', () => {
       .expect(403)));
 
   it('should reject non-field tokens', testService((service) =>
-    service.post('/v1/sessions').send({ email: 'alice@opendatakit.org', password: 'alice' })
+    service.post('/v1/sessions').send({ email: 'alice@getodk.org', password: 'alice' })
       .then(({ body }) => service.get(`/v1/key/${body.token}/users/current`)
         .expect(403))));
 

--- a/test/integration/api/assignments.js
+++ b/test/integration/api/assignments.js
@@ -251,14 +251,14 @@ describe('api: /assignments', () => {
                 })))))));
 
       it('should log the action in the audit log', testService((service, { Audit, User }) =>
-        User.getByEmail('chelsea@opendatakit.org')
+        User.getByEmail('chelsea@getodk.org')
           .then((maybeChelsea) => maybeChelsea.get())
           .then((chelsea) => service.login('alice', (asAlice) =>
             asAlice.get('/v1/roles/admin').expect(200).then(({ body }) => body.id)
               .then((adminRoleId) => asAlice.post(`/v1/assignments/${adminRoleId}/${chelsea.actor.id}`)
                 .expect(200)
                 .then(() => Promise.all([
-                  User.getByEmail('alice@opendatakit.org').then((maybeAlice) => maybeAlice.get()),
+                  User.getByEmail('alice@getodk.org').then((maybeAlice) => maybeAlice.get()),
                   Audit.getLatestWhere({ action: 'assignment.create' })
                 ]))
                 .then(([ alice, audit ]) => {
@@ -316,7 +316,7 @@ describe('api: /assignments', () => {
               .then(() => asAlice.get('/v1/assignments').expect(403))))));
 
       it('should log the action in the audit log', testService((service, { Audit, User }) =>
-        User.getByEmail('alice@opendatakit.org')
+        User.getByEmail('alice@getodk.org')
           .then((maybeAlice) => maybeAlice.get())
           .then((alice) => service.login('alice', (asAlice) =>
             asAlice.get('/v1/roles/admin').expect(200).then(({ body }) => body.id)
@@ -441,7 +441,7 @@ describe('/projects/:id/assignments', () => {
               })))))));
 
       it('should log the action in the audit log', testService((service, { Audit, Project, User }) =>
-        User.getByEmail('chelsea@opendatakit.org')
+        User.getByEmail('chelsea@getodk.org')
           .then((maybeChelsea) => maybeChelsea.get())
           .then((chelsea) => service.login('alice', (asAlice) =>
             asAlice.get('/v1/roles/admin').expect(200).then(({ body }) => body.id)
@@ -449,7 +449,7 @@ describe('/projects/:id/assignments', () => {
                 .expect(200)
                 .then(() => Promise.all([
                   Project.getById(1).then((x) => x.get()),
-                  User.getByEmail('alice@opendatakit.org').then((maybeAlice) => maybeAlice.get()),
+                  User.getByEmail('alice@getodk.org').then((maybeAlice) => maybeAlice.get()),
                   Audit.getLatestWhere({ action: 'assignment.create' })
                 ]))
                 .then(([ project, alice, audit ]) => {
@@ -506,7 +506,7 @@ describe('/projects/:id/assignments', () => {
                 .then(({ body }) => { body.length.should.equal(0); })))))));
 
       it('should log the action in the audit log', testService((service, { Audit, Project, User }) =>
-        User.getByEmail('bob@opendatakit.org')
+        User.getByEmail('bob@getodk.org')
           .then((maybeBob) => maybeBob.get())
           .then((bob) => service.login('alice', (asAlice) =>
             asAlice.get('/v1/roles/manager').expect(200).then(({ body }) => body.id)
@@ -514,7 +514,7 @@ describe('/projects/:id/assignments', () => {
                 .expect(200)
                 .then(() => Promise.all([
                   Project.getById(1).then((x) => x.get()),
-                  User.getByEmail('alice@opendatakit.org').then((x) => x.get()),
+                  User.getByEmail('alice@getodk.org').then((x) => x.get()),
                   Audit.getLatestWhere({ action: 'assignment.delete' })
                 ]))
                 .then(([ project, alice, audit ]) => {

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -32,13 +32,13 @@ describe('/audits', () => {
             .send({ name: 'renamed audit project' })
             .expect(200)
             .then(() => asAlice.post('/v1/users')
-              .send({ displayName: 'david', email: 'david@opendatakit.org' })
+              .send({ displayName: 'david', email: 'david@getodk.org' })
               .expect(200))
             .then(() => Promise.all([
               asAlice.get('/v1/audits').expect(200).then(({ body }) => body),
               Project.getById(projectId).then((o) => o.get()),
-              User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
-              User.getByEmail('david@opendatakit.org').then((o) => o.get())
+              User.getByEmail('alice@getodk.org').then((o) => o.get()),
+              User.getByEmail('david@getodk.org').then((o) => o.get())
             ]))
             .then(([ audits, project, alice, david ]) => {
               audits.length.should.equal(3);
@@ -49,7 +49,7 @@ describe('/audits', () => {
               audits[0].acteeId.should.equal(david.actor.acteeId);
               audits[0].details.should.eql({ data: {
                 actor: { displayName: 'david', type: 'user' },
-                email: 'david@opendatakit.org', password: null
+                email: 'david@getodk.org', password: null
               } });
               audits[0].loggedAt.should.be.a.recentIsoDate();
 
@@ -77,7 +77,7 @@ describe('/audits', () => {
             .set('Content-Type', 'text/xml')
             .expect(200)
             .then(() => asAlice.post('/v1/users')
-              .send({ displayName: 'david', email: 'david@opendatakit.org' })
+              .send({ displayName: 'david', email: 'david@getodk.org' })
               .expect(200))
             .then(() => Promise.all([
               asAlice.get('/v1/audits').set('X-Extended-Metadata', true)
@@ -86,8 +86,8 @@ describe('/audits', () => {
                 .then((project) => project.getFormByXmlFormId('simple')
                   .then((o) => o.get())
                   .then((form) => [ project, form ])),
-              User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
-              User.getByEmail('david@opendatakit.org').then((o) => o.get())
+              User.getByEmail('alice@getodk.org').then((o) => o.get()),
+              User.getByEmail('david@getodk.org').then((o) => o.get())
             ]))
             .then(([ audits, [ project, form ], alice, david ]) => {
               audits.length.should.equal(4);
@@ -102,7 +102,7 @@ describe('/audits', () => {
               audits[0].actee.should.eql(plain(david.actor.forApi()));
               audits[0].details.should.eql({ data: {
                 actor: { displayName: 'david', type: 'user' },
-                email: 'david@opendatakit.org', password: null
+                email: 'david@getodk.org', password: null
               } });
               audits[0].loggedAt.should.be.a.recentIsoDate();
 
@@ -176,7 +176,7 @@ describe('/audits', () => {
             .set('Content-Type', 'text/xml')
             .expect(200)
             .then(() => asAlice.post('/v1/users')
-              .send({ displayName: 'david', email: 'david@opendatakit.org' })
+              .send({ displayName: 'david', email: 'david@getodk.org' })
               .expect(200))
             .then(() => asAlice.get('/v1/audits?action=form.create')
               .expect(200)
@@ -192,7 +192,7 @@ describe('/audits', () => {
           .send({ name: 'audit project' })
           .expect(200)
           .then(() => asAlice.post('/v1/users')
-            .send({ displayName: 'david', email: 'david@opendatakit.org' })
+            .send({ displayName: 'david', email: 'david@getodk.org' })
             .expect(200)
             .then(({ body }) => body.id)
             .then((davidId) => asAlice.patch(`/v1/users/${davidId}`)
@@ -227,7 +227,7 @@ describe('/audits', () => {
             .then(() => asAlice.delete(`/v1/projects/${projectId}`)
               .expect(200)))
           .then(() => asAlice.post('/v1/users')
-            .send({ displayName: 'david', email: 'david@opendatakit.org' })
+            .send({ displayName: 'david', email: 'david@getodk.org' })
             .expect(200))
           .then(() => asAlice.get('/v1/audits?action=project')
             .expect(200)
@@ -254,7 +254,7 @@ describe('/audits', () => {
             .then(() => asAlice.delete(`/v1/projects/${projectId}/forms/simple`)
               .expect(200)))
           .then(() => asAlice.post('/v1/users')
-            .send({ displayName: 'david', email: 'david@opendatakit.org' })
+            .send({ displayName: 'david', email: 'david@getodk.org' })
             .expect(200))
           .then(() => asAlice.get('/v1/audits?action=form')
             .expect(200)
@@ -297,7 +297,7 @@ describe('/audits', () => {
             .set('Content-Type', 'text/xml')
             .expect(200)
             .then(() => asAlice.post('/v1/users')
-              .send({ displayName: 'david', email: 'david@opendatakit.org' })
+              .send({ displayName: 'david', email: 'david@getodk.org' })
               .expect(200))
             .then(() => asAlice.get('/v1/audits?action=form.create')
               .set('X-Extended-Metadata', true)
@@ -348,7 +348,7 @@ describe('/audits', () => {
             })))));
 
     it('should filter extended data by start date+time', testService((service, { db, Audit, User }) =>
-      User.getByEmail('alice@opendatakit.org').then((o) => o.get())
+      User.getByEmail('alice@getodk.org').then((o) => o.get())
         .then((alice) => Promise.all(
           [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
             .map((day) => new Audit({ loggedAt: `2000-01-${day}T00:00Z`, action: `test.${day}`, actorId: alice.actor.id, acteeId: alice.actor.acteeId }))
@@ -410,7 +410,7 @@ describe('/audits', () => {
             })))));
 
     it('should filter extended data by end date+time', testService((service, { db, Audit, User }) =>
-      User.getByEmail('alice@opendatakit.org').then((o) => o.get())
+      User.getByEmail('alice@getodk.org').then((o) => o.get())
         .then((alice) => Promise.all(
           [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
             .map((day) => new Audit({ loggedAt: `2000-01-${day}T00:00Z`, action: `test.${day}`, actorId: alice.actor.id, acteeId: alice.actor.acteeId }))

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -1211,7 +1211,7 @@ describe('api: /projects/:id/forms', () => {
           .send({ name: 'a fancy name', state: 'closing' })
           .expect(200)
           .then(() => Promise.all([
-            User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
+            User.getByEmail('alice@getodk.org').then((o) => o.get()),
             Project.getById(1).then((o) => o.get())
               .then((project) => project.getFormByXmlFormId('simple')).then((o) => o.get()),
             Audit.getLatestByAction('form.update').then((o) => o.get())
@@ -1242,7 +1242,7 @@ describe('api: /projects/:id/forms', () => {
           .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
             .expect(200)
             .then(() => Promise.all([
-              User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
+              User.getByEmail('alice@getodk.org').then((o) => o.get()),
               Audit.getLatestByAction('form.delete').then((o) => o.get())
             ])
             .then(([ alice, log ]) => {
@@ -2208,7 +2208,7 @@ describe('api: /projects/:id/forms', () => {
                 .set('Content-Type', 'text/csv')
                 .expect(200)
                 .then(() => Promise.all([
-                  User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
+                  User.getByEmail('alice@getodk.org').then((o) => o.get()),
                   Project.getById(1).then((o) => o.get())
                     .then((project) => project.getFormByXmlFormId('withAttachments')).then((o) => o.get())
                     .then((form) => FormAttachment.getByFormDefIdAndName(form.draftDefId, 'goodone.csv')
@@ -2303,7 +2303,7 @@ describe('api: /projects/:id/forms', () => {
                 .set('Content-Type', 'text/csv')
                 .expect(200)
                 .then(() => Promise.all([
-                  User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
+                  User.getByEmail('alice@getodk.org').then((o) => o.get()),
                   Project.getById(1).then((o) => o.get())
                     .then((project) => project.getFormByXmlFormId('withAttachments'))
                     .then((o) => o.get())

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -540,7 +540,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(() => Promise.all([
             Project.getById(1).then((o) => o.get()),
-            User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
+            User.getByEmail('alice@getodk.org').then((o) => o.get()),
             Audit.getLatestWhere({ action: 'project.update' }).then((o) => o.get())
           ]))
           .then(([ project, alice, log ]) => {

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -188,7 +188,7 @@ describe('api: /key/:key', () => {
 
   it('should allow cookie+public-link', testService((service) =>
     service.post('/v1/sessions')
-      .send({ email: 'alice@opendatakit.org', password: 'alice' })
+      .send({ email: 'alice@getodk.org', password: 'alice' })
       .expect(200)
       .then(({ body }) => body.token)
       .then((aliceToken) => service.login('alice', (asAlice) =>

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -6,7 +6,7 @@ describe('api: /sessions', () => {
   describe('POST', () => {
     it('should return a new session if the information is valid', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@opendatakit.org', password: 'chelsea' })
+        .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
         .expect(200)
         .then(({ body }) => {
           body.should.be.a.Session();
@@ -14,7 +14,7 @@ describe('api: /sessions', () => {
 
     it('should treat email addresses case insensitively', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'cHeLsEa@oPeNdAtAkIt.OrG', password: 'chelsea' })
+        .send({ email: 'cHeLsEa@gEtOdK.OrG', password: 'chelsea' })
         .expect(200)
         .then(({ body }) => {
           body.should.be.a.Session();
@@ -22,7 +22,7 @@ describe('api: /sessions', () => {
 
     it('should provide a csrf token when the session returns', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@opendatakit.org', password: 'chelsea' })
+        .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
         .expect(200)
         .then(({ body }) => {
           body.csrf.should.be.a.token();
@@ -30,7 +30,7 @@ describe('api: /sessions', () => {
 
     it('should set cookie information when the session returns', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@opendatakit.org', password: 'chelsea' })
+        .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
         .expect(200)
         .then(({ body, headers }) => {
           // i don't know how this becomes an array but i think superagent does it.
@@ -49,13 +49,13 @@ describe('api: /sessions', () => {
 
     it('should return a 401 if the password is wrong', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@opendatakit.org', password: 'letmein' })
+        .send({ email: 'chelsea@getodk.org', password: 'letmein' })
         .expect(401)
         .then(({ body }) => body.message.should.equal('Could not authenticate with the provided credentials.'))));
 
     it('should return a 401 if the email is wrong', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'winnifred@opendatakit.org', password: 'winnifred' })
+        .send({ email: 'winnifred@getodk.org', password: 'winnifred' })
         .expect(401)
         .then(({ body }) => body.message.should.equal('Could not authenticate with the provided credentials.'))));
 
@@ -74,7 +74,7 @@ describe('api: /sessions', () => {
 
     it('should return the active session if it exists', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => service.get('/v1/sessions/restore')
           .set('X-Forwarded-Proto', 'https')
@@ -93,7 +93,7 @@ describe('api: /sessions', () => {
 
     it('should return a 403 if the user cannot delete the given token', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => {
           const token = body.token;
@@ -103,7 +103,7 @@ describe('api: /sessions', () => {
 
     it('should invalidate the token if successful', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => {
           const token = body.token;
@@ -131,7 +131,7 @@ describe('api: /sessions', () => {
 
     it('should allow non-admins to delete their own sessions', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@opendatakit.org', password: 'chelsea' })
+        .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
         .expect(200)
         .then(({ body }) => {
           const token = body.token;
@@ -176,7 +176,7 @@ describe('api: /sessions', () => {
 
     it('should clear the cookie if successful for the current session', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => {
           const token = body.token;
@@ -191,7 +191,7 @@ describe('api: /sessions', () => {
 
     it('should not clear the cookie if using some other session', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => body.token)
         .then((token) => service.login('alice', (asAlice) =>
@@ -203,7 +203,7 @@ describe('api: /sessions', () => {
 
     it('should not log the action in the audit log for users', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => body.token)
         .then((token) => service.delete('/v1/sessions/' + token)
@@ -250,7 +250,7 @@ describe('api: /sessions', () => {
   describe('cookie CSRF auth', () => {
     it('should reject if the CSRF token is missing', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => service.post('/v1/projects')
           .send({ name: 'my project' })
@@ -260,7 +260,7 @@ describe('api: /sessions', () => {
 
     it('should reject if the CSRF token is wrong', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => service.post('/v1/projects')
           .send({ name: 'my project', __csrf: 'nope' })
@@ -270,7 +270,7 @@ describe('api: /sessions', () => {
 
     it('should succeed if the CSRF token is correct', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
         .then(({ body }) => service.post('/v1/projects')
           .send({ name: 'my project', __csrf: body.csrf })

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -19,7 +19,7 @@ describe('api: /users', () => {
           .expect(({ body }) => {
             body.forEach((user) => user.should.be.a.User());
             body.map((user) => user.displayName).should.eql([ 'Alice', 'Bob', 'Chelsea' ]);
-            body.map((user) => user.email).should.eql([ 'alice@opendatakit.org', 'bob@opendatakit.org', 'chelsea@opendatakit.org' ]);
+            body.map((user) => user.email).should.eql([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org' ]);
           }))));
 
     it('should search user display names if a query is given', testService((service) =>
@@ -33,26 +33,26 @@ describe('api: /users', () => {
               body.length.should.equal(2);
               body.forEach((user) => user.should.be.a.User());
               body.map((user) => user.displayName).should.eql([ 'Alice', 'alicia' ]);
-              body.map((user) => user.email).should.eql([ 'alice@opendatakit.org', 'test@email.org' ]);
+              body.map((user) => user.email).should.eql([ 'alice@getodk.org', 'test@email.org' ]);
             })))));
 
     it('should search user emails if a query is given', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
-          .send({ email: 'david@closeddatakit.org', displayName: 'David' })
+          .send({ email: 'david@getcdk', displayName: 'David' })
           .expect(200)
-          .then(() => asAlice.get('/v1/users?q=opendatakit')
+          .then(() => asAlice.get('/v1/users?q=getodk')
             .expect(200)
             .then(({ body }) => {
               body.length.should.equal(3);
               body.forEach((user) => user.should.be.a.User());
               body.map((user) => user.displayName).should.containDeep([ 'Alice', 'Bob', 'Chelsea' ]);
-              body.map((user) => user.email).should.containDeep([ 'alice@opendatakit.org', 'bob@opendatakit.org', 'chelsea@opendatakit.org' ]);
+              body.map((user) => user.email).should.containDeep([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org' ]);
             })))));
 
     it('should search with compound phrases if given', testService((service) =>
       service.login('alice', (asAlice) =>
-        asAlice.get('/v1/users?q=chelsea opendatakit')
+        asAlice.get('/v1/users?q=chelsea getodk')
           .expect(200)
           .then(({ body }) => {
             body.length.should.equal(3);
@@ -63,15 +63,15 @@ describe('api: /users', () => {
           }))));
 
     it('should reject unauthed users even if they exactly match an email', testService((service) =>
-      service.get('/v1/users/?q=alice@opendatakit.org').expect(403)));
+      service.get('/v1/users/?q=alice@getodk.org').expect(403)));
 
     it('should return an exact email match to any authed user', testService((service) =>
       service.login('chelsea', (asChelsea) =>
-        asChelsea.get('/v1/users/?q=alice@opendatakit.org')
+        asChelsea.get('/v1/users/?q=alice@getodk.org')
           .expect(200)
           .then(({ body }) => {
             body.length.should.equal(1);
-            body[0].email.should.equal('alice@opendatakit.org');
+            body[0].email.should.equal('alice@getodk.org');
             body[0].displayName.should.equal('Alice');
           }))));
   });
@@ -80,41 +80,41 @@ describe('api: /users', () => {
     it('should prohibit non-admins from creating users', testService((service) =>
       service.login('bob', (asBob) =>
         asBob.post('/v1/users')
-          .send({ email: 'david@opendatakit.org' })
+          .send({ email: 'david@getodk.org' })
           .expect(403))));
 
     it('should hash and store passwords if provided', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
-          .send({ email: 'david@opendatakit.org', password: 'apassword' })
+          .send({ email: 'david@getodk.org', password: 'apassword' })
           .expect(200)
-          .then(() => service.login({ email: 'david@opendatakit.org', password: 'apassword' }, (asDavid) =>
+          .then(() => service.login({ email: 'david@getodk.org', password: 'apassword' }, (asDavid) =>
             asDavid.get('/v1/users/current').expect(200))))));
 
     it('should not accept and hash blank passwords', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
-          .send({ email: 'david@opendatakit.org', password: '' })
+          .send({ email: 'david@getodk.org', password: '' })
           .expect(200)
-          .then(() => service.login({ email: 'david@opendatakit.org', password: '' }, (failed) =>
+          .then(() => service.login({ email: 'david@getodk.org', password: '' }, (failed) =>
             failed.get('/v1/users/current').expect(401))))));
 
     it('should send an email to provisioned users', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
-          .send({ email: 'david@opendatakit.org', password: 'david' })
+          .send({ email: 'david@getodk.org', password: 'david' })
           .expect(200)
           .then(() => {
             const email = global.inbox.pop();
             global.inbox.length.should.equal(0);
-            email.to.should.eql([{ address: 'david@opendatakit.org', name: '' }]);
+            email.to.should.eql([{ address: 'david@getodk.org', name: '' }]);
             email.subject.should.equal('ODK Central account created');
           }))));
 
     it('should send a token which can reset the new user password', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
-          .send({ email: 'david@opendatakit.org' })
+          .send({ email: 'david@getodk.org' })
           .expect(200)
           .then(() => {
             const token = /token=([a-z0-9!$]+)/i.exec(global.inbox.pop().html)[1];
@@ -122,7 +122,7 @@ describe('api: /users', () => {
               .send({ new: 'testreset' })
               .set('Authorization', 'Bearer ' + token)
               .expect(200)
-              .then(() => service.login({ email: 'david@opendatakit.org', password: 'testreset' }, (asDavid) =>
+              .then(() => service.login({ email: 'david@getodk.org', password: 'testreset' }, (asDavid) =>
                 asDavid.get('/v1/users/current').expect(200)));
           }))));
 
@@ -130,17 +130,17 @@ describe('api: /users', () => {
     it('should duplicate the email into the display name if not given', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
-          .send({ email: 'david@opendatakit.org' })
-          .then(({ body }) => body.displayName.should.equal('david@opendatakit.org')))));
+          .send({ email: 'david@getodk.org' })
+          .then(({ body }) => body.displayName.should.equal('david@getodk.org')))));
 
     it('should log the action in the audit log', testService((service, { Audit, User }) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
-          .send({ email: 'david@opendatakit.org' })
+          .send({ email: 'david@getodk.org' })
           .expect(200)
           .then(() => Promise.all([
-            User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
-            User.getByEmail('david@opendatakit.org').then((o) => o.get()),
+            User.getByEmail('alice@getodk.org').then((o) => o.get()),
+            User.getByEmail('david@getodk.org').then((o) => o.get()),
             Audit.getLatestByAction('user.create').then((o) => o.get())
           ])
           .then(([ alice, david, log ]) => {
@@ -148,8 +148,8 @@ describe('api: /users', () => {
             log.acteeId.should.equal(david.actor.acteeId);
             log.details.should.eql({
               data: {
-                email: 'david@opendatakit.org',
-                actor: { displayName: 'david@opendatakit.org', type: 'user' },
+                email: 'david@getodk.org',
+                actor: { displayName: 'david@getodk.org', type: 'user' },
                 password: null
               }
             });
@@ -159,12 +159,12 @@ describe('api: /users', () => {
   describe('/reset/initiate POST', () => {
     it('should send an email with a helpful message if no account exists', testService((service) =>
       service.post('/v1/users/reset/initiate')
-        .send({ email: 'winnifred@opendatakit.org' })
+        .send({ email: 'winnifred@getodk.org' })
         .expect(200)
         .then(() => {
           const email = global.inbox.pop();
           global.inbox.length.should.equal(0);
-          email.to.should.eql([{ address: 'winnifred@opendatakit.org', name: '' }]);
+          email.to.should.eql([{ address: 'winnifred@getodk.org', name: '' }]);
           email.subject.should.equal('ODK Central account password reset');
           email.html.should.match(/no account exists/);
         })));
@@ -177,24 +177,24 @@ describe('api: /users', () => {
             .then((chelseaId) => asAlice.delete('/v1/users/' + chelseaId)
               .expect(200)
               .then(() => service.post('/v1/users/reset/initiate')
-                .send({ email: 'chelsea@opendatakit.org' })
+                .send({ email: 'chelsea@getodk.org' })
                 .expect(200)
                 .then(() => {
                   const email = global.inbox.pop();
                   global.inbox.length.should.equal(0);
-                  email.to.should.eql([{ address: 'chelsea@opendatakit.org', name: '' }]);
+                  email.to.should.eql([{ address: 'chelsea@getodk.org', name: '' }]);
                   email.subject.should.equal('ODK Central account password reset');
                   email.html.should.match(/account has been deleted/);
                 })))))));
 
     it('should send an email with a token which can reset the user password', testService((service) =>
       service.post('/v1/users/reset/initiate')
-        .send({ email: 'alice@opendatakit.org' })
+        .send({ email: 'alice@getodk.org' })
         .expect(200)
         .then(() => {
           const email = global.inbox.pop();
           global.inbox.length.should.equal(0);
-          email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
+          email.to.should.eql([{ address: 'alice@getodk.org', name: '' }]);
           email.subject.should.equal('ODK Central account password reset');
           const token = /token=([a-z0-9!$]+)/i.exec(email.html)[1];
 
@@ -202,13 +202,13 @@ describe('api: /users', () => {
             .send({ new: 'reset!' })
             .set('Authorization', 'Bearer ' + token)
             .expect(200)
-            .then(() => service.login({ email: 'alice@opendatakit.org', password: 'reset!' }, (asAlice) =>
+            .then(() => service.login({ email: 'alice@getodk.org', password: 'reset!' }, (asAlice) =>
               asAlice.get('/v1/users/current').expect(200)));
         })));
 
     it('should not allow password reset token replay', testService((service) =>
       service.post('/v1/users/reset/initiate')
-        .send({ email: 'alice@opendatakit.org' })
+        .send({ email: 'alice@getodk.org' })
         .expect(200)
         .then(() => /token=([a-z0-9!$]+)/i.exec(global.inbox.pop().html)[1])
         .then((token) => service.post('/v1/users/reset/verify')
@@ -222,23 +222,23 @@ describe('api: /users', () => {
 
     it('should fail the request if invalidation is requested but not allowed', testService((service) =>
       service.post('/v1/users/reset/initiate?invalidate=true')
-        .send({ email: 'alice@opendatakit.org' })
+        .send({ email: 'alice@getodk.org' })
         .expect(403)));
 
     it('should invalidate the existing password if requested', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users/reset/initiate?invalidate=true')
-          .send({ email: 'bob@opendatakit.org' })
+          .send({ email: 'bob@getodk.org' })
           .expect(200)
           .then(() => {
             // should still send the email.
             const email = global.inbox.pop();
             global.inbox.length.should.equal(0);
-            email.to.should.eql([{ address: 'bob@opendatakit.org', name: '' }]);
+            email.to.should.eql([{ address: 'bob@getodk.org', name: '' }]);
             email.subject.should.equal('ODK Central account password reset');
 
             return service.post('/v1/sessions')
-              .send({ email: 'bob@opendatakit.org', password: 'bob' })
+              .send({ email: 'bob@getodk.org', password: 'bob' })
               .expect(401);
           }))));
 
@@ -257,7 +257,7 @@ describe('api: /users', () => {
       service.login('chelsea', (asChelsea) =>
         asChelsea.get('/v1/users/current')
           .expect(200)
-          .then(({ body }) => body.email.should.equal('chelsea@opendatakit.org')))));
+          .then(({ body }) => body.email.should.equal('chelsea@getodk.org')))));
 
     it('should not return sidewide verbs if not extended', testService((service) =>
       service.login('alice', (asAlice) =>
@@ -305,7 +305,7 @@ describe('api: /users', () => {
             .expect(200)
             .then(({ body }) => {
               body.should.be.a.User();
-              body.email.should.equal('alice@opendatakit.org');
+              body.email.should.equal('alice@getodk.org');
             })))));
 
     it('should allow nonadministrator users to get themselves', testService((service) =>
@@ -315,7 +315,7 @@ describe('api: /users', () => {
             .expect(200)
             .then(({ body }) => {
               body.should.be.a.User();
-              body.email.should.equal('chelsea@opendatakit.org');
+              body.email.should.equal('chelsea@getodk.org');
             })))));
 
     it('should reject if the user does not exist', testService((service) =>
@@ -377,7 +377,7 @@ describe('api: /users', () => {
             .then(() => asChelsea.get('/v1/users/' + chelseaId)
               .then(({ body }) => {
                 body.should.be.a.User();
-                body.email.should.equal('chelsea@opendatakit.org');
+                body.email.should.equal('chelsea@getodk.org');
                 body.displayName.should.equal('a new display name');
               }))))));
 
@@ -386,14 +386,14 @@ describe('api: /users', () => {
         asAlice.get('/v1/users/current')
           .expect(200)
           .then((before) => asAlice.patch(`/v1/users/${before.body.id}`)
-            .send({ email: 'david123@opendatakit.org' })
+            .send({ email: 'david123@getodk.org' })
             .expect(200)
             .then(() => {
               const email = global.inbox.pop();
               global.inbox.length.should.equal(0);
-              email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
+              email.to.should.eql([{ address: 'alice@getodk.org', name: '' }]);
               email.subject.should.equal('ODK Central account email changed');
-              email.html.should.equal('<html>Hello!<p><p>We are emailing because you have an ODK Central data collection account, and somebody has just changed the email address associated with the account from this one you are reading right now (alice@opendatakit.org) to a new address (david123@opendatakit.org).</p><p>If this was you, please feel free to ignore this email. Otherwise, please contact your local ODK system administrator immediately.</p></html>');
+              email.html.should.equal('<html>Hello!<p><p>We are emailing because you have an ODK Central data collection account, and somebody has just changed the email address associated with the account from this one you are reading right now (alice@getodk.org) to a new address (david123@getodk.org).</p><p>If this was you, please feel free to ignore this email. Otherwise, please contact your local ODK system administrator immediately.</p></html>');
             })))));
 
     it('should not send an email to a user when their email does not change', testService((service) =>
@@ -401,7 +401,7 @@ describe('api: /users', () => {
         asAlice.get('/v1/users/current')
           .expect(200)
           .then((before) => asAlice.patch(`/v1/users/${before.body.id}`)
-            .send({ email: 'alice@opendatakit.org' })
+            .send({ email: 'alice@getodk.org' })
             .expect(200)
             .then(() => {
               global.inbox.length.should.equal(0);
@@ -409,12 +409,12 @@ describe('api: /users', () => {
 
     it('should log the action in the audit log', testService((service, { User, Audit }) =>
       service.login('alice', (asAlice) =>
-        User.getByEmail('chelsea@opendatakit.org').then((o) => o.get())
+        User.getByEmail('chelsea@getodk.org').then((o) => o.get())
           .then((chelsea) => asAlice.patch('/v1/users/' + chelsea.actor.id)
             .send({ displayName: 'cool chelsea', other: 'data' })
             .expect(200)
             .then(() => Promise.all([
-              User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
+              User.getByEmail('alice@getodk.org').then((o) => o.get()),
               Audit.getLatestByAction('user.update').then((o) => o.get())
             ])
           .then(([ alice, log ]) => {
@@ -458,7 +458,7 @@ describe('api: /users', () => {
           .then(({ body }) => {
             body.success.should.equal(true);
             return service.post('/v1/sessions')
-              .send({ email: 'alice@opendatakit.org', password: 'newpassword' })
+              .send({ email: 'alice@getodk.org', password: 'newpassword' })
               .expect(200);
           }))));
 
@@ -469,7 +469,7 @@ describe('api: /users', () => {
             .send({ old: 'chelsea', new: 'newchelsea' })
             .expect(200)
             .then(() => service.post('/v1/sessions')
-              .send({ email: 'chelsea@opendatakit.org', password: 'newchelsea' })
+              .send({ email: 'chelsea@getodk.org', password: 'newchelsea' })
               .expect(200))))));
 
     it('should send an email to a user when their password changes', testService((service) =>
@@ -482,7 +482,7 @@ describe('api: /users', () => {
             .then(() => {
               const email = global.inbox.pop();
               global.inbox.length.should.equal(0);
-              email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
+              email.to.should.eql([{ address: 'alice@getodk.org', name: '' }]);
               email.subject.should.equal('ODK Central account password change');
             })))));
 
@@ -494,7 +494,7 @@ describe('api: /users', () => {
             .send({ old: 'alice', new: 'newpassword' })
             .expect(200)
             .then(() => Promise.all([
-              User.getByEmail('alice@opendatakit.org').then((o) => o.get()),
+              User.getByEmail('alice@getodk.org').then((o) => o.get()),
               Audit.getLatestWhere({ action: 'user.update' }).then((o) => o.get())
             ]))
             .then(([ alice, log ]) => {
@@ -547,7 +547,7 @@ describe('api: /users', () => {
 
     it('should log an audit upon delete', testService((service, { Audit, User }) =>
       service.login('alice', (asAlice) =>
-        User.getByEmail('chelsea@opendatakit.org')
+        User.getByEmail('chelsea@getodk.org')
           .then((maybeChelsea) => maybeChelsea.get())
           .then((chelsea) => asAlice.delete('/v1/users/' + chelsea.actor.id)
             .expect(200)
@@ -570,7 +570,7 @@ describe('api: /users', () => {
             .then((chelseaId) => asAlice.delete('/v1/users/' + chelseaId)
               .expect(200)
               .then(() => service.post('/v1/sessions')
-                .send({ email: 'chelsea@opendatakit.org', password: 'chelsea' })
+                .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
                 .expect(401)))))));
 
     it('should disable active sessions', testService((service) =>

--- a/test/integration/fixtures/01-users.js
+++ b/test/integration/fixtures/01-users.js
@@ -1,9 +1,9 @@
 
 module.exports = ({ all, User, Actor, Membership, Project }) => {
   const users = [
-    { type: 'user', email: 'alice@opendatakit.org', password: 'alice', displayName: 'Alice' },
-    { type: 'user', email: 'bob@opendatakit.org', password: 'bob', displayName: 'Bob' },
-    { type: 'user', email: 'chelsea@opendatakit.org', password: 'chelsea', displayName: 'Chelsea' } ]
+    { type: 'user', email: 'alice@getodk.org', password: 'alice', displayName: 'Alice' },
+    { type: 'user', email: 'bob@getodk.org', password: 'bob', displayName: 'Bob' },
+    { type: 'user', email: 'chelsea@getodk.org', password: 'chelsea', displayName: 'Chelsea' } ]
     .map((data) => User.fromData(data));
 
   // hash the passwords, create our three test users, then add grant Alice and Bob their rights.

--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -242,7 +242,7 @@ describe('managed encryption', () => {
               .expect(200)
               .then(({ body }) => body[0].id),
             service.post('/v1/sessions')
-              .send({ email: 'alice@opendatakit.org', password: 'alice' })
+              .send({ email: 'alice@getodk.org', password: 'alice' })
               .expect(200)
               .then(({ body }) => body)
           ]))

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -87,7 +87,7 @@ const authProxy = (token) => ({
 const augment = (service) => {
   service.login = function(user, test) {
     const credentials = (typeof user === 'string')
-      ? { email: `${user}@opendatakit.org`, password: user }
+      ? { email: `${user}@getodk.org`, password: user }
       : user;
 
     return service.post('/v1/sessions').send(credentials)

--- a/test/integration/task/account.js
+++ b/test/integration/task/account.js
@@ -7,17 +7,17 @@ const { createUser, promoteUser, setUserPassword } = require(appRoot + '/lib/tas
 describe('task: accounts', () => {
   describe('createUser', () => {
     it('should create a user account', testTask(({ User }) =>
-      createUser('testuser@opendatakit.org', 'aoeu')
+      createUser('testuser@getodk.org', 'aoeu')
         .then((result) => {
-          result.email.should.equal('testuser@opendatakit.org');
-          return User.getByEmail('testuser@opendatakit.org')
+          result.email.should.equal('testuser@getodk.org');
+          return User.getByEmail('testuser@getodk.org')
             .then((user) => user.isDefined().should.equal(true));
         })));
 
     it('should log an audit entry', testTask(({ Audit, User }) =>
-      createUser('testuser@opendatakit.org', 'aoeu')
+      createUser('testuser@getodk.org', 'aoeu')
         .then((result) => Promise.all([
-          User.getByEmail('testuser@opendatakit.org').then((o) => o.get()),
+          User.getByEmail('testuser@getodk.org').then((o) => o.get()),
           Audit.getLatestWhere({ action: 'user.create' }).then((o) => o.get())
         ]))
         .then(([ user, log ]) => {
@@ -31,20 +31,20 @@ describe('task: accounts', () => {
     // TODO: for now, we simply check if the user can create a nonexistent actee
     // species to verify the */* grant. eventually we should be more precise.
     it('should promote a user account to admin', testTask(({ Actee, User }) =>
-      User.fromApi({ email: 'testuser@opendatakit.org', displayName: 'test user' }).create()
+      User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }).create()
         .then((user) => user.actor.can('user.create', User.species()))
         .then((allowed) => {
           allowed.should.equal(false);
-          return promoteUser('testuser@opendatakit.org')
-            .then(() => User.getByEmail('testuser@opendatakit.org')
+          return promoteUser('testuser@getodk.org')
+            .then(() => User.getByEmail('testuser@getodk.org')
               .then(getOrNotFound)
               .then((user) => user.actor.can('user.create', User.species()))
               .then((allowed) => allowed.should.equal(true)));
         })));
 
     it('should log an audit entry', testTask(({ Audit, Role, User }) =>
-      User.fromApi({ email: 'testuser@opendatakit.org', displayName: 'test user' }).create()
-        .then((user) => promoteUser('testuser@opendatakit.org')
+      User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }).create()
+        .then((user) => promoteUser('testuser@getodk.org')
           .then(() => Promise.all([
             Audit.getLatestWhere({ action: 'assignment.create' }).then((o) => o.get()),
             Role.getBySystemName('admin').then((o) => o.get())
@@ -59,19 +59,19 @@ describe('task: accounts', () => {
 
   describe('setUserPassword', () => {
     it('should set a user password', testTask(({ User, crypto }) =>
-      User.fromApi({ email: 'testuser@opendatakit.org', displayName: 'test user' }).create()
-        .then(() => setUserPassword('testuser@opendatakit.org', 'aoeu'))
-        .then(() => User.getByEmail('testuser@opendatakit.org'))
+      User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }).create()
+        .then(() => setUserPassword('testuser@getodk.org', 'aoeu'))
+        .then(() => User.getByEmail('testuser@getodk.org'))
         .then(getOrNotFound)
         .then((user) => crypto.verifyPassword('aoeu', user.password))
         .then((verified) => verified.should.equal(true))));
 
     it('should log an audit entry', testTask(({ Audit, User, crypto }) =>
-      User.fromApi({ email: 'testuser@opendatakit.org', displayName: 'test user' }).create()
-        .then(() => setUserPassword('testuser@opendatakit.org', 'aoeu'))
+      User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }).create()
+        .then(() => setUserPassword('testuser@getodk.org', 'aoeu'))
         .then(() => Promise.all([
           Audit.getLatestWhere({ action: 'user.update' }).then((o) => o.get()),
-          User.getByEmail('testuser@opendatakit.org').then((o) => o.get())
+          User.getByEmail('testuser@getodk.org').then((o) => o.get())
         ])
         .then(([ log, user ]) => {
           log.acteeId.should.equal(user.actor.acteeId);

--- a/test/integration/worker/worker.js
+++ b/test/integration/worker/worker.js
@@ -64,7 +64,7 @@ describe('worker', () => {
 
     it('should mark the event as processed after on job completion', testContainerFullTrx(async (container) => {
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       const event = await Audit.log(alice.actor, 'submission.attachment.create', alice.actor);
 
       const jobMap = { 'submission.attachment.create': [ () => Promise.resolve() ] };
@@ -101,7 +101,7 @@ describe('worker', () => {
     // TODO: we should be able to not do this as of block 8.
     it('should unclaim the event and mark failure in case of failure', testContainerFullTrx(async (container) => {
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       const event = await Audit.log(alice.actor, 'submission.attachment.update', alice.actor);
 
       const jobMap = { 'submission.attachment.update': [ () => Promise.reject({ uh: 'oh' }) ] };
@@ -120,7 +120,7 @@ describe('worker', () => {
     it('should return null if there are no unprocessed events', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.log(alice.actor, 'test.event', alice.actor);
       should.not.exist(await check());
     }));
@@ -128,7 +128,7 @@ describe('worker', () => {
     it('should mark the event as claimed', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.log(alice.actor, 'submission.attachment.update', alice.actor);
       const event = (await check());
       event.claimed.should.be.a.recentDate();
@@ -139,7 +139,7 @@ describe('worker', () => {
     it('should not mark any other events as claimed', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.log(alice.actor, 'submission.attachment.update', alice.actor);
       await Audit.log(alice.actor, 'submission.attachment.update', alice.actor);
       await Audit.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -156,7 +156,7 @@ describe('worker', () => {
     it('should return the oldest eligible event', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.log(alice.actor, 'submission.attachment.update', alice.actor, { is: 'oldest' });
       await Audit.log(alice.actor, 'submission.attachment.update', alice.actor, { is: 'older' });
       await Audit.log(alice.actor, 'submission.attachment.update', alice.actor, { is: 'newer' });
@@ -167,7 +167,7 @@ describe('worker', () => {
     it('should not return a recently failed event', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.of(alice.actor, 'submission.attachment.update', alice.actor)
         .with({ lastFailure: new Date() })
         .create();
@@ -177,7 +177,7 @@ describe('worker', () => {
     it('should retry a previously failed event after some time', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.of(alice.actor, 'submission.attachment.update', alice.actor)
         .with({
           failures: 4,
@@ -190,7 +190,7 @@ describe('worker', () => {
     it('should not return a repeatedly failed event', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.of(alice.actor, 'submission.attachment.update', alice.actor)
         .with({ failures: 6 })
         .create();
@@ -200,7 +200,7 @@ describe('worker', () => {
     it('should claim a stale/hung event', testContainer(async (container) => {
       const check = checker(container);
       const { Audit, User } = container;
-      const alice = (await User.getByEmail('alice@opendatakit.org')).get();
+      const alice = (await User.getByEmail('alice@getodk.org')).get();
       await Audit.of(alice.actor, 'submission.attachment.update', alice.actor)
         .with({ claimed: DateTime.local().minus(Duration.fromObject({ hours: 3 })).toJSDate() })
         .create();

--- a/test/unit/data/odata-filter.js
+++ b/test/unit/data/odata-filter.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -1096,7 +1096,7 @@ describe('form schema', () => {
         </data>
       </instance>
       <bind nodeset="/data/name" type="string"/>
-      <submission action="https://opendatakit.org/custom-action"/>
+      <submission action="https://getodk.org/custom-action"/>
     </model>
   </h:head>
 </h:html>`;
@@ -1112,7 +1112,7 @@ describe('form schema', () => {
         </data>
       </instance>
       <bind nodeset="/data/name" type="string"/>
-      <submission action="https://opendatakit.org/custom-action" base64RsaPublicKey="mybase64key"/>
+      <submission action="https://getodk.org/custom-action" base64RsaPublicKey="mybase64key"/>
     </model>
   </h:head>
 </h:html>`));
@@ -1130,7 +1130,7 @@ describe('form schema', () => {
         </data>
       </instance>
       <bind nodeset="/data/name" type="string"/>
-      <submission action="https://opendatakit.org/custom-action" /  
+      <submission action="https://getodk.org/custom-action" /  
       >
     </model>
   </h:head>
@@ -1147,7 +1147,7 @@ describe('form schema', () => {
         </data>
       </instance>
       <bind nodeset="/data/name" type="string"/>
-      <submission action="https://opendatakit.org/custom-action"  base64RsaPublicKey="mybase64key"/  
+      <submission action="https://getodk.org/custom-action"  base64RsaPublicKey="mybase64key"/  
       >
     </model>
   </h:head>

--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -86,7 +86,7 @@ describe('preprocessors', () => {
     describe('Basic auth', () => {
       it('should reject non-https Basic auth requests', () =>
         Promise.resolve(sessionHandler(
-          { Auth, User: mockUser('alice@opendatakit.org') },
+          { Auth, User: mockUser('alice@getodk.org') },
           new Context(
             createRequest({ headers: { Authorization: 'Basic abracadabra' } }),
             { fieldKey: Option.none() }
@@ -95,10 +95,10 @@ describe('preprocessors', () => {
 
       it('should fail the request if an improperly-formatted Basic auth is given', () =>
         Promise.resolve(sessionHandler(
-          { Auth, User: mockUser('alice@opendatakit.org') },
+          { Auth, User: mockUser('alice@getodk.org') },
           new Context(
             createRequest({ headers: {
-              Authorization: `Basic ${Buffer.from('alice@opendatakit.org:', 'utf8').toString('base64')}`,
+              Authorization: `Basic ${Buffer.from('alice@getodk.org:', 'utf8').toString('base64')}`,
               'X-Forwarded-Proto': 'https'
             } }),
             { fieldKey: Option.none() }
@@ -107,10 +107,10 @@ describe('preprocessors', () => {
 
       it('should fail the request if the Basic auth user cannot be found', () =>
         Promise.resolve(sessionHandler(
-          { Auth, User: mockUser('alice@opendatakit.org') },
+          { Auth, User: mockUser('alice@getodk.org') },
           new Context(
             createRequest({ headers: {
-              Authorization: `Basic ${Buffer.from('bob@opendatakit.org:bob', 'utf8').toString('base64')}`,
+              Authorization: `Basic ${Buffer.from('bob@getodk.org:bob', 'utf8').toString('base64')}`,
               'X-Forwarded-Proto': 'https'
             } }),
             { fieldKey: Option.none() }
@@ -119,10 +119,10 @@ describe('preprocessors', () => {
 
       it('should fail the request if the Basic auth credentials are not right', () =>
         Promise.resolve(sessionHandler(
-          { Auth, User: mockUser('alice@opendatakit.org', 'willnevermatch'), crypto },
+          { Auth, User: mockUser('alice@getodk.org', 'willnevermatch'), crypto },
           new Context(
             createRequest({ headers: {
-              Authorization: `Basic ${Buffer.from('alice@opendatakit.org:alice', 'utf8').toString('base64')}`,
+              Authorization: `Basic ${Buffer.from('alice@getodk.org:alice', 'utf8').toString('base64')}`,
               'X-Forwarded-Proto': 'https'
             } }),
             { fieldKey: Option.none() }
@@ -132,10 +132,10 @@ describe('preprocessors', () => {
       it('should set the appropriate session if valid Basic auth credentials are given @slow', () =>
         hashPassword('alice').then((hashed) =>
           Promise.resolve(sessionHandler(
-            { Auth, User: mockUser('alice@opendatakit.org', hashed), crypto },
+            { Auth, User: mockUser('alice@getodk.org', hashed), crypto },
             new Context(
               createRequest({ headers: {
-                Authorization: `Basic ${Buffer.from('alice@opendatakit.org:alice', 'utf8').toString('base64')}`,
+                Authorization: `Basic ${Buffer.from('alice@getodk.org:alice', 'utf8').toString('base64')}`,
                 'X-Forwarded-Proto': 'https'
               } }),
               { fieldKey: Option.none() }

--- a/test/unit/util/http.js
+++ b/test/unit/util/http.js
@@ -25,11 +25,11 @@ describe('util/http', () => {
   describe('urlPathname', () => {
     const { urlPathname } = http;
     it('should return the pathname part of a url', () => {
-      urlPathname('https://www.opendatakit.org/help').should.equal('/help');
+      urlPathname('https://www.getodk.org/help').should.equal('/help');
     });
 
     it('should not include query parameters', () => {
-      urlPathname('https://www.opendatakit.org/a/test/path?and=some&extra=bits').should.equal('/a/test/path');
+      urlPathname('https://www.getodk.org/a/test/path?and=some&extra=bits').should.equal('/a/test/path');
     });
   });
 


### PR DESCRIPTION
I've tried to do this safely, but this PR is high-risk because it touches a lot of files and needs careful review! Ideally, this should be merged early in the release cycle to further de-risk it.

I've been careful not to touch:
* XML namespace URLs because those should not change.
* OData namespace because I don't understand the implications. If they can be changed with little impact, they probably should be changed.