### PR TITLE
improve: increase stack trace limit.

### DIFF
--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -32,8 +32,11 @@ const mail = mailer(merge(config.get('default.email'), { env }));
 const googler = require('../external/google');
 const google = googler(config.get('default.external.google'));
 
-// get a sentry and xlsform client, and a password module.
+// get a sentry and configure errors.
 const Sentry = require('../external/sentry').init(config.get('default.external.sentry'));
+Error.stackTrackLimit = 20;
+
+// get an xlsform client and a password module.
 const xlsform = require('../external/xlsform').init(config.get('default.xlsform'));
 const bcrypt = require('../util/crypto').password(require('bcrypt'));
 


### PR DESCRIPTION
Making this change because we've encountered errors in Sentry whose stack trace ends before it indicates what line in Central triggered the error. Example: https://sentry.io/organizations/getodk/issues/2703129106/?project=5724763