### PR TITLE
Move formId extension check from Form.fromXml to Form ingestion resource (migration patch)

### DIFF
--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -103,13 +103,6 @@ class Form extends Frame.define(
       const xmlFormId = idText.map(blankStringToNull)
         .orThrow(Problem.user.missingParameter({ field: 'formId' }));
 
-      if (/\.(xlsx?|xml)$/.test(xmlFormId))
-        throw Problem.user.unexpectedValue({
-          field: 'formId',
-          value: xmlFormId,
-          reason: 'The Form ID cannot end in .xls, .xlsx, or .xml. Please either specify an allowed ID in the form itself, or rename the file (eg change form.xls.xls to form.xls).'
-        });
-
       const version = versionText.orElse('');
       const name = nameText.orNull();
       const key = pubKey.map((k) => new Key({ public: k }));

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -67,8 +67,14 @@ module.exports = (service, endpoint) => {
       Form.fromXml(input))
     )
     /* eslint-enable indent */
+      .then(rejectIf((partial) => (/\.(xlsx?|xml)$/.test(partial.xmlFormId)),
+        (partial) => Problem.user.unexpectedValue({
+          field: 'formId',
+          value: partial.xmlFormId,
+          reason: 'The Form ID cannot end in .xls, .xlsx, or .xml. Please either specify an allowed ID in the form itself, or rename the file (eg change form.xls.xls to form.xls).'
+        })))
       // if we don't have managed encryption, or the form carries its own key,
-      // we can use the form xml as-is. otherwise we must inject things.
+      // we can use the form xml as-is. otherwise we must inject things
       .then((partial) => (((project.keyId == null) || partial.aux.key.isDefined())
         ? partial
         : Keys.getById(project.keyId)

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -420,7 +420,34 @@ describe('api: /projects/:id/forms', () => {
             body.hash.should.equal('07ed8a51cc3f6472b7dfdc14c2005861');
           }))));
 
-    it('should reject if form id is too long', testService((service) =>
+    it('should reject if form id ends in .xml', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple.replace(/id=".*"/i, 'id="formid.xml"'))
+          .set('Content-Type', 'application/xml')
+          .expect(400)
+          .then(({ body }) => {
+            body.code.should.equal(400.8);
+          }))));
+
+    it('should reject if form id ends in .xls(x)', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple.replace(/id=".*"/i, 'id="formid.xls"'))
+          .set('Content-Type', 'application/xml')
+          .expect(400)
+          .then(({ body }) => {
+            body.code.should.equal(400.8);
+          })
+          .then(asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.simple.replace(/id=".*"/i, 'id="formid.xlsx"'))
+            .set('Content-Type', 'application/xml')
+            .expect(400)
+            .then(({ body }) => {
+              body.code.should.equal(400.8);
+            })))));
+
+    it('should reject if form id contains is too long', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms')
           .send(testData.forms.simple.replace(/id=".*"/i, 'id="simple_form_with_form_id_length_more_than_sixty_four_characters_long"'))

--- a/test/unit/model/frames/form.js
+++ b/test/unit/model/frames/form.js
@@ -36,22 +36,6 @@ describe('Form', () => {
           failure.problemCode.should.equal(400.2);
         }));
 
-    it('should reject if the formId ends in .xml', () =>
-      Form.fromXml('<html><head><model><instance><data id="form.xml"><field/></data></instance></model></head></html>')
-        .should.be.rejected()
-        .then((failure) => {
-          failure.isProblem.should.equal(true);
-          failure.problemCode.should.equal(400.8);
-          failure.problemDetails.field.should.equal('formId');
-          failure.problemDetails.value.should.equal('form.xml');
-          failure.problemDetails.reason.includes('change form.xls.xls to form.xls').should.equal(true);
-        }));
-
-    it('should reject if the formId ends in .xls(x)', () => Promise.all([
-      Form.fromXml('<html><head><model><instance><data id="form.xls"><field/></data></instance></model></head></html>').should.be.rejected(),
-      Form.fromXml('<html><head><model><instance><data id="form.xlsx"><field/></data></instance></model></head></html>').should.be.rejected()
-    ]));
-
     it('should return a populated Form object if the xml passes', () => {
       const xml = '<html><head><model><instance><data id="mycoolform"><field/></data></instance></model></head></html>';
       return Form.fromXml(xml).then((partial) => {


### PR DESCRIPTION
There was an issue with database migrations where the migration to backfill form def names used `Form.fromXml`, which was checking for `.xml` and `.xslx` extensions inside formIDs and throwing an error. This was causing the whole migration to fail, which was no good! The original purpose of this formID check was to prevent forms with this formID pattern from even being uploaded.

This extension check has now been moved from `fromXml` to a `getPartial()` method used in the form ingestion resource.