### PR TITLE
improve: add support for some parentheses in OData filter.

### DIFF
--- a/lib/data/odata-filter.js
+++ b/lib/data/odata-filter.js
@@ -68,6 +68,11 @@ const op = (node) => {
     return binaryOp(node.value.left, node.value.right, 'or');
   } else if (node.type === 'NotExpression') {
     return sql`(not ${op(node.value)})`;
+  } else if (node.type === 'BoolParenExpression') {
+    // Because we add parentheses elsewhere, we don't need to add another set of
+    // parentheses here. The main effect of a BoolParenExpression is the way it
+    // restructures the AST.
+    return op(node.value);
   } else {
     throw Problem.internal.unsupportedODataExpression({ at: node.position, type: node.type, text: node.raw });
   }

--- a/test/unit/data/odata-filter.js
+++ b/test/unit/data/odata-filter.js
@@ -28,6 +28,11 @@ describe('OData filter query transformer', () => {
     odataFilter('1 eq null').should.eql(sql`(${'1'} is not distinct from ${null})`);
   });
 
+  it('should allow parentheses around a boolean expression', () => {
+    const result = odataFilter('(1 lt 2 or 3 lt 4) and 5 lt 6');
+    result.should.eql(sql`(((${'1'} < ${'2'}) or (${'3'} < ${'4'})) and (${'5'} < ${'6'}))`);
+  });
+
   it('should transform date extraction method calls', () => {
     odataFilter('2020 eq year(2020-01-01)').should.eql(sql`(${'2020'} is not distinct from extract(year from ${'2020-01-01'}))`);
     odataFilter('2020 eq year(__system/submissionDate)').should.eql(sql`(${'2020'} is not distinct from extract(year from ${sql.identifier([ 'submissions', 'createdAt' ])}))`);


### PR DESCRIPTION
This is useful for grouping with `and` and `or`. That's needed for an upcoming PR to Frontend that will combine a series of expressions using `or`.

There seems to be another type of parentheses in the syntax: `ParenExpression`. I think that's used to add parentheses around an expression that's not a boolean expression. However, I don't think we allow such expressions right now. We should probably add support for `ParenExpression` if/when we add support for `add`, `mul`, etc.