### PR TITLE
Calculate diffs between versions of XML submissions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2446,6 +2446,45 @@ It is important to note that this endpoint returns whatever is _currently_ uploa
 + Response 403 (application/json)
     + Attributes (Error 403)
 
+### Getting changes between Versions [GET /v1/projects/{projectId}/forms/{xmlFormId}/submissions/{instanceId}/diffs
+
+This returns the changes, or edits, between different versions of a Submission. These changes are returned in an object that is indexed by the `instanceId` that uniquely identifies that version. Between two submissions, there is an array of objects representing how each field changed. This change object contains the old and new values, as well as the path of that changed node in the Submission XML. These changes reflect the updated `instanceID` and `deprecatedID` fields as well as the edited value.
+
++ Response 200
+		+ Attributes (array[array[Submission Diff Value]])
+
+    + Body
+
+			{
+			  "two": [
+			    {
+			      "new": "Donna",
+			      "old": "Dana",
+			      "path": ["name"]
+			    },
+			    {
+			      "new": "55",
+			      "old": "44",
+			      "path": ["age"]
+			    },
+			    {
+			      "new": "two",
+			      "old": "one",
+			      "path": ["meta", "instanceID"]
+			    },
+			    {
+			      "new": "one",
+			      "old": null,
+			      "path": ["meta", "deprecatedID"]
+			      ]
+			    }
+			  ]
+			}
+
+
++ Response 403 (application/json)
+    + Attributes (Error 403)
+
 ## Draft Submissions [/v1/projects/{projectId}/forms/{xmlFormId}/draft/submissions]
 
 All [Draft Forms](/reference/forms/draft-form) feature a `/submissions` subresource (`/draft/submissions`), which is identical to the same subresource on the form itself. These submissions exist only as long as the Draft Form does: they are removed if the Draft Form is published, and they are abandoned if the Draft Form is deleted or overwritten.
@@ -3876,6 +3915,11 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 + hasIssues (string) - Somebody has flagged that this submission has potential problems that need to be addressed.
 + rejected (string) - Somebody has flagged that this submission should be ignored.
 + approved (string) - Somebody has approved this submission.
+
+## Submission Diff Value (object)
++ new (string, nullable) - The new value of this node, which can either be a simple string, or JSON string representing a larger structural change to the Submission XML. It can also be null if this field no longer exists in the Submission.
++ old (string, nullable) - The old value of this node, with similar properties to `new`. It can be null if this field did not exist previously.
++ path (array) - An array representing the path (XPath) in the Submission tree for this node. It does not include the outermost path `data`. For elements that are part of repeat groups, the path element is the node name and the index (starting at 0), e.g. ['child', 2] is the third child.
 
 ## Success (object)
 + success: `true` (boolean, required)

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -11,6 +11,8 @@ const { Readable } = require('stream');
 const hparser = require('htmlparser2');
 const { SchemaStack } = require('./schema');
 const { noop } = require('../util/util');
+const { contains, isEmpty, map, max, union } = require('ramda');
+
 
 // reads submission xml with the streaming parser, and outputs a stream of every
 // field in the submission. does no processing at all to localize repeat groups,
@@ -57,5 +59,136 @@ const submissionXmlToFieldStream = (fields, xml) => {
   return outStream;
 };
 
-module.exports = { submissionXmlToFieldStream };
+// Reads XML without reading form schema
+const submissionXmlToObj = (xml) => {
+  const fieldStack = [];
+  const data = {};
+  let currNode = data;
+  const nodeStack = [ currNode ];
+
+  let textBuffer = ''; // agglomerates text nodes that come as multiple events.
+
+  const parser = new hparser.Parser({
+    onopentag: (tagName) => {
+      fieldStack.push(tagName);
+      nodeStack.push(currNode);
+
+      if (tagName in currNode) {
+        // tagname is already present so this is probably a repeat
+        if (!Array.isArray(currNode[tagName])) {
+          // make it into an array if not already an arary
+          currNode[tagName] = [currNode[tagName]];
+        }
+
+        // push empty object to put child contents into
+        const newObj = {};
+        currNode[tagName].push(newObj);
+        currNode = newObj;
+      } else {
+        // tag name does not yet exist, make empty object
+        currNode[tagName] = {};
+        currNode = currNode[tagName];
+      }
+
+      textBuffer = '';
+    },
+    ontext(text) {
+      textBuffer += text;
+    },
+    onclosetag() {
+      const field = fieldStack.pop();
+      currNode = nodeStack.pop();
+
+      if (isEmpty(currNode[field])) {
+        // only set terminal node text values
+        currNode[field] = textBuffer;
+      }
+    },
+  }, { xmlMode: true, decodeEntities: true });
+
+  parser.write(xml);
+  parser.end();
+
+  return data;
+};
+
+// Helper function for formatting the diff representation of one node
+//   curr and prev: values
+//   xpath: full tree path as an array, not including the current node
+//   key: current node key
+//   index: node index if it is within a repeat group
+const formatDiff = (curr, prev, keyStack, key, index = null) => ({
+  new: curr || null,
+  old: prev || null,
+  path: keyStack.slice(1).concat(index ? [[key, index]] : [key]), // first stack element 'data' removed
+});
+
+const compareObjects = (a, b, keyStack = []) => {
+  const ak = Object.keys(a); // more recent submission
+  const bk = Object.keys(b); // previous submission
+  const allKeys = union(ak, bk);
+
+  const differences = [];
+
+  for (const key of allKeys) {
+    // Check for keys that are not both present
+    if (!(contains(key, ak)) || !(contains(key, bk))) {
+      // if one key is missing, that one will be undefined
+      differences.push(formatDiff(a[key], b[key], keyStack, key));
+    } else {
+      // Compare the same keys
+      let valueA = a[key];
+      let valueB = b[key];
+
+      // If one is an array and the other isn't, make both into arrays
+      if (Array.isArray(valueA) && !Array.isArray(valueB))
+        valueB = [valueB];
+      else if (!Array.isArray(valueA) && Array.isArray(valueB))
+        valueA = [valueA];
+
+      if (Array.isArray(valueA) && Array.isArray(valueB)) {
+        // If they are both arrays, iterate through the longer one
+        for (let i = 0; i < max(valueA.length, valueB.length); i += 1) {
+          const innerValueA = valueA[i];
+          const innerValueB = valueB[i];
+
+          if (!innerValueA || !innerValueB) {
+            differences.push(formatDiff(innerValueA, innerValueB, keyStack, key, i));
+          } else {
+            differences.push(...compareObjects(
+              innerValueA,
+              innerValueB,
+              keyStack.concat([[ key, i ]])
+            ));
+          }
+        }
+      } else if (typeof (a[key]) === 'object' && typeof (b[key]) === 'object') {
+        // If children are both objects, compare them recursively
+        differences.push(...compareObjects(
+          a[key],
+          b[key],
+          keyStack.concat(key)
+        ));
+      } else if (valueA.toString() !== valueB.toString()) {
+        // If they are both different values, note the change
+        differences.push(formatDiff(valueA, valueB, keyStack, key));
+      }
+      // else: the values are the same
+    }
+  }
+
+  return differences;
+};
+
+const diffSubmissions = (versions) => new Promise((resolve) => {
+  const diffs = {};
+  const jsonVersions = map((v) => ({instanceId: v.instanceId, content: submissionXmlToObj(v.xml)}), versions);
+
+  for (let i = 0; i < versions.length - 1; i += 1) {
+    diffs[jsonVersions[i].instanceId] = compareObjects(jsonVersions[i].content, jsonVersions[i + 1].content);
+  }
+  resolve(diffs);
+});
+
+module.exports = { submissionXmlToFieldStream, submissionXmlToObj, compareObjects, diffSubmissions, formatDiff };
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -19,6 +19,7 @@ const Problem = require('../util/problem');
 const { streamBriefcaseCsvs } = require('../data/briefcase');
 const { streamAttachments } = require('../data/attachments');
 const { streamClientAudits } = require('../data/client-audits');
+const { diffSubmissions } = require('../data/submission');
 const { resolve } = require('../util/promise');
 const { isBlank, noargs } = require('../util/util');
 const { zipStreamFromParts } = require('../util/zip');
@@ -469,6 +470,19 @@ module.exports = (service, endpoint) => {
           Submissions.verifyVersion(form.id, params.rootId, params.instanceId, draft)
         ]))
         .then(([ blob ]) => binary(blob.contentType, params.name, blob.content))));
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Diffs between all versions of a submission
+
+    service.get(`${base}/:rootId/diffs`, endpoint(({ Forms, Submissions }, { params, auth }) =>
+      getForm(params, Forms)
+        .then(auth.canOrReject('submission.read'))
+        .then((form) => Promise.all([
+          Submissions.getDefsByFormAndLogicalId(form.id, params.rootId, draft),
+          Submissions.getByIds(params.projectId, params.formId, params.rootId, draft)
+            .then(getOrNotFound)
+        ]))
+        .then(([ versions ]) => diffSubmissions(versions))));
   };
 
   // reify for draft/nondraft

--- a/test/unit/data/submission.js
+++ b/test/unit/data/submission.js
@@ -2,7 +2,7 @@ require('should');
 const appRoot = require('app-root-path');
 const { always, construct } = require('ramda');
 const { toObjects } = require('streamtest').v2;
-const { submissionXmlToFieldStream } = require(appRoot + '/lib/data/submission');
+const { submissionXmlToFieldStream, submissionXmlToObj, compareObjects, diffSubmissions, formatDiff } = require(appRoot + '/lib/data/submission');
 const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
 const testData = require(appRoot + '/test/data/xml');
 
@@ -59,3 +59,419 @@ describe('submission field streamer', () => {
   });
 });
 
+describe('submission xml to object', () => {
+
+  it('should return an object representation of xml', (done) => {
+    const data = submissionXmlToObj(testData.instances.simple.one);
+    const expected = {
+      data: { 
+        meta: { 
+          instanceID: 'one'
+        }, 
+        name: 'Alice', 
+        age: '30' 
+      }
+    };
+    data.should.eql(expected);
+    done();
+  });
+
+  it('should return an object of xml with repeats in array', (done) => {
+    const data = submissionXmlToObj(testData.instances.withrepeat.two);
+    const expected = {
+      data: { 
+        'orx:meta': { 
+          'orx:instanceID': 'rtwo'
+        }, 
+        name: 'Bob', 
+        age: '34',
+        children: {
+          child: [
+            { name: 'Billy', age: '4' },
+            { name: 'Blaine', age: '6' },
+          ]
+        }
+      }
+    };
+    data.should.eql(expected);
+    done();
+  });
+
+  it('should return an object of xml with single repeat as non-array', (done) => {
+    const data = submissionXmlToObj(testData.instances.withrepeat.three);
+    const expected = {
+      data: { 
+        'orx:meta': { 
+          'orx:instanceID': 'rthree'
+        }, 
+        name: 'Chelsea', 
+        age: '38',
+        children: {
+          child: { name: 'Candace', age: '2' }
+        }
+      }
+    };
+    data.should.eql(expected);
+    done();
+  });
+
+  it('should return an object of xml of double repeat', (done) => {
+    const data = submissionXmlToObj(testData.instances.doubleRepeat.double);
+    const expected = {
+      "data": {
+        "children": {
+          "child": [
+            { "name": "Alice" },
+            { "name": "Bob",
+              "toys": {
+                "toy": [
+                  { "name": "Twilight Sparkle" },
+                  { "name": "Pinkie Pie" },
+                  { "name": "Applejack" },
+                  { "name": "Spike" }
+                ]
+              }
+            },
+            { "name": "Chelsea",
+              "toys": {
+                "toy": [
+                  { "name": "Rainbow Dash" },
+                  { "name": "Rarity" },
+                  { "name": "Fluttershy" },
+                  { "name": "Princess Luna" }
+                ]
+              }
+            }
+          ]
+        },
+        "name": "Vick",
+        "orx:meta": {
+          "orx:instanceID": "double"
+        }
+      }
+    };
+    data.should.eql(expected);
+    done();
+  });
+
+  it('should handle xml with repeat not inside a group', (done) => {
+    const xml = `<instance>
+        <data id="repeats" version="2014083101">
+            <person>
+                <name>Amy</name>
+                <relationship>sibling</relationship>
+            </person>
+            <person>
+                <name>Beth</name>
+                <relationship>sibling</relationship>
+            </person>
+            <person>
+                <name>Chase</name>
+                <relationship>sibling</relationship>
+            </person>
+            <meta>
+                <instanceID/>
+            </meta>
+        </data>
+    </instance>`
+
+    const data = submissionXmlToObj(xml);
+    const expected = {
+      "instance": {
+        "data": {
+          "meta": {
+            "instanceID": "",
+          },
+          "person": [
+            {
+              "name": "Amy",
+              "relationship": "sibling"
+            },
+            {
+              "name": "Beth",
+              "relationship": "sibling"
+            },
+            {
+              "name": "Chase",
+              "relationship": "sibling"
+            }
+          ]
+        }
+      }
+    };
+    data.should.eql(expected);
+    done();
+  });
+
+  it('should return a client audit submission xml as object', (done) => {
+    const data = submissionXmlToObj(testData.instances.clientAudits.one);
+    const expected = {
+      data: {
+        meta: { instanceID: 'one', audit: 'audit.csv' },
+        name: 'Alice',
+        age: '30'
+      }
+    };
+    data.should.eql(expected);
+    done();
+  });
+
+});
+
+describe('submission diffs', () => {
+
+  it('should format the diff of a single node with useful metadata', (done) => {
+    const diff = formatDiff("newName", "oldName", ['data', 'person'], 'name');
+    const expected = { new: 'newName', old: 'oldName', path: [ 'person', 'name' ] };
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should format the diff with missing value represented as null', (done) => {
+    const diff = formatDiff({name: 'Scootaloo'}, undefined, ['data', 'children', ['child', 2]], 'favorite_toy');
+    const expected = {
+      "new": {
+        "name": "Scootaloo"
+      },
+      "old": null,
+      "path": ["children", ["child", 2], "favorite_toy"]
+    };
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff of simple edits', (done) => {
+    const xml1 = submissionXmlToObj(testData.instances.simple.one);
+    const xml2 = submissionXmlToObj(testData.instances.simple.two);
+    const diff = compareObjects(xml1, xml2);
+    const expected = [
+      {
+        "new": "one",
+        "old": "two",
+        "path": ["meta", "instanceID"]
+      },
+      {
+        "new": "Alice",
+        "old": "Bob",
+        "path": ["name"]
+      },
+      {
+        "new": "30",
+        "old": "34",
+        "path": ["age"]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff with missing fields', (done) => {
+    const xml1 = submissionXmlToObj(testData.instances.simple.one);
+    const xml2 = submissionXmlToObj(testData.instances.simple.one.replace('<age>30</age>',''));    
+    
+    // compare in one direction
+    let diff = compareObjects(xml1, xml2);
+    let expected = [
+      {
+        "new": "30",
+        "old": null,
+        "path": ["age"]
+      }
+    ];
+    diff.should.eql(expected);
+
+    // compare other direction, too
+    diff = compareObjects(xml2, xml1);
+    expected = [
+      {
+        "new": null,
+        "old": "30",
+        "path": ["age"]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff with missing subtree', (done) => {
+    const xml1 = submissionXmlToObj(testData.instances.withrepeat.three);
+    const xml2 = submissionXmlToObj(testData.instances.withrepeat.three.replace('<children><child><name>Candace</name><age>2</age></child></children>',''));
+    
+    let diff = compareObjects(xml1, xml2);
+    let expected = [
+      {
+        "new": {
+          "child": {
+            "name": "Candace",
+            "age": "2"
+          }
+        },
+        "old": null,
+        "path": ["children"]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff where repeat elements edited', (done) => {
+    const xml1 = submissionXmlToObj(testData.instances.withrepeat.two);
+    const xml2 = submissionXmlToObj(testData.instances.withrepeat.two.replace('Billy', 'William').replace('6', '16'));
+    const diff = compareObjects(xml1, xml2);
+    const expected = [
+      {
+        "new": "Billy",
+        "old": "William",
+        "path": ["children", ["child", 0], "name"]
+      },
+      {
+        "new": "6",
+        "old": "16",
+        "path": ["children", ["child", 1], "age"]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff where one repeat deleted, one remaining', (done) => {
+    // Object representation has two repeat elements represented as an array and 
+    // one singleton repeat as an object, making it harder to compare
+    const xml1 = submissionXmlToObj(testData.instances.withrepeat.two);
+    const xml2 = submissionXmlToObj(testData.instances.withrepeat.two.replace('<child><name>Blaine</name><age>6</age></child>',''));
+    const diff = compareObjects(xml1, xml2);
+    const expected = [
+      {
+        "new": {
+          "name": "Blaine",
+          "age": "6"
+        },
+        "old": null,
+        "path": ["children", ["child", 1]]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff with major edits to values and repeat contents', (done) => {
+    const xml1 = submissionXmlToObj(testData.instances.withrepeat.two);
+    const xml2 = submissionXmlToObj(testData.instances.withrepeat.three);
+    const diff = compareObjects(xml1, xml2);
+    const expected = [
+      {
+        "new": "rtwo",
+        "old": "rthree",
+        "path": ["orx:meta", "orx:instanceID"]
+      },
+      {
+        "new": "Bob",
+        "old": "Chelsea",
+        "path": ["name"]
+      },
+      {
+        "new": "34",
+        "old": "38",
+        "path": ["age"]
+      },
+      {
+        "new": "Billy",
+        "old": "Candace",
+        "path": ["children", ["child", 0], "name"]
+      },
+      {
+        "new": "4",
+        "old": "2",
+        "path": ["children", ["child", 0], "age"]
+      },
+      {
+        "new": {
+          "name": "Blaine",
+          "age": "6"
+        },
+        "old": null,
+        "path": ["children", ["child", 1]]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff with edit deeper in repeat', (done) => {
+    const xml1 = submissionXmlToObj(testData.instances.doubleRepeat.double);
+    const xml2 = submissionXmlToObj(testData.instances.doubleRepeat.double.replace('Rarity', 'Scootaloo'));
+    const diff = compareObjects(xml1, xml2);
+    const expected = [
+      {
+        "new": "Rarity",
+        "old": "Scootaloo",
+        "path": ["children", ["child", 2], "toys", ["toy", 1], "name"]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+
+  it('should return diff of modified binary file with changed name', (done) => {
+    const xml1 = submissionXmlToObj(testData.instances.binaryType.one);
+    const xml2 = submissionXmlToObj(testData.instances.binaryType.one.replace('<file1>my_file1.mp4</file1>', '<file1>my_file_previous.mp4</file1>'));
+    const diff = compareObjects(xml1, xml2);
+    const expected = [
+      {
+        "new": "my_file1.mp4",
+        "old": "my_file_previous.mp4",
+        "path": ["file1"]
+      }
+    ];
+    diff.should.eql(expected);
+    done();
+  });
+});
+
+describe('diffs of array of submission versions', () => {
+
+  it('should compare multiple different versions of submission xml', () => {
+    const versions = [
+      { instanceId: 'three', xml: testData.instances.simple.one.replace('Alice', 'Anne').replace('30', '35') },
+      { instanceId: 'two', xml: testData.instances.simple.one.replace('Alice', 'Anne') },
+      { instanceId: 'one', xml: testData.instances.simple.one }
+    ];
+    return diffSubmissions(versions).then((diffs) => {
+      const expected = {
+        'three': [
+          {
+            "new": "35",
+            "old": "30",
+            "path": ["age"]
+          }
+        ],
+        'two': [
+          {
+            "new": "Anne",
+            "old": "Alice",
+            "path": ["name"]
+          }
+        ]
+      };
+      diffs.should.eql(expected);
+    });
+  });
+
+  it('should return empty array when only one version to compare', () => {
+    const versions = [
+      { xml: testData.instances.simple.one }
+    ];
+    return diffSubmissions(versions).then((diffs) => {
+      const expected = {};
+      diffs.should.eql(expected);
+    });
+  });
+
+  it('should return empty array when zero versions to compare', () => {
+    const versions = [];
+    return diffSubmissions(versions).then((diffs) => {
+      const expected = {};
+      diffs.should.eql(expected);
+    });
+  });
+});


### PR DESCRIPTION
I've added an API endpoint for fetching the diffs/deltas/edits between submission versions given the root/original Instance ID:

`/v1/projects/{projectId}/forms/{xmlFormId}/submissions/{rootInstanceId}/diffs`

It returns an object of arrays of edits. So a name + age form with two separate edits

a) name: "Gordin" -> "Gordon"
b) age: 22 -> 12

would look like:
```
{
  "uuid:8fd73636-1d02-4162-877a-97bed07436bb":[
    {
      "new":"Gordon",
      "old":"Gordin",
      "path":[
        "name"
      ]
    },
    {
      "new":"12",
      "old":"22",
      "path":[
        "age"
      ]
    },
    {
      "new":"uuid:8fd73636-1d02-4162-877a-97bed07436bb",
      "old":"uuid:89d2c893-e3c2-431f-a2d4-2ac1595c7ed2",
      "path":[
        "meta",
        "instanceID"
      ]
    },
    {
      "new":"uuid:89d2c893-e3c2-431f-a2d4-2ac1595c7ed2",
      "old":null,
      "path":[
        "meta",
        "deprecatedID"
      ]
    }
  ]
}
```

Edits that are within repeats have their paths annotated with `[node_name, repeat_index]`. This is an example of changing the "animal_type" property of the 4th animal:

    {
      "new": "otter (silver fur on head)",
      "old": "otter",
      "path": ["animal_group", ["animal_details", 3], "animal_type"]
    },

Under the hood, the steps are:
1) convert Submission XML to objects
2) recursively compare two objects based on their keys 

It's inspired by this library (https://github.com/jvdieten/diff-js-xml) but I recreated what it does using external libraries with libraries we already have, and I cleaned up the diffing code. E.g. `diff-js-xml` uses `sax` to convert from XML, but we already use `htmlparser2`, so I wrote an XML parser based on other XML parsing already in `central-backed`.  (I was having trouble with the supposedly built-in DOM parser in htmlparser2.)