### PR TITLE
improve: exclude analytics audit log entries from nonverbose query.

### DIFF
--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -33,7 +33,7 @@ values (${actorId}, ${action}, ${acteeId}, ${(details == null) ? null : JSON.str
 // TODO: some sort of central table for all these things, not here.
 const actionCondition = (action) => {
   if (action === 'nonverbose')
-    return sql`action not in ('submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup')`;
+    return sql`action not in ('submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup', 'analytics')`;
   else if (action === 'user')
     return sql`action in ('user.create', 'user.update', 'user.delete', 'user.assignment.create', 'user.assignment.delete', 'user.session.create')`;
   else if (action === 'field_key')


### PR DESCRIPTION
Making this change so that `analytics` audit log entries are no longer shown in the Frontend audit log. (These audit log entries will be shown on the "Usage Reporting" page instead.)