### PR TITLE
Update form name by storing name on FormDef instead of Form

### DIFF
--- a/lib/formats/openrosa.js
+++ b/lib/formats/openrosa.js
@@ -43,7 +43,7 @@ const formListTemplate = template(200, `<?xml version="1.0" encoding="UTF-8"?>
   {{#forms}}
     <xform>
       <formID>{{xmlFormId}}</formID>
-      <name>{{name}}{{^name}}{{xmlFormId}}{{/name}}</name>
+      <name>{{def.name}}{{^def.name}}{{xmlFormId}}{{/def.name}}</name>
       <version>{{def.version}}</version>
       <hash>md5:{{def.hash}}</hash>
       <downloadUrl>{{{domain}}}{{{basePath}}}/forms/{{urlSafeXmlFormId}}{{#draft}}/draft{{/draft}}.xml</downloadUrl>

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -51,10 +51,10 @@ class Form extends Frame.define(
   table('forms'),
   'id',                                 'projectId',    readable,
   'xmlFormId',    readable,             'state',        readable, writable,
-  'currentDefId',                       'draftDefId',
-  'enketoOnceId', readable,             'enketoId',     readable,
+  'currentDefId',
+  'draftDefId',                         'enketoId',     readable,
+  'enketoOnceId', readable,             'acteeId',
   'createdAt',    readable,             'updatedAt',    readable,
-  'acteeId',
   embedded('createdBy'), embedded('publishedBy')
 ) {
   get def() { return this.aux.def; }
@@ -149,7 +149,6 @@ Form.Extended = class extends Frame.define(
       submissions: this.submissions || 0,
       lastSubmission: this.lastSubmission,
       excelContentType: this.excelContentType,
-      name: this.name,
     };
   }
 };

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -113,7 +113,7 @@ class Form extends Frame.define(
       const version = versionText.orElse('');
       const name = nameText.orNull();
       const key = pubKey.map((k) => new Key({ public: k }));
-      return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version, name: name }), key });
+      return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version, name }), key });
     });
 
     return (typeof xml === 'string')

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -40,6 +40,7 @@ const Problem = require('../../util/problem');
 
 // sentinel values used below (oh how i long for case classes..)
 const DraftVersion = Symbol('draft version');
+const PublishedVersion = Symbol('published version');
 const AllVersions = Symbol('all versions');
 
 
@@ -50,10 +51,10 @@ class Form extends Frame.define(
   table('forms'),
   'id',                                 'projectId',    readable,
   'xmlFormId',    readable,             'state',        readable, writable,
-  'name',         readable,             'currentDefId',
-  'draftDefId',                         'enketoId',     readable,
-  'enketoOnceId', readable,             'acteeId',
+  'currentDefId',                       'draftDefId',
+  'enketoOnceId', readable,             'enketoId',     readable,
   'createdAt',    readable,             'updatedAt',    readable,
+  'acteeId',
   embedded('createdBy'), embedded('publishedBy')
 ) {
   get def() { return this.aux.def; }
@@ -112,7 +113,7 @@ class Form extends Frame.define(
       const version = versionText.orElse('');
       const name = nameText.orNull();
       const key = pubKey.map((k) => new Key({ public: k }));
-      return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version }), key });
+      return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version, name: name }), key });
     });
 
     return (typeof xml === 'string')
@@ -129,6 +130,7 @@ class Form extends Frame.define(
   }
 
   static get DraftVersion() { return DraftVersion; }
+  static get PublishedVersion() { return PublishedVersion; }
   static get AllVersions() { return AllVersions; }
 }
 
@@ -140,13 +142,14 @@ Form.Partial = class extends Form {};
 
 Form.Extended = class extends Frame.define(
   'submissions',        readable,       'lastSubmission', readable,
-  'excelContentType',   readable
+  'excelContentType',   readable,       'name',           readable
 ) {
   forApi() {
     return {
       submissions: this.submissions || 0,
       lastSubmission: this.lastSubmission,
-      excelContentType: this.excelContentType
+      excelContentType: this.excelContentType,
+      name: this.name,
     };
   }
 };
@@ -164,7 +167,8 @@ Form.Def = Frame.define(
   'hash',        readable,              'sha',          readable,
   'sha256',      readable,              'draftToken',   readable,
   'enketoId',    readable,              'createdAt',
-  'publishedAt', readable,              'xlsBlobId'
+  'publishedAt', readable,              'xlsBlobId',
+  'name',        readable
 );
 Form.Xml = Frame.define(into('xml'), 'xml');
 

--- a/lib/model/migrations/20210423-01-add-name-to-form-def.js
+++ b/lib/model/migrations/20210423-01-add-name-to-form-def.js
@@ -10,15 +10,15 @@
 const { Form } = require('../frames');
 
 const up = async (db) => {
-	// All column "name" to form_defs to store the title of a form
-	// Most places in central, the name of a form is called the "name"
-	// and only in the XForm/XLSForm is it called "title", so we are going
-	// with calling it "name" everywhere in the code, even in the database.
-	await db.schema.table('form_defs', (fd) => {
-		fd.text('name')
-	});
+  // All column "name" to form_defs to store the title of a form
+  // Most places in central, the name of a form is called the "name"
+  // and only in the XForm/XLSForm is it called "title", so we are going
+  // with calling it "name" everywhere in the code, even in the database.
+  await db.schema.table('form_defs', (fd) => {
+    fd.text('name');
+  });
 
-	await db.raw('ALTER TABLE form_defs DISABLE TRIGGER check_managed_key');
+  await db.raw('ALTER TABLE form_defs DISABLE TRIGGER check_managed_key');
 
   const work = [];
   for await (const def of db.select('*').from('form_defs').stream()) {

--- a/lib/model/migrations/20210423-01-add-name-to-form-def.js
+++ b/lib/model/migrations/20210423-01-add-name-to-form-def.js
@@ -1,0 +1,41 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { Form } = require('../frames');
+
+const up = async (db) => {
+	// All column "name" to form_defs to store the title of a form
+	// Most places in central, the name of a form is called the "name"
+	// and only in the XForm/XLSForm is it called "title", so we are going
+	// with calling it "name" everywhere in the code, even in the database.
+	await db.schema.table('form_defs', (fd) => {
+		fd.text('name')
+	});
+
+	await db.raw('ALTER TABLE form_defs DISABLE TRIGGER check_managed_key');
+
+  const work = [];
+  for await (const def of db.select('*').from('form_defs').stream()) {
+    const partial = await Form.fromXml(def.xml);
+    if (partial.def.name == null) continue;
+
+    const data = { name: partial.def.name };
+    work.push(db.update(data).into('form_defs').where({ id: def.id }));
+  }
+  await Promise.all(work);
+
+  await db.raw('ALTER TABLE form_defs ENABLE TRIGGER check_managed_key');
+};
+
+const down = (db) => db.schema.table('form_defs', (fd) => {
+  fd.dropColumn('name');
+});
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20210423-02-drop-form-name.js
+++ b/lib/model/migrations/20210423-02-drop-form-name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { Form } = require('../frames');
+
+const up = async (db) => {
+  await db.raw('ALTER TABLE forms RENAME COLUMN name to nonactive_name');
+};
+
+const down = async (db) => {
+  await db.raw('ALTER TABLE forms RENAME COLUMN nonactive_name to name');
+};
+
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20210423-02-drop-form-name.js
+++ b/lib/model/migrations/20210423-02-drop-form-name.js
@@ -7,8 +7,6 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { Form } = require('../frames');
-
 const up = async (db) => {
   await db.raw('ALTER TABLE forms RENAME COLUMN name to nonactive_name');
 };

--- a/lib/model/migrations/20210423-02-drop-form-name.js
+++ b/lib/model/migrations/20210423-02-drop-form-name.js
@@ -7,13 +7,13 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const up = async (db) => {
-  await db.raw('ALTER TABLE forms RENAME COLUMN name to nonactive_name');
-};
+const up = (db) => db.schema.table('forms', (f) => {
+  f.dropColumn('name');
+});
 
-const down = async (db) => {
-  await db.raw('ALTER TABLE forms RENAME COLUMN nonactive_name to name');
-};
+const down = (db) => db.schema.table('forms', (f) => {
+  f.text('name');
+});
 
 
 module.exports = { up, down };

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -106,11 +106,10 @@ const createVersion = (partial, form, publish = false) => ({ run, one, FormAttac
         ? def.with({ publishedAt: new Date(), xml: partial.xml })
         : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
       .then(compose(one, insert))
-      .then(ignoringResult((savedDef) => {
-        return ((publish === true)
+      .then(ignoringResult((savedDef) =>
+        ((publish === true)
           ? Forms._update(form, { currentDefId: savedDef.id })
-          : Forms._update(form, { draftDefId: savedDef.id }));
-      })),
+          : Forms._update(form, { draftDefId: savedDef.id })))),
     // process the form schema locally while everything happens
     getFormFields(partial.xml)
   ])

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -106,10 +106,9 @@ const createVersion = (partial, form, publish = false) => ({ run, one, FormAttac
         ? def.with({ publishedAt: new Date(), xml: partial.xml })
         : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
       .then(compose(one, insert))
-      .then(ignoringResult((savedDef) =>
-        ((publish === true)
-          ? Forms._update(form, { currentDefId: savedDef.id })
-          : Forms._update(form, { draftDefId: savedDef.id })))),
+      .then(ignoringResult((savedDef) => ((publish === true)
+        ? Forms._update(form, { currentDefId: savedDef.id })
+        : Forms._update(form, { draftDefId: savedDef.id })))),
     // process the form schema locally while everything happens
     getFormFields(partial.xml)
   ])

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -45,12 +45,12 @@ const _createNew = (form, def, project, publish) => ({ oneFirst, Actees, Forms }
   Actees.provision('form', project)
     .then((actee) => oneFirst(sql`
 with def as
-  (insert into form_defs ("formId", xml, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt")
-  values (nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null})
+  (insert into form_defs ("formId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt")
+  values (nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null})
   returning *),
 form as
-  (insert into forms (id, name, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "createdAt")
-  select def."formId", ${form.name}, ${form.xmlFormId}, ${form.state || 'open'}, ${project.id}, def.id, ${actee.id}, def."createdAt" from def
+  (insert into forms (id, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "createdAt")
+  select def."formId", ${form.xmlFormId}, ${form.state || 'open'}, ${project.id}, def.id, ${actee.id}, def."createdAt" from def
   returning forms.*)
 select id from form`))
     .then(() => Forms.getByProjectAndXmlFormId(project.id, form.xmlFormId, false,
@@ -106,9 +106,11 @@ const createVersion = (partial, form, publish = false) => ({ run, one, FormAttac
         ? def.with({ publishedAt: new Date(), xml: partial.xml })
         : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
       .then(compose(one, insert))
-      .then(ignoringResult((savedDef) => ((publish === true)
-        ? Forms._update(form, { currentDefId: savedDef.id, name: partial.name })
-        : Forms._update(form, { draftDefId: savedDef.id, name: partial.name })))),
+      .then(ignoringResult((savedDef) => {
+        return ((publish === true)
+          ? Forms._update(form, { currentDefId: savedDef.id })
+          : Forms._update(form, { draftDefId: savedDef.id }));
+      })),
     // process the form schema locally while everything happens
     getFormFields(partial.xml)
   ])
@@ -230,7 +232,7 @@ inner join
   on filtered.id=forms.id
 where "projectId"=${projectId} and state not in ('closing', 'closed') and "currentDefId" is not null
   ${options.ifArg('formID', (xmlFormId) => sql` and "xmlFormId"=${xmlFormId}`)} and "deletedAt" is null
-order by coalesce(forms.name, forms."xmlFormId") asc`)
+order by coalesce(form_defs.name, forms."xmlFormId") asc`)
   .then(map(_openRosaJoiner));
 
 
@@ -241,8 +243,9 @@ order by coalesce(forms.name, forms."xmlFormId") asc`)
 /* eslint-disable indent */
 const versionJoinCondition = (version) => (
   (version === '___') ? versionJoinCondition('') :
-  (version == null) ? sql`form_defs.id=forms."currentDefId"` :
+  (version == null) ? sql`form_defs.id=coalesce(forms."currentDefId", forms."draftDefId")` :
   (version === Form.DraftVersion) ? sql`form_defs.id=forms."draftDefId"` :
+  (version === Form.PublishedVersion) ? sql`form_defs.id=forms."currentDefId"` :
   (version === Form.AllVersions) ? sql`form_defs."formId"=forms.id and form_defs."publishedAt" is not null` :
   sql`form_defs."formId"=forms.id and form_defs.version=${version} and form_defs."publishedAt" is not null`
 );
@@ -288,7 +291,7 @@ ${extend|| sql`
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
     on form_defs."xlsBlobId"=xls.id`}
 where ${equals(options.condition)} and forms."deletedAt" is null
-order by coalesce(name, "xmlFormId") asc`);
+order by coalesce(form_defs.name, "xmlFormId") asc`);
 
 const _getWithoutXml = extender(Form, Form.Def)(Form.Extended, Actor.into('createdBy'))(_getSql);
 const _getWithXml = extender(Form, Form.Def, Form.Xml)(Form.Extended, Actor.into('createdBy'))(_getSql);

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -92,7 +92,7 @@ module.exports = (service, endpoint) => {
     ])
       .then(([ project, form ]) => auth.canOrReject('form.update', form)
         .then(() => ((request.is('*/*') === false) // false only if no request body.
-          ? Forms.getByProjectAndXmlFormId(params.projectId, params.id, true)
+          ? Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.PublishedVersion)
             .then(getOrNotFound)
             .then((published) => ((published.xml == null)
               ? reject(Problem.user.missingParameter({ field: 'xml' }))

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -80,7 +80,7 @@ module.exports = (service, endpoint) => {
   const ensureDef = rejectIf((form) => form.def.id == null, noargs(Problem.user.notFound));
 
   odataResource('/projects/:projectId/forms/:id.svc', false, (Forms, auth, params) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id)
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.PublishedVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then((form) => auth.canOrReject('submission.read', form)));


### PR DESCRIPTION
Closes #355 by moving a form's `name` (or <title> as defined in the form XML) from Form to FormDef. Form will always reference the appropriate FormDef and get the name from there.

This PR includes a migration that adds `name` to the `form_defs` table and backfills it with form title information read from form XML. It also includes a migration to drop the `name` field from the `forms` table. (Er, I was nervous about dropping that field so I just changed the column name but will change the migration to drop the column before I finalize this PR.)

One thing that changes is that a little bit more information about an unpublished form comes through the API (like its `version` and `sha`) when that information used to be `null`. It is still possible to determine if a form is unpublished by looking at its `publishedAt` field, though. We should probably add a note about this to the docs.

Endpoints that only show published forms (like the OpenRosa `formList`) are unaffected and work the same as before.