### PR TITLE
new: OData: implement $expand=*

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Next, create a database and user in Postgres. Either use the same settings as th
 
 ```sql
 CREATE USER jubilant WITH PASSWORD 'jubilant';
+CREATE DATABASE jubilant_test with owner=jubilant encoding=UTF8;
 CREATE DATABASE jubilant with owner=jubilant encoding=UTF8;
 \c jubilant;
 CREATE EXTENSION IF NOT EXISTS CITEXT;

--- a/docs/api.md
+++ b/docs/api.md
@@ -2894,7 +2894,7 @@ While the latest 4.01 OData specification adds a new JSON EDMX CSDL format, most
 + Response 406 (application/json)
     + Attributes (Error 406)
 
-### Data Document [GET /v1/projects/{projectId}/forms/{xmlFormId}.svc/{table}{?%24skip,%24top,%24count,%24wkt,%24filter}]
+### Data Document [GET /v1/projects/{projectId}/forms/{xmlFormId}.svc/{table}{?%24skip,%24top,%24count,%24wkt,%24filter,%24expand}]
 
 The data documents are the straightforward JSON representation of each table of `Submission` data. They follow the [corresponding specification](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html), but apart from the representation of geospatial data as GeoJSON rather than the ODK proprietary format, the output here should not be at all surprising. If you are looking for JSON output of Submission data, this is the best place to look.
 
@@ -2902,7 +2902,7 @@ The `$top` and `$skip` querystring parameters, specified by OData, apply `limit`
 
 As of ODK Central v1.1, the [`$filter` querystring parameter](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358948) is partially supported. In OData, you can use `$filter` to filter by any data field in the schema. In ODK Central, the only fields you can reference are `__system/submitterId` and `__system/submissionDate`. These refer to the numeric `actorId` and the timestamp `createdAt` of the submission overall. The operators `lt`, `lte`, `eq`, `neq`, `gte`, `gt`, `not`, `and`, and `or` are supported. The built-in functions `now`, `year`, `month`, `day`, `hour`, `minute`, `second` are supported. These supported elements may be combined in any way, but all other `$filter` features will cause an error. Please see the [OData documentation](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358948) on `$filter` for more information.
 
-In this release of Central, `$expand` is not yet supported. This will likely change in the future, once we can instate Navigation Properties.
+If you want to expand all repetitions, you can use `%24expand=&#42;`. This might be helpful if you want to get a full dump of all submissions within a single query.
 
 The _nonstandard_ `$wkt` querystring parameter may be set to `true` to request that geospatial data is returned as a [Well-Known Text (WKT) string](https://en.wikipedia.org/wiki/Well-known_text) rather than a GeoJSON structure. This exists primarily to support Tableau, which cannot yet read GeoJSON, but you may find it useful as well depending on your mapping software. **Please note** that both GeoJSON and WKT follow a `(lon, lat, alt)` coördinate ordering rather than the ODK-proprietary `lat lon alt`. This is so that the values map neatly to `(x, y, z)`. GPS accuracy information is not a part of either standards specification, and so is presently omitted from OData output entirely. GeoJSON support may come in a future version.
 
@@ -2916,6 +2916,7 @@ As the vast majority of clients only support the JSON OData format, that is the 
     + `%24count`: `true` (boolean, optional) - If set to `true`, an `@odata.count` property will be added to the result indicating the total number of rows, ignoring the above paging parameters.
     + `%24wkt`: `true` (boolean, optional) - If set to `true`, geospatial data will be returned as Well-Known Text (WKT) strings rather than GeoJSON structures.
     + `%24filter`: `year(__system/submissionDate) lt year(now())` (string, optional) - If provided, will filter responses to those matching the query. Only the fields `__system/submitterId` and `__system/submissionDate` are available to reference. The operators `lt`, `lte`, `eq`, `neq`, `gte`, `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`, `year`, `month`, `day`, `hour`, `minute`, `second`.
+    + `%24expand`: `&#42;` (string, optional) - Repetitions, which should get expanded. Currently, only `&#42` is implemented, which expands all repetitions.
 
 + Response 200 (application/json)
     + Body

--- a/lib/data/json.js
+++ b/lib/data/json.js
@@ -180,9 +180,8 @@ const submissionToOData = (fields, table, { xml, encHasData, submission, submitt
           // the appropriate visible structure, and if we are in state 1 we are at the visible
           // structure so we need to build the list. but if we are past that ignore unless we
           // are $expand'd into the object.
-          // TODO: check for $expand.
           const branchState = getBranchState(schemaStack, table);
-          if (branchState < 1) { // TODO: check for $expand
+          if (branchState < 1 || options.expand === '*') {
             // verify that we have an array to push into in our data obj.
             if (dataPtr[outname] == null) dataPtr[outname] = [];
 

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -266,7 +266,7 @@ const isJsonType = (x) => /(^|,)(application\/json|json)($|;|,)/i.test(x);
 const isXmlType = (x) => /(^|,)(application\/(atom(svc)?\+)?xml|atom|xml)($|;|,)/i.test(x);
 
 // various supported odata constants:
-const supportedParams = [ '$format', '$count', '$skip', '$top', '$filter', '$wkt' ];
+const supportedParams = [ '$format', '$count', '$skip', '$top', '$filter', '$wkt', '$expand' ];
 const supportedFormats = {
   json: [ 'application/json', 'json' ],
   xml: [ 'application/xml', 'atom' ]

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -293,6 +293,9 @@ const odataPreprocessor = (format) => (_, context) => {
   for (const key of Object.keys(context.query))
     if (supportedParams.indexOf(key) < 0)
       return reject(Problem.internal.notImplemented({ feature: key }));
+
+  if (context.query.$expand && context.query.$expand !== '*')
+    return reject(Problem.internal.unsupportedODataExpandExpression({ text: context.query.$expand }));
 };
 
 // respond with the appropriate OData version (section 8.1.5).

--- a/lib/outbound/odata.js
+++ b/lib/outbound/odata.js
@@ -70,8 +70,8 @@ const nextUrlFor = (limit, offset, count, originalUrl) =>
     : urlWithQueryParams(originalUrl, { $skip: (offset + limit), $top: null }));
 
 // Given a querystring object, returns an object of relevant OData options. Right
-// now that is only { wkt: Bool }
-const extractOptions = (query) => ({ wkt: isTrue(query.$wkt) });
+// now that is only { wkt: Bool, expand: String }
+const extractOptions = (query) => ({ wkt: isTrue(query.$wkt), expand: query.$expand });
 
 // Given a tableParts: [ String ] and a schemaLookup: Object given by schemaAsLookup(),
 // ensures that the table implied by tableParts actually exists in schemaLookup.

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -160,6 +160,7 @@ const problems = {
     // returned when we don't support certain kinds of odata filter expressions.
     unsupportedODataExpression: problem(501.4, (({ at, type, text }) => `The given OData filter expression uses features not supported by this server: ${type} at ${at} ("${text}")`)),
     unsupportedODataField: problem(501.5, (({ at, text }) => `The given OData filter expression references fields not supported by this server: ${text} at ${at}`)),
+    unsupportedODataExpandExpression: problem(501.6, (({ text }) => `The given OData expand expression is not supported by this server: "${text}". Currently, only "$expand=*" is supported.`)),
 
     // used internally when a task fails to complete in a reasonable length of time.
     timeout: problem(502.1, () => 'The task took too long to run.'),

--- a/test/unit/data/json.js
+++ b/test/unit/data/json.js
@@ -407,6 +407,32 @@ describe('submissionToOData', () => {
       });
     }));
 
+  it('should expand all repeat tables for $expand=*', () =>
+    fieldsFor(testData.forms.withrepeat).then((fields) => {
+      const submission = mockSubmission('two', testData.instances.withrepeat.two);
+      return submissionToOData(fields, 'Submissions', submission, { expand: '*' }).then((result) => {
+        result.should.eql([{
+          __id: 'two',
+          __system,
+          meta: { instanceID: 'two' },
+          name: 'Bob',
+          age: 34,
+          children: {
+            'child@odata.navigationLink': "Submissions('two')/children/child",
+            child: [{
+              __id: 'cf9a1b5cc83c6d6270c1eb98860d294eac5d526d',
+              age: 4,
+              name: 'Billy'
+            }, {
+              __id: 'c76d0ccc6d5da236be7b93b985a80413d2e3e172',
+              age: 6,
+              name: 'Blaine'
+            }]
+          }
+        }]);
+      });
+    }));
+
   it('should extract subtable rows within repeats', () =>
     fieldsFor(testData.forms.withrepeat).then((fields) => {
       const row = { submission: { instanceId: 'two' }, xml: testData.instances.withrepeat.two };

--- a/test/unit/data/json.js
+++ b/test/unit/data/json.js
@@ -408,30 +408,86 @@ describe('submissionToOData', () => {
     }));
 
   it('should expand all repeat tables for $expand=*', () =>
-    fieldsFor(testData.forms.withrepeat).then((fields) => {
-      const submission = mockSubmission('two', testData.instances.withrepeat.two);
-      return submissionToOData(fields, 'Submissions', submission, { expand: '*' }).then((result) => {
-        result.should.eql([{
-          __id: 'two',
-          __system,
-          meta: { instanceID: 'two' },
-          name: 'Bob',
-          age: 34,
-          children: {
-            'child@odata.navigationLink': "Submissions('two')/children/child",
-            child: [{
-              __id: 'cf9a1b5cc83c6d6270c1eb98860d294eac5d526d',
-              age: 4,
-              name: 'Billy'
-            }, {
-              __id: 'c76d0ccc6d5da236be7b93b985a80413d2e3e172',
-              age: 6,
-              name: 'Blaine'
-            }]
-          }
-        }]);
-      });
-    }));
+    fieldsFor(testData.forms.doubleRepeat)
+      .then((fields) => {
+        const submission = mockSubmission('two', testData.instances.doubleRepeat.double);
+        return submissionToOData(fields, 'Submissions', submission, { expand: '*' })
+          .then((result) => {
+            result.should.eql([
+              {
+                __id: 'two',
+                name: 'Vick',
+                __system: {
+                  submissionDate: '2017-09-20T17:10:43Z',
+                  submitterId: '5',
+                  submitterName: 'Alice',
+                  attachmentsPresent: 0,
+                  attachmentsExpected: 0,
+                  status: null
+                },
+                meta: { instanceID: 'double' },
+                children: {
+                  'child@odata.navigationLink': 'Submissions(\'two\')/children/child',
+                  child: [
+                    {
+                      __id: 'cf9a1b5cc83c6d6270c1eb98860d294eac5d526d',
+                      name: 'Alice'
+                    }, {
+                      __id: 'c76d0ccc6d5da236be7b93b985a80413d2e3e172',
+                      name: 'Bob',
+                      toys: {
+                        'toy@odata.navigationLink': 'Submissions(\'two\')/children/child(\'c76d0ccc6d5da236be7b93b985a80413d2e3e172\')/toys/toy',
+                        toy: [
+                          {
+                            __id: 'edc8e56945b78ca7d8edeb54c98d5f5e1dec8490',
+                            name: 'Twilight Sparkle'
+                          },
+                          {
+                            __id: '7715214d84af857ba4e64bacc89a31dce16620bb',
+                            name: 'Pinkie Pie'
+                          },
+                          {
+                            __id: 'f69554753d1a7b9d4c6a63596d9776619a232ece',
+                            name: 'Applejack'
+                          },
+                          {
+                            __id: 'ee6ee4f76495c2a7839b2893ab3b409f08bcffaa',
+                            name: 'Spike'
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      __id: '57c0d9e982699e087c34a22696c10753a15beb6c',
+                      name: 'Chelsea',
+                      toys: {
+                        'toy@odata.navigationLink': 'Submissions(\'two\')/children/child(\'57c0d9e982699e087c34a22696c10753a15beb6c\')/toys/toy',
+                        toy: [
+                          {
+                            __id: '0c2ddb3ec8921091961dce34fa2dfbdd25ed368c',
+                            name: 'Rainbow Dash'
+                          },
+                          {
+                            __id: 'efa00a552968b84b1784b4c9c820a32a03cf4aea',
+                            name: 'Rarity'
+                          },
+                          {
+                            __id: '611d4cbce170a9525ccb79a2fd48acb7cc1ef844',
+                            name: 'Fluttershy'
+                          },
+                          {
+                            __id: 'ed4a384b1dfd9002409e5279a2720a685e0e162d',
+                            name: 'Princess Luna'
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]);
+          });
+      }));
 
   it('should extract subtable rows within repeats', () =>
     fieldsFor(testData.forms.withrepeat).then((fields) => {

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -623,8 +623,14 @@ describe('endpoints', () => {
           .should.be.rejectedWith(Problem, { problemCode: 501.1 });
       });
 
+      it('should reject requests for unsupported OData $expand values', () => {
+        const request = createRequest({ url: '/odata.svc?$expand=magic' });
+        return odataPreprocessor('json')(null, new Context(request), request)
+          .should.be.rejectedWith(Problem, { problemCode: 501.6 });
+      });
+
       it('should allow appropriate requests through', () => {
-        const request = createRequest({ url: '/odata.svc?$top=50', headers: { 'OData-MaxVersion': '4.0', accept: 'application/json' } });
+        const request = createRequest({ url: '/odata.svc?$top=50&$expand=*', headers: { 'OData-MaxVersion': '4.0', accept: 'application/json' } });
         should.not.exist(odataPreprocessor('json')(null, new Context(request), request));
       });
     });


### PR DESCRIPTION
As discussed here https://forum.getodk.org/t/extend-api-to-retrieve-plain-json/32204, $expand is now implemented with "*" as only available option for now.

Additionally, enhanced README.md to create the test database, too.

Related to #84 