### PR TITLE
Consider updatedAt for lastSubmission date in "extended" project forms list

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -750,7 +750,7 @@ The Projects listing endpoint is somewhat unique in that it is freely accessible
 
 Currently, there are no paging or filtering options, so listing `Project`s will get you every Project you have access to.
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `appUsers` count of App Users and `forms` count of Forms within the Project, as well as the `lastSubmission` timestamp of the latest submission to any for in the project, if any.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `appUsers` count of App Users and `forms` count of Forms within the Project, as well as the `lastSubmission` timestamp of the latest submission to any form in the project, if any. The response will also include the `lastSubmissionUpdate` timestamp, indicating when a submission to any form in the project was last modified.
 
 + Response 200 (application/json)
     This is the standard response, if Extended Metadata is not requested:
@@ -784,7 +784,7 @@ To create a Project, the only information you must supply (via POST body) is the
 
 To get just the details of a single Project, `GET` its single resource route by its numeric ID.
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `appUsers` count of App Users and `forms` count of forms within the Project, as well as the `lastSubmission` timestamp of the latest submission to any for in the project, if any.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `appUsers` count of App Users and `forms` count of forms within the Project, as well as the `lastSubmission` timestamp of the latest submission to any form in the project, if any. The response will also include the `lastSubmissionUpdate` timestamp, indicating when a submission to any form in the project was last modified.
 
 In addition, the extended metadata version of this endpoint (but not the overall Project listing) returns an array of the `verbs` the authenticated Actor is able to perform on/within the Project.
 
@@ -1070,7 +1070,7 @@ Currently, there are no paging or filtering options, so listing `Form`s will get
 
 As of version 1.2, Forms that are unpublished (that only carry a draft and have never been published) will appear with full metadata detail. Previously, certain details like `name` were omitted. You can determine that a Form is unpublished by checking the `publishedAt` value: it will be `null` for unpublished forms.
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that each Form has and the `lastSubmission` most recent submission timestamp, as well as the Actor the Form was `createdBy`.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that each Form has and the `lastSubmission` most recent submission timestamp, as well as the Actor the Form was `createdBy`. The response will also include the `lastSubmissionUpdate` timestamp, indicating when a submission was last modified.
 
 + Response 200 (application/json)
     This is the standard response, if Extended Metadata is not requested:
@@ -1162,7 +1162,7 @@ The API will currently check the XML's structure in order to extract the informa
 
 #### Getting Form Details [GET]
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that this Form has, as well as the `lastSubmission` most recent submission timestamp.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that this Form has, as well as the `lastSubmission` most recent submission timestamp. The response will also include the `lastSubmissionUpdate` timestamp, indicating when a submission was last modified.
 
 + Response 200 (application/json)
     This is the standard response, if Extended Metadata is not requested:
@@ -3934,6 +3934,7 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 ## Extended Form (Form)
 + submissions: `10` (number, required) - The number of `Submission`s that have been submitted to this `Form`.
 + lastSubmission: `2018-04-18T03:04:51.695Z` (string, optional) - ISO date format. The timestamp of the most recent submission, if any.
++ lastSubmissionUpdate: `2018-04-18T03:04:51.695Z` (string, optional) - ISO date format. Timestamp, indicating when a submission was last modified.
 + createdBy: (Actor, optional) - The full information of the Actor who created this Form.
 + excelContentType: (string, optional) - If the Form was created by uploading an Excel file, this field contains the MIME type of that file.
 
@@ -3976,6 +3977,7 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 + appUsers: `4` (number, required) - The number of App Users created within this Project.
 + forms: `7` (number, required) - The number of forms within this Project.
 + lastSubmission: `2018-04-18T03:04:51.695Z` (string, optional) - ISO date format. The timestamp of the most recent submission to any form in this project, if any.
++ lastSubmissionUpdate: `2018-04-18T03:04:51.695Z` (string, optional) - ISO date format. Timestamp, indicating when a submission to any form in the project was last modified.
 
 ## Public Link (Actor)
 + token: `d1!E2GVHgpr4h9bpxxtqUJ7EVJ1Q$Dusm2RBXg8XyVJMCBCbvyE8cGacxUx3bcUT` (string, optional) - If present, this is the Token to include as the `st` query parameter for this `Public Link`. If not present, this `Public Link` has been revoked.

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -114,11 +114,16 @@ const Project = Frame.define(
 );
 Project.Extended = class extends Frame.define(
   'forms',      readable,               'lastSubmission', readable,
-  'appUsers',   readable
+  'appUsers',   readable,               'lastSubmissionUpdate', readable,
 ) {
   // default these properties to 0, since sql gives null if they're 0.
   forApi() {
-    return { forms: this.forms || 0, appUsers: this.appUsers || 0, lastSubmission: this.lastSubmission };
+    return {
+      forms: this.forms || 0,
+      appUsers: this.appUsers || 0,
+      lastSubmission: this.lastSubmission,
+      lastSubmissionUpdate: this.lastSubmissionUpdate
+    };
   }
 };
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -134,13 +134,14 @@ Form.Partial = class extends Form {};
 // EXTENDED FORM
 
 Form.Extended = class extends Frame.define(
-  'submissions',        readable,       'lastSubmission', readable,
-  'excelContentType',   readable
+  'submissions',        readable,       'lastSubmission',           readable,
+  'excelContentType',   readable,       'lastSubmissionUpdate',     readable
 ) {
   forApi() {
     return {
       submissions: this.submissions || 0,
       lastSubmission: this.lastSubmission,
+      lastSubmissionUpdate: this.lastSubmissionUpdate,
       excelContentType: this.excelContentType
     };
   }

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -279,7 +279,8 @@ select ${fields} from forms
 left outer join form_defs on ${versionJoinCondition(version)}
 ${extend|| sql`
   left outer join
-    (select "formId", count(id)::integer as "submissions", max("createdAt") as "lastSubmission" from submissions
+    (select "formId", count(id)::integer as "submissions", max("createdAt") as "lastSubmission",
+        max("updatedAt") as "lastSubmissionUpdate" from submissions
       where draft=${version === Form.DraftVersion} and "deletedAt" is null
       group by "formId") as submission_stats
     on forms.id=submission_stats."formId"

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -75,9 +75,11 @@ const _get = extender(Project)(Project.Extended)((fields, extend, options, actor
 select ${fields} from projects
 ${extend|| sql`
   left outer join
-    (select "projectId", count(forms.id)::integer as forms, max("lastSubByForm") as "lastSubmission" from forms
+    (select "projectId", count(forms.id)::integer as forms, max("lastSubByForm") as "lastSubmission",
+      max("lastSubUpdateByForm") as "lastSubmissionUpdate" from forms
       left outer join
-        (select "formId", max("createdAt") as "lastSubByForm" from submissions
+        (select "formId", max("createdAt") as "lastSubByForm",
+            max("updatedAt") as "lastSubUpdateByForm" from submissions
           where "deletedAt" is null and draft=false
           group by "formId") as submission_stats
         on forms.id=submission_stats."formId"

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -174,9 +174,10 @@ should.Assertion.add('ExtendedForm', function() {
   this.params = { operator: 'to be a ExtendedForm' };
 
   this.obj.should.be.a.Form();
-  Object.keys(this.obj).should.containDeep([ 'submissions', 'lastSubmission' ]);
+  Object.keys(this.obj).should.containDeep([ 'submissions', 'lastSubmission', 'lastSubmissionUpdate' ]);
   if (this.obj.submissions != null) this.obj.submissions.should.be.a.Number();
   if (this.obj.lastSubmission != null) this.obj.lastSubmission.should.be.an.isoDate();
+  if (this.obj.lastSubmissionUpdate != null) this.obj.lastSubmissionUpdate.should.be.an.isoDate();
 });
 
 should.Assertion.add('Project', function() {
@@ -193,10 +194,11 @@ should.Assertion.add('ExtendedProject', function() {
   this.params = { operator: 'to be a Project' };
 
   this.obj.should.be.a.Project();
-  Object.keys(this.obj).should.containDeep([ 'forms', 'appUsers', 'lastSubmission' ]);
+  Object.keys(this.obj).should.containDeep([ 'forms', 'appUsers', 'lastSubmission', 'lastSubmissionUpdate' ]);
   this.obj.forms.should.be.a.Number();
   this.obj.appUsers.should.be.a.Number();
   if (this.obj.lastSubmission != null) this.obj.lastSubmission.should.be.an.isoDate();
+  if (this.obj.lastSubmissionUpdate != null) this.obj.lastSubmissionUpdate.should.be.an.isoDate();
 });
 
 should.Assertion.add('Role', function() {

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -46,6 +46,7 @@ describe('api: /projects/:id/forms', () => {
               const simple = body.find((form) => form.xmlFormId === 'simple');
               simple.submissions.should.equal(1);
               simple.lastSubmission.should.be.a.recentIsoDate();
+              should(simple.lastSubmissionUpdate).equal(null);
             })))));
   });
 
@@ -882,6 +883,7 @@ describe('api: /projects/:id/forms', () => {
                 body.should.be.an.ExtendedForm();
                 body.xmlFormId.should.equal('simple2');
                 (body.lastSubmission == null).should.equal(true);
+                (body.lastSubmissionUpdate == null).should.equal(true);
                 body.submissions.should.equal(0);
                 body.createdBy.should.be.an.Actor();
                 body.createdBy.displayName.should.equal('Alice');
@@ -2016,6 +2018,7 @@ describe('api: /projects/:id/forms', () => {
                 body.should.be.an.ExtendedForm();
                 body.submissions.should.equal(1);
                 body.lastSubmission.should.be.a.recentIsoDate();
+                (body.lastSubmissionUpdate == null).should.equal(true);
               })))));
 
     it('should return the correct enketoId with extended draft', testService((service, container) =>

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -120,11 +120,13 @@ describe('api: /projects', () => {
             body[0].forms.should.equal(0);
             body[0].appUsers.should.equal(0);
             should.not.exist(body[0].lastSubmission);
+            should.not.exist(body[0].lastSubmissionUpdate);
 
             body[1].name.should.equal('Default Project');
             body[1].forms.should.equal(2);
             body[1].appUsers.should.equal(2);
             body[1].lastSubmission.should.be.a.recentIsoDate();
+            should.not.exist(body[1].lastSubmissionUpdate);
           })))));
 
     it('should return extended metadata if requested', testService((service) =>
@@ -251,6 +253,7 @@ describe('api: /projects', () => {
             body.should.be.an.ExtendedProject();
             body.forms.should.equal(2);
             should.not.exist(body.lastSubmission);
+            should.not.exist(body.lastSubmissionUpdate);
           })
           .then(() => Promise.all([
             asAlice.post('/v1/projects/1/forms/simple/submissions')
@@ -269,6 +272,7 @@ describe('api: /projects', () => {
               body.should.be.an.ExtendedProject();
               body.forms.should.equal(2);
               body.lastSubmission.should.be.a.recentIsoDate();
+              should.not.exist(body.lastSubmissionUpdate);
             })))));
 
     it('should not count deleted app users', testService((service) =>


### PR DESCRIPTION
Hello,

It will be great if the `lastSubmission` timestamp in the response from `projects/:projectId/forms` also indicate if a submission was recently edited.

I am using this endpoint to figure which forms have new submissions and hence import them in another application. Now, with submission editing in place (:champagne:), I can't find an efficient method to catch the "edits".

Thank you!