### PR TITLE
noop: add comment about using DEBUG variable with Knex migration CLI.

### DIFF
--- a/lib/model/knexfile.js
+++ b/lib/model/knexfile.js
@@ -21,6 +21,10 @@ NODE_CONFIG_DIR=../../config npx knex migrate:up --knexfile lib/model/knexfile.j
 In production (after the service is up):
 
 docker-compose exec --env NODE_CONFIG_DIR=../../config service npx knex migrate:up --knexfile lib/model/knexfile.js 20211111-01-my-migration.js
+
+The DEBUG environment variable can also be helpful. For example:
+
+NODE_CONFIG_DIR=../../config DEBUG=knex:query,knex:bindings npx knex migrate:up --knexfile lib/model/knexfile.js 20211111-01-my-migration.js
 */
 
 const config = require('config');


### PR DESCRIPTION
Knex documents the `DEBUG` environment variable under its FAQ: https://knexjs.org/#faq. I found this variable helpful while working on #429 and #430, because it makes it easy to view the queries being run (along with their bindings!). Just adding a comment so that we remember this variable the next time we use the Knex migration CLI.