### PR TITLE
bug: prevent migration from being killed by using Postgres xml type.

### DIFF
--- a/lib/model/migrations/20210423-01-add-name-to-form-def.js
+++ b/lib/model/migrations/20210423-01-add-name-to-form-def.js
@@ -19,17 +19,12 @@ const up = async (db) => {
   });
 
   await db.raw('ALTER TABLE form_defs DISABLE TRIGGER check_managed_key');
-
-  const work = [];
-  for await (const def of db.select('*').from('form_defs').stream()) {
-    const partial = await Form.fromXml(def.xml);
-    if (partial.def.name == null) continue;
-
-    const data = { name: partial.def.name };
-    work.push(db.update(data).into('form_defs').where({ id: def.id }));
-  }
-  await Promise.all(work);
-
+  await db.raw(`update form_defs
+set name = (xpath(
+  '/*[local-name() = ''html'']/*[local-name() = ''head'']/*[local-name() = ''title'']/text()',
+  xml::xml
+))[1]::text
+where xml_is_well_formed_document(xml)`);
   await db.raw('ALTER TABLE form_defs ENABLE TRIGGER check_managed_key');
 };
 


### PR DESCRIPTION
A migration is being killed in rare cases. I tried to patch the migration's JavaScript in #429, but ran into issues. This PR tries to fix the issue by taking a different approach, replacing the JavaScript with a single Postgres statement. That Postgres statement makes use of the Postgres `xml` data type. I tried this PR on the problem server, and with it, the migration was able to complete (after about 30 seconds). 🎉 It seems that Postgres is better able to manage the resources around parsing the relatively large XForms on the server.

I'll also add comments about specific lines below.

References:

https://www.postgresql.org/docs/9.6/datatype-xml.html
https://www.postgresql.org/docs/9.6/functions-xml.html