### PR TITLE
Keeping Form name/title consistent with XForm title

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -807,7 +807,6 @@ You can inspect the Request format for this endpoint to see the exact nested dat
         + forms: (array, optional) - If given, the Form metadata to update.
             + (object)
                 + xmlFormId: `simple` (string, required) - The `id` of this form as given in its XForms XML definition.
-                + name: `Simple Form` (string, optional) - The name to display for this form
                 + state: (Form State, required) - The present lifecycle status of this form.
                 + assignments: (array, optional) - If given, the Assignments to apply to this Form. And if given, any existing Assignments that are not specified here will be revoked.
                     + (object)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1246,13 +1246,12 @@ You may optionally add the querystring parameter `?odata=true` to sanitize the f
 
 #### Modifying a Form [PATCH]
 
-It is currently possible to modify two things about a `Form`: its `name`, which is its friendly display name, and its `state`, which governs whether it is available for download onto survey clients and whether it accepts new `Submission`s. See the `state` Attribute in the Request documentation to the right to see the possible values and their meanings.
+It is currently possible to modify only one thing about a `Form`: its `state`, which governs whether it is available for download onto survey clients and whether it accepts new `Submission`s. See the `state` Attribute in the Request documentation to the right to see the possible values and their meanings.
 
 We use `PATCH` rather than `PUT` to represent the update operation, so that you only have to supply the properties you wish to change. Anything you do not supply will remain untouched.
 
 + Request (application/json)
     + Attributes
-        + name: `A New Name` (string, optional) - If supplied, the Form friendly name will be updated to this value.
         + state (Form State, optional) - If supplied, the Form lifecycle state will move to this value.
 
 + Response 200 (application/json)

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -50,7 +50,7 @@ class Form extends Frame.define(
   table('forms'),
   'id',                                 'projectId',    readable,
   'xmlFormId',    readable,             'state',        readable, writable,
-  'name',         readable, writable,   'currentDefId',
+  'name',         readable,             'currentDefId',
   'draftDefId',                         'enketoId',     readable,
   'enketoOnceId', readable,             'acteeId',
   'createdAt',    readable,             'updatedAt',    readable,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -107,8 +107,8 @@ const createVersion = (partial, form, publish = false) => ({ run, one, FormAttac
         : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
       .then(compose(one, insert))
       .then(ignoringResult((savedDef) => ((publish === true)
-        ? Forms._update(form, { currentDefId: savedDef.id })
-        : Forms._update(form, { draftDefId: savedDef.id })))),
+        ? Forms._update(form, { currentDefId: savedDef.id, name: partial.name })
+        : Forms._update(form, { draftDefId: savedDef.id, name: partial.name })))),
     // process the form schema locally while everything happens
     getFormFields(partial.xml)
   ])

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -2934,6 +2934,28 @@ describe('api: /projects/:id/forms', () => {
     </mediaFile>
   </manifest>`);
                 }))))));
+
+      context('renaming', () => {
+        const withRenamedTitle = (newTitle) => testData.forms.simple
+          .replace('Simple', `${newTitle}`);
+
+        it('should rename the form based on the latest draft title', testService((service) =>
+          service.login('alice', (asAlice) =>
+            asAlice.get('/v1/projects/1/forms/simple')
+              .expect(200)
+              .then(({ body }) => {
+                body.name.should.equal("Simple");
+              })
+              .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+                .set('Content-Type', 'application/xml')
+                .send(withRenamedTitle("New Title"))
+                .expect(200))
+                .then(() =>  asAlice.get('/v1/projects/1/forms/simple')
+                  .expect(200)
+                  .then(({ body }) => {
+                    body.name.should.equal("New Title");
+                  })))));
+      });
     });
 
     describe('.xml GET', () => {

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -1212,7 +1212,7 @@ describe('api: /projects/:id/forms', () => {
     it('should log the action in the audit log', testService((service, { Projects, Forms, Users, Audits }) =>
       service.login('alice', (asAlice) =>
         asAlice.patch('/v1/projects/1/forms/simple')
-          .send({ name: 'a fancy name', state: 'closing' })
+          .send({ state: 'closing' })
           .expect(200)
           .then(() => Promise.all([
             Users.getByEmail('alice@opendatakit.org').then((o) => o.get()),
@@ -1223,7 +1223,7 @@ describe('api: /projects/:id/forms', () => {
           .then(([ alice, form, log ]) => {
             log.actorId.should.equal(alice.actor.id);
             log.acteeId.should.equal(form.acteeId);
-            log.details.should.eql({ data: { name: 'a fancy name', state: 'closing' } });
+            log.details.should.eql({ data: { state: 'closing' } });
           })))));
   });
 

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -1164,18 +1164,16 @@ describe('api: /projects/:id/forms', () => {
     it('should update allowed fields', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.patch('/v1/projects/1/forms/simple')
-          .send({ name: 'a fancy name', state: 'closing' })
+          .send({ state: 'closing' })
           .expect(200)
           .then(({ body }) => {
             body.should.be.a.Form();
-            body.name.should.equal('a fancy name');
             body.state.should.equal('closing');
           })
           .then(() => asAlice.get('/v1/projects/1/forms/simple')
             .expect(200)
             .then(({ body }) => {
               body.should.be.a.Form();
-              body.name.should.equal('a fancy name');
               body.state.should.equal('closing');
             })))));
 
@@ -1188,7 +1186,12 @@ describe('api: /projects/:id/forms', () => {
     it('should not update disallowed fields', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.patch('/v1/projects/1/forms/simple')
-          .send({ xmlFormId: 'changed', xml: 'changed', hash: 'changed' })
+          .send({
+            xmlFormId: 'changed',
+            xml: 'changed',
+            hash: 'changed',
+            name: 'a fancy name'
+          })
           .expect(200)
           .then(() => Promise.all([
             asAlice.get('/v1/projects/1/forms/simple')
@@ -1197,6 +1200,7 @@ describe('api: /projects/:id/forms', () => {
               .then(({ body }) => {
                 body.xmlFormId.should.equal('simple');
                 body.hash.should.equal('5c09c21d4c71f2f13f6aa26227b2d133');
+                body.name.should.equal('Simple');
               }),
             asAlice.get('/v1/projects/1/forms/simple.xml')
               .expect(200)


### PR DESCRIPTION
This resolves an issue brought up in [getodk/central#29](https://github.com/getodk/central/issues/29#issuecomment-800617039) and described in the [Central block 12 release criteria](https://docs.google.com/document/d/10uUU1nlIFRPJmtTr-zukKDXFY0flFAw_kuvDXZqLgxg).

There are two main changes:

**1. Update form name based on latest XForm title when new draft is uploaded**

Previously, Central's form display name was read once from the initial form's title. Now, the form display name will update if a user uploads a new version of a form with a different title. More specifically, any time a user uploads a new draft, the form name/title will update. 

Changing the name here (vs. on form publication or some other place) seemed like the best option, especially when working with forms only in draft mode. Drafts seem to be the only channel through which an existing form can change.

Theoretically, there could be an open, published form with an old title, and a new draft with a new title, and Central would show the new (draft) title while Collect would show the old title from the old (published) form. Hopefully this isn't that common, but having a title that is too new seems better than having a title that never gets updated.

**2. Remove ability to update form name via PATCH**

Previously, central-backend supported updating the form's name via the PATCH request, but it was not exposed through central-frontend. Since we overwrite form names with any new draft, we have removed the ability to change a form's name through the API. 

This PR doesn't address the renaming "form name" --> "form title" in the early discussion of [getodk/central#29](https://github.com/getodk/central/issues/29). The Form field that refers to the XForm title is still called "name". 