### PR TITLE
Fix to failing test

### DIFF
--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -272,7 +272,7 @@ const getSearchAppearance = (e, _, { appearance }) => {
   // l/rtrim allow spaces between " and , at the field delimit.
   let basename;
   try {
-    [ basename ] = parse(quote + argStr, { quote, ltrim: true, rtrim: true });
+    [[ basename ]] = parse(quote + argStr, { quote, ltrim: true, rtrim: true });
   } catch (ex) {
     throw Problem.user.unexpectedValue({ field: 'search() appearance', value: appearance, reason: 'broken syntax, maybe unmatched quotes?' });
   }


### PR DESCRIPTION
This test was failing because `basename` seemed to be an array instead of a string, e.g. `[ 'fileone' ]`

```
1) form schema
       expectedFormAttachments
         should detect primitive search() appearances:
     TypeError: basename.endsWith is not a function
      at getSearchAppearance (lib/data/schema.js:284:27
```

