### PR TITLE
bug #337: $top=0 would accidentally give ALL rows.

### DIFF
--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -51,7 +51,8 @@ const extractPathContext = (subpath) =>
 // performed by the database and therefore what actual slicing to do (doLimit/doOffset).
 // { limit: Int, offset: Int, doLimit: Int, doOffset: Int, shouldCount: Bool }.
 const extractPaging = (table, query) => {
-  const limit = parseInt(query.$top, 10) || Infinity;
+  const parsedLimit = parseInt(query.$top, 10);
+  const limit = Number.isNaN(parsedLimit) ? Infinity : parsedLimit;
   const offset = parseInt(query.$skip, 10) || 0;
   const shouldCount = isTrue(query.$count);
   const result = { limit: max(0, limit), offset: max(0, offset), shouldCount };

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -254,6 +254,19 @@ describe('api: /forms/:id.svc', () => {
             });
           }))));
 
+    it('should return just a count if asked', testService((service) =>
+      withSubmission(service, (asAlice) =>
+        asAlice.get("/v1/projects/1/forms/doubleRepeat.svc/Submissions('double')/children/child?$top=0&$count=true")
+          .expect(200)
+          .then(({ body }) => {
+            body.should.eql({
+              '@odata.context': 'http://localhost:8989/v1/projects/1/forms/doubleRepeat.svc/$metadata#Submissions.children.child',
+              '@odata.nextLink': "http://localhost:8989/v1/projects/1/forms/doubleRepeat.svc/Submissions('double')/children/child?%24count=true&%24skip=0",
+              '@odata.count': 3,
+              value: []
+            });
+          }))));
+
     // HACK: this test sort of relies on some trickery to make the backend
     // thing the submission is encrypted even though it isn't (see the replace
     // call). there is some chance this methodology is fragile. (mark1)


### PR DESCRIPTION
* resolves #337.