### PR TITLE
bug: return to supporting quote inside unquoted field of client audit.

### DIFF
--- a/lib/data/client-audits.js
+++ b/lib/data/client-audits.js
@@ -16,7 +16,7 @@ const { zipPart } = require('../util/zip');
 const headers = [ 'event', 'node', 'start', 'end', 'latitude', 'longitude', 'accuracy', 'old-value', 'new-value' ];
 
 // used by parseClientAudits below.
-const parseOptions = { bom: true, trim: true, skip_empty_lines: true, relax_column_count: true };
+const parseOptions = { bom: true, trim: true, skip_empty_lines: true, relax_column_count: true, relax: true };
 const headerLookup = {};
 for (const header of headers) headerLookup[header] = true;
 


### PR DESCRIPTION
We used to support that case, but it was unintentionally removed in 62df8a770b05a87e8d20e686d86d28db540f0d68.