### PR TITLE
Purge forms and associated resources

### DIFF
--- a/lib/bin/purge-forms.js
+++ b/lib/bin/purge-forms.js
@@ -21,5 +21,6 @@ const cliArgs = {
 cli.parse(cliArgs);
 
 cli.main((args, options) => {
-  run(purgeForms(options.force, options.formId));
+  run(purgeForms(options.force, options.formId)
+    .then((count) => { return `Forms purged: ${count}`; }));
 });

--- a/lib/bin/purge-forms.js
+++ b/lib/bin/purge-forms.js
@@ -1,0 +1,25 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+//
+// This script checks for (soft-)deleted forms and purges any that were deleted
+// over 30 days ago.
+
+const { run } = require('../task/task');
+const { purgeForms } = require('../task/purge');
+
+const cli = require('cli');
+const cliArgs = {
+  force: [ 'f', 'Force any soft-deleted form to be purged right away.', 'bool', false ],
+  formId: [ 'id', 'Purge a specific form based on its id.', 'int' ]
+};
+cli.parse(cliArgs);
+
+cli.main((args, options) => {
+  run(purgeForms(options.force, options.formId));
+});

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -17,7 +17,7 @@ const Option = require('../util/option');
 const Actee = Frame.define(
   table('actees'),
   'id', 'species',
-  'deletedAt', readable,                'details', readable
+  'purgedAt', readable,                'details', readable
 );
 
 const Actor = Frame.define(

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -17,7 +17,8 @@ const Option = require('../util/option');
 const Actee = Frame.define(
   table('actees'),
   'id', 'species',
-  'purgedAt', readable,                'details', readable
+  'purgedAt', readable,                'details', readable,
+  'purgedName', readable
 );
 
 const Actor = Frame.define(

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -14,7 +14,11 @@ const Option = require('../util/option');
 
 /* eslint-disable no-multi-spaces */
 
-const Actee = Frame.define(table('actees'), 'id', 'species');
+const Actee = Frame.define(
+  table('actees'),
+  'id', 'species',
+  'deletedAt', readable,                'details', readable
+);
 
 const Actor = Frame.define(
   table('actors'),

--- a/lib/model/migrations/20211027-01-add-purgeddAt-details-to-actees.js
+++ b/lib/model/migrations/20211027-01-add-purgeddAt-details-to-actees.js
@@ -1,0 +1,26 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.schema.table('actees', (t) => {
+    t.dateTime('purgedAt');
+    t.json('details');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.table('actees', (t) => {
+    t.dropColumn('purgedAt');
+    t.dropColumn('details');
+  });
+};
+
+module.exports = { up, down };
+
+

--- a/lib/model/migrations/20211027-01-add-purgeddAt-details-to-actees.js
+++ b/lib/model/migrations/20211027-01-add-purgeddAt-details-to-actees.js
@@ -10,13 +10,15 @@
 const up = async (db) => {
   await db.schema.table('actees', (t) => {
     t.dateTime('purgedAt');
-    t.json('details');
+    t.text('purgedName');
+    t.jsonb('details');
   });
 };
 
 const down = async (db) => {
   await db.schema.table('actees', (t) => {
     t.dropColumn('purgedAt');
+    t.dropColumn('purgedName');
     t.dropColumn('details');
   });
 };

--- a/lib/model/migrations/20211027-01-add-purgeddAt-details-to-actees.js
+++ b/lib/model/migrations/20211027-01-add-purgeddAt-details-to-actees.js
@@ -1,6 +1,6 @@
 // Copyright 2021 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20211101-01-form-cascade-delete.js
+++ b/lib/model/migrations/20211101-01-form-cascade-delete.js
@@ -1,0 +1,98 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+// Migrations to set up cascading deletes when a form is purged
+
+const up = async (db) => {
+  await db.schema.table('form_defs', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+  });
+
+  await db.schema.table('form_attachments', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('cascade');
+  });
+
+  await db.schema.table('form_fields', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('cascade');
+  });
+
+  await db.schema.table('public_links', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+  });
+
+  await db.schema.table('submissions', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+  });
+
+  await db.schema.table('submission_defs', (t) => {
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('cascade');
+  });
+
+  await db.schema.table('comments', (t) => {
+    t.dropForeign('submissionId');
+    t.foreign('submissionId').references('submissions.id').onDelete('cascade');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.table('form_defs', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+  });
+
+  await db.schema.table('form_attachments', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('no action');
+  });
+
+  await db.schema.table('form_fields', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('no action');
+  });
+
+  await db.schema.table('public_links', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+  });
+
+  await db.schema.table('submissions', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+  });
+
+  await db.schema.table('submission_defs', (t) => {
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('no action');
+  });
+
+  await db.schema.table('comments', (t) => {
+    t.dropForeign('submissionId');
+    t.foreign('submissionId').references('submissions.id').onDelete('no action');
+  });
+};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20211101-01-form-cascade-delete.js
+++ b/lib/model/migrations/20211101-01-form-cascade-delete.js
@@ -50,6 +50,14 @@ const up = async (db) => {
     t.dropForeign('submissionId');
     t.foreign('submissionId').references('submissions.id').onDelete('cascade');
   });
+
+  await db.schema.table('form_field_values', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+
+    t.dropForeign('submissionDefId');
+    t.foreign('submissionDefId').references('submission_defs.id').onDelete('cascade');
+  });
 };
 
 const down = async (db) => {
@@ -92,6 +100,14 @@ const down = async (db) => {
   await db.schema.table('comments', (t) => {
     t.dropForeign('submissionId');
     t.foreign('submissionId').references('submissions.id').onDelete('no action');
+  });
+
+  await db.schema.table('form_field_values', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+
+    t.dropForeign('submissionDefId');
+    t.foreign('submissionDefId').references('submission_defs.id').onDelete('no action');
   });
 };
 

--- a/lib/model/migrations/20211101-01-form-cascade-delete.js
+++ b/lib/model/migrations/20211101-01-form-cascade-delete.js
@@ -1,6 +1,6 @@
 // Copyright 2021 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20211117-01-add-form-restore-verb.js
+++ b/lib/model/migrations/20211117-01-add-form-restore-verb.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20211117-01-add-form-restore-verb.js
+++ b/lib/model/migrations/20211117-01-add-form-restore-verb.js
@@ -9,6 +9,8 @@
 
 const { without } = require('ramda');
 
+/* eslint-disable no-await-in-loop */
+
 const up = async (db) => {
   // grant rights.
   for (const system of [ 'admin', 'manager' ]) {

--- a/lib/model/migrations/20211210-01-purge-deleted-forms.js
+++ b/lib/model/migrations/20211210-01-purge-deleted-forms.js
@@ -1,0 +1,64 @@
+// Copyright 2019 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+
+// This migration permanently purges all forms that were previously marked as deleted.
+// This is part of a central-backend update (1.4) that allows listing and restoring deleted
+// forms, but since there was no way to access forms deleted prior to this release, we
+// are removing old deleted forms.
+
+// Purging steps
+// 1. Redact notes about forms from the audit table that reference a form
+//    (includes one kind of comment on a submission)
+// 2. Log the purge in the audit log with actor not set because purging isn't accessible through the api
+// 3. Update actees table for the specific form to leave some useful information behind
+// 4. Delete the forms and their resources from the database
+// 5. Purge unattached blobs
+
+
+const up = (db) =>
+  db.raw(`
+update audits set notes = ''
+from forms
+where audits."acteeId" = forms."acteeId"
+and forms."deletedAt" is not null`)
+    .then(() => db.raw(`
+insert into audits ("action", "acteeId", "loggedAt")
+select 'form.purge', "acteeId",  clock_timestamp()
+from forms
+where forms."deletedAt" is not null`))
+    .then(() => db.raw(`
+update actees set "purgedAt" = clock_timestamp(),
+  "purgedName" = form_defs."name",
+  "details" = json_build_object('projectId', forms."projectId",
+                                'formId', forms.id,
+                                'xmlFormId', forms."xmlFormId",
+                                'deletedAt', forms."deletedAt",
+                                'version', form_defs."version")
+from forms
+left outer join form_defs on forms."currentDefId" = form_defs.id
+where actees.id = forms."acteeId"
+and forms."deletedAt" is not null`))
+    .then(() => db.raw(`
+delete from forms
+where forms."deletedAt" is not null`))
+    .then(() => db.raw(`
+delete from blobs
+  using blobs as b
+  left join client_audits as ca on ca."blobId" = b.id
+  left join submission_attachments as sa on sa."blobId" = b.id
+  left join form_attachments as fa on fa."blobId" = b.id
+where (blobs.id = b.id and
+  ca."blobId" is null and
+  sa."blobId" is null and
+  fa."blobId" is null)`));
+
+const down = () => {};
+
+module.exports = { up, down };

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -9,7 +9,7 @@
 
 const { sql } = require('slonik');
 const { map } = require('ramda');
-const { Actor, Audit, Form, Project } = require('../frames');
+const { Actee, Actor, Audit, Form, Project } = require('../frames');
 const { extender, equals, page, QueryOptions } = require('../../util/db');
 const Option = require('../../util/option');
 const { construct } = require('../../util/util');
@@ -66,14 +66,15 @@ const auditFilterer = (options) => {
   return (result.length === 0) ? sql`true` : sql.join(result, sql` and `);
 };
 
-const _get = extender(Audit)(Option.of(Actor), Option.of(Actor.alias('actee_actor', 'acteeActor')), Option.of(Form), Option.of(Form.Def), Option.of(Project))((fields, extend, options) => sql`
+const _get = extender(Audit)(Option.of(Actor), Option.of(Actor.alias('actee_actor', 'acteeActor')), Option.of(Form), Option.of(Form.Def), Option.of(Project), Option.of(Actee))((fields, extend, options) => sql`
 select ${fields} from audits
   ${extend|| sql`
     left outer join actors on actors.id=audits."actorId"
     left outer join projects on projects."acteeId"=audits."acteeId"
     left outer join actors as actee_actor on actee_actor."acteeId"=audits."acteeId"
     left outer join forms on forms."acteeId"=audits."acteeId"
-    left outer join form_defs on form_defs.id=forms."currentDefId"`}
+    left outer join form_defs on form_defs.id=forms."currentDefId"
+    left outer join actees on actees.id=audits."acteeId"`}
   where ${equals(options.condition)} and ${auditFilterer(options)}
   order by "loggedAt" desc, audits.id desc
   ${page(options)}`);
@@ -86,7 +87,7 @@ const get = (options = QueryOptions.none) => ({ all }) =>
     // TODO: better if we don't have to loop over all this data twice.
     return rows.map((row) => {
       const form = row.aux.form.map((f) => f.withAux('def', row.aux.def));
-      const actees = [ row.aux.acteeActor, form, row.aux.project ];
+      const actees = [ row.aux.acteeActor, form, row.aux.project, row.aux.actee ];
       return new Audit(row, { actor: row.aux.actor, actee: Option.firstDefined(actees) });
     });
   });

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -31,5 +31,17 @@ const getById = (blobId) => ({ maybeOne }) =>
   maybeOne(sql`select * from blobs where id=${blobId}`)
     .then(map(construct(Blob)));
 
-module.exports = { ensure, getById };
+const purgeUnattached = () => ({ all }) =>
+  all(sql`
+delete from blobs
+  using blobs as b
+  left join client_audits as ca on ca."blobId" = b.id
+  left join submission_attachments as sa on sa."blobId" = b.id
+  left join form_attachments as fa on fa."blobId" = b.id
+where (blobs.id = b.id and
+  ca."blobId" is null and
+  sa."blobId" is null and
+  fa."blobId" is null)`);
+
+module.exports = { ensure, getById, purgeUnattached };
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -184,6 +184,13 @@ restore.audit = (form) => (log) => log('form.restore', form);
 ////////////////////////////////////////////////////////////////////////////////
 // PURGING SOFT-DELETED FORMS
 
+// The main ways we'd want to choose forms to purge are
+// 1. by their deletedAt date (30+ days in the past)
+//    (this would be the default behavior of a purge cron job)
+// 2. if deletedAt is set at all
+//    (useful to purge forms immediately for testing or other time sensitive scenarios)
+// 3. by a specific form id if deletedAt is also set (again for testing or potential future scenarios)
+
 const DAY_RANGE = 30;
 const _trashedFilter = (force, id) => {
   const idFilter = (id
@@ -194,6 +201,13 @@ const _trashedFilter = (force, id) => {
     : sql`forms."deletedAt" < current_date - cast(${DAY_RANGE} as int) ${idFilter}`);
 };
 
+// Purging steps
+// 1. Redact notes about forms from the audit table that reference a form
+//    (includes one kind of comment on a submission)
+// 2. Log the purge in the audit log with actor not set because purging isn't accessible through the api
+// 3. Update actees table for the specific form to leave some useful information behind
+// 4. Delete the forms and their resources from the database
+// 5. Purge unattached blobs
 const purge = (force = false, id = null) => ({ run, all, Blobs }) =>
   run(sql`
 update audits set notes = ''

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -168,7 +168,7 @@ update.audit = (form, data) => (log) => log('form.update', form, { data });
 
 const _updateDef = (form, data) => ({ one }) => one(updater(form.def, data));
 
-const del = (form) => ({ run, Assignments }) =>
+const del = (form) => ({ run, Forms, Assignments }) =>
   run(markDeleted(form))
     .then(() => ((form.currentDefId === null)
       ? Forms.purge(true, form.id)
@@ -228,7 +228,7 @@ update actees set "purgedAt" = clock_timestamp(),
                                 'deletedAt', forms."deletedAt",
                                 'version', form_defs."version")
 from forms
-left outer join form_defs on forms."currentDefId" = form_defs.id
+left outer join form_defs on coalesce(forms."currentDefId", forms."draftDefId") = form_defs.id
 where actees.id = forms."acteeId"
 and ${_trashedFilter(force, id)}`))
     .then(() => all(sql`

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -232,9 +232,13 @@ left outer join form_defs on forms."currentDefId" = form_defs.id
 where actees.id = forms."acteeId"
 and ${_trashedFilter(force, id)}`))
     .then(() => all(sql`
-delete from forms
-where ${_trashedFilter(force, id)}`))
-    .then(Blobs.purgeUnattached);
+with deleted as (
+  delete from forms
+  where ${_trashedFilter(force, id)}
+returning *)
+select count(*) from deleted`))
+    .then((count) => Blobs.purgeUnattached()
+      .then(() => Promise.resolve(count[0].count)));
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -175,7 +175,7 @@ const del = (form) => ({ run, Assignments }) =>
       : null));
 del.audit = (form) => (log) => log('form.delete', form);
 
-const restore = (form) => ({ run, Forms }) =>
+const restore = (form) => ({ run }) =>
   run(markUndeleted(form));
 restore.audit = (form) => (log) => log('form.restore', form);
 
@@ -232,12 +232,9 @@ left outer join form_defs on forms."currentDefId" = form_defs.id
 where actees.id = forms."acteeId"
 and ${_trashedFilter(force, id)}`))
     .then(() => all(sql`
-with deleted as (
-  delete from forms
-  where ${_trashedFilter(force, id)}
-  returning *)
-select id, "xmlFormId" from deleted`))
-    .then(() => Blobs.purgeUnattached());
+delete from forms
+where ${_trashedFilter(force, id)}`))
+    .then(Blobs.purgeUnattached);
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -182,21 +182,26 @@ restore.audit = (form) => (log) => log('form.restore', form);
 // PURGING SOFT-DELETED FORMS
 
 const DAY_RANGE = 30;
-const _trashedFilter = (force) => (force
-  ? sql`forms."deletedAt" is not null`
-  : sql`forms."deletedAt" < current_date - cast(${DAY_RANGE} as int)`);
+const _trashedFilter = (force, id) => {
+  const idFilter = (id
+    ? sql`and forms.id = ${id}`
+    : sql``);
+  return (force
+    ? sql`forms."deletedAt" is not null ${idFilter}`
+    : sql`forms."deletedAt" < current_date - cast(${DAY_RANGE} as int) ${idFilter}`);
+};
 
-const purge = (force = false) => ({ run, all, Blobs }) =>
+const purge = (force = false, id = null) => ({ run, all, Blobs }) =>
   run(sql`
 update audits set notes = ''
 from forms
 where audits."acteeId" = forms."acteeId"
-and ${_trashedFilter(force)}`)
+and ${_trashedFilter(force, id)}`)
     .then(() => run(sql`
 insert into audits ("action", "acteeId", "loggedAt")
 select 'form.purge', "acteeId",  clock_timestamp()
 from forms
-where ${_trashedFilter(force)}`))
+where ${_trashedFilter(force, id)}`))
     .then(() => run(sql`
 update actees set "purgedAt" = clock_timestamp(),
   "details" = json_build_object('projectId', forms."projectId",
@@ -207,11 +212,11 @@ update actees set "purgedAt" = clock_timestamp(),
 from forms
 left outer join form_defs on forms."currentDefId" = form_defs.id
 where actees.id = forms."acteeId"
-and ${_trashedFilter(force)}`))
+and ${_trashedFilter(force, id)}`))
     .then(() => all(sql`
 with deleted as (
   delete from forms
-  where ${_trashedFilter(force)}
+  where ${_trashedFilter(force, id)}
   returning *)
 select id, "xmlFormId" from deleted`))
     .then(() => Blobs.purgeUnattached());

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -221,10 +221,11 @@ from forms
 where ${_trashedFilter(force, id)}`))
     .then(() => run(sql`
 update actees set "purgedAt" = clock_timestamp(),
+  "purgedName" = form_defs."name",
   "details" = json_build_object('projectId', forms."projectId",
                                 'formId', forms.id,
                                 'xmlFormId', forms."xmlFormId",
-                                'name', form_defs."name",
+                                'deletedAt', forms."deletedAt",
                                 'version', form_defs."version")
 from forms
 left outer join form_defs on forms."currentDefId" = form_defs.id

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -186,7 +186,7 @@ const _trashedFilter = (force) => (force
   ? sql`forms."deletedAt" is not null`
   : sql`forms."deletedAt" < current_date - cast(${DAY_RANGE} as int)`);
 
-const purge = (force = false) => ({ run, all }) =>
+const purge = (force = false) => ({ run, all, Blobs }) =>
   run(sql`
 update audits set notes = ''
 from forms
@@ -213,7 +213,8 @@ with deleted as (
   delete from forms
   where ${_trashedFilter(force)}
   returning *)
-select id, "xmlFormId" from deleted`));
+select id, "xmlFormId" from deleted`))
+    .then(() => Blobs.purgeUnattached());
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -169,7 +169,10 @@ update.audit = (form, data) => (log) => log('form.update', form, { data });
 const _updateDef = (form, data) => ({ one }) => one(updater(form.def, data));
 
 const del = (form) => ({ run, Assignments }) =>
-  run(markDeleted(form));
+  run(markDeleted(form))
+    .then(() => ((form.currentDefId === null)
+      ? Forms.purge(true, form.id)
+      : null));
 del.audit = (form) => (log) => log('form.delete', form);
 
 const restore = (form) => ({ run, Forms }) =>

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -191,8 +191,24 @@ const purge = (force = false) => ({ run, all }) =>
 update audits set notes = ''
 from forms
 where audits."acteeId" = forms."acteeId"
-and ${_trashedFilter(force)}
-  `).then(() => all(sql`
+and ${_trashedFilter(force)}`)
+    .then(() => run(sql`
+insert into audits ("action", "acteeId", "loggedAt")
+select 'form.purge', "acteeId",  clock_timestamp()
+from forms
+where ${_trashedFilter(force)}`))
+    .then(() => run(sql`
+update actees set "purgedAt" = clock_timestamp(),
+  "details" = json_build_object('projectId', forms."projectId",
+                                'formId', forms.id,
+                                'xmlFormId', forms."xmlFormId",
+                                'name', form_defs."name",
+                                'version', form_defs."version")
+from forms
+left outer join form_defs on forms."currentDefId" = form_defs.id
+where actees.id = forms."acteeId"
+and ${_trashedFilter(force)}`))
+    .then(() => all(sql`
 with deleted as (
   delete from forms
   where ${_trashedFilter(force)}

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -179,6 +179,28 @@ restore.audit = (form) => (log) => log('form.restore', form);
 
 
 ////////////////////////////////////////////////////////////////////////////////
+// PURGING SOFT-DELETED FORMS
+
+const DAY_RANGE = 30;
+const _trashedFilter = (force) => (force
+  ? sql`forms."deletedAt" is not null`
+  : sql`forms."deletedAt" < current_date - cast(${DAY_RANGE} as int)`);
+
+const purge = (force = false) => ({ run, all }) =>
+  run(sql`
+update audits set notes = ''
+from forms
+where audits."acteeId" = forms."acteeId"
+and ${_trashedFilter(force)}
+  `).then(() => all(sql`
+with deleted as (
+  delete from forms
+  where ${_trashedFilter(force)}
+  returning *)
+select id, "xmlFormId" from deleted`));
+
+
+////////////////////////////////////////////////////////////////////////////////
 // ENCRYPTION
 
 // takes a Key object and a suffix to add to the form version string.
@@ -379,7 +401,7 @@ order by actors."displayName" asc`)
 module.exports = {
   fromXls, _createNew, createNew, createVersion,
   publish, clearDraft,
-  _update, update, _updateDef, del, restore,
+  _update, update, _updateDef, del, restore, purge,
   setManagedKey,
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,

--- a/lib/task/purge.js
+++ b/lib/task/purge.js
@@ -7,18 +7,9 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const config = require('config');
-const { isEmpty } = require('ramda');
-
 const { task } = require('./task');
-const { buildSubmission } = require('../data/analytics');
-const { getConfiguration } = require('./config');
-const Problem = require('../util/problem');
 
-
-const purgeForms = task.withContainer(({ Forms, Audits }) => (force, formId) => {
-  console.log("inside purgeForms task", force, formId);
-  return Forms.purge(force, formId);
-});
+const purgeForms = task.withContainer(({ Forms }) => (force, formId) =>
+  Forms.purge(force, formId));
 
 module.exports = { purgeForms };

--- a/lib/task/purge.js
+++ b/lib/task/purge.js
@@ -1,0 +1,24 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const config = require('config');
+const { isEmpty } = require('ramda');
+
+const { task } = require('./task');
+const { buildSubmission } = require('../data/analytics');
+const { getConfiguration } = require('./config');
+const Problem = require('../util/problem');
+
+
+const purgeForms = task.withContainer(({ Forms, Audits }) => (force, formId) => {
+  console.log("inside purgeForms task", force, formId);
+  return Forms.purge(force, formId);
+});
+
+module.exports = { purgeForms };

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -3,40 +3,49 @@ const should = require('should');
 const { sql } = require('slonik');
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
+const { createReadStream } = require('fs');
 
-const countFormRecords = (container, formId) => {
-  return Promise.all([
-    container.oneFirst(sql`select count(*) from forms where id=${formId}`),
-    container.oneFirst(sql`select count(*) from form_defs where "formId"=${formId}`),
-    container.oneFirst(sql`select count(*) from form_attachments where "formId"=${formId}`)
-  ]);
-};
 
-describe.only('query module form purge', () => {
+describe('query module form purge', () => {
   it('should purge a soft-deleted form', testService((service, container) =>
     service.login('alice', (asAlice) =>
       asAlice.delete('/v1/projects/1/forms/simple')
         .expect(200)
         .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
-        .then(() => countFormRecords(container, 1)
-          .then((counts) => {
-            counts.should.eql([0, 0, 0]);
-          })))));
-  
-  it('should not find any matching forms records in the database', testService((service, container) =>
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ])
+        .then((counts) => {
+          counts.should.eql([0, 0]);
+        })))));
+
+  it('should purge a form deleted over 30 days ago', testService((service, container) =>
     service.login('alice', (asAlice) =>
-      container.Forms.getByProjectAndXmlFormId(1, 'simple').then((o) => o.get())
-        .then(( ghostForm ) => countFormRecords(container, ghostForm.id)
-          .then((counts) => {
-            counts.should.eql([1, 1, 0]);
-          })
-          .then(() => asAlice.delete('/v1/projects/1/forms/simple')
-            .expect(200))
-          .then(() => container.Forms.purge(true))
-          .then(() => countFormRecords(container, ghostForm.id)
-            .then((counts) => {
-              counts.should.eql([0, 0, 0]);
-            }))))));
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(() => container.run(sql`update forms set "deletedAt" = '1999-1-1' where id=1`))
+        .then(() => container.Forms.purge()) // purge forms deleted more than 30 days ago
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ])
+        .then((counts) => {
+          counts.should.eql([0, 0]);
+        })))));
+
+  it('should not purge a recently deleted form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(() => container.Forms.purge()) // purge forms deleted more than 30 days ago
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ])
+        .then((counts) => {
+          counts.should.eql([1, 1]);
+        })))));
 
   it('should log the purge action in the audit log', testService((service, container) =>
     service.login('alice', (asAlice) =>
@@ -82,17 +91,14 @@ describe.only('query module form purge', () => {
           .expect(200))
         .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
           .expect(200))
-        .then(() => countFormRecords(container, 1) // after delete, before purge
-          .then((counts) => {
-            counts.should.eql([1, 3, 0]);
-          }))
         .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
-        .then(() => countFormRecords(container, 1)
-        .then((counts) => {
-          counts.should.eql([0, 0, 0]);
-        })))));
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ]))
+        .then((counts) => counts.should.eql([0, 0])))));
 
-  it('should purge attachments of a form', testService((service, container) =>
+  it('should purge attachments (and blobs) of a form', testService((service, container) =>
     service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms')
         .send(testData.forms.withAttachments)
@@ -106,14 +112,113 @@ describe.only('query module form purge', () => {
         .then(() => container.Forms.getByProjectAndXmlFormId(1, 'withAttachments').then((o) => o.get())
         .then((ghostForm) => asAlice.delete('/v1/projects/1/forms/withAttachments')
           .expect(200)
-          .then(() => countFormRecords(container, ghostForm.id)
-            .then((counts) => {
-              counts.should.eql([1, 1, 2]);
-            }))
           .then(() => container.Forms.purge(true))
-          .then(() => countFormRecords(container, ghostForm.id)
-            .then((counts) => {
-              counts.should.eql([0, 0, 0]);
-            })))))));
+          .then(() => Promise.all([
+            container.oneFirst(sql`select count(*) from forms where id=${ghostForm.id}`),
+            container.oneFirst(sql`select count(*) from form_defs where "formId"=${ghostForm.id}`),
+            container.oneFirst(sql`select count(*) from form_attachments where "formId"=${ghostForm.id}`),
+            container.oneFirst(sql`select count(*) from blobs`)
+          ]))
+          .then((counts) => counts.should.eql([0, 0, 0, 0])))))));
 
+  describe('puring form submissions', () => {
+    const withSimpleIds = (deprecatedId, instanceId) => testData.instances.simple.one
+      .replace('one</instance', `${instanceId}</instanceID><deprecatedID>${deprecatedId}</deprecated`);
+
+    it('should delete all defs of a submission', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.put('/v1/projects/1/forms/simple/submissions/one')
+            .send(withSimpleIds('one', 'two'))
+            .set('Content-Type', 'text/xml')
+            .expect(200))
+          .then(() => container.oneFirst(sql`select count(*) from submission_defs`)
+            .then((count) => { count.should.equal(2); }))
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.oneFirst(sql`select count(*) from submission_defs`)
+            .then((count) => { count.should.equal(0); })))));
+
+    it('should purge attachments and blobs associated with the submission', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+            .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+            .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+            .expect(201))
+          .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments')
+            .expect(200)
+            .then(({ body }) => {
+              body.should.eql([
+                { name: 'here_is_file2.jpg', exists: true },
+                { name: 'my_file1.mp4', exists: true }
+              ]);
+            }))
+          .then(() => asAlice.delete('/v1/projects/1/forms/binaryType'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.oneFirst(sql`select count(*) from submission_attachments`)
+            .then((count) => count.should.equal(0)))
+          .then(() => container.oneFirst(sql`select count(*) from blobs`)
+            .then((count) => count.should.equal(0))))));
+
+    it('should purge submission comments from comments table', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions/one/comments')
+            .send({ body: 'new comment here' })
+            .expect(200))
+          .then(() => container.oneFirst(sql`select count(*) from comments`)
+            .then((count) => count.should.equal(1)))
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.oneFirst(sql`select count(*) from comments`)
+            .then((count) => count.should.equal(0))))));
+
+    it('should purge submission comments from notes fields of audits table', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.patch('/v1/projects/1/forms/simple/submissions/one')
+            .send({ reviewState: 'approved' })
+            .set('X-Action-Notes', 'secret note')
+            .expect(200))
+          .then(() => container.Audits.getLatestByAction('submission.update')
+            .then((audit) => { audit.get().notes.should.equal('secret note'); }))
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.Audits.getLatestByAction('submission.update')
+            .then((audit) => { audit.get().notes.should.equal(''); })))));
+
+    it('should purge client audit log attachments', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.clientAudits)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('audit.csv', createReadStream(appPath + '/test/data/audit.csv'), { filename: 'audit.csv' })
+            .attach('xml_submission_file', Buffer.from(testData.instances.clientAudits.one), { filename: 'data.xml' })
+            .expect(201)
+          .then(() => asAlice.delete('/v1/projects/1/forms/audits'))
+          .then(() => container.Forms.purge(true))
+          .then(() => Promise.all([
+            container.oneFirst(sql`select count(*) from client_audits`),
+            container.oneFirst(sql`select count(*) from blobs`)
+          ])
+          .then((count) => count.should.eql([0, 0])))))));
+  });
 });

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -5,39 +5,115 @@ const { testService } = require('../setup');
 const testData = require('../../data/xml');
 
 const countFormRecords = (container, formId) => {
-  console.log("formId", formId);
   return Promise.all([
     container.oneFirst(sql`select count(*) from forms where id=${formId}`),
-    container.oneFirst(sql`select count(*) from form_defs where "formId"=${formId}`)
+    container.oneFirst(sql`select count(*) from form_defs where "formId"=${formId}`),
+    container.oneFirst(sql`select count(*) from form_attachments where "formId"=${formId}`)
   ]);
 };
 
-describe('query module form purge', () => {
+describe.only('query module form purge', () => {
   it('should purge a soft-deleted form', testService((service, container) =>
     service.login('alice', (asAlice) =>
       asAlice.delete('/v1/projects/1/forms/simple')
         .expect(200)
         .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
         .then(() => countFormRecords(container, 1)
-          .then(([ formCount, formDefCount ]) => {
-            formCount.should.equal(0);
-            formDefCount.should.equal(0);
+          .then((counts) => {
+            counts.should.eql([0, 0, 0]);
           })))));
   
   it('should not find any matching forms records in the database', testService((service, container) =>
     service.login('alice', (asAlice) =>
       container.Forms.getByProjectAndXmlFormId(1, 'simple').then((o) => o.get())
         .then(( ghostForm ) => countFormRecords(container, ghostForm.id)
-          .then(([ formCount, formDefCount ]) => {
-            formCount.should.equal(1);
-            formDefCount.should.equal(1);
+          .then((counts) => {
+            counts.should.eql([1, 1, 0]);
           })
           .then(() => asAlice.delete('/v1/projects/1/forms/simple')
             .expect(200))
           .then(() => container.Forms.purge(true))
           .then(() => countFormRecords(container, ghostForm.id)
-            .then(([ formCount, formDefCount ]) => {
-              formCount.should.equal(0);
-              formDefCount.should.equal(0);
+            .then((counts) => {
+              counts.should.eql([0, 0, 0]);
             }))))));
+
+  it('should log the purge action in the audit log', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      container.Forms.getByProjectAndXmlFormId(1, 'simple').then((o) => o.get()) // get the form before we delete it
+        .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200)
+          .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+          .then(() => container.Audits.getLatestByAction('form.purge'))
+          .then((audit) => {
+            audit.isDefined().should.equal(true);
+            audit.get().acteeId.should.equal(form.acteeId);
+          })))));
+
+  it('should update the actee table with purgedAt details', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      container.Forms.getByProjectAndXmlFormId(1, 'simple').then((o) => o.get()) // get the form before we delete it
+        .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200)
+          .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+          .then(() => container.one(sql`select * from actees where id = ${form.acteeId}`))
+          .then((res) => {
+            const deletedFormDetails = {
+              projectId: 1,
+              formId: 1,
+              xmlFormId: 'simple',
+              name: 'Simple',
+              version: ''
+            };
+            res.details.should.eql(deletedFormDetails);
+          })))));
+
+  it('should purge a form with multiple versions', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms/simple/draft')
+        .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="2"'))
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft/publish')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+          .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="3"'))
+          .set('Content-Type', 'application/xml')
+          .expect(200))
+        .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200))
+        .then(() => countFormRecords(container, 1) // after delete, before purge
+          .then((counts) => {
+            counts.should.eql([1, 3, 0]);
+          }))
+        .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+        .then(() => countFormRecords(container, 1)
+        .then((counts) => {
+          counts.should.eql([0, 0, 0]);
+        })))));
+
+  it('should purge attachments of a form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send('this is goodone.csv')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
+          .expect(200))
+        .then(() => container.Forms.getByProjectAndXmlFormId(1, 'withAttachments').then((o) => o.get())
+        .then((ghostForm) => asAlice.delete('/v1/projects/1/forms/withAttachments')
+          .expect(200)
+          .then(() => countFormRecords(container, ghostForm.id)
+            .then((counts) => {
+              counts.should.eql([1, 1, 2]);
+            }))
+          .then(() => container.Forms.purge(true))
+          .then(() => countFormRecords(container, ghostForm.id)
+            .then((counts) => {
+              counts.should.eql([0, 0, 0]);
+            })))))));
+
 });

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -1,0 +1,43 @@
+const appPath = require('app-root-path');
+const should = require('should');
+const { sql } = require('slonik');
+const { testService } = require('../setup');
+const testData = require('../../data/xml');
+
+const countFormRecords = (container, formId) => {
+  console.log("formId", formId);
+  return Promise.all([
+    container.oneFirst(sql`select count(*) from forms where id=${formId}`),
+    container.oneFirst(sql`select count(*) from form_defs where "formId"=${formId}`)
+  ]);
+};
+
+describe('query module form purge', () => {
+  it('should purge a soft-deleted form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+        .then(() => countFormRecords(container, 1)
+          .then(([ formCount, formDefCount ]) => {
+            formCount.should.equal(0);
+            formDefCount.should.equal(0);
+          })))));
+  
+  it('should not find any matching forms records in the database', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      container.Forms.getByProjectAndXmlFormId(1, 'simple').then((o) => o.get())
+        .then(( ghostForm ) => countFormRecords(container, ghostForm.id)
+          .then(([ formCount, formDefCount ]) => {
+            formCount.should.equal(1);
+            formDefCount.should.equal(1);
+          })
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple')
+            .expect(200))
+          .then(() => container.Forms.purge(true))
+          .then(() => countFormRecords(container, ghostForm.id)
+            .then(([ formCount, formDefCount ]) => {
+              formCount.should.equal(0);
+              formDefCount.should.equal(0);
+            }))))));
+});

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -86,14 +86,12 @@ describe('query module form purge', () => {
           .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
           .then(() => container.one(sql`select * from actees where id = ${form.acteeId}`))
           .then((res) => {
-            const deletedFormDetails = {
-              projectId: 1,
-              formId: 1,
-              xmlFormId: 'simple',
-              name: 'Simple',
-              version: ''
-            };
-            res.details.should.eql(deletedFormDetails);
+            res.details.projectId.should.equal(1);
+            res.details.formId.should.equal(1);
+            res.details.version.should.equal('');
+            res.details.xmlFormId.should.equal('simple');
+            res.details.deletedAt.should.be.an.isoDate();
+            res.purgedName.should.equal('Simple');
           })))));
 
   it('should purge a form with multiple versions', testService((service, container) =>

--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -1,0 +1,64 @@
+const appRoot = require('app-root-path');
+const should = require('should');
+const { testTask } = require('../setup');
+const { purgeForms } = require(appRoot + '/lib/task/purge');
+const { setConfiguration } = require(appRoot + '/lib/task/config');
+
+// The basics of this task are tested here, including returning the count
+// of purged forms, but the full functionality is more thoroughly tested in 
+// test/integration/other/form-purging.js
+
+describe('task: purge deleted forms', () => {
+  it('should not purge recently deleted forms by default', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(purgeForms)
+      .then((count) => {
+        count.should.equal(0);
+      }))));
+
+  it('should purge recently deleted form if forced', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true))
+      .then((count) => {
+        count.should.equal(1);
+      }))));
+
+  it('should return count for multiple forms purged', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true))
+      .then((count) => {
+        count.should.equal(2);
+      })))));
+
+  it('should not purge specific recently deleted form', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(false, 1))
+      .then((count) => {
+        count.should.equal(0);
+      }))));
+
+  it('should purge specific recently deleted form if forced', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true, 1))
+      .then((count) => {
+        count.should.equal(1);
+      }))));
+
+  it('should force purge only specific form', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true, 1))
+      .then((count) => {
+        count.should.equal(1);
+      })))));
+});
+


### PR DESCRIPTION
This PR enables the purging of soft-deleted forms and their associated resources (definitions, versions, submissions, attachments, comments, etc.)

Purging follows these steps:
1. Redact notes about forms from the audit table that reference a form (includes one kind of comment on a submission)
2. Log the purge in the audit log with actor not set
3. Update actees table for the specific form to leave some useful information behind
4. Delete the forms and their resources from the database
5. Purge unattached blobs

As a side effect of deleting/purging Forms, we needed to address issue getodk/central#127 and decide what to display in the audit log for deleted resources. To do this, we added `purgedAt`, `purgedName`, `details` to `Actees` to capture information about a permanently removed resources and then exposed this info via the audit log API. 

This PR has a number of high-impact migrations:

* New fields described above on `actees` table
* Cascaded delete constraints on all form-related database tables
* Purging all previously soft-deleted forms regardless of deletion date

Purging is done through a task and command line script that will be called via cron job in the main Central repo. The script will be called daily to purge forms deleted over 30 days prior, but can also be used to purge a specific form by its numeric id.