### PR TITLE
Strip xml prefix (e.g. orx:) from field names in diffs

### DIFF
--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -13,7 +13,9 @@ const hparser = require('htmlparser2');
 const fmdiff = require('fast-myers-diff');
 const { SchemaStack } = require('./schema');
 const { noop } = require('../util/util');
+const { stripNamespacesFromPath } = require('../util/xml');
 const { union, last, pluck } = require('ramda');
+
 
 
 // reads submission xml with the streaming parser, and outputs a stream of every
@@ -210,14 +212,14 @@ const _diffObj = (a, b, subpath) => {
   for (const key of union(a[keys], b[keys])) {
     const av = a[key];
     if (!Object.prototype.hasOwnProperty.call(a, key)) { // null -> b
-      results.push({ new: b[key], path: subpath.concat([ key ]) });
+      results.push({ new: b[key], path: subpath.concat([ stripNamespacesFromPath(key) ]) });
     } else if (!Object.prototype.hasOwnProperty.call(b, key)) { // a -> null
-      results.push({ old: av, path: subpath.concat([ key ]) });
+      results.push({ old: av, path: subpath.concat([ stripNamespacesFromPath(key) ]) });
     } else if (av[subhash] == null) { // primitive
       if (av !== b[key]) // a -> b
-        results.push({ old: av, new: b[key], path: subpath.concat([ key ]) });
+        results.push({ old: av, new: b[key], path: subpath.concat([ stripNamespacesFromPath(key) ]) });
     } else if (av[subhash] !== b[key][subhash]) { // structural a -> b
-      results.push(..._recurseDiff(av, b[key], subpath, key));
+      results.push(..._recurseDiff(av, b[key], subpath, stripNamespacesFromPath(key)));
     }
   }
   return results;

--- a/test/unit/data/submission.js
+++ b/test/unit/data/submission.js
@@ -406,7 +406,7 @@ describe('diffing', () => {
           { instanceId: 'three', xml: testData.instances.withrepeat.three }
         ]);
         const expected = [
-          { old: 'rthree', new: 'rtwo', path: [ 'orx:meta', 'orx:instanceID' ] },
+          { old: 'rthree', new: 'rtwo', path: [ 'meta', 'instanceID' ] },
           { old: 'Chelsea', new: 'Bob', path: [ 'name' ] },
           { old: '38', new: '34', path: [ 'age' ] },
           { old: 'Candace', new: 'Billy', path: [ 'children', [ 'child', 0 ], 'name' ] },
@@ -587,6 +587,19 @@ describe('diffing', () => {
         });
       });
     });
+
+    it('should strip XML prefix from field names', () =>
+      structuralFieldsFor(testData.forms.withrepeat).then((fields) => {
+        const newer = '<data id="withrepeat" version="1.0"><orx:meta><orx:instanceID>john</orx:instanceID></orx:meta><name>Bob</name><age>34</age><children><child><name>Billy</name><age>4</age></child><child><name>Blaine</name><age>6</age></child></children></data>';
+        const older = '<data id="withrepeat" version="1.0"><orx:meta><orx:instanceID>jon</orx:instanceID></orx:meta><name>Bob</name><age>34</age><children><child><name>Billy</name><age>4</age></child><child><name>Blaine</name><age>6</age></child></children></data>';
+
+        diffSubmissions(fields, [
+          { instanceId: 'john', xml: newer },
+          { instanceId: 'jon', xml: older }
+        ]).should.eql({
+          'john': [{ old: 'jon', new: 'john', path: [ 'meta', 'instanceID'] }]
+        });
+      }));
   });
 });
 


### PR DESCRIPTION
This addresses issue #410 