### PR TITLE
bug: stringify backups.google credentials before setting them

### DIFF
--- a/lib/bin/backup.js
+++ b/lib/bin/backup.js
@@ -41,7 +41,7 @@ run(emailing('backupFailed', auditing('backup', async () => {
     await uploadFile(drive, folderId, createReadStream(tmpfilePath));
   } finally {
     // in case these changed:
-    persistCredentials(drive);
+    await persistCredentials(drive);
   }
 
   return { success: true, configSetAt: config.setAt };

--- a/lib/task/google.js
+++ b/lib/task/google.js
@@ -29,7 +29,7 @@ const initDrive = (configKey) => getConfigurationJsonValue(configKey).then((cred
 
 // if our credentials have changed, save them.
 const persistCredentials = (drive) => (credentialsChanged(drive.credentials, drive.auth.credentials)
-  ? setConfiguration(drive.configKey, drive.auth.credentials)
+  ? setConfiguration(drive.configKey, JSON.stringify(drive.auth.credentials))
   : task.noop);
 
 // because our google grant only allows us access to files we created in the


### PR DESCRIPTION
I made this change after encountering this error:

```
TypeError: Unexpected value expression.
    at sql (/usr/odk/node_modules/slonik/dist/factories/createSqlTag.js:45:23)
    at /usr/odk/lib/model/query/configs.js:19:49
    at module.<computed> (/usr/odk/lib/model/container.js:30:33)
    at /usr/odk/lib/task/task.js:51:44
    at persistCredentials (/usr/odk/lib/task/google.js:32:5)
    at /usr/odk/lib/bin/backup.js:44:5
    at processTicksAndRejections (internal/process/task_queues.js:85:5)
```

This PR calls `JSON.stringify()` on an object before passing it to `Configs.set()`, which is what seems to be done elsewhere.

I also await `persistCredentials()`, since I think that returns a promise.