### PR TITLE
noop: add edit to Enketo mock.

### DIFF
--- a/lib/external/enketo.js
+++ b/lib/external/enketo.js
@@ -23,7 +23,8 @@ const Problem = require('../util/problem');
 
 const mock = {
   create: () => Promise.reject(Problem.internal.enketoNotConfigured()),
-  createOnceToken: () => Promise.reject(Problem.internal.enketoNotConfigured())
+  createOnceToken: () => Promise.reject(Problem.internal.enketoNotConfigured()),
+  edit: () => Promise.reject(Problem.internal.enketoNotConfigured())
 };
 
 const enketo = (hostname, pathname, port, protocol, apiKey) => {


### PR DESCRIPTION
Without this, an error message is shown:

```
TypeError: enketo.edit is not a function
```