### PR TITLE
Fix node warning when running `cli.js` caused by dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1419,9 +1419,9 @@
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
     "colors": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
-      "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1648,11 +1648,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
-    "deep-equal": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3461,11 +3456,6 @@
         }
       }
     },
-    "i": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -4887,9 +4877,9 @@
       "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanoid": {
       "version": "3.1.23",
@@ -4920,11 +4910,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "ncp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
-      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
     },
     "negotiator": {
       "version": "0.6.1",
@@ -5728,11 +5713,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "pkginfo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -5788,16 +5768,22 @@
       "dev": true
     },
     "prompt": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
-      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.2.0.tgz",
+      "integrity": "sha512-iGerYRpRUg5ZyC+FJ/25G5PUKuWAGRjW1uOlhX7Pi3O5YygdK6R+KEaBjRbHSkU5vfS5PZCltSPZdDtUYwRCZA==",
       "requires": {
+        "async": "~0.9.0",
         "colors": "^1.1.2",
-        "pkginfo": "0.x.x",
         "read": "1.0.x",
         "revalidator": "0.1.x",
-        "utile": "0.3.x",
-        "winston": "2.1.x"
+        "winston": "2.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
       }
     },
     "propagate": {
@@ -6035,14 +6021,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
       "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "requires": {
-        "glob": "^7.0.5"
-      }
     },
     "roarr": {
       "version": "4.0.11",
@@ -7285,26 +7263,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "utile": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
-      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
-      "requires": {
-        "async": "~0.9.0",
-        "deep-equal": "~0.2.1",
-        "i": "0.3.x",
-        "mkdirp": "0.x.x",
-        "ncp": "1.0.x",
-        "rimraf": "2.x.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        }
-      }
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -7425,16 +7383,15 @@
       }
     },
     "winston": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
-      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+      "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",
         "cycle": "1.0.x",
         "eyes": "0.1.x",
         "isstream": "0.1.x",
-        "pkginfo": "0.3.x",
         "stack-trace": "0.0.x"
       },
       "dependencies": {
@@ -7447,11 +7404,6 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        },
-        "pkginfo": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "odata-v4-parser": "~0.1",
     "pg": "~8",
     "pg-query-stream": "~4",
-    "prompt": "~1",
+    "prompt": "^1.2.0",
     "ramda": "~0",
     "sanitize-filename": "~1",
     "slonik": "~23",


### PR DESCRIPTION
The previously used version of the `prompt` dependency apparently had
a problem with a circular import, resulting in an error message such as

> Warning: Accessing non-existent property 'padLevels' of module
> exports inside circular dependency

when running the `cli.js` script. While it's unclear whether this
caused any functional issues, it's fixed in v1.2 of `prompt`.

Fixes #419

---

PS: It'd be really nice if you could add the `Hacktoberfest` topic to this repository ([more info](https://hacktoberfest.digitalocean.com/resources/maintainers)), since then my pull-requests here will be counted towards my goal :)