### PR TITLE
improve: worker resiliency, hopefully.

### DIFF
--- a/lib/util/promise.js
+++ b/lib/util/promise.js
@@ -22,7 +22,7 @@ const resolve = Promise.resolve.bind(Promise);
 
 // restricts the length of time a promise can run for to some number of seconds,
 // else throws a timeout Problem.
-const timebound = (promise, bound = 120) => new Promise((pass, fail) => {
+const timebound = (promise, bound = 600) => new Promise((pass, fail) => {
   let timedOut = false;
   const timeout = setTimeout(() => {
     timedOut = true;

--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -70,25 +70,61 @@ with q as
 update audits set claimed=clock_timestamp() from q where audits.id=q.id returning *`)
   .then(head);
 
+// tiny struct thing to just store worker last report status below.
+const stati = { idle: Symbol('idle'), check: Symbol('check'), run: Symbol('run') };
+class Status {
+  constructor() { this.set(stati.idle); }
+  set(status) { this.status = status; this.at = (new Date()).getTime(); }
+}
+
 // main loop. kicks off a check and attempts to process the result of the check.
 // if there was something to do, takes a break while that happens; the runner will
 // call back into the scheduler when it's done.
 // if there was nothing to do, immediately schedules a subsequent check at a capped
 // exponential backoff rate.
-const scheduler = (check, run) => {
-  const reschedule = (delay = 3000) => {
-    check()
-      .then((event) => run(event, reschedule))
-      .then((running) => {
-        if (!running) setTimeout(() => { reschedule(min(delay * 2, 25000)); }, delay);
-      });
-  };
-  return reschedule;
-};
-
-// injects all the relevant contexts and kicks off the scheduler.
 const worker = (container, jobMap = defaultJobMap) => {
-  scheduler(checker(container), runner(container, jobMap))();
+  let enable = true; // we allow the caller to abort for testing.
+  const check = checker(container);
+  const run = runner(container, jobMap);
+  const status = new Status();
+  const withStatus = (x, chain) => { status.set(x); return chain; };
+
+  // this is the main loop, which should already try to hermetically catch its own
+  // failures and restart itself.
+  const now = (delay = 3000) => {
+    if (!enable) return;
+    const wait = () => { now(min(delay * 2, 25000)); };
+    try {
+      withStatus(stati.check, check())
+        .then((event) => withStatus(stati.run, run(event, now)))
+        .then((running) => { if (!running) withStatus(stati.idle, wait); })
+        .catch((err) => {
+          process.stderr.write(`!! unexpected worker loop error: ${inspect(err)}\n`);
+          wait();
+        });
+    } catch (ex) {
+      process.stderr.write(`!! unexpected worker invocation error: ${inspect(ex)}\n`);
+      wait();
+    }
+  };
+  now();
+
+  // this is the watchdog timer, which ensures that the worker has reported back
+  // in a reasonable time for what it claims to be doing. if not, it starts a new
+  // check immediately. there is some theoretical chance if the worker was secretly
+  // fine we'll end up with extras, but it seems unlikely.
+  const woof = (which) => {
+    process.stderr.write(`!! unexpected worker loss in ${which} (${status.at})\n`);
+    now();
+  };
+  const watchdog = setInterval(() => {
+    const delta = (new Date()).getTime() - status.at;
+    if ((delta > 60000) && (status.status === stati.idle)) woof('idle');
+    else if ((delta > 120000) && (status.status === stati.check)) woof('check');
+    else if ((delta > 720000) && (status.status === stati.run)) woof('run');
+  }, 60000);
+
+  return () => { enable = false; clearInterval(watchdog); };
 };
 
 // for testing: chews through the event queue serially until there is nothing left to process.
@@ -101,5 +137,5 @@ const exhaust = async (container, jobMap = defaultJobMap) => {
   while (await check().then(runWait)); // eslint-disable-line no-await-in-loop
 };
 
-module.exports = { runner, checker, scheduler, worker, exhaust };
+module.exports = { runner, checker, worker, exhaust };
 


### PR DESCRIPTION
* one try/catch we didn't have before, around checker invocation.
* one .catch() we didn't have before, around checker promise result.
* watchdog timer which kicks the loop if it looks stale.