### PR TITLE
improve: add knexfile.js for Knex migration CLI.

### DIFF
--- a/lib/model/knexfile.js
+++ b/lib/model/knexfile.js
@@ -1,0 +1,33 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+/*
+This file is for use with the Knex migration CLI. Run `npx knex` from the
+repository root, specifying the path of this file to --knexfile. Because the
+Knex CLI will change the working directory to the directory of this file
+(lib/model), you will also need to specify the NODE_CONFIG_DIR environment
+variable so that `config` can find the configuration. (NODE_CONFIG_DIR may be a
+relative path, but it will need to be relative to lib/model.) For example, in
+local development:
+
+NODE_CONFIG_DIR=../../config npx knex migrate:up --knexfile lib/model/knexfile.js 20211111-01-my-migration.js
+
+In production (after the service is up):
+
+docker-compose exec --env NODE_CONFIG_DIR=../../config service npx knex migrate:up --knexfile lib/model/knexfile.js 20211111-01-my-migration.js
+*/
+
+const config = require('config');
+const { connectionObject } = require('../util/db');
+
+module.exports = {
+  client: 'pg',
+  connection: connectionObject(config.get('default.database'))
+};
+


### PR DESCRIPTION
We want to be able to manage Knex migrations from the command line: that will facilitate troubleshooting when a migration fails in production and will also aid local development. In particular, we want to be able to list completed and pending migrations, and we want to be able to run one migration at a time.

We thought about writing our own CLI, but I think we can actually benefit from the built-in Knex [migration CLI](https://knexjs.org/#Migrations-CLI). The Knex CLI is not easy to set up, but once it's set up, it seems to work nicely. The output is clear, and in contrast to the JavaScript API, the CLI automatically outputs the stack trace if there is a migration failure. There is also a `--debug` flag that seems potentially useful. The CLI also allows you to run a specific migration.

The best way to set up the Knex CLI seems to be to use a [`knexfile.js`](https://knexjs.org/#knexfile), which this PR adds.

I've tested this out locally and on a testing server.