### PR TITLE
track and return more of: formVersion, deviceId, userAgent

### DIFF
--- a/lib/data/briefcase.js
+++ b/lib/data/briefcase.js
@@ -35,13 +35,14 @@ const pushPtr = (stack) => stack.push(ptr(stack));
 // given a row to write to, a decorated schema-field object, and metadata, writes
 // the metadata to the row and returns it.
 /* eslint-disable no-param-reassign */
-const writeMetadata = (out, idxs, submission, submitter, attachments, status) => {
+const writeMetadata = (out, idxs, submission, submitter, formVersion, attachments, status) => {
   out[idxs.submissionDate] = (new Date(submission.createdAt)).toISOString();
   out[idxs.key] = submission.instanceId;
   if (submitter != null) {
     out[idxs.submitterID] = submitter.id;
     out[idxs.submitterName] = submitter.displayName;
   }
+  out[idxs.formVersion] = formVersion;
   out[idxs.attachmentsPresent] = attachments.present || 0;
   out[idxs.attachmentsExpected] = attachments.expected || 0;
   if (status != null)
@@ -272,6 +273,7 @@ const streamBriefcaseCsvs = (inStream, inFields, xmlFormId, selectValues, decryp
     rootMeta.reviewState = rootHeader.length;          rootHeader.push('ReviewState');
     rootMeta.deviceID = rootHeader.length;             rootHeader.push('DeviceID');
     rootMeta.edits = rootHeader.length;                rootHeader.push('Edits');
+    rootMeta.formVersion = rootHeader.length;          rootHeader.push('FormVersion');
   }
 
   // then set up our main transform stream to handle incoming database records. it doesn't
@@ -303,13 +305,13 @@ const streamBriefcaseCsvs = (inStream, inFields, xmlFormId, selectValues, decryp
           (xml === null) ? 'not decrypted' : null; // eslint-disable-line indent
         if (status != null) {
           const result = new Array(rootHeader.length);
-          writeMetadata(result, rootMeta, submission, submission.aux.submitter, submission.aux.attachment, status);
+          writeMetadata(result, rootMeta, submission, submission.aux.submitter, submission.aux.exports.formVersion, submission.aux.attachment, status);
           return done(null, result);
         }
 
         // write the root row we get back from parsing the xml.
         processRow(xml, submission.instanceId, fields, rootHeader, selectValues).then((result) => {
-          writeMetadata(result, rootMeta, submission, submission.aux.submitter, submission.aux.attachment);
+          writeMetadata(result, rootMeta, submission, submission.aux.submitter, submission.aux.exports.formVersion, submission.aux.attachment);
           done(null, result);
         }, done); // pass through errors.
       } catch (ex) { done(ex); }

--- a/lib/data/odata.js
+++ b/lib/data/odata.js
@@ -149,7 +149,8 @@ const submissionToOData = (fields, table, submission, options = {}) => new Promi
         reviewState: submission.reviewState || null,
         deviceId: submission.deviceId || null,
         // because of how we compute this value we don't need to default it to 0:
-        edits: submission.aux.edit.count
+        edits: submission.aux.edit.count,
+        formVersion: submission.aux.exports.formVersion
       }
     });
 

--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -143,6 +143,7 @@ const edmxTemplater = template(`<?xml version="1.0" encoding="UTF-8"?>
         <Property Name="reviewState" Type="org.opendatakit.submission.ReviewState"/>
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="edits" Type="Edm.Int64"/>
+        <Property Name="formVersion" Type="Edm.String"/>
       </ComplexType>
       <EnumType Name="Status">
         <Member Name="notDecrypted"/>

--- a/lib/model/frames/submission.js
+++ b/lib/model/frames/submission.js
@@ -96,6 +96,8 @@ Submission.Def = Frame.define(
   embedded('submitter')
 );
 
+Submission.Extended = Frame.define('formVersion', readable);
+
 Submission.Xml = Frame.define(table('submission_defs', 'xml'), 'xml');
 
 Submission.Encryption = Frame.define(into('encryption'), 'encHasData', 'encData', 'encIndex',  'encKeyId');

--- a/lib/model/frames/submission.js
+++ b/lib/model/frames/submission.js
@@ -91,12 +91,15 @@ Submission.Def = Frame.define(
   'signature',                          'createdAt',    readable,
   'instanceName', readable,             'instanceId',   readable,
   'current',      readable,             'xml',
+  'root',
   embedded('submitter')
 );
 
 Submission.Xml = Frame.define(table('submission_defs', 'xml'), 'xml');
 
 Submission.Encryption = Frame.define(into('encryption'), 'encHasData', 'encData', 'encIndex',  'encKeyId');
+
+Submission.Exports = Frame.define(into('exports'), 'formVersion');
 
 
 module.exports = { Submission };

--- a/lib/model/frames/submission.js
+++ b/lib/model/frames/submission.js
@@ -91,7 +91,8 @@ Submission.Def = Frame.define(
   'signature',                          'createdAt',    readable,
   'instanceName', readable,             'instanceId',   readable,
   'current',      readable,             'xml',
-  'root',
+  'root',                               'deviceId',     readable,
+  'userAgent',    readable,
   embedded('submitter')
 );
 

--- a/lib/model/migrations/20211109-01-add-user-agent-to-submissions.js
+++ b/lib/model/migrations/20211109-01-add-user-agent-to-submissions.js
@@ -1,0 +1,28 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.schema.table('submission_defs', (sds) => {
+    sds.string('userAgent');
+    sds.string('deviceId');
+  });
+
+  await db.raw(`update submission_defs set "deviceId"=submissions."deviceId"
+    from submissions
+    where submissions.id=submission_defs."submissionId"
+      and submission_defs.id in (select min(id) from submission_defs group by "submissionId")`);
+};
+
+const down = (db) => db.schema.table('submission_defs', (sds) => {
+  sds.dropColumn('userAgent');
+  sds.dropColumn('deviceId');
+});
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20211114-01-flag-initial-submission-def.js
+++ b/lib/model/migrations/20211114-01-flag-initial-submission-def.js
@@ -1,0 +1,23 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.schema.table('submission_defs', (sds) => {
+    sds.boolean('root');
+  });
+  await db.raw(`update submission_defs set root=true
+  where id in (select min(id) from submission_defs group by "submissionId")`);
+};
+
+const down = (db) => db.schema.table('submission_defs', (sds) => {
+  sds.dropColumn('root');
+});
+
+module.exports = { up, down };
+

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -20,18 +20,19 @@ const Problem = require('../../util/problem');
 ////////////////////////////////////////////////////////////////////////////////
 // SUBMISSION CREATE
 
-const _defInsert = (id, partial, formDefId, actorId, root) => sql`insert into submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current)
-  values (${id}, ${sql.binary(partial.xml)}, ${formDefId}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), ${root}, true)
+const _defInsert = (id, partial, formDefId, actorId, root, deviceId, userAgent) => sql`insert into submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
+  values (${id}, ${sql.binary(partial.xml)}, ${formDefId}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), ${root}, true, ${deviceId}, ${userAgent})
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('submissions', 'id'))`;
 
 // creates both the submission and its initial submission def in one go.
-const createNew = (partial, form, deviceIdIn = null) => ({ one, context }) => {
+const createNew = (partial, form, deviceIdIn = null, userAgentIn = null) => ({ one, context }) => {
   const actorId = context.auth.actor.map((actor) => actor.id).orNull();
   const deviceId = blankStringToNull(deviceIdIn);
+  const userAgent = blankStringToNull(userAgentIn);
 
   return one(sql`
-with def as (${_defInsert(nextval, partial, form.def.id, actorId, true)}),
+with def as (${_defInsert(nextval, partial, form.def.id, actorId, true, deviceId, userAgent)}),
 ins as (insert into submissions (id, "formId", "instanceId", "submitterId", "deviceId", draft, "createdAt")
   select def."submissionId", ${form.id}, ${partial.instanceId}, def."submitterId", ${deviceId}, ${form.def.publishedAt == null}, def."createdAt" from def
   returning submissions.*)
@@ -56,15 +57,17 @@ createNew.audit = (submission, _, form) => (log) =>
   log('submission.create', form, { submissionId: submission.id, instanceId: submission.instanceId });
 createNew.audit.withResult = true;
 
-const createVersion = (partial, deprecated, form) => ({ one, context }) => {
+const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn = null) => ({ one, context }) => {
   const actorId = context.auth.actor.map((actor) => actor.id).orNull();
+  const deviceId = blankStringToNull(deviceIdIn);
+  const userAgent = blankStringToNull(userAgentIn);
 
   // we already do transactions but it just feels nice to have the cte do it all at once.
   return one(sql`
 with logical as (update submissions set "reviewState"='edited', "updatedAt"=clock_timestamp()
   where id=${deprecated.submissionId})
 , upd as (update submission_defs set current=false where "submissionId"=${deprecated.submissionId})
-${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null)}`)
+${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, deviceId, userAgent)}`)
     // TODO/HACK: lame that we are reconstructing this this way.
     .then((saved) => new Submission({ instanceId: partial.instanceId },
       { def: new Submission.Def(saved), xml: new Submission.Xml({ xml: partial.xml }) }));

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -20,8 +20,8 @@ const Problem = require('../../util/problem');
 ////////////////////////////////////////////////////////////////////////////////
 // SUBMISSION CREATE
 
-const _defInsert = (id, partial, formDefId, actorId) => sql`insert into submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", current)
-  values (${id}, ${sql.binary(partial.xml)}, ${formDefId}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), true)
+const _defInsert = (id, partial, formDefId, actorId, root) => sql`insert into submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current)
+  values (${id}, ${sql.binary(partial.xml)}, ${formDefId}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), ${root}, true)
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('submissions', 'id'))`;
 
@@ -31,7 +31,7 @@ const createNew = (partial, form, deviceIdIn = null) => ({ one, context }) => {
   const deviceId = blankStringToNull(deviceIdIn);
 
   return one(sql`
-with def as (${_defInsert(nextval, partial, form.def.id, actorId)}),
+with def as (${_defInsert(nextval, partial, form.def.id, actorId, true)}),
 ins as (insert into submissions (id, "formId", "instanceId", "submitterId", "deviceId", draft, "createdAt")
   select def."submissionId", ${form.id}, ${partial.instanceId}, def."submitterId", ${deviceId}, ${form.def.publishedAt == null}, def."createdAt" from def
   returning submissions.*)
@@ -64,7 +64,7 @@ const createVersion = (partial, deprecated, form) => ({ one, context }) => {
 with logical as (update submissions set "reviewState"='edited', "updatedAt"=clock_timestamp()
   where id=${deprecated.submissionId})
 , upd as (update submission_defs set current=false where "submissionId"=${deprecated.submissionId})
-${_defInsert(deprecated.submissionId, partial, form.def.id, actorId)}`)
+${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null)}`)
     // TODO/HACK: lame that we are reconstructing this this way.
     .then((saved) => new Submission({ instanceId: partial.instanceId },
       { def: new Submission.Def(saved), xml: new Submission.Xml({ xml: partial.xml }) }));
@@ -211,7 +211,7 @@ where "formId"=${formId} and draft=${draft} and submissions."deletedAt" is null`
 
 const _exportUnjoiner = unjoiner(Submission, Submission.Def, Submission.Xml, Submission.Encryption,
   Actor.alias('actors', 'submitter'), Frame.define(table('attachments'), 'present', 'expected'),
-  Frame.define(table('edits'), 'count'));
+  Frame.define(table('edits'), 'count'), Submission.Exports); // TODO: figure out how to combine some of these
 
 // TODO: this is a terrible hack to add some logic to one of our select fields. this is
 // the /only/ place we need to do this in the entire codebase right now. so for now
@@ -241,6 +241,10 @@ left outer join
     from submission_attachments
     group by "submissionDefId") as attachments
   on attachments."submissionDefId"=submission_defs.id
+inner join (select "formDefId", "submissionId" from submission_defs where root is true) as roots
+  on roots."submissionId"=submission_defs."submissionId"
+inner join (select id, version as "formVersion" from form_defs) as fds
+  on fds.id=roots."formDefId"
 ${encrypted ? sql`
 left outer join (select id, "keyId" as "encKeyId" from form_defs) as form_defs on form_defs.id=submission_defs."formDefId"
 left outer join (select id, content as "encData" from blobs) as blobs on blobs.id=submission_attachments."blobId"`

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -181,12 +181,15 @@ inner join submissions on submissions.id = submission_defs."submissionId" and su
 where submission_defs.id=${submissionDefId}`)
   .then(map(construct(Submission.Def)));
 
-const _getDef = extender(Submission.Def)(Actor.into('submitter'))((fields, extend, options, formId, draft) => sql`
+const _getDef = extender(Submission.Def)(Actor.into('submitter'), Submission.Extended)((fields, extend, options, formId, draft) => sql`
 select ${fields} from submission_defs
 inner join
   (select id, "instanceId" from submissions where "formId"=${formId} and draft=${draft} and "deletedAt" is null)
   as submissions on submissions.id=submission_defs."submissionId"
-${extend|| sql`left outer join actors on actors.id=submission_defs."submitterId"`}
+${extend|| sql`
+  left outer join actors on actors.id=submission_defs."submitterId"
+  inner join (select id, version as "formVersion" from form_defs) as fds
+    on fds.id=submission_defs."formDefId"`}
 where ${equals(options.condition)}
 order by submission_defs.id desc`);
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -68,7 +68,7 @@ module.exports = (service, endpoint) => {
         .then(always({ code: 204, body: '' }))));
 
     // Nonstandard REST; OpenRosa-specific API.
-    service.post(path, multipart.any(), endpoint.openRosa(({ Forms, Submissions, SubmissionAttachments }, { params, files, auth, query }) =>
+    service.post(path, multipart.any(), endpoint.openRosa(({ Forms, Submissions, SubmissionAttachments }, { params, files, auth, query, headers }) =>
       Submission.fromXml(findMultipart(files).buffer)
         .then((partial) => getForm(auth, params, partial.xmlFormId, Forms, partial.def.version)
           .catch(forceAuthFailed)
@@ -111,7 +111,7 @@ module.exports = (service, endpoint) => {
                   }
                   // NEW SUBMISSION REQUEST: create a new submission and attachments.
                   return Promise.all([
-                    Submissions.createNew(partial, form, query.deviceID),
+                    Submissions.createNew(partial, form, query.deviceID, headers['user-agent']),
                     Forms.getBinaryFields(form.def.id)
                   ]).then(([ saved, binaryFields ]) => SubmissionAttachments.create(saved, form, binaryFields, files));
                 });
@@ -162,7 +162,7 @@ module.exports = (service, endpoint) => {
   // and repeated for draft/nondraft.
 
   const restSubmission = (base, draft, getForm) => {
-    service.post(`${base}/submissions`, endpoint(({ Forms, Submissions, SubmissionAttachments }, { params, auth, query }, request) =>
+    service.post(`${base}/submissions`, endpoint(({ Forms, Submissions, SubmissionAttachments }, { params, auth, query, headers }, request) =>
       Submission.fromXml(request)
         .then((partial) => getForm(params, Forms, partial.def.version)
           .then((form) => auth.canOrReject('submission.create', form))
@@ -171,7 +171,7 @@ module.exports = (service, endpoint) => {
               return reject(Problem.user.unexpectedValue({ field: 'form id', value: partial.xmlFormId, reason: 'did not match the form ID in the URL' }));
 
             return Promise.all([
-              Submissions.createNew(partial, form, query.deviceID),
+              Submissions.createNew(partial, form, query.deviceID, headers['user-agent']),
               Forms.getBinaryFields(form.def.id)
             ])
               .then(([ submission, binaryFields ]) =>
@@ -179,7 +179,7 @@ module.exports = (service, endpoint) => {
                   .then(always(submission)));
           }))));
 
-    service.put(`${base}/submissions/:instanceId`, endpoint(({ Forms, Submissions, SubmissionAttachments }, { params, auth }, request) =>
+    service.put(`${base}/submissions/:instanceId`, endpoint(({ Forms, Submissions, SubmissionAttachments }, { params, auth, query, headers }, request) =>
       Submission.fromXml(request).then((partial) => {
         if (partial.xmlFormId !== params.formId)
           return reject(Problem.user.unexpectedValue({ field: 'form id', value: partial.xmlFormId, reason: 'did not match the form ID in the URL' }));
@@ -196,7 +196,7 @@ module.exports = (service, endpoint) => {
             .then(getOrNotFound) // this request exists just to check existence and fail the whole request.
         ])
           .then(([ deprecated, form ]) => Promise.all([
-            Submissions.createVersion(partial, deprecated, form),
+            Submissions.createVersion(partial, deprecated, form, query.deviceID, headers['user-agent']),
             Forms.getBinaryFields(form.def.id),
             SubmissionAttachments.getForFormAndInstanceId(form.id, deprecatedId, draft),
           ])

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -250,13 +250,13 @@ should.Assertion.add('SimpleCsv', function() {
 
   const csv = this.obj.split('\n').map((row) => row.split(','));
   csv.length.should.equal(5); // header + 3 data rows + newline
-  csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits' ]);
+  csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);
   csv[1].shift().should.be.an.recentIsoDate();
-  csv[1].should.eql([ 'three','Chelsea','38','three','5','Alice','0','0','','','','0' ]);
+  csv[1].should.eql([ 'three','Chelsea','38','three','5','Alice','0','0','','','','0', '' ]);
   csv[2].shift().should.be.an.recentIsoDate();
-  csv[2].should.eql([ 'two','Bob','34','two','5','Alice','0','0','','','','0' ]);
+  csv[2].should.eql([ 'two','Bob','34','two','5','Alice','0','0','','','','0', '' ]);
   csv[3].shift().should.be.an.recentIsoDate();
-  csv[3].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0' ]);
+  csv[3].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0', '' ]);
   csv[4].should.eql([ '' ]);
 });
 
@@ -265,12 +265,15 @@ should.Assertion.add('EncryptedSimpleCsv', function() {
 
   const csv = this.obj.split('\n').map((row) => row.split(','));
   csv.length.should.equal(5); // header + 3 data rows + newline
-  csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits' ]);
+  csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);
   csv[1].shift().should.be.an.recentIsoDate();
+  csv[1].pop().should.match(/^\[encrypted:........\]$/);
   csv[1].should.eql([ 'three','Chelsea','38','three','5','Alice','1','1','','','','0' ]);
   csv[2].shift().should.be.an.recentIsoDate();
+  csv[2].pop().should.match(/^\[encrypted:........\]$/);
   csv[2].should.eql([ 'two','Bob','34','two','5','Alice','1','1','','','','0' ]);
   csv[3].shift().should.be.an.recentIsoDate();
+  csv[3].pop().should.match(/^\[encrypted:........\]$/);
   csv[3].should.eql([ 'one','Alice','30','one','5','Alice','1','1','','','','0' ]);
   csv[4].should.eql([ '' ]);
 });

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -145,7 +145,8 @@ describe('api: /forms/:id.svc', () => {
                   status: null,
                   reviewState: null,
                   deviceId: 'testid',
-                  edits: 0
+                  edits: 0,
+                  formVersion: '1.0'
                 },
                 children: {
                   'child@odata.navigationLink': "Submissions('double')/children/child"
@@ -216,7 +217,8 @@ describe('api: /forms/:id.svc', () => {
                     status: 'missingEncryptedFormData',
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: 'working3'
                   }
                 }]
               });
@@ -256,7 +258,8 @@ describe('api: /forms/:id.svc', () => {
                     status: 'notDecrypted',
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: 'working3'
                   }
                 }]
               });
@@ -444,7 +447,8 @@ describe('api: /forms/:id.svc', () => {
                   status: null,
                   reviewState: null,
                   deviceId: null,
-                  edits: 0
+                  edits: 0,
+                  formVersion: '1.0'
                 },
                 meta: { instanceID: "rthree" },
                 name: "Chelsea",
@@ -464,7 +468,8 @@ describe('api: /forms/:id.svc', () => {
                   status: null,
                   reviewState: null,
                   deviceId: null,
-                  edits: 0
+                  edits: 0,
+                  formVersion: '1.0'
                 },
                 meta: { instanceID: "rtwo" },
                 name: "Bob",
@@ -484,7 +489,8 @@ describe('api: /forms/:id.svc', () => {
                   status: null,
                   reviewState: null,
                   deviceId: null,
-                  edits: 0
+                  edits: 0,
+                  formVersion: '1.0'
                 },
                 meta: { instanceID: "rone" },
                 name: "Alice",
@@ -551,7 +557,8 @@ describe('api: /forms/:id.svc', () => {
                   status: null,
                   reviewState: null,
                   deviceId: null,
-                  edits: 0
+                  edits: 0,
+                  formVersion: '1.0'
                 },
                 meta: { instanceID: "rtwo" },
                 name: "Bob",
@@ -587,7 +594,8 @@ describe('api: /forms/:id.svc', () => {
                   status: null,
                   reviewState: null,
                   deviceId: null,
-                  edits: 0
+                  edits: 0,
+                  formVersion: '1.0'
                 },
                 meta: { instanceID: "rthree" },
                 name: "Chelsea",
@@ -639,8 +647,9 @@ describe('api: /forms/:id.svc', () => {
                       attachmentsExpected: 0,
                       status: null,
                       reviewState: null,
-                    deviceId: null,
-                    edits: 0
+                      deviceId: null,
+                      edits: 0,
+                      formVersion: '1.0'
                     },
                     meta: { instanceID: "rthree" },
                     name: "Chelsea",
@@ -660,7 +669,8 @@ describe('api: /forms/:id.svc', () => {
                       status: null,
                       reviewState: null,
                       deviceId: null,
-                      edits: 0
+                      edits: 0,
+                    formVersion: '1.0'
                     },
                     meta: { instanceID: "rone" },
                     name: "Alice",
@@ -698,7 +708,8 @@ describe('api: /forms/:id.svc', () => {
                     status: null,
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: '1.0'
                   },
                   meta: { instanceID: "rone" },
                   name: "Alice",
@@ -736,7 +747,8 @@ describe('api: /forms/:id.svc', () => {
                     status: null,
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: '1.0'
                   },
                   meta: { instanceID: "rone" },
                   name: "Alice",
@@ -779,7 +791,8 @@ describe('api: /forms/:id.svc', () => {
                     status: null,
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: '1.0'
                   },
                   meta: { instanceID: 'rone' },
                   name: 'Alice',
@@ -823,7 +836,8 @@ describe('api: /forms/:id.svc', () => {
                     status: null,
                     reviewState: 'rejected',
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: '1.0'
                   },
                   meta: { instanceID: "rtwo" },
                   name: "Bob",
@@ -947,7 +961,8 @@ describe('api: /forms/:id.svc', () => {
                     status: 'missingEncryptedFormData',
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: 'working3'
                   }
                 }, {
                   __id: 'uuid:dcf4a151-5088-453f-99e6-369d67828f7a',
@@ -961,7 +976,8 @@ describe('api: /forms/:id.svc', () => {
                     status: 'missingEncryptedFormData',
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: 'working3'
                   }
                 }]
               });
@@ -1010,7 +1026,8 @@ describe('api: /forms/:id.svc', () => {
                     status: 'notDecrypted',
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: 'working3'
                   }
                 }, {
                   __id: 'uuid:dcf4a151-5088-453f-99e6-369d67828f7a',
@@ -1024,7 +1041,8 @@ describe('api: /forms/:id.svc', () => {
                     status: 'notDecrypted',
                     reviewState: null,
                     deviceId: null,
-                    edits: 0
+                    edits: 0,
+                    formVersion: 'working3'
                   }
                 }]
               });
@@ -1196,7 +1214,8 @@ describe('api: /forms/:id.svc', () => {
                       status: null,
                       reviewState: null,
                       deviceId: null,
-                      edits: 0
+                      edits: 0,
+                      formVersion: '1.0'
                     },
                     children: {
                       'child@odata.navigationLink': "Submissions('double')/children/child"
@@ -1276,7 +1295,8 @@ describe('api: /forms/:id.svc', () => {
                       status: null,
                       reviewState: null,
                       deviceId: null,
-                      edits: 0
+                      edits: 0,
+                      formVersion: '1.0'
                     },
                     meta: { instanceID: "rthree" },
                     name: "Chelsea",
@@ -1296,7 +1316,8 @@ describe('api: /forms/:id.svc', () => {
                       status: null,
                       reviewState: null,
                       deviceId: null,
-                      edits: 0
+                      edits: 0,
+                      formVersion: '1.0'
                     },
                     meta: { instanceID: "rtwo" },
                     name: "Bob",
@@ -1316,7 +1337,8 @@ describe('api: /forms/:id.svc', () => {
                       status: null,
                       reviewState: null,
                       deviceId: null,
-                      edits: 0
+                      edits: 0,
+                      formVersion: '1.0'
                     },
                     meta: { instanceID: "rone" },
                     name: "Alice",

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -3675,9 +3675,10 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
           .send(testData.instances.simple.one.replace(/<\/meta>/, '<orx:instanceName>custom name</orx:instanceName></meta>'))
           .set('Content-Type', 'text/xml')
           .expect(200)
-          .then(() => asAlice.put('/v1/projects/1/forms/simple/submissions/one')
+          .then(() => asAlice.put('/v1/projects/1/forms/simple/submissions/one?deviceID=updateDevice')
             .send(withSimpleIds('one', 'two'))
             .set('Content-Type', 'text/xml')
+            .set('User-Agent', 'central/tests')
             .expect(200))
           .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/versions')
             .expect(200)
@@ -3689,6 +3690,11 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
               body[1].submitterId.should.equal(5);
               should(body[0].instanceName).equal(null);
               body[1].instanceName.should.equal('custom name');
+
+              body[0].deviceId.should.equal('updateDevice');
+              body[0].userAgent.should.equal('central/tests');
+              (body[1].deviceId == null).should.equal(true);
+              body[1].userAgent.should.equal('node-superagent/3.8.3');
             })))));
 
     it('should return extended submission details', testService((service) =>

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1538,7 +1538,6 @@ describe('api: /forms/:id/submissions', () => {
           .then(() => new Promise((done) =>
             zipStreamToFiles(asAlice.get('/v1/projects/1/forms/simple/submissions.csv.zip?deletedFields=true'), (result) => {
               result.filenames.should.containDeep([ 'simple.csv' ]);
-              console.log(result['simple.csv']);
               const lines = result['simple.csv'].split('\n');
               lines[0].should.equal('SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
               lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)

--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -215,6 +215,7 @@ describe('managed encryption', () => {
           .then((keyId) => new Promise((done) =>
             zipStreamToFiles(asAlice.get(`/v1/projects/1/forms/simple/submissions.csv.zip?${keyId}=supersecret`), (result) => {
               result.filenames.should.eql([ 'simple.csv' ]);
+              console.log(result['simple.csv']);
               result['simple.csv'].should.be.an.EncryptedSimpleCsv();
               done();
             }))))));
@@ -503,13 +504,15 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                 result.filenames.should.eql([ 'simple.csv' ]);
                 const csv = result['simple.csv'].split('\n').map((row) => row.split(','));
                 csv.length.should.equal(5); // header + 3 data rows + newline
-                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits' ]);
+                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);
                 csv[1].shift().should.be.an.recentIsoDate();
+                csv[1].pop().should.match(/^\[encrypted:........\]$/);
                 csv[1].should.eql([ 'three','Chelsea','38','three','5','Alice','1','1','','','','0' ]);
                 csv[2].shift().should.be.an.recentIsoDate();
+                csv[2].pop().should.match(/^\[encrypted:........\]$/);
                 csv[2].should.eql([ 'two','Bob','34','two','5','Alice','1','1','','','','0' ]);
                 csv[3].shift().should.be.an.recentIsoDate();
-                csv[3].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0' ]);
+                csv[3].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0','' ]);
                 csv[4].should.eql([ '' ]);
                 done();
               })))))));
@@ -534,13 +537,15 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
 
                 const csv = result['simple.csv'].split('\n').map((row) => row.split(','));
                 csv.length.should.equal(5); // header + 3 data rows + newline
-                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits' ]);
+                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);
                 csv[1].shift().should.be.an.recentIsoDate();
+                csv[1].pop().should.match(/^\[encrypted:........\]$/);
                 csv[1].should.eql([ '','','','three','5','Alice','1','1','not decrypted','','','0' ]);
                 csv[2].shift().should.be.an.recentIsoDate();
+                csv[2].pop().should.match(/^\[encrypted:........\]$/);
                 csv[2].should.eql([ '','','','two','5','Alice','1','1','not decrypted','','','0' ]);
                 csv[3].shift().should.be.an.recentIsoDate();
-                csv[3].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0' ]);
+                csv[3].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0','' ]);
                 csv[4].should.eql([ '' ]);
                 done();
               })))))));
@@ -583,8 +588,20 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             .then(({ body }) => body.map((key) => key.id)))
           .then((keyIds) => new Promise((done) =>
             zipStreamToFiles(asAlice.get(`/v1/projects/1/forms/simple/submissions.csv.zip?${keyIds[1]}=supersecret&${keyIds[0]}=superdupersecret`), (result) => {
-              result.filenames.should.eql([ 'simple.csv' ]);
-              result['simple.csv'].should.be.an.EncryptedSimpleCsv();
+              console.log('simple.csv');
+              const csv = result['simple.csv'].split('\n').map((row) => row.split(','));
+              csv.length.should.equal(5); // header + 3 data rows + newline
+              csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);
+              csv[1].shift().should.be.an.recentIsoDate();
+              csv[1].pop().should.match(/^two\[encrypted:........\]$/);
+              csv[1].should.eql([ 'three','Chelsea','38','three','5','Alice','1','1','','','','0' ]);
+              csv[2].shift().should.be.an.recentIsoDate();
+              csv[2].pop().should.match(/^two\[encrypted:........\]$/);
+              csv[2].should.eql([ 'two','Bob','34','two','5','Alice','1','1','','','','0' ]);
+              csv[3].shift().should.be.an.recentIsoDate();
+              csv[3].pop().should.match(/^\[encrypted:........\]$/);
+              csv[3].should.eql([ 'one','Alice','30','one','5','Alice','1','1','','','','0' ]);
+              csv[4].should.eql([ '' ]);
               done();
             }))))));
 
@@ -613,11 +630,12 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
 
                 const csv = result['simple.csv'].split('\n').map((row) => row.split(','));
                 csv.length.should.equal(4); // header + 2 data rows + newline
-                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits' ]);
+                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);
                 csv[1].shift().should.be.an.recentIsoDate();
+                csv[1].pop().should.match(/^\[encrypted:........\]$/);
                 csv[1].should.eql([ '','','','two','5','Alice','0','1','missing encrypted form data','','','0' ]);
                 csv[2].shift().should.be.an.recentIsoDate();
-                csv[2].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0' ]);
+                csv[2].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0','' ]);
                 csv[3].should.eql([ '' ]);
                 done();
               })))))));
@@ -644,11 +662,12 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
 
                 const csv = result['simple.csv'].split('\n').map((row) => row.split(','));
                 csv.length.should.equal(4); // header + 2 data rows + newline
-                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits' ]);
+                csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);
                 csv[1].shift().should.be.an.recentIsoDate();
+                csv[1].pop().should.match(/^\[encrypted:........\]$/);
                 csv[1].should.eql([ '','','','two','5','Alice','0','1','missing encrypted form data','','','0' ]);
                 csv[2].shift().should.be.an.recentIsoDate();
-                csv[2].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0' ]);
+                csv[2].should.eql([ 'one','Alice','30','one','5','Alice','0','0','','','','0','' ]);
                 csv[3].should.eql([ '' ]);
                 done();
               })))))));

--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -215,7 +215,6 @@ describe('managed encryption', () => {
           .then((keyId) => new Promise((done) =>
             zipStreamToFiles(asAlice.get(`/v1/projects/1/forms/simple/submissions.csv.zip?${keyId}=supersecret`), (result) => {
               result.filenames.should.eql([ 'simple.csv' ]);
-              console.log(result['simple.csv']);
               result['simple.csv'].should.be.an.EncryptedSimpleCsv();
               done();
             }))))));
@@ -588,7 +587,6 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             .then(({ body }) => body.map((key) => key.id)))
           .then((keyIds) => new Promise((done) =>
             zipStreamToFiles(asAlice.get(`/v1/projects/1/forms/simple/submissions.csv.zip?${keyIds[1]}=supersecret&${keyIds[0]}=superdupersecret`), (result) => {
-              console.log('simple.csv');
               const csv = result['simple.csv'].split('\n').map((row) => row.split(','));
               csv.length.should.equal(5); // header + 3 data rows + newline
               csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY', 'SubmitterID', 'SubmitterName', 'AttachmentsPresent', 'AttachmentsExpected', 'Status', 'ReviewState', 'DeviceID', 'Edits', 'FormVersion' ]);

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -14,12 +14,12 @@ const { zipStreamFromParts } = require(appRoot + '/lib/util/zip');
 // the complexity of recursive in-zip csv file generation. hard to test unitly.
 
 // takes care of instance envelope boilerplate.
-const instance = (id, data) => ({
+const instance = (id, data, formVersion = 'version') => ({
   instanceId: id,
   createdAt: new Date('2018-01-01T00:00:00Z'),
   def: {},
   xml: `<data id="data">${data}</data>`,
-  aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 } }
+  aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 }, exports: { formVersion } }
 });
 
 const withSubmitter = (id, displayName, row) => ({ ...row, aux: { ...row.aux, submitter: { id, displayName } } });
@@ -63,10 +63,10 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,Alice,30,"Seattle, WA",one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,Chelsea,38,"San Francisco, CA",three,,,0,0,,,,0
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,Alice,30,"Seattle, WA",one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,Chelsea,38,"San Francisco, CA",three,,,0,0,,,,0,version
 `);
       done();
     });
@@ -78,7 +78,7 @@ describe('.csv.zip briefcase output @slow', () => {
       createdAt: new Date('2018-01-01T00:00:00Z'),
       def: {},
       xml: '<data id="data">',
-      aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 } }
+      aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 }, exports: { formVersion: '' } }
     }]);
 
     // not hanging is the assertion here:
@@ -114,10 +114,10 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,Alice,30,"Seattle, WA",one,4,daniela,0,0,,,,0
-2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,8,hernando,0,0,,,,0
-2018-01-01T00:00:00.000Z,Chelsea,38,"San Francisco, CA",three,15,lito,0,0,,,,0
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,Alice,30,"Seattle, WA",one,4,daniela,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,8,hernando,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,Chelsea,38,"San Francisco, CA",three,15,lito,0,0,,,,0,version
 `);
       done();
     });
@@ -152,10 +152,10 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,Alice,30,"Seattle, WA",one,,,2,4,,,,0
-2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,,,1,4,,,,0
-2018-01-01T00:00:00.000Z,Chelsea,38,"San Francisco, CA",three,,,3,3,,,,0
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,Alice,30,"Seattle, WA",one,,,2,4,,,,0,version
+2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,,,1,4,,,,0,version
+2018-01-01T00:00:00.000Z,Chelsea,38,"San Francisco, CA",three,,,3,3,,,,0,version
 `);
       done();
     });
@@ -189,9 +189,9 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,,,,one,,,0,0,missing encrypted form data,,,0
-2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,,,0,0,,rejected,,0
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,,,,one,,,0,0,missing encrypted form data,,,0,version
+2018-01-01T00:00:00.000Z,Bob,34,"Portland, OR",two,,,0,0,,rejected,,0,version
 `);
       done();
     });
@@ -224,8 +224,8 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,,,,one,,,0,0,missing encrypted form data,,test device,0
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,,,,one,,,0,0,missing encrypted form data,,test device,0,version
 `);
       done();
     });
@@ -258,8 +258,45 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,,,,one,,,0,0,,,,3
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,,,,one,,,0,0,,,,3,version
+`);
+      done();
+    });
+  });
+
+  it('should list each submission form version', (done) => {
+    const formXml = `
+      <?xml version="1.0"?>
+      <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+        <h:head>
+          <model>
+            <instance>
+              <data id="mytestform">
+                <name/>
+                <age/>
+                <hometown/>
+              </data>
+            </instance>
+            <bind nodeset="/data/name" type="string"/>
+            <bind type="integer" nodeset="/data/age"/>
+            <bind nodeset="/data/hometown" type="select1"/>
+          </model>
+        </h:head>
+      </h:html>`;
+
+    const one = instance('one', 'xml');
+    one.aux.exports.formVersion = 'original';
+    const two = instance('two', 'xml');
+    two.aux.exports.formVersion = 'updated';
+    const inStream = streamTest.fromObjects([ one, two ]);
+
+    callAndParse(inStream, formXml, 'mytestform', (result) => {
+      result.filenames.should.eql([ 'mytestform.csv' ]);
+      result['mytestform.csv'].should.equal(
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,,,,one,,,0,0,,,,0,original
+2018-01-01T00:00:00.000Z,,,,two,,,0,0,,,,0,updated
 `);
       done();
     });
@@ -292,8 +329,8 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,\xABAlice\xBB,30,"Seattle, WA",one,,,0,0,,,,0
+`SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,\xABAlice\xBB,30,"Seattle, WA",one,,,0,0,,,,0,version
 `);
       done();
     });
@@ -328,10 +365,10 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'mytestform', (result) => {
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
-`SubmissionDate,name,age,location-Latitude,location-Longitude,location-Altitude,location-Accuracy,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,Alice,30,47.649434,-122.347737,26.8,3.14,one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,Bob,34,47.599115,-122.331753,10,,two,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,Chelsea,38,,,,,three,,,0,0,,,,0
+`SubmissionDate,name,age,location-Latitude,location-Longitude,location-Altitude,location-Accuracy,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,Alice,30,47.649434,-122.347737,26.8,3.14,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,Bob,34,47.599115,-122.331753,10,,two,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,Chelsea,38,,,,,three,,,0,0,,,,0,version
 `);
       done();
     });
@@ -347,9 +384,9 @@ describe('.csv.zip briefcase output @slow', () => {
       zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] })), (result) => {
         result.filenames.should.eql([ 'selectMultiple.csv' ]);
         result['selectMultiple.csv'].should.equal(
-`SubmissionDate,q1,q1/x,q1/y,q1/z,g1-q2,g1-q2/m,g1-q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,b,0,0,0,m x,1,0,two,,,0,0,,,,0
+`SubmissionDate,q1,q1/x,q1/y,q1/z,g1-q2,g1-q2/m,g1-q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,b,0,0,0,m x,1,0,two,,,0,0,,,,0,version
 `);
         done();
       });
@@ -395,10 +432,10 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'structuredform', (result) => {
       result.filenames.should.eql([ 'structuredform.csv' ]);
       result['structuredform.csv'].should.equal(
-`SubmissionDate,meta-instanceID,name,home-type,home-address-street,home-address-city,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,one,Alice,Apartment,101 Pike St,"Seattle, WA",one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,two,Bob,Condo,20 Broadway,"Portland, OR",two,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,three,Chelsea,House,99 Mission Ave,"San Francisco, CA",three,,,0,0,,,,0
+`SubmissionDate,meta-instanceID,name,home-type,home-address-street,home-address-city,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,one,Alice,Apartment,101 Pike St,"Seattle, WA",one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,two,Bob,Condo,20 Broadway,"Portland, OR",two,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,three,Chelsea,House,99 Mission Ave,"San Francisco, CA",three,,,0,0,,,,0,version
 `);
       done();
     });
@@ -444,10 +481,10 @@ describe('.csv.zip briefcase output @slow', () => {
       zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'structuredform', undefined, undefined, false, { groupPaths: false })), (result) => {
         result.filenames.should.eql([ 'structuredform.csv' ]);
         result['structuredform.csv'].should.equal(
-`SubmissionDate,instanceID,name,type,street,city,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,one,Alice,Apartment,101 Pike St,"Seattle, WA",one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,two,Bob,Condo,20 Broadway,"Portland, OR",two,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,three,Chelsea,House,99 Mission Ave,"San Francisco, CA",three,,,0,0,,,,0
+`SubmissionDate,instanceID,name,type,street,city,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,one,Alice,Apartment,101 Pike St,"Seattle, WA",one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,two,Bob,Condo,20 Broadway,"Portland, OR",two,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,three,Chelsea,House,99 Mission Ave,"San Francisco, CA",three,,,0,0,,,,0,version
 `);
       done();
       });
@@ -464,9 +501,9 @@ describe('.csv.zip briefcase output @slow', () => {
       zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] }, undefined, false, { groupPaths: false })), (result) => {
         result.filenames.should.eql([ 'selectMultiple.csv' ]);
         result['selectMultiple.csv'].should.equal(
-`SubmissionDate,q1,q1/x,q1/y,q1/z,q2,q2/m,q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,b,0,0,0,m x,1,0,two,,,0,0,,,,0
+`SubmissionDate,q1,q1/x,q1/y,q1/z,q2,q2/m,q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,b,0,0,0,m x,1,0,two,,,0,0,,,,0,version
 `);
         done();
       });
@@ -531,10 +568,10 @@ describe('.csv.zip briefcase output @slow', () => {
     callAndParse(inStream, formXml, 'singlerepeat', (result) => {
       result.filenames.should.containDeep([ 'singlerepeat.csv', 'singlerepeat-child.csv' ]);
       result['singlerepeat.csv'].should.equal(
-`SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,one,Alice,30,one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,two,Bob,34,two,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,three,Chelsea,38,three,,,0,0,,,,0
+`SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,one,Alice,30,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,two,Bob,34,two,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,three,Chelsea,38,three,,,0,0,,,,0,version
 `);
       result['singlerepeat-child.csv'].should.equal(
 `name,age,PARENT_KEY,KEY
@@ -668,10 +705,10 @@ Candace,2,three,three/children/child[1]
     callAndParse(inStream, formXml, 'multirepeat', (result) => {
       result.filenames.should.containDeep([ 'multirepeat.csv', 'multirepeat-child.csv', 'multirepeat-toy.csv' ]);
       result['multirepeat.csv'].should.equal(
-`SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,one,Alice,30,one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,two,Bob,34,two,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,three,Chelsea,38,three,,,0,0,,,,0
+`SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,one,Alice,30,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,two,Bob,34,two,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,three,Chelsea,38,three,,,0,0,,,,0,version
 `);
       result['multirepeat-child.csv'].should.equal(
 `name,age,PARENT_KEY,KEY
@@ -728,8 +765,8 @@ Pod racer,three/children/child[1],three/children/child[1]/toy[3]
     callAndParse(inStream, formXml, 'pathprefix', (result) => {
       result.filenames.should.containDeep([ 'pathprefix.csv', 'pathprefix-children.csv' ]);
       result['pathprefix.csv'].should.equal(
-`SubmissionDate,name,children-status,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,Alice,Living at home,one,,,0,0,,,,0
+`SubmissionDate,name,children-status,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,Alice,Living at home,one,,,0,0,,,,0,version
 `);
       result['pathprefix-children.csv'].should.equal(
 `name,PARENT_KEY,KEY
@@ -811,14 +848,14 @@ Chelsea,one,one/children[2]
     <n0:instanceID>uuid:39f3dd36-161e-45cb-a1a4-395831d253a7</n0:instanceID>
   </n0:meta>
 </data>`,
-      aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 } }
+      aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 }, exports: { formVersion: '' } }
     }]);
 
     callAndParse(inStream, formXml, 'all-data-types', (result) => {
       result.filenames.should.containDeep([ 'all-data-types.csv' ]);
       result['all-data-types.csv'].should.equal(
-`SubmissionDate,some_string,some_int,some_decimal,some_date,some_time,some_date_time,some_geopoint-Latitude,some_geopoint-Longitude,some_geopoint-Altitude,some_geopoint-Accuracy,some_geotrace,some_geoshape,some_barcode,meta-instanceID,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-04-26T08:58:20.525Z,Hola,123,123.456,2018-04-26,08:56:00.000Z,2018-04-26T08:56:00.000Z,43.3149254,-1.9869671,71.80000305175781,15.478,43.314926 -1.9869713 71.80000305175781 10.0;43.3149258 -1.9869694 71.80000305175781 10.0;43.3149258 -1.9869694 71.80000305175781 10.0;,43.31513313655808 -1.9863833114504814 0.0 0.0;43.31552832470026 -1.987161487340927 0.0 0.0;43.315044828733015 -1.9877894595265388 0.0 0.0;43.31459255404834 -1.9869402050971987 0.0 0.0;43.31513313655808 -1.9863833114504814 0.0 0.0;,000049499094,uuid:39f3dd36-161e-45cb-a1a4-395831d253a7,uuid:39f3dd36-161e-45cb-a1a4-395831d253a7,,,0,0,,,,0
+`SubmissionDate,some_string,some_int,some_decimal,some_date,some_time,some_date_time,some_geopoint-Latitude,some_geopoint-Longitude,some_geopoint-Altitude,some_geopoint-Accuracy,some_geotrace,some_geoshape,some_barcode,meta-instanceID,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-04-26T08:58:20.525Z,Hola,123,123.456,2018-04-26,08:56:00.000Z,2018-04-26T08:56:00.000Z,43.3149254,-1.9869671,71.80000305175781,15.478,43.314926 -1.9869713 71.80000305175781 10.0;43.3149258 -1.9869694 71.80000305175781 10.0;43.3149258 -1.9869694 71.80000305175781 10.0;,43.31513313655808 -1.9863833114504814 0.0 0.0;43.31552832470026 -1.987161487340927 0.0 0.0;43.315044828733015 -1.9877894595265388 0.0 0.0;43.31459255404834 -1.9869402050971987 0.0 0.0;43.31513313655808 -1.9863833114504814 0.0 0.0;,000049499094,uuid:39f3dd36-161e-45cb-a1a4-395831d253a7,uuid:39f3dd36-161e-45cb-a1a4-395831d253a7,,,0,0,,,,0,
 `);
       done();
     });
@@ -938,14 +975,14 @@ Chelsea,one,one/children[2]
     <n0:instanceID>uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b</n0:instanceID>
   </n0:meta>
 </data>`,
-      aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 } }
+      aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 }, exports: { formVersion: '' } }
     }]);
 
     callAndParse(inStream, formXml, 'nested-repeats', (result) => {
       result.filenames.should.containDeep([ 'nested-repeats.csv', 'nested-repeats-g1.csv', 'nested-repeats-g2.csv', 'nested-repeats-g3.csv' ]);
       result['nested-repeats.csv'].should.equal(
-`SubmissionDate,meta-instanceID,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-02-01T11:35:19.178Z,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b,,,0,0,,,,0
+`SubmissionDate,meta-instanceID,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-02-01T11:35:19.178Z,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b,,,0,0,,,,0,
 `);
       result['nested-repeats-g1.csv'].should.equal(
 `t1,PARENT_KEY,KEY
@@ -1030,10 +1067,10 @@ some text 3.1.4,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b/g1[3]/g2[1],uuid:0a1b8
     callAndParse(inStream, formXml, 'ambiguous', (result) => {
       result.filenames.should.containDeep([ 'ambiguous.csv', 'ambiguous-entry~1.csv', 'ambiguous-entry~2.csv' ]);
       result['ambiguous.csv'].should.equal(
-`SubmissionDate,meta-instanceID,name,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits
-2018-01-01T00:00:00.000Z,one,Alice,one,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,two,Bob,two,,,0,0,,,,0
-2018-01-01T00:00:00.000Z,three,Chelsea,three,,,0,0,,,,0
+`SubmissionDate,meta-instanceID,name,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,one,Alice,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,two,Bob,two,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,three,Chelsea,three,,,0,0,,,,0,version
 `);
       result['ambiguous-entry~1.csv'].should.equal(
 `name,PARENT_KEY,KEY

--- a/test/unit/data/odata.js
+++ b/test/unit/data/odata.js
@@ -14,7 +14,8 @@ const __system = {
   status: null,
   reviewState: null,
   deviceId: null,
-  edits: 0
+  edits: 0,
+  formVersion: ''
 };
 const mockSubmission = (instanceId, xml) => ({
   xml,
@@ -25,7 +26,8 @@ const mockSubmission = (instanceId, xml) => ({
   aux: {
     submitter: { id: 5, displayName: 'Alice' },
     attachment: { present: 0, expected: 0 },
-    edit: { count: 0 }
+    edit: { count: 0 },
+    exports: { formVersion: '' }
   }
 });
 
@@ -100,7 +102,8 @@ describe('submissionToOData', () => {
           status: null,
           reviewState: null,
           deviceId: null,
-          edits: 0
+          edits: 0,
+          formVersion: ''
         }
       }]);
     });
@@ -557,7 +560,8 @@ describe('submissionToOData', () => {
                   status: null,
                   reviewState: null,
                   deviceId: null,
-                  edits: 0
+                  edits: 0,
+                  formVersion: ''
                 },
                 meta: { instanceID: 'double' },
                 children: {

--- a/test/unit/formats/odata.js
+++ b/test/unit/formats/odata.js
@@ -18,7 +18,8 @@ const __system = {
   status: null,
   reviewState: null,
   deviceId: null,
-  edits: 0
+  edits: 0,
+  formVersion: ''
 };
 const mockSubmission = (instanceId, xml) => ({
   xml,
@@ -26,7 +27,7 @@ const mockSubmission = (instanceId, xml) => ({
   createdAt: __system.submissionDate,
   updatedAt: null,
   def: {},
-  aux: { submitter, attachment, encryption: {}, edit: { count: 0 } }
+  aux: { submitter, attachment, encryption: {}, edit: { count: 0 }, exports: { formVersion: '' } }
 });
 
 describe('odata message composition', () => {
@@ -79,6 +80,7 @@ describe('odata message composition', () => {
         <Property Name="reviewState" Type="org.opendatakit.submission.ReviewState"/>
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="edits" Type="Edm.Int64"/>
+        <Property Name="formVersion" Type="Edm.String"/>
       </ComplexType>
       <EnumType Name="Status">
         <Member Name="notDecrypted"/>
@@ -123,6 +125,7 @@ describe('odata message composition', () => {
         <Property Name="reviewState" Type="org.opendatakit.submission.ReviewState"/>
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="edits" Type="Edm.Int64"/>
+        <Property Name="formVersion" Type="Edm.String"/>
       </ComplexType>
       <EnumType Name="Status">
         <Member Name="notDecrypted"/>
@@ -185,6 +188,7 @@ describe('odata message composition', () => {
         <Property Name="reviewState" Type="org.opendatakit.submission.ReviewState"/>
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="edits" Type="Edm.Int64"/>
+        <Property Name="formVersion" Type="Edm.String"/>
       </ComplexType>
       <EnumType Name="Status">
         <Member Name="notDecrypted"/>
@@ -237,6 +241,7 @@ describe('odata message composition', () => {
         <Property Name="reviewState" Type="org.opendatakit.submission.ReviewState"/>
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="edits" Type="Edm.Int64"/>
+        <Property Name="formVersion" Type="Edm.String"/>
       </ComplexType>
       <EnumType Name="Status">
         <Member Name="notDecrypted"/>
@@ -388,6 +393,7 @@ describe('odata message composition', () => {
         <Property Name="reviewState" Type="org.opendatakit.submission.ReviewState"/>
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="edits" Type="Edm.Int64"/>
+        <Property Name="formVersion" Type="Edm.String"/>
       </ComplexType>
       <EnumType Name="Status">
         <Member Name="notDecrypted"/>
@@ -465,6 +471,7 @@ describe('odata message composition', () => {
         <Property Name="reviewState" Type="org.opendatakit.submission.ReviewState"/>
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="edits" Type="Edm.Int64"/>
+        <Property Name="formVersion" Type="Edm.String"/>
       </ComplexType>
       <EnumType Name="Status">
         <Member Name="notDecrypted"/>
@@ -548,7 +555,7 @@ describe('odata message composition', () => {
           })));
       });
 
-      const instances = (count) => (new Array(count)).fill({ xml: '<data/>', def: {}, aux: { submitter, attachment, edit: { count: 0 } } });
+      const instances = (count) => (new Array(count)).fill({ xml: '<data/>', def: {}, aux: { submitter, attachment, edit: { count: 0 }, exports: { formVersion: '' } } });
       it('should provide no nextUrl if the final row is accounted for', (done) => {
         const query = { $top: '3', $skip: '7' };
         const inRows = streamTest.fromObjects(instances(10));


### PR DESCRIPTION
the goal here is to do the following:

1. return an extra `FormVersion`/`formVersion` field on csv/odata export. this field reflects only the original "root" version of a submission, it does not update if the submission is edited.
2. return an extra `formVersion` field on extended submission version request. ditto it's the root version.
3. track and return `userAgent` for each submission version.
4. track and return `deviceId` for each submission version.

this pr does _not_ deprecate the existing `deviceId` on the _logical_ submission, which will also always reflect the initial submission. it only adds an _additional_ `deviceId` to version requests.

this pr does _not_ add `userAgent` to submission logical requests. maybe it should.