### PR TITLE
Delete API that fetches list of trashed forms and lets trashed forms be restored

### DIFF
--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -55,6 +55,7 @@ class Form extends Frame.define(
   'draftDefId',                         'enketoId',     readable,
   'enketoOnceId', readable,             'acteeId',
   'createdAt',    readable,             'updatedAt',    readable,
+  'deletedAt',
   embedded('createdBy'), embedded('publishedBy')
 ) {
   get def() { return this.aux.def; }
@@ -83,7 +84,10 @@ class Form extends Frame.define(
     const enketoOnceId = (this.def.id === this.currentDefId) ? this.enketoOnceId : null;
     /* eslint-enable indent */
 
-    return Object.assign(Frame.prototype.forApi.call(this), { enketoId, enketoOnceId });
+    // Include deletedAt in response only if it is not null (most likely on resources about soft-deleted forms)
+    const deletedAtField = this.deletedAt ? { deletedAt: this.deletedAt } : null;
+
+    return Object.assign(Frame.prototype.forApi.call(this), { enketoId, enketoOnceId }, deletedAtField);
   }
 
   // Given an XML string, returns Promise[Object]. If the Promise rejects, the XML

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -49,7 +49,7 @@ const AllVersions = Symbol('all versions');
 
 class Form extends Frame.define(
   table('forms'),
-  'id',           readable,             'projectId',    readable,
+  'id',                                 'projectId',    readable,
   'xmlFormId',    readable,             'state',        readable, writable,
   'currentDefId',
   'draftDefId',                         'enketoId',     readable,
@@ -85,9 +85,10 @@ class Form extends Frame.define(
     /* eslint-enable indent */
 
     // Include deletedAt in response only if it is not null (most likely on resources about soft-deleted forms)
-    const deletedAtField = this.deletedAt ? { deletedAt: this.deletedAt } : null;
+    // and also include the numeric form id (used to restore)
+    const deletedAtIdFields = this.deletedAt ? { deletedAt: this.deletedAt, id: this.id } : null;
 
-    return Object.assign(Frame.prototype.forApi.call(this), { enketoId, enketoOnceId }, deletedAtField);
+    return Object.assign(Frame.prototype.forApi.call(this), { enketoId, enketoOnceId }, deletedAtIdFields);
   }
 
   // Given an XML string, returns Promise[Object]. If the Promise rejects, the XML

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -49,7 +49,7 @@ const AllVersions = Symbol('all versions');
 
 class Form extends Frame.define(
   table('forms'),
-  'id',                                 'projectId',    readable,
+  'id',           readable,             'projectId',    readable,
   'xmlFormId',    readable,             'state',        readable, writable,
   'currentDefId',
   'draftDefId',                         'enketoId',     readable,

--- a/lib/model/migrations/20211117-01-add-form-restore-verb.js
+++ b/lib/model/migrations/20211117-01-add-form-restore-verb.js
@@ -1,0 +1,31 @@
+// Copyright 2020 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { without } = require('ramda');
+
+const up = async (db) => {
+  // grant rights.
+  for (const system of [ 'admin', 'manager' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = verbs.concat([ 'form.restore' ]);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+};
+
+const down = async (db) => {
+  // grant rights.
+  for (const system of [ 'admin', 'manager' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = without([ 'form.restore' ], verbs);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+};
+
+module.exports = { up, down };
+

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -43,7 +43,7 @@ const actionCondition = (action) => {
   else if (action === 'project')
     return sql`action in ('project.create', 'project.update', 'project.delete')`;
   else if (action === 'form')
-    return sql`action in ('form.create', 'form.update', 'form.delete', 'form.attachment.update', 'form.submission.export', 'form.update.draft.set', 'form.update.draft.delete', 'form.update.publish')`;
+    return sql`action in ('form.create', 'form.update', 'form.delete', 'form.restore', 'form.attachment.update', 'form.submission.export', 'form.update.draft.set', 'form.update.draft.delete', 'form.update.publish')`;
   else if (action === 'submission')
     return sql`action in ('submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update')`;
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -316,7 +316,8 @@ const getByProjectId = (projectId, xml, version, options = QueryOptions.none, de
   _get(all, options.withCondition({ projectId }), xml, version, deleted);
 const getByProjectAndXmlFormId = (projectId, xmlFormId, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ projectId, xmlFormId }), xml, version, deleted);
-
+const getByProjectAndNumericId = (projectId, id, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>
+  _get(maybeOne, options.withCondition({ projectId, 'forms.id': id }), xml, version, deleted);
 
 ////////////////////////////////////////////////////////////////////////////////
 // SCHEMA
@@ -387,7 +388,8 @@ module.exports = {
   _update, update, _updateDef, del, restore,
   setManagedKey,
   getByAuthForOpenRosa,
-  getVersions, getByActeeIdForUpdate, getByActeeId, getByProjectId, getByProjectAndXmlFormId,
+  getVersions, getByActeeIdForUpdate, getByActeeId,
+  getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
   lockDefs, getAllSubmitters
 };

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -278,9 +278,11 @@ join form_defs on ${versionJoinCondition(version)}
 where "acteeId"=${acteeId} and "deletedAt" is null`)
   .then(map(_unjoiner));
 
+// most of the time we want to exclude soft-deleted forms but sometimes we *just* want the soft-deleted forms
+const filterDeleted = (deleted) => (deleted ? sql`forms."deletedAt" is not null` : sql`forms."deletedAt" is null`);
 
 // there are many combinations of required fields here so we compose our own extender variant.
-const _getSql = ((fields, extend, options, version) => sql`
+const _getSql = ((fields, extend, options, version, deleted = false) => sql`
 select ${fields} from forms
 left outer join form_defs on ${versionJoinCondition(version)}
 ${extend|| sql`
@@ -294,16 +296,16 @@ ${extend|| sql`
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
     on form_defs."xlsBlobId"=xls.id`}
-where ${equals(options.condition)} and forms."deletedAt" is null
+where ${equals(options.condition)} and ${filterDeleted(deleted)}
 order by coalesce(form_defs.name, "xmlFormId") asc`);
 
 const _getWithoutXml = extender(Form, Form.Def)(Form.Extended, Actor.into('createdBy'))(_getSql);
 const _getWithXml = extender(Form, Form.Def, Form.Xml)(Form.Extended, Actor.into('createdBy'))(_getSql);
-const _get = (exec, options, xml, version) =>
-  ((xml === true) ? _getWithXml : _getWithoutXml)(exec, options, version);
+const _get = (exec, options, xml, version, deleted) =>
+  ((xml === true) ? _getWithXml : _getWithoutXml)(exec, options, version, deleted);
 
-const getByProjectId = (projectId, xml, version, options = QueryOptions.none) => ({ all }) =>
-  _get(all, options.withCondition({ projectId }), xml, version);
+const getByProjectId = (projectId, xml, version, options = QueryOptions.none, deleted = false) => ({ all }) =>
+  _get(all, options.withCondition({ projectId }), xml, version, deleted);
 const getByProjectAndXmlFormId = (projectId, xmlFormId, xml, version, options = QueryOptions.none) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ projectId, xmlFormId }), xml, version);
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -286,9 +286,6 @@ join form_defs on ${versionJoinCondition(version)}
 where "acteeId"=${acteeId} and "deletedAt" is null`)
   .then(map(_unjoiner));
 
-// most of the time we want to exclude soft-deleted forms but sometimes we *just* want the soft-deleted forms
-const filterDeleted = (deleted) => (deleted ? sql`forms."deletedAt" is not null` : sql`forms."deletedAt" is null`);
-
 // there are many combinations of required fields here so we compose our own extender variant.
 const _getSql = ((fields, extend, options, version, deleted = false) => sql`
 select ${fields} from forms
@@ -304,7 +301,7 @@ ${extend|| sql`
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
     on form_defs."xlsBlobId"=xls.id`}
-where ${equals(options.condition)} and ${filterDeleted(deleted)}
+where ${equals(options.condition)} and forms."deletedAt" is ${deleted ? sql`not` : sql``} null
 order by coalesce(form_defs.name, "xmlFormId") asc`);
 
 const _getWithoutXml = extender(Form, Form.Def)(Form.Extended, Actor.into('createdBy'))(_getSql);

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -13,7 +13,7 @@ const { Frame, into } = require('../frame');
 const { Actor, Blob, Form } = require('../frames');
 const { getFormFields, merge } = require('../../data/schema');
 const { generateToken } = require('../../util/crypto');
-const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, QueryOptions } = require('../../util/db');
+const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, ignoringResult } = require('../../util/promise');
 const { splitStream } = require('../../util/stream');
 const { construct } = require('../../util/util');
@@ -172,6 +172,14 @@ const del = (form) => ({ run, Assignments }) =>
   Promise.all([ run(markDeleted(form)), Assignments.revokeByActeeId(form.acteeId) ]);
 del.audit = (form) => (log) => log('form.delete', form);
 
+const restore = (form) => ({ run, Forms }) =>
+  Forms.getByProjectAndXmlFormId(form.projectId, form.xmlFormId)
+    .then((activeForm) => (activeForm.isDefined()
+      ? reject(Problem.user.uniquenessViolation({ fields: 'xmlFormId', values: form.xmlFormId }))
+      : run(markUndeleted(form))));
+restore.audit = (form) => (log) => log('form.restore', form);
+
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // ENCRYPTION
@@ -306,8 +314,8 @@ const _get = (exec, options, xml, version, deleted) =>
 
 const getByProjectId = (projectId, xml, version, options = QueryOptions.none, deleted = false) => ({ all }) =>
   _get(all, options.withCondition({ projectId }), xml, version, deleted);
-const getByProjectAndXmlFormId = (projectId, xmlFormId, xml, version, options = QueryOptions.none) => ({ maybeOne }) =>
-  _get(maybeOne, options.withCondition({ projectId, xmlFormId }), xml, version);
+const getByProjectAndXmlFormId = (projectId, xmlFormId, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>
+  _get(maybeOne, options.withCondition({ projectId, xmlFormId }), xml, version, deleted);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -376,7 +384,7 @@ order by actors."displayName" asc`)
 module.exports = {
   fromXls, _createNew, createNew, createVersion,
   publish, clearDraft,
-  _update, update, _updateDef, del,
+  _update, update, _updateDef, del, restore,
   setManagedKey,
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId, getByProjectId, getByProjectAndXmlFormId,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -173,10 +173,7 @@ const del = (form) => ({ run, Assignments }) =>
 del.audit = (form) => (log) => log('form.delete', form);
 
 const restore = (form) => ({ run, Forms }) =>
-  Forms.getByProjectAndXmlFormId(form.projectId, form.xmlFormId)
-    .then((activeForm) => (activeForm.isDefined()
-      ? reject(Problem.user.uniquenessViolation({ fields: 'xmlFormId', values: form.xmlFormId }))
-      : run(markUndeleted(form))));
+  run(markUndeleted(form));
 restore.audit = (form) => (log) => log('form.restore', form);
 
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -40,6 +40,12 @@ module.exports = (service, endpoint) => {
       .then((project) => auth.canOrReject('form.list', project))
       .then((project) => Forms.getByProjectId(project.id, false, undefined, queryOptions))));
 
+  service.get('/projects/:projectId/deletedForms', endpoint(({ Forms, Projects }, { auth, params, queryOptions }) =>
+    Projects.getById(params.projectId)
+      .then(getOrNotFound)
+      .then((project) => auth.canOrReject('form.list', project))
+      .then((project) => Forms.getByProjectId(project.id, false, undefined, queryOptions, true))));
+
   // non-REST openrosa endpoint for project-specialized formlist.
   service.get('/projects/:projectId/formList', endpoint.openRosa(({ Forms, Projects, env }, { auth, params, originalUrl, queryOptions }) =>
     Projects.getById(params.projectId)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -270,9 +270,6 @@ module.exports = (service, endpoint) => {
   service.post('/projects/:projectId/forms/:id/restore', endpoint(({ Forms }, { auth, params }) =>
     Forms.getByProjectAndNumericId(params.projectId, params.id, false, null, QueryOptions.none, true)
       .then(getOrNotFound)
-      .catch((err) => ((err.name === 'DataIntegrityError')
-        ? Promise.reject(Problem.internal.notImplemented({ feature: 'restoring ambiguous xmlFormId' }))
-        : Promise.reject(err)))
       .then((form) => auth.canOrReject('form.delete', form))
       .then(Forms.restore)
       .then(success)));

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -271,8 +271,9 @@ module.exports = (service, endpoint) => {
   ////////////////////////////////////////
   // RESTORE / UNDELETE
 
+  // Instead of the xmlFormId, this endpoint uses the numeric form id in the database
   service.post('/projects/:projectId/forms/:id/restore', endpoint(({ Forms }, { auth, params }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, null, QueryOptions.none, true)
+    Forms.getByProjectAndNumericId(params.projectId, params.id, false, null, QueryOptions.none, true)
       .then(getOrNotFound)
       .catch((err) => ((err.name === 'DataIntegrityError')
         ? Promise.reject(Problem.internal.notImplemented({ feature: 'restoring ambiguous xmlFormId' }))

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -269,6 +269,20 @@ module.exports = (service, endpoint) => {
 
 
   ////////////////////////////////////////
+  // RESTORE / UNDELETE
+
+  service.post('/projects/:projectId/forms/:id/restore', endpoint(({ Forms }, { auth, params }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, null, QueryOptions.none, true)
+      .then(getOrNotFound)
+      .catch((err) => ((err.name === 'DataIntegrityError')
+        ? Promise.reject(Problem.internal.notImplemented({ feature: 'restoring ambiguous xmlFormId' }))
+        : Promise.reject(err)))
+      .then((form) => auth.canOrReject('form.delete', form))
+      .then(Forms.restore)
+      .then(success)));
+
+
+  ////////////////////////////////////////
   // DRAFT ATTACHMENT R/W ENDPOINTS
 
   service.post('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Blobs, FormAttachments, Forms }, { auth, headers, params }, request) =>

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -33,18 +33,13 @@ const ensureDef = rejectIf(((form) => form.def.id == null), noargs(Problem.user.
 
 
 module.exports = (service, endpoint) => {
+  // This forms list can also be used to get a list of just the soft-deleted forms by adding ?deleted=true
   // TODO: paging.
-  service.get('/projects/:projectId/forms', endpoint(({ Forms, Projects }, { auth, params, queryOptions }) =>
+  service.get('/projects/:projectId/forms', endpoint(({ Forms, Projects }, { auth, params, query, queryOptions }) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('form.list', project))
-      .then((project) => Forms.getByProjectId(project.id, false, undefined, queryOptions))));
-
-  service.get('/projects/:projectId/deletedForms', endpoint(({ Forms, Projects }, { auth, params, queryOptions }) =>
-    Projects.getById(params.projectId)
-      .then(getOrNotFound)
-      .then((project) => auth.canOrReject('form.list', project))
-      .then((project) => Forms.getByProjectId(project.id, false, undefined, queryOptions, true))));
+      .then((project) => Forms.getByProjectId(project.id, false, undefined, queryOptions, isTrue(query.deleted)))));
 
   // non-REST openrosa endpoint for project-specialized formlist.
   service.get('/projects/:projectId/formList', endpoint.openRosa(({ Forms, Projects, env }, { auth, params, originalUrl, queryOptions }) =>

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -270,7 +270,7 @@ module.exports = (service, endpoint) => {
   service.post('/projects/:projectId/forms/:id/restore', endpoint(({ Forms }, { auth, params }) =>
     Forms.getByProjectAndNumericId(params.projectId, params.id, false, null, QueryOptions.none, true)
       .then(getOrNotFound)
-      .then((form) => auth.canOrReject('form.delete', form))
+      .then((form) => auth.canOrReject('form.restore', form))
       .then(Forms.restore)
       .then(success)));
 

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -175,6 +175,9 @@ returning *`;
 const markDeleted = (obj) =>
   sql`update ${raw(obj.constructor.table)} set "deletedAt"=now() where id=${obj.id}`;
 
+const markUndeleted = (obj) =>
+  sql`update ${raw(obj.constructor.table)} set "deletedAt"=null where id=${obj.id}`;
+
 
 ////////////////////////////////////////
 // query fragment util
@@ -431,7 +434,7 @@ const postgresErrorToProblem = (x) => {
 module.exports = {
   connectionString, connectionObject,
   unjoiner, extender, equals, page, queryFuncs,
-  insert, insertMany, updater, markDeleted,
+  insert, insertMany, updater, markDeleted, markUndeleted,
   QueryOptions,
   postgresErrorToProblem
 };

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -1383,13 +1383,13 @@ describe('api: /projects/:id/forms', () => {
   describe('/deletedForms (listing trashed forms)', () => {
     it('should reject unless the user can read', testService((service) =>
       service.login('chelsea', (asChelsea) =>
-        asChelsea.get('/v1/projects/1/deletedForms').expect(403))));
+        asChelsea.get('/v1/projects/1/forms?deleted=true').expect(403))));
     
     it('should list soft-deleted forms', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.delete('/v1/projects/1/forms/withrepeat')
           .expect(200)
-          .then(() => asAlice.get('/v1/projects/1/deletedForms')
+          .then(() => asAlice.get('/v1/projects/1/forms?deleted=true')
             .expect(200)
             .then(({ body }) => {
               should.exist(body[0].deletedAt);
@@ -1410,7 +1410,7 @@ describe('api: /projects/:id/forms', () => {
           .expect(200)
           .then(() => asAlice.delete('/v1/projects/1/forms/simple')
             .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/deletedForms')
+            .then(() => asAlice.get('/v1/projects/1/forms?deleted=true')
               .set('X-Extended-Metadata', 'true')
               .expect(200)
               .then(({ body }) => {

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -1448,7 +1448,10 @@ describe('api: /projects/:id/forms', () => {
         asAlice.delete('/v1/projects/1/forms/simple')
           .expect(200)
           .then(() => asAlice.post('/v1/projects/1/forms/simple/restore')
-            .expect(400))))); // bad request
+            .expect(400)
+            .then(({ body }) => {
+              body.code.should.equal(400.11); // Invalid input data type
+            })))));
 
     it('should restore a soft-deleted form', testService((service) =>
       service.login('alice', (asAlice) =>

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -49,6 +49,61 @@ describe('api: /projects/:id/forms', () => {
             })))));
   });
 
+  describe('../forms?deleted=true GET', () => {
+    it('should reject unless the user can read', testService((service) =>
+      service.login('chelsea', (asChelsea) =>
+        asChelsea.get('/v1/projects/1/forms?deleted=true').expect(403))));
+
+    it('should list soft-deleted forms', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.delete('/v1/projects/1/forms/withrepeat')
+          .expect(200)
+          .then(() => asAlice.get('/v1/projects/1/forms?deleted=true')
+            .expect(200)
+            .then(({ body }) => {
+              should.exist(body[0].deletedAt);
+              body.forEach((form) => form.should.be.a.Form());
+              body.map((form) => form.id).should.eql([ 2 ]);
+              body.map((form) => form.projectId).should.eql([ 1 ]);
+              body.map((form) => form.xmlFormId).should.eql([ 'withrepeat' ]);
+              body.map((form) => form.name).should.eql([ null ]);
+              body.map((form) => form.hash).should.eql([ 'e7e9e6b3f11fca713ff09742f4312029' ]);
+              body.map((form) => form.version).should.eql([ '1.0' ]);
+            })))));
+
+    it('should list soft-deleted forms including extended metadata and submissions', testService((service) =>
+      service.login('alice', (asAlice) =>
+         asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple')
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1/forms?deleted=true')
+              .set('X-Extended-Metadata', 'true')
+              .expect(200)
+              .then(({ body }) => {
+                const simple = body.find((form) => form.xmlFormId === 'simple');
+                should.exist(simple.deletedAt);
+                simple.submissions.should.equal(1);
+                simple.lastSubmission.should.be.a.recentIsoDate();
+              }))))));
+
+    it('should not include deletedAt form field on regular forms', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/projects/1/forms')
+          .set('X-Extended-Metadata', 'true')
+          .expect(200)
+          .then(({ body }) => {
+            body.forEach((form) => form.hasOwnProperty('deletedAt').should.be.false());
+          })
+          .then(() => asAlice.get('/v1/projects/1/forms')
+            .expect(200)
+            .then(({ body }) => {
+              body.forEach((form) => form.hasOwnProperty('deletedAt').should.be.false());
+            })))));
+  });
+
   describe('../formList GET', () => {
     it('should reject if there is no authentication', testService((service) =>
       service.get('/v1/projects/1/formList')
@@ -1378,61 +1433,6 @@ describe('api: /projects/:id/forms', () => {
               .then(({ body }) => {
                 body.should.eql([]);
               }))))));
-  });
-
-  describe('/deletedForms (listing trashed forms)', () => {
-    it('should reject unless the user can read', testService((service) =>
-      service.login('chelsea', (asChelsea) =>
-        asChelsea.get('/v1/projects/1/forms?deleted=true').expect(403))));
-    
-    it('should list soft-deleted forms', testService((service) =>
-      service.login('alice', (asAlice) =>
-        asAlice.delete('/v1/projects/1/forms/withrepeat')
-          .expect(200)
-          .then(() => asAlice.get('/v1/projects/1/forms?deleted=true')
-            .expect(200)
-            .then(({ body }) => {
-              should.exist(body[0].deletedAt);
-              body.forEach((form) => form.should.be.a.Form());
-              body.map((form) => form.id).should.eql([ 2 ]);
-              body.map((form) => form.projectId).should.eql([ 1 ]);
-              body.map((form) => form.xmlFormId).should.eql([ 'withrepeat' ]);
-              body.map((form) => form.name).should.eql([ null ]);
-              body.map((form) => form.hash).should.eql([ 'e7e9e6b3f11fca713ff09742f4312029' ]);
-              body.map((form) => form.version).should.eql([ '1.0' ]);
-            })))));
-
-    it('should list soft-deleted forms including extended metadata and submissions', testService((service) =>
-      service.login('alice', (asAlice) =>
-         asAlice.post('/v1/projects/1/forms/simple/submissions')
-          .send(testData.instances.simple.one)
-          .set('Content-Type', 'application/xml')
-          .expect(200)
-          .then(() => asAlice.delete('/v1/projects/1/forms/simple')
-            .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/forms?deleted=true')
-              .set('X-Extended-Metadata', 'true')
-              .expect(200)
-              .then(({ body }) => {
-                const simple = body.find((form) => form.xmlFormId === 'simple');
-                should.exist(simple.deletedAt);
-                simple.submissions.should.equal(1);
-                simple.lastSubmission.should.be.a.recentIsoDate();
-              }))))));
-
-    it('should not include deletedAt form field on regular forms', testService((service) =>
-      service.login('alice', (asAlice) =>
-        asAlice.get('/v1/projects/1/forms')
-          .set('X-Extended-Metadata', 'true')
-          .expect(200)
-          .then(({ body }) => {
-            body.forEach((form) => form.hasOwnProperty('deletedAt').should.be.false());
-          })
-          .then(() => asAlice.get('/v1/projects/1/forms')
-            .expect(200)
-            .then(({ body }) => {
-              body.forEach((form) => form.hasOwnProperty('deletedAt').should.be.false());
-            })))));
   });
 
   describe('/:id/restore (undeleting trashed forms)', () => {

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -25,7 +25,6 @@ describe('api: /projects/:id/forms', () => {
           .expect(200)
           .then(({ body }) => {
             body.forEach((form) => form.should.be.a.Form());
-            body.map((form) => form.id).should.eql([ 1, 2 ]);
             body.map((form) => form.projectId).should.eql([ 1, 1 ]);
             body.map((form) => form.xmlFormId).should.eql([ 'simple', 'withrepeat' ]);
             body.map((form) => form.name).should.eql([ 'Simple', null ]);
@@ -1395,6 +1394,7 @@ describe('api: /projects/:id/forms', () => {
             .then(({ body }) => {
               should.exist(body[0].deletedAt);
               body.forEach((form) => form.should.be.a.Form());
+              body.map((form) => form.id).should.eql([ 2 ]);
               body.map((form) => form.projectId).should.eql([ 1 ]);
               body.map((form) => form.xmlFormId).should.eql([ 'withrepeat' ]);
               body.map((form) => form.name).should.eql([ null ]);

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -303,7 +303,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
-            body.verbs.length.should.be.greaterThan(34);
+            body.verbs.length.should.be.greaterThan(39);
             body.verbs.should.containDeep([ 'user.password.invalidate', 'project.delete' ]);
           }))));
 
@@ -314,7 +314,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
-            body.verbs.length.should.be.lessThan(25);
+            body.verbs.length.should.be.lessThan(26);
             body.verbs.should.containDeep([ 'assignment.create', 'project.delete' ]);
             body.verbs.should.not.containDeep([ 'project.create' ]);
           }))));


### PR DESCRIPTION
This exposes two new endpoints:

1. `/projects/:projectId/deletedForms` that fetches list of deleted forms for display in the frontend (in a trash section below the rest of a project's forms). All the same info about a form is there as well as an additional `deletedAt` field.

2. `/projects/:projectId/forms/:id/restore` that restores a soft-deleted form with a given (numeric) form id.

There are two quirks of this `restore` endpoint:
1. While you can (soft-)delete a form and then make a new one with the same `xmlFormId`, you can't restore the deleted form while an active form of the same `xmlFormId` exists. This will be prevented and explained in both the backend API and the frontend.

~2. It's possible to have multiple deleted forms with the same `xmlFormId`, but different integer form ids in the database, in which case the above restore endpoint is ambiguous and wont work.~ We resolved this by making the restore endpoint take the integer id of the form, which is now exposed through the API. 

<img width="962" alt="Screen Shot 2021-11-09 at 9 54 25 AM" src="https://user-images.githubusercontent.com/76205/140978927-3fd44cfe-2e4e-40ec-85eb-5117c5a54029.png">
