### PR TITLE
Add purged info (name, purged date, details) to actees table

### DIFF
--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -26,7 +26,7 @@ const Actor = Frame.define(
   'id',         readable,               'type',         readable,
   'acteeId',                            'displayName',  readable, writable,
   'meta',                               'createdAt',    readable,
-  'updatedAt',  readable
+  'updatedAt',  readable,               'deletedAt',    readable
 );
 
 class Assignment extends Frame.define(
@@ -114,7 +114,7 @@ const Project = Frame.define(
   'id',         readable,               'name',         readable, writable,
   'archived',   readable, writable,     'acteeId',
   'keyId',      readable,               'createdAt',    readable,
-  'updatedAt',  readable,
+  'updatedAt',  readable,               'deletedAt',    readable,
   species('project')
 );
 Project.Extended = class extends Frame.define(

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -14,7 +14,12 @@ const Option = require('../util/option');
 
 /* eslint-disable no-multi-spaces */
 
-const Actee = Frame.define(table('actees'), 'id', 'species');
+const Actee = Frame.define(
+  table('actees'),
+  'id', 'species',
+  'purgedAt', readable,                'details', readable,
+  'purgedName', readable
+);
 
 const Actor = Frame.define(
   table('actors'),

--- a/lib/model/migrations/20210423-01-add-name-to-form-def.js
+++ b/lib/model/migrations/20210423-01-add-name-to-form-def.js
@@ -7,8 +7,6 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { Form } = require('../frames');
-
 const up = async (db) => {
   // All column "name" to form_defs to store the title of a form
   // Most places in central, the name of a form is called the "name"

--- a/lib/model/migrations/20211117-01-add-form-restore-verb.js
+++ b/lib/model/migrations/20211117-01-add-form-restore-verb.js
@@ -1,6 +1,6 @@
 // Copyright 2020 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
-// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
 // This file is part of ODK Central. It is subject to the license terms in
 // the LICENSE file found in the top-level directory of this distribution and at
 // https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,

--- a/lib/model/migrations/20211117-01-add-form-restore-verb.js
+++ b/lib/model/migrations/20211117-01-add-form-restore-verb.js
@@ -9,6 +9,8 @@
 
 const { without } = require('ramda');
 
+/* eslint-disable no-await-in-loop */
+
 const up = async (db) => {
   // grant rights.
   for (const system of [ 'admin', 'manager' ]) {

--- a/lib/model/migrations/20211129-01-add-purged-details-to-actees.js
+++ b/lib/model/migrations/20211129-01-add-purged-details-to-actees.js
@@ -1,0 +1,28 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.schema.table('actees', (t) => {
+    t.dateTime('purgedAt');
+    t.text('purgedName');
+    t.jsonb('details');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.table('actees', (t) => {
+    t.dropColumn('purgedAt');
+    t.dropColumn('purgedName');
+    t.dropColumn('details');
+  });
+};
+
+module.exports = { up, down };
+
+

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -9,7 +9,7 @@
 
 const { sql } = require('slonik');
 const { map } = require('ramda');
-const { Actor, Audit, Form, Project } = require('../frames');
+const { Actee, Actor, Audit, Form, Project } = require('../frames');
 const { extender, equals, page, QueryOptions } = require('../../util/db');
 const Option = require('../../util/option');
 const { construct } = require('../../util/util');
@@ -66,14 +66,15 @@ const auditFilterer = (options) => {
   return (result.length === 0) ? sql`true` : sql.join(result, sql` and `);
 };
 
-const _get = extender(Audit)(Option.of(Actor), Option.of(Actor.alias('actee_actor', 'acteeActor')), Option.of(Form), Option.of(Form.Def), Option.of(Project))((fields, extend, options) => sql`
+const _get = extender(Audit)(Option.of(Actor), Option.of(Actor.alias('actee_actor', 'acteeActor')), Option.of(Form), Option.of(Form.Def), Option.of(Project), Option.of(Actee))((fields, extend, options) => sql`
 select ${fields} from audits
   ${extend|| sql`
     left outer join actors on actors.id=audits."actorId"
     left outer join projects on projects."acteeId"=audits."acteeId"
     left outer join actors as actee_actor on actee_actor."acteeId"=audits."acteeId"
     left outer join forms on forms."acteeId"=audits."acteeId"
-    left outer join form_defs on form_defs.id=forms."currentDefId"`}
+    left outer join form_defs on form_defs.id=forms."currentDefId"
+    left outer join actees on actees.id=audits."acteeId"`}
   where ${equals(options.condition)} and ${auditFilterer(options)}
   order by "loggedAt" desc, audits.id desc
   ${page(options)}`);
@@ -86,7 +87,7 @@ const get = (options = QueryOptions.none) => ({ all }) =>
     // TODO: better if we don't have to loop over all this data twice.
     return rows.map((row) => {
       const form = row.aux.form.map((f) => f.withAux('def', row.aux.def));
-      const actees = [ row.aux.acteeActor, form, row.aux.project ];
+      const actees = [ row.aux.acteeActor, form, row.aux.project, row.aux.actee ];
       return new Audit(row, { actor: row.aux.actor, actee: Option.firstDefined(actees) });
     });
   });

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -168,11 +168,11 @@ update.audit = (form, data) => (log) => log('form.update', form, { data });
 
 const _updateDef = (form, data) => ({ one }) => one(updater(form.def, data));
 
-const del = (form) => ({ run, Assignments }) =>
+const del = (form) => ({ run }) =>
   run(markDeleted(form));
 del.audit = (form) => (log) => log('form.delete', form);
 
-const restore = (form) => ({ run, Forms }) =>
+const restore = (form) => ({ run }) =>
   run(markUndeleted(form));
 restore.audit = (form) => (log) => log('form.restore', form);
 

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -502,9 +502,10 @@ describe('/audits', () => {
         // There is not a way in the code to purge anything (yet)
         // so we manually create a purged actee that is not in any other table
         // and log an audit about it.
+        // TODO: replace this test with one that uses the external API to purge something as soon as it is available.
         const acteeId = '11111111-2222-3333-4444-555555555555';
         await container.run(sql`insert into actees ("id", "purgedAt", "purgedName", "details")
-          values (${acteeId}, '1999-1-1', 'Purged Actee Name', '{"projectId": 123}')`);
+          values (${acteeId}, '1999-01-01T00:00:00.000Z', 'Purged Actee Name', '{"projectId": 123}')`);
         await container.Audits.log(null, 'dummy.action', { acteeId }, 'test');
 
         return service.login('alice', (asAlice) =>
@@ -513,7 +514,7 @@ describe('/audits', () => {
               // first audit is user login, second is about purged actee
               const purgedActee = body[1].actee;
               purgedActee.purgedName.should.equal('Purged Actee Name');
-              purgedActee.purgedAt.should.not.be.null();
+              purgedActee.purgedAt.should.eql('1999-01-01T00:00:00.000Z');
               purgedActee.details.should.eql({ projectId: 123 });
             }));
         }));
@@ -525,7 +526,7 @@ describe('/audits', () => {
             .then(({ body }) => {
               const deletedActee = body[0].actee; // actee of most recent audit, which is a form
               deletedActee.name.should.equal('Simple');
-              deletedActee.deletedAt.should.not.be.null();
+              deletedActee.deletedAt.should.be.a.recentIsoDate();
             }))));
 
       it('should get the deletedAt date of a deleted user', testService((service, { Projects, Forms, Users, Audits }) =>
@@ -537,7 +538,7 @@ describe('/audits', () => {
             .then(({ body }) => {
               const deletedActee = body[0].actee;
               deletedActee.displayName.should.equal('Chelsea');
-              deletedActee.deletedAt.should.not.be.null();
+              deletedActee.deletedAt.should.be.a.recentIsoDate();
             }))));
 
       it('should get the deletedAt date of a deleted project', testService((service, { Projects, Forms, Users, Audits }) =>
@@ -548,7 +549,7 @@ describe('/audits', () => {
             .then(({ body }) => {
               const deletedActee = body[0].actee;
               deletedActee.name.should.equal('Default Project');
-              deletedActee.deletedAt.should.not.be.null();
+              deletedActee.deletedAt.should.be.a.recentIsoDate();
             }))));
 
       it('should get the deletedAt date of a deleted app user', testService((service, { Projects, Forms, Users, Audits }) =>
@@ -562,7 +563,7 @@ describe('/audits', () => {
             .then(({ body }) => {
               const deletedActee = body[0].actee;
               deletedActee.displayName.should.equal('App User Name');
-              deletedActee.deletedAt.should.not.be.null();
+              deletedActee.deletedAt.should.be.a.recentIsoDate();
             }))));
 
       it('should get the deletedAt date of a deleted public link', testService((service, { Projects, Forms, Users, Audits }) =>
@@ -575,7 +576,7 @@ describe('/audits', () => {
             .then(({ body }) => {
               const deletedActee = body[0].actee;
               deletedActee.displayName.should.equal('Public Link Name');
-              deletedActee.deletedAt.should.not.be.null();
+              deletedActee.deletedAt.should.be.a.recentIsoDate();
             }))));
     });
   });

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -517,6 +517,16 @@ describe('/audits', () => {
               purgedActee.details.should.eql({ projectId: 123 });
             }));
         }));
+
+      it('should get the deletedAt date of a deleted form actee', testService((service, { Projects, Forms, Users, Audits }) =>
+        service.login('alice', (asAlice) =>
+          asAlice.delete('/v1/projects/1/forms/simple')
+            .then(() => asAlice.get('/v1/audits').set('X-Extended-Metadata', true))
+            .then(({ body }) => {
+              const deletedActee = body[0].actee; // actee (form) of most recent audit
+              deletedActee.name.should.equal('Simple');
+              deletedActee.deletedAt.should.not.be.null();
+            }))));
     });
   });
 });


### PR DESCRIPTION
This PR adds purged information fields (`purgedAt`, `purgedName`, and `details`) to the Actees table. 
* `purgedAt` is when the actee was purged
* `purgedName` is a name field to use anywhere this actee is expected to have a name, and likely came from the original Actee
* `details` can store in JSON any other infromation about the actee that needs to be kept around (e.g. the project and form id of a purged form)

It also exposes the purged information through the Audit log API for actees that no longer exist in their original tables. 

Still to do:
- [x] Test that purged info is exposed through audit API.
- [x] Test that deleted info is exposed through audit API too.

(Note: I split PR #431 into more manageable PRs, though now there is a specific order for merging them.)