### PR TITLE
Fixing a bug that resulted in Collect not being able to download forms from Central instances using custom ports

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -19,8 +19,9 @@
     },
     "enketo": {},
     "env": {
-      "domain": "http://localhost:8989",
-      "sysadminAccount": "no-reply@getodk.org"
+      "domain": "http://localhost",
+      "sysadminAccount": "no-reply@getodk.org",
+      "port": "8989"
     },
     "external": {
       "google": {

--- a/lib/formats/openrosa.js
+++ b/lib/formats/openrosa.js
@@ -46,7 +46,7 @@ const formListTemplate = template(200, `<?xml version="1.0" encoding="UTF-8"?>
       <name>{{def.name}}{{^def.name}}{{xmlFormId}}{{/def.name}}</name>
       <version>{{def.version}}</version>
       <hash>md5:{{def.hash}}</hash>
-      <downloadUrl>{{{domain}}}{{{basePath}}}/forms/{{urlSafeXmlFormId}}{{#draft}}/draft{{/draft}}.xml</downloadUrl>
+      <downloadUrl>{{{domain}}}:{{{port}}}{{{basePath}}}/forms/{{urlSafeXmlFormId}}{{#draft}}/draft{{/draft}}.xml</downloadUrl>
       {{#aux.openRosa.hasAttachments}}
       <manifestUrl>{{{domain}}}{{{basePath}}}/forms/{{urlSafeXmlFormId}}{{#draft}}/draft{{/draft}}/manifest</manifestUrl>
       {{/aux.openRosa.hasAttachments}}
@@ -65,7 +65,7 @@ const formManifestTemplate = template(200, `<?xml version="1.0" encoding="UTF-8"
     <mediaFile>
       <filename>{{name}}</filename>
       <hash>md5:{{aux.openRosa.md5}}</hash>
-      <downloadUrl>{{{domain}}}{{{basePath}}}/attachments/{{urlName}}</downloadUrl>
+      <downloadUrl>{{{domain}}}:{{{port}}}{{{basePath}}}/attachments/{{urlName}}</downloadUrl>
     </mediaFile>
     {{/blobId}}
   {{/attachments}}

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -47,7 +47,7 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then(rejectIf((() => auth.actor.isEmpty()), noargs(Problem.user.openRosaAuthenticationRequired)))
       .then((project) => Forms.getByAuthForOpenRosa(project.id, auth, queryOptions.allowArgs('formID')))
-      .then((forms) => formList({ forms, basePath: path.resolve(originalUrl, '..'), domain: env.domain }))));
+      .then((forms) => formList({ forms, basePath: path.resolve(originalUrl, '..'), domain: env.domain, port: env.port }))));
 
   ////////////////////////////////////////////////////////////////////////////////
   // FORM CREATION, DRAFT CREATION / PUBLISH / DELETE
@@ -193,7 +193,7 @@ module.exports = (service, endpoint) => {
         .then((form) => auth.canOrReject('form.read', form))
         .then((form) => FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id)
           .then((attachments) =>
-            formManifest({ attachments, basePath: path.resolve(originalUrl, '..'), domain: env.domain })))));
+            formManifest({ attachments, basePath: path.resolve(originalUrl, '..'), domain: env.domain, port: env.port })))));
 
     ////////////////////////////////////////
     // READ-ONLY ATTACHMENT ENDPOINTS
@@ -318,7 +318,7 @@ module.exports = (service, endpoint) => {
         .then((hasAttachments) =>
           // TODO: trying to use the existing template generator here is really awkward.
           formList({
-            draft: true, forms: [ form.withAux('openRosa', { hasAttachments }) ], basePath: path.resolve(originalUrl, '../../../..'), domain: env.domain
+		  draft: true, forms: [ form.withAux('openRosa', { hasAttachments }) ], basePath: path.resolve(originalUrl, '../../../..'), domain: env.domain, port: env.port
           })))));
 
   service.get('/test/:key/projects/:projectId/forms/:id/draft/manifest', endpoint.openRosa(({ FormAttachments, Forms, env }, { params, originalUrl }) =>
@@ -328,7 +328,7 @@ module.exports = (service, endpoint) => {
       .then(checkFormToken(params.key))
       .then((form) => FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id)
         .then((attachments) =>
-          formManifest({ attachments, basePath: path.resolve(originalUrl, '..'), domain: env.domain })))));
+          formManifest({ attachments, basePath: path.resolve(originalUrl, '..'), domain: env.domain, port: env.port })))));
 
   service.get('/test/:key/projects/:projectId/forms/:id/draft.xml', endpoint(({ Forms }, { params }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.DraftVersion)


### PR DESCRIPTION
Hi!

My first time contributing here, so my apologies if I've failed to follow appropriate procedures. Long story short, it turns out that when you install Central using non-standard ports, the server appears to work normally until you try to download forms to Collect. Collect is able to list the forms on the server, but errors out when trying to download them. A user on the forums did some detective work and noticed that when the formList endpoint is queried, Central currently returns a downloadUrl that omits the custom port number defined in the overall central .env file, resulting in Collect defaulting to attempting to download the forms on port 443 and failing.

In this PR I edited forms.js and openrosa.js to specify the custom port, resulting in a correct downloadUrl being returned. I'm reading the port a 'port' entry in the config. I am happy to go into the main central repo and make changes to config.json.template, start-odk.sh, and the docker-compose file so that the HTTPS_PORT variable from the .env file is added into local.json as 'port' during install, but I wanted to make sure that this solution was acceptable in general before I went and did that as well.

Thanks!