### PR TITLE
bug: fix reference to query module in reapSessions task.

### DIFF
--- a/lib/task/reap-sessions.js
+++ b/lib/task/reap-sessions.js
@@ -11,6 +11,6 @@
 // overladen and bogged down over time.
 
 const { task } = require('./task');
-const reapSessions = task.withContainer(({ Session }) => Session.reap);
+const reapSessions = task.withContainer(({ Sessions }) => Sessions.reap);
 module.exports = { reapSessions };
 

--- a/test/integration/task/reap-sessions.js
+++ b/test/integration/task/reap-sessions.js
@@ -2,15 +2,15 @@ const appRoot = require('app-root-path');
 const should = require('should');
 const { sql } = require('slonik');
 const { testTask } = require('../setup');
-const { reapSessions } = require(appRoot + '/lib/task/account');
-const { Actor, Session } = require(appRoot + '/lib/model/frames');
+const { reapSessions } = require(appRoot + '/lib/task/reap-sessions');
+const { Actor } = require(appRoot + '/lib/model/frames');
 
 describe('task: reap-sessions', () => {
   it('should remove expired sessions', testTask(({ oneFirst, Actors, Sessions }) =>
     Actors.create(new Actor({ displayName: 'actor', type: 'actor' }))
       .then((actor) => Promise.all([ 2000, 2001, 2002, 2003, 3000, 3001, 3002, 3003 ]
         .map((year) => Sessions.create(actor, new Date(`${year}-01-01`)))))
-      .then(() => Sessions.reap())
+      .then(() => reapSessions())
       .then(() => oneFirst(sql`select count(*) from sessions`))
       .then((count) => { count.should.equal(4); })));
 });


### PR DESCRIPTION
Making a small change to the `reapSessions` task. (I ran the `reapSessions` task as part of debugging something unrelated and noticed that the task threw an error.)