### PR TITLE
bug: decode/encode URLs for OData .../Submissions(':id') endpoints.

### DIFF
--- a/lib/data/odata.js
+++ b/lib/data/odata.js
@@ -78,7 +78,7 @@ const hashId = (schemaStack, instanceId, slicer = identity) => {
 const navigationLink = (schemaStack, instanceId, slicer = identity) => {
   const fieldStack = slicer(schemaStack.fieldStack);
 
-  const result = [ `Submissions('${instanceId}')` ];
+  const result = [ `Submissions('${encodeURIComponent(instanceId)}')` ];
   for (let i = 0; i < fieldStack.length; i += 1) {
     const field = fieldStack[i];
     // don't output an ID for the very last repeat, since we want the whole table:

--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -38,10 +38,9 @@ const getServiceRoot = (subpath) => {
 // Given an OData URL subpath, returns a contextStack: [ [ pathName: String, tableId: String? ] ]
 // that the subpath represents.
 const extractPathContext = (subpath) =>
-  // slash is not a valid identifier character, so we can split on / blithely.
-  // we also have to slice(1) to drop the first element, due to the leading /.
+  // we have to slice(1) to drop the first element, due to the leading /.
   subpath.split('/').slice(1).map((part) => {
-    const match = /^([^(]+)\('((?:uuid:)?[a-z0-9-]+)'\)$/i.exec(part);
+    const match = /^([^(]+)\('((?:uuid:)?[a-z0-9-]+)'\)$/i.exec(decodeURIComponent(part));
     return (match == null) ? [ part, null ] : [ match[1], match[2] ];
   });
 

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -39,7 +39,7 @@ module.exports = (service, endpoint) => {
 
     // serves filtered single-row data.
     //const singleRowRegex = /^\/projects\/(\d+)\/forms\/([a-z0-9-_]+).svc\/Submissions\((?:'|%27)((?:uuid:)?[a-z0-9-]+)(?:'|%27)\)(\/.*)*$/i;
-    const uuidRegex = /^(?:'|%27)((?:uuid:)?[a-z0-9-]+)(?:'|%27)$/i;
+    const uuidRegex = /^'((?:uuid:)?[a-z0-9-]+)'$/i;
     const getUuid = (str) => {
       const matches = uuidRegex.exec(str);
       if (matches == null) throw Problem.user.notFound();
@@ -51,7 +51,7 @@ module.exports = (service, endpoint) => {
           Forms.getFields(form.def.id),
           Submissions.getForExport(form.id, getUuid(params.uuid), draft).then(getOrNotFound)
         ])
-          .then(([ fields, row ]) => singleRowToOData(fields, row, env.domain, decodeURI(originalUrl), query))));
+          .then(([ fields, row ]) => singleRowToOData(fields, row, env.domain, originalUrl, query))));
 
     // TODO: because of the way express compiles the *, we have to register this twice.
     service.get(`${base}/Submissions\\((:uuid)\\)`, singleRecord);


### PR DESCRIPTION
The base branch of this PR is `issa/1.2-misc`. However, the parent commit is 79f7863835eb1cb60ada0691c727b0dafe8a8bba on `master`, so this PR could also be merged into `master`.

The goal of this PR is to update the OData .../Submissions(':instanceId') endpoint so that the `uuid:` prefix of an instance ID may be encoded. The encoding will be preserved in the OData URLs that the endpoint returns: both the form ID and the instance ID will remain encoded. Not all instance IDs have a `uuid:` prefix, but some do. This PR intersects with getodk/central-frontend#429, which adds a submission detail page that uses this endpoint.

With these changes, I think the endpoint may also be pretty close to being able to accept an instance ID that is not a UUID.

CircleCI is failing, but I think it's also failing on `master`. I was able to successfully run test/integration/api/odata.js locally.

See the commit message for additional notes. I'll also add some notes here about specific lines.