### PR TITLE
Implement additional filtering for Sentry

### DIFF
--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -1,7 +1,93 @@
 const { inspect } = require('util');
 const { isBlank } = require('../util/util');
 
-const sensitiveEndpoints = ['/users/reset/verify', '/users/(.*?)/password'];
+
+// Endpoints where query strings are sensitive and should be removed
+const sensitiveEndpoints = [
+  ['GET', '/users[^/]'], // ?q=<part of name or email>
+  ['GET', '/projects/([^/]*)/forms/([^/]*)/submissions.csv'], // ?key=passphrase for managed encryption
+  ['GET', '/projects/([^/]*)/forms/([^/]*)/draft/submissions.csv'], // ?key=passphrase for managed encryption
+  ['GET', '/projects/([^/]*)/formList'], // ?st=token for enketo public link access (showing form)
+  ['HEAD', '/projects/([^/]*)/formList'], // ?st=token for enketo public link access (showing form)
+  ['POST', '/projects/([^/]*)/submission'], // ?st=token for enketo public link access (submitting)
+];
+
+const isSensitiveEndpoint = (request) => {
+  for (const [method, endpoint] of sensitiveEndpoints) {
+    if (request.method === method && request.url.match(endpoint)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const filterTokenFromUrl = (url) => {
+  // remove user token from any URL
+  if (url.match('/v1/key/(.*?)')) {
+    return url.replace(/v1\/key\/([^/]*)/, 'v1/key/[FILTERED]');
+  }
+
+  // remove draft token from any URL
+  if (url.match('/v1/test/(.*?)')) {
+    return url.replace(/v1\/test\/([^/]*)/, 'v1/test/[FILTERED]');
+  }
+
+  // return original URL if there are no tokens
+  return url;
+};
+
+const sanitizeEventRequest = (event) => {
+  /* eslint-disable no-param-reassign */
+  if (event.request) {
+
+    // clear out all cookie values
+    if (event.request.headers && event.request.headers.cookie) {
+      const cookies = event.request.headers.cookie.split('; ')
+        .map((cookie) => cookie.slice(0, cookie.indexOf('=')))
+        .join(', ');
+
+      event.request.headers.cookie = cookies;
+    }
+
+    // clear out cookie values not stored in request header
+    if (event.request.cookies)
+      event.request.cookies = null;
+
+    // clear out Authorization header
+    if (event.request.headers && event.request.headers.authorization)
+      event.request.headers.authorization = null;
+
+    // clear out referer header (from enketo submission, can have ?st=token in url)
+    if (event.request.headers && event.request.headers.referer)
+      event.request.headers.referer = null;
+
+    // clear out x-action-notes
+    if (event.request.headers && event.request.headers['x-action-notes'])
+      event.request.headers['x-action-notes'] = null;
+
+    // clear out request body data for all endpoints
+    if (event.request.data)
+      event.request.data = null;
+
+    // remove sensitive info from URL via query string or path
+    if (event.request.url) {
+      // handle endpoints that might expose sensitive data through query params
+      if (isSensitiveEndpoint(event.request) && event.request.query_string) {
+        // remove query string from request data and from URL
+        event.request.query_string = null;
+        // remove it from URL, too, otherwise Sentry will find it
+        event.request.url = event.request.url.split('?')[0]; // eslint-disable-line prefer-destructuring
+      }
+
+      // filter out access tokens embedded in URLs
+      event.request.url = filterTokenFromUrl(event.request.url);
+    }
+  }
+
+  /* eslint-enable no-param-reassign */
+
+  return event;
+};
 
 const init = (config) => {
   if ((config == null) || isBlank(config.key) || isBlank(config.project)) {
@@ -24,35 +110,17 @@ const init = (config) => {
   Sentry.init({
     dsn: `https://${config.key}@sentry.io/${config.project}`,
     beforeSend(event) {
-      if (event.request) {
-        // clear out all cookie values
-        if (event.request.headers && event.request.headers.cookie) {
-          const cookies = event.request.headers.cookie.split('; ')
-            .map((cookie) => cookie.slice(0, cookie.indexOf('=')))
-            .join(', ');
-
-          event.request.headers.cookie = cookies; // eslint-disable-line no-param-reassign
-        }
-
-        // clear out all request body data for sensitive endpoints (logging in, etc)
-        if (event.request.url) {
-          for (const endpoint of sensitiveEndpoints) {
-            if (event.request.url.match(endpoint)) {
-              event.request.data = null; // eslint-disable-line no-param-reassign
-            }
-          }
-        }
-      }
+      const sanitizedEvent = sanitizeEventRequest(event);
 
       // only file the event if it is a bare exception or it is a true 500.x Problem.
-      const error = event.extra.Error;
-      if (error == null) return event; // we aren't sure why there isn't an exception; pass through.
-      if ((error.isProblem !== true) || (error.httpCode === 500)) return event; // throw exceptions.
+      const error = sanitizedEvent.extra.Error;
+      if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
+      if ((error.isProblem !== true) || (error.httpCode === 500)) return sanitizedEvent; // throw exceptions.
       return null; // we have a user-space problem.
     }
   });
   return Sentry;
 };
 
-module.exports = { init };
+module.exports = { init, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };
 

--- a/test/unit/external/sanitize-sentry.js
+++ b/test/unit/external/sanitize-sentry.js
@@ -1,0 +1,570 @@
+require('should');
+const appRoot = require('app-root-path');
+const { sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl } = require(appRoot + '/lib/external/sentry');
+
+// These cases are based on real requests!
+const cases = [
+  // Request body with sensitive data
+  [
+    {
+      cookies: {},
+      data: '{"email":"test-email","password":"test-pass"}',
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: 'application/json, */*;q=0.5',
+        connection: 'keep-alive',
+        'content-type': 'application/json',
+        'content-length': '48'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/sessions'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: 'application/json, */*;q=0.5',
+        connection: 'keep-alive',
+        'content-type': 'application/json',
+        'content-length': '48'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/sessions'
+    }
+  ],
+  // Authorization header
+  [
+   {
+      cookies: {},
+      data: '{}',
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: '*/*',
+        connection: 'keep-alive',
+        authorization: 'Bearer sdff.....sdQ'
+      },
+      method: 'GET',
+      query_string: null,
+      url: 'http://localhost/v1/projects/3/forms'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: '*/*',
+        connection: 'keep-alive',
+        authorization: null
+      },
+      method: 'GET',
+      query_string: null,
+      url: 'http://localhost/v1/projects/3/forms'
+    }
+  ],
+  // Cookies and query strings from the frontend
+  [
+    {
+      cookies: {
+        csrftoken: 'j0j...U5',
+        __enketo_meta_deviceid: 's:localhost:zgC...hAE',
+        __csrf: 'kGa...w1d',
+        session: 'Aj...nR'
+      },
+      data: '{}',
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90", "Google Chrome";v="90"',
+        'sec-ch-ua-mobile': '?0',
+        'upgrade-insecure-requests': '1',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36',
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-user': '?1',
+        'sec-fetch-dest': 'document',
+        referer: 'http://localhost:8989/',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: 'csrftoken=j0j3....QU5; __enketo_meta_deviceid=s%3Alocalhost%3AzgCh....AE; __csrf=kG2...1d; session=Ajp....vjSnR'
+      },
+      method: 'GET',
+      query_string: '%24filter=__system%2FsubmitterId+eq+26+and+__system%2FreviewState+eq+null',
+      url: 'http://localhost/v1/projects/3/forms/odata-fake-planets/submissions.csv.zip?%24filter=__system%2FsubmitterId+eq+26+and+__system%2FreviewState+eq+null'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90", "Google Chrome";v="90"',
+        'sec-ch-ua-mobile': '?0',
+        'upgrade-insecure-requests': '1',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36',
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-user': '?1',
+        'sec-fetch-dest': 'document',
+        referer: null,
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
+      },
+      method: 'GET',
+      query_string: null,
+      url: 'http://localhost/v1/projects/3/forms/odata-fake-planets/submissions.csv.zip'
+    }
+  ],
+  // URL with draft form token
+  [
+    {
+      cookies: {},
+      data: '{}',
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: '*/*',
+        connection: 'keep-alive',
+        'x-openrosa-version': '1.0',
+        'content-type': 'multipart/form-data; boundary=58a8898824454fadb1e9d19fac47882c',
+        'content-length': '311'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/test/qiswR....yc9u/projects/3/forms/draft/submission'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: '*/*',
+        connection: 'keep-alive',
+        'x-openrosa-version': '1.0',
+        'content-type': 'multipart/form-data; boundary=58a8898824454fadb1e9d19fac47882c',
+        'content-length': '311'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/test/[FILTERED]/projects/3/forms/draft/submission'
+    }
+  ],
+  // URL with app user token
+  [
+    {
+      cookies: {},
+      data: '{}',
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: '*/*',
+        connection: 'keep-alive',
+        'x-openrosa-version': '1.0',
+        'content-type': 'text/xml'
+      },
+      method: 'GET',
+      query_string: null,
+      url: 'http://localhost/v1/key/rf9......7i/projects/3/formList'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: '*/*',
+        connection: 'keep-alive',
+        'x-openrosa-version': '1.0',
+        'content-type': 'text/xml'
+      },
+      method: 'GET',
+      query_string: null,
+      url: 'http://localhost/v1/key/[FILTERED]/projects/3/formList'
+    }
+  ],
+  // URL with useful query parameters to preserve
+  [
+    {
+      cookies: {
+        csrftoken: 'j0,,U5',
+        __enketo_meta_deviceid: 's..hAE',
+        __csrf: 'tdg...12lwQ',
+        session: 'RPPE..dUz'
+      },
+      data: '{}',
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90", "Google Chrome";v="90"',
+        accept: 'application/json, text/plain, */*',
+        authorization: 'Bearer RPPEyOgimjSQY7rQfFDCcFLaySdCMRJflCunYoKoXpvh5JLB5nvrm4lju$QfSdUz',
+        'sec-ch-ua-mobile': '?0',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-dest': 'empty',
+        referer: 'http://localhost:8989/',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: 'csrftoken=j0j32..6LEzgQU5; __enketo_meta_deviceid=s%3Alo...ucHhAE; __csrf=tdgs7t0..12lwQ; session=RPP..dUz'
+      },
+      method: 'GET',
+      query_string: '%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null',
+      url: 'http://localhost/v1/projects/3/forms/odata-fake-planets.svc/Submissions?%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null'
+    }
+    ,
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90", "Google Chrome";v="90"',
+        accept: 'application/json, text/plain, */*',
+        authorization: null,
+        'sec-ch-ua-mobile': '?0',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-dest': 'empty',
+        referer: null,
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
+      },
+      method: 'GET',
+      query_string: '%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null',
+      url: 'http://localhost/v1/projects/3/forms/odata-fake-planets.svc/Submissions?%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null'
+    }
+  ],
+  // Example of Enketo submission
+  [
+    {
+      cookies: {
+        csrftoken: 'j..5',
+        __enketo_meta_deviceid: 's..AE',
+        __csrf: 't..Q',
+        session: 'RP..Uz'
+      },
+      data: '{"__csrf":"td..wQ"}',
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '619',
+        date: 'Wed, 19 May 2021 21:59:37 GMT',
+        'cache-control': 'max-age=0',
+        'x-openrosa-version': '1.0',
+        'content-type': 'multipart/form-data; boundary=----WebKitFormBoundaryL2oytYPxI0mUpe2B',
+        'sec-ch-ua-mobile': '?0',
+        'x-openrosa-instance-id': 'uuid:acc694d9-63af-4893-9d19-6877c3f39fa1',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
+        'x-openrosa-deprecated-id': '',
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90", "Google Chrome";v="90"',
+        accept: '*/*',
+        origin: 'http://localhost:8989',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-dest': 'empty',
+        referer: 'http://localhost:8989/-/XoecwziQ',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: 'csrftoken=j0j3..QU5; __enketo_meta_deviceid=s%3Aloc..AE; __csrf=tdg..lwQ; session=RP..SdUz'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/projects/5/submission'
+    }
+    ,
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '619',
+        date: 'Wed, 19 May 2021 21:59:37 GMT',
+        'cache-control': 'max-age=0',
+        'x-openrosa-version': '1.0',
+        'content-type': 'multipart/form-data; boundary=----WebKitFormBoundaryL2oytYPxI0mUpe2B',
+        'sec-ch-ua-mobile': '?0',
+        'x-openrosa-instance-id': 'uuid:acc694d9-63af-4893-9d19-6877c3f39fa1',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
+        'x-openrosa-deprecated-id': '',
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90", "Google Chrome";v="90"',
+        accept: '*/*',
+        origin: 'http://localhost:8989',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-dest': 'empty',
+        referer:  null,
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/projects/5/submission'
+    }
+  ],
+  // Example of Enketo public access link (showing form)
+  [
+    {
+      cookies: {
+        __enketo_meta_deviceid: 's:localhost:ZzE...hFp4',
+        _csrf: 'W...Ua'
+      },
+      data: '{}',
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '0',
+        cookie: '__enketo_meta_deviceid=s%3Aloc..p4; _csrf=W_..Ua',
+        'x-openrosa-version': '1.0',
+        date: 'Mon, 14 Jun 2021 18:47:25 GMT'
+      },
+      method: 'HEAD',
+      query_string: 'formID=simple-name-age&st=Cpl...62M0d',
+      url: 'http://localhost/v1/projects/5/formList?formID=simple-name-age&st=Cpl..M0d'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '0',
+        cookie: '__enketo_meta_deviceid, _csrf',
+        'x-openrosa-version': '1.0',
+        date: 'Mon, 14 Jun 2021 18:47:25 GMT'
+      },
+      method: 'HEAD',
+      query_string: null,
+      url: 'http://localhost/v1/projects/5/formList'
+    }
+  ],
+  // Example of Enketo public access link (submitting form)
+  [
+    {
+      cookies: {
+        __enketo_meta_deviceid: 's:localhost:Zz...p4',
+        _csrf: 'W_..Ua'
+      },
+      data: '{}',
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '460',
+        date: 'Mon, 14 Jun 2021 19:05:52 GMT',
+        'cache-control': 'max-age=0',
+        'x-openrosa-version': '1.0',
+        'content-type': 'multipart/form-data; boundary=----WebKitFormBoundaryAhdIGqG3gmVb17IB',
+        'sec-ch-ua-mobile': '?0',
+        'x-openrosa-instance-id': 'uuid:4c1129d2-cf06-4cda-bde9-645340368dea',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
+        'x-openrosa-deprecated-id': '',
+        'sec-ch-ua': '" Not;A Brand";v="99", "Google Chrome";v="91", "Chromium";v="91"',
+        accept: '*/*',
+        origin: 'http://localhost:8989',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-dest': 'empty',
+        referer: 'http://localhost:8989/-/single/Xo..iQ?st=Cp...d',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZzEustWflva1byvA.R..p4; _csrf=W_..a'
+      },
+      method: 'POST',
+      query_string: 'st=Cpl...M0d',
+      url: 'http://localhost/v1/projects/5/submission?st=Cpl...M0d'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '460',
+        date: 'Mon, 14 Jun 2021 19:05:52 GMT',
+        'cache-control': 'max-age=0',
+        'x-openrosa-version': '1.0',
+        'content-type': 'multipart/form-data; boundary=----WebKitFormBoundaryAhdIGqG3gmVb17IB',
+        'sec-ch-ua-mobile': '?0',
+        'x-openrosa-instance-id': 'uuid:4c1129d2-cf06-4cda-bde9-645340368dea',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
+        'x-openrosa-deprecated-id': '',
+        'sec-ch-ua': '" Not;A Brand";v="99", "Google Chrome";v="91", "Chromium";v="91"',
+        accept: '*/*',
+        origin: 'http://localhost:8989',
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-dest': 'empty',
+        referer: null,
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9',
+        cookie: '__enketo_meta_deviceid, _csrf'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/projects/5/submission'
+    }
+  ],
+  // Example of Enketo public access link (both key and ?st token in query string)
+  [
+    {
+      cookies: {
+        __enketo_meta_deviceid: 's:localhost:Zz..4',
+        _csrf: 'W..Ua'
+      },
+      data: '{}',
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '0',
+        cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZz..Fp4; _csrf=W..Ua',
+        'x-openrosa-version': '1.0',
+        date: 'Mon, 14 Jun 2021 19:08:30 GMT'
+      },
+      method: 'HEAD',
+      query_string: 'formID=simple-name-age&st=CplI..0d',
+      url: 'http://localhost/v1/key/Cpl.0d/projects/5/formList?formID=simple-name-age&st=Cpl...M0d'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        'x-forwarded-proto': 'https',
+        host: 'localhost:8383',
+        connection: 'close',
+        'content-length': '0',
+        cookie: '__enketo_meta_deviceid, _csrf',
+        'x-openrosa-version': '1.0',
+        date: 'Mon, 14 Jun 2021 19:08:30 GMT'
+      },
+      method: 'HEAD',
+      query_string: null,
+      url: 'http://localhost/v1/key/[FILTERED]/projects/5/formList'
+    }
+  ],
+  // Example of X-Action-Notes header being removed
+  [
+    {
+      cookies: {},
+      data: '{"displayName":"Test Display Name"}',
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: 'application/json, */*;q=0.5',
+        connection: 'keep-alive',
+        'content-type': 'application/json',
+        'x-action-notes': 'some test note',
+        authorization: 'Bearer Ojz....1I',
+        'content-length': '36'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/projects/3/forms/simple-form/public-links'
+    },
+    {
+      cookies: null,
+      data: null,
+      headers: {
+        host: 'localhost:8383',
+        'user-agent': 'HTTPie/2.4.0',
+        'accept-encoding': 'gzip, deflate',
+        accept: 'application/json, */*;q=0.5',
+        connection: 'keep-alive',
+        'content-type': 'application/json',
+        'x-action-notes': null,
+        authorization: null,
+        'content-length': '36'
+      },
+      method: 'POST',
+      query_string: null,
+      url: 'http://localhost/v1/projects/3/forms/simple-form/public-links'
+    }
+  ]
+];
+
+// sensitive endpoints where querystrings need to be removed
+const sensitiveEndpoints = [
+  ['GET', '/v1/users?q=personal_name'],
+  ['GET', '/v1/projects/6/forms/formid/submissions.csv?keyid=pass'],
+  ['GET', '/v1/projects/6/forms/formid/submissions.csv.zip?keyid=pass'],
+  ['GET', '/v1/projects/6/forms/formid/draft/submissions.csv?keyid=pass'],
+  ['GET', '/v1/projects/6/forms/formid/draft/submissions.csv.zip?keyid=pass'],
+  ['HEAD', '/v1/projects/6/formList?formID=my_form_id&st=enketo_token'],
+  ['POST', '/v1/projects/6/submission?st=enketo_token']
+];
+
+// non-sensitive endpoints to send along useful querystrings
+const nonSensitiveEndpoints = [
+  ['GET', '/v1/users/reset/initiate?invalidate=true'],
+  ['POST', '/v1/projects/6/forms/formid/submissions.csv?attachments=false'],
+  ['POST', '/v1/projects/6/forms/formid/submissions.csv.zip?attachments=false'],
+  ['POST', '/v1/projects/6/forms/formid/draft/submissions.csv?attachments=false'],
+  ['POST', '/v1/projects/6/forms/formid/draft/submissions.csv.zip?attachments=false'],
+];
+
+const filteredTokenUrls = [
+  ['/v1/key/APP_USER_KEY/projects/3/formList', '/v1/key/[FILTERED]/projects/3/formList'],
+  ['/v1/test/DRAFT_TOKEN/projects/3/forms/draft/submission', '/v1/test/[FILTERED]/projects/3/forms/draft/submission'],
+  ['/v1/projects/2/forms/test/attachments', '/v1/projects/2/forms/test/attachments'], // the form ID is 'test' but doesn't get filtered
+  ['/v1/key/PUBLIC_ACCESS_KEY/projects/5/formList?formID=form_id&st=PUBLIC_ACCESS_KEY', '/v1/key/[FILTERED]/projects/5/formList?formID=form_id&st=PUBLIC_ACCESS_KEY'] // query string removal is not in the filtering step
+]
+
+describe('external: sanitize-sentry', () => {
+  it('removes sensitive data from request objects ', () => {
+    for (const [input, expectedOutput] of cases) {
+      sanitizeEventRequest({ request: input }).should.eql({ request: expectedOutput });
+    }
+  });
+
+  it('identifies sensitive URLs ', () => {
+    for (const [method, url] of sensitiveEndpoints) {
+      isSensitiveEndpoint({url, method}).should.equal(true);
+    }
+  });
+
+  it('identifies non-sensitive URLs ', () => {
+    for (const [method, url] of nonSensitiveEndpoints) {
+      isSensitiveEndpoint({url, method}).should.equal(false);
+    }
+  });
+
+  it('filters app user and draft tokens from URLs', () => {
+    for (const [inputUrl, expectedUrl ] of filteredTokenUrls) {
+      filterTokenFromUrl(inputUrl).should.equal(expectedUrl);
+    }
+  });
+});
+


### PR DESCRIPTION
Closes #347. This issue requested filtering out the request body for a number of endpoints. These are endpoints that might contain emails and other sensitive information. (Note that extra sensitive information, such as passwords, was already filtered by Sentry, but with this change, that information is erased before it is even sent to Sentry.) The issue also requested filtering out the query parameters of certain endpoints.

* /sessions
* /users
* /users/:id (covered by endpoint regex `/users`)
* /users/reset/initiate
* /projects/:id/key
* /config/backups/initiate
* /backup (at least the POST version)
* any more...?

Changes:
1. I've expanded the list of sensitive endpoints, and any matching endpoint, regardless of what kind of GET/POST/PUT request it is, will have both it's request body filtered out, and have all query parameters removed from the request and the URL that is sent to Sentry.

2. Cookies, including CSRF tokens, are more thoroughly removed. Previously, cookies were summarized in the request header, but getting passed through in the request object and still visible in Sentry.

3. The `Authorization` header is removed when it is present.

4. Authentication tokens that are part of a URL, such as those used with [App User Authentication](https://odkcentral.docs.apiary.io/#reference/authentication/app-user-authentication/using-app-user-authentication) and [Draft Testing](https://odkcentral.docs.apiary.io/#reference/openrosa-endpoints/draft-testing-endpoints/openrosa-form-submission-api) are removed.

5. [Help?] I'm not sure what the `st` query parameter of a public link refers to. I see one that is part of an Enketo URL, which is outside of `central-backend`'s + Sentry's realm.

How to test this is going to be interesting! I have been trying it out with a dev sentry account, breaking the code, making various API requests, and checking that the information is getting removed... Not sure if there's a more repeatable way to test.