### PR TITLE
Purge forms and all related resources

### DIFF
--- a/lib/bin/purge-forms.js
+++ b/lib/bin/purge-forms.js
@@ -1,0 +1,25 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+//
+// This script checks for (soft-)deleted forms and purges any that were deleted
+// over 30 days ago.
+
+const { run } = require('../task/task');
+const { purgeForms } = require('../task/purge');
+
+const cli = require('cli');
+const cliArgs = {
+  force: [ 'f', 'Force any soft-deleted form to be purged right away.', 'bool', false ],
+  formId: [ 'i', 'Purge a specific form based on its id.', 'int' ]
+};
+cli.parse(cliArgs);
+
+cli.main((args, options) =>
+  run(purgeForms(options.force, options.formId)
+    .then((count) => `Forms purged: ${count}`)));

--- a/lib/model/migrations/20220121-01-form-cascade-delete.js
+++ b/lib/model/migrations/20220121-01-form-cascade-delete.js
@@ -1,0 +1,114 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+// Migrations to set up cascading deletes when a form is purged
+
+const up = async (db) => {
+  await db.schema.table('form_defs', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+  });
+
+  await db.schema.table('form_attachments', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('cascade');
+  });
+
+  await db.schema.table('form_fields', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('cascade');
+  });
+
+  await db.schema.table('public_links', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+  });
+
+  await db.schema.table('submissions', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+  });
+
+  await db.schema.table('submission_defs', (t) => {
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('cascade');
+  });
+
+  await db.schema.table('comments', (t) => {
+    t.dropForeign('submissionId');
+    t.foreign('submissionId').references('submissions.id').onDelete('cascade');
+  });
+
+  await db.schema.table('form_field_values', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('cascade');
+
+    t.dropForeign('submissionDefId');
+    t.foreign('submissionDefId').references('submission_defs.id').onDelete('cascade');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.table('form_defs', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+  });
+
+  await db.schema.table('form_attachments', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('no action');
+  });
+
+  await db.schema.table('form_fields', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('no action');
+  });
+
+  await db.schema.table('public_links', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+  });
+
+  await db.schema.table('submissions', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+  });
+
+  await db.schema.table('submission_defs', (t) => {
+    t.dropForeign('formDefId');
+    t.foreign('formDefId').references('form_defs.id').onDelete('no action');
+  });
+
+  await db.schema.table('comments', (t) => {
+    t.dropForeign('submissionId');
+    t.foreign('submissionId').references('submissions.id').onDelete('no action');
+  });
+
+  await db.schema.table('form_field_values', (t) => {
+    t.dropForeign('formId');
+    t.foreign('formId').references('forms.id').onDelete('no action');
+
+    t.dropForeign('submissionDefId');
+    t.foreign('submissionDefId').references('submission_defs.id').onDelete('no action');
+  });
+};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20220121-02-purge-deleted-forms.js
+++ b/lib/model/migrations/20220121-02-purge-deleted-forms.js
@@ -24,30 +24,34 @@
 
 const up = (db) =>
   db.raw(`
-update audits set notes = ''
-from forms
-where audits."acteeId" = forms."acteeId"
-and forms."deletedAt" is not null`)
-    .then(() => db.raw(`
-insert into audits ("action", "acteeId", "loggedAt")
-select 'form.purge', "acteeId",  clock_timestamp()
-from forms
-where forms."deletedAt" is not null`))
-    .then(() => db.raw(`
-update actees set "purgedAt" = clock_timestamp(),
-  "purgedName" = form_defs."name",
-  "details" = json_build_object('projectId', forms."projectId",
-                                'formId', forms.id,
-                                'xmlFormId', forms."xmlFormId",
-                                'deletedAt', forms."deletedAt",
-                                'version', form_defs."version")
-from forms
-left outer join form_defs on forms."currentDefId" = form_defs.id
-where actees.id = forms."acteeId"
-and forms."deletedAt" is not null`))
-    .then(() => db.raw(`
-delete from forms
-where forms."deletedAt" is not null`))
+with redacted_audits as (
+    update audits set notes = ''
+    from forms
+    where audits."acteeId" = forms."acteeId"
+    and forms."deletedAt" is not null
+  ), purge_audits as (
+    insert into audits ("action", "acteeId", "loggedAt")
+    select 'form.purge', "acteeId",  clock_timestamp()
+    from forms
+    where forms."deletedAt" is not null
+  ), update_actees as (
+    update actees set "purgedAt" = clock_timestamp(),
+      "purgedName" = form_defs."name",
+      "details" = json_build_object('projectId', forms."projectId",
+                                    'formId', forms.id,
+                                    'xmlFormId', forms."xmlFormId",
+                                    'deletedAt', forms."deletedAt",
+                                    'version', form_defs."version")
+    from forms
+    left outer join form_defs on coalesce(forms."currentDefId", forms."draftDefId") = form_defs.id
+    where actees.id = forms."acteeId"
+    and forms."deletedAt" is not null
+  ), deleted_forms as (
+    delete from forms
+    where forms."deletedAt" is not null
+    returning *
+  )
+select "id" from deleted_forms`)
     .then(() => db.raw(`
 delete from blobs
   using blobs as b

--- a/lib/model/migrations/20220121-02-purge-deleted-forms.js
+++ b/lib/model/migrations/20220121-02-purge-deleted-forms.js
@@ -1,0 +1,64 @@
+// Copyright 2019 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+
+// This migration permanently purges all forms that were previously marked as deleted.
+// This is part of a central-backend update (1.4) that allows listing and restoring deleted
+// forms, but since there was no way to access forms deleted prior to this release, we
+// are removing old deleted forms.
+
+// Purging steps
+// 1. Redact notes about forms from the audit table that reference a form
+//    (includes one kind of comment on a submission)
+// 2. Log the purge in the audit log with actor not set because purging isn't accessible through the api
+// 3. Update actees table for the specific form to leave some useful information behind
+// 4. Delete the forms and their resources from the database
+// 5. Purge unattached blobs
+
+
+const up = (db) =>
+  db.raw(`
+update audits set notes = ''
+from forms
+where audits."acteeId" = forms."acteeId"
+and forms."deletedAt" is not null`)
+    .then(() => db.raw(`
+insert into audits ("action", "acteeId", "loggedAt")
+select 'form.purge', "acteeId",  clock_timestamp()
+from forms
+where forms."deletedAt" is not null`))
+    .then(() => db.raw(`
+update actees set "purgedAt" = clock_timestamp(),
+  "purgedName" = form_defs."name",
+  "details" = json_build_object('projectId', forms."projectId",
+                                'formId', forms.id,
+                                'xmlFormId', forms."xmlFormId",
+                                'deletedAt', forms."deletedAt",
+                                'version', form_defs."version")
+from forms
+left outer join form_defs on forms."currentDefId" = form_defs.id
+where actees.id = forms."acteeId"
+and forms."deletedAt" is not null`))
+    .then(() => db.raw(`
+delete from forms
+where forms."deletedAt" is not null`))
+    .then(() => db.raw(`
+delete from blobs
+  using blobs as b
+  left join client_audits as ca on ca."blobId" = b.id
+  left join submission_attachments as sa on sa."blobId" = b.id
+  left join form_attachments as fa on fa."blobId" = b.id
+where (blobs.id = b.id and
+  ca."blobId" is null and
+  sa."blobId" is null and
+  fa."blobId" is null)`));
+
+const down = () => {};
+
+module.exports = { up, down };

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -43,7 +43,7 @@ const actionCondition = (action) => {
   else if (action === 'project')
     return sql`action in ('project.create', 'project.update', 'project.delete')`;
   else if (action === 'form')
-    return sql`action in ('form.create', 'form.update', 'form.delete', 'form.restore', 'form.attachment.update', 'form.submission.export', 'form.update.draft.set', 'form.update.draft.delete', 'form.update.publish')`;
+    return sql`action in ('form.create', 'form.update', 'form.delete', 'form.restore', 'form.purge', 'form.attachment.update', 'form.submission.export', 'form.update.draft.set', 'form.update.draft.delete', 'form.update.publish')`;
   else if (action === 'submission')
     return sql`action in ('submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update')`;
 

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -31,5 +31,17 @@ const getById = (blobId) => ({ maybeOne }) =>
   maybeOne(sql`select * from blobs where id=${blobId}`)
     .then(map(construct(Blob)));
 
-module.exports = { ensure, getById };
+const purgeUnattached = () => ({ all }) =>
+  all(sql`
+delete from blobs
+  using blobs as b
+  left join client_audits as ca on ca."blobId" = b.id
+  left join submission_attachments as sa on sa."blobId" = b.id
+  left join form_attachments as fa on fa."blobId" = b.id
+where (blobs.id = b.id and
+  ca."blobId" is null and
+  sa."blobId" is null and
+  fa."blobId" is null)`);
+
+module.exports = { ensure, getById, purgeUnattached };
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -205,8 +205,8 @@ const _trashedFilter = (force, id) => {
 // 3. Update actees table for the specific form to leave some useful information behind
 // 4. Delete the forms and their resources from the database
 // 5. Purge unattached blobs
-const purge = (force = false, id = null) => ({ all, Blobs }) =>
-  all(sql`
+const purge = (force = false, id = null) => ({ oneFirst, Blobs }) =>
+  oneFirst(sql`
 with redacted_audits as (
     update audits set notes = ''
     from forms
@@ -234,9 +234,9 @@ with redacted_audits as (
     where ${_trashedFilter(force, id)}
     returning *
   )
-select "id", "xmlFormId", "projectId" from deleted_forms`)
-    .then((res) => Blobs.purgeUnattached()
-      .then(() => Promise.resolve(res)));
+select count(*) from deleted_forms`)
+    .then((count) => Blobs.purgeUnattached()
+      .then(() => Promise.resolve(count)));
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -205,37 +205,38 @@ const _trashedFilter = (force, id) => {
 // 3. Update actees table for the specific form to leave some useful information behind
 // 4. Delete the forms and their resources from the database
 // 5. Purge unattached blobs
-const purge = (force = false, id = null) => ({ run, all, Blobs }) =>
-  run(sql`
-update audits set notes = ''
-from forms
-where audits."acteeId" = forms."acteeId"
-and ${_trashedFilter(force, id)}`)
-    .then(() => run(sql`
-insert into audits ("action", "acteeId", "loggedAt")
-select 'form.purge', "acteeId",  clock_timestamp()
-from forms
-where ${_trashedFilter(force, id)}`))
-    .then(() => run(sql`
-update actees set "purgedAt" = clock_timestamp(),
-  "purgedName" = form_defs."name",
-  "details" = json_build_object('projectId', forms."projectId",
-                                'formId', forms.id,
-                                'xmlFormId', forms."xmlFormId",
-                                'deletedAt', forms."deletedAt",
-                                'version', form_defs."version")
-from forms
-left outer join form_defs on coalesce(forms."currentDefId", forms."draftDefId") = form_defs.id
-where actees.id = forms."acteeId"
-and ${_trashedFilter(force, id)}`))
-    .then(() => all(sql`
-with deleted as (
-  delete from forms
-  where ${_trashedFilter(force, id)}
-returning *)
-select count(*) from deleted`))
-    .then((count) => Blobs.purgeUnattached()
-      .then(() => Promise.resolve(count[0].count)));
+const purge = (force = false, id = null) => ({ all, Blobs }) =>
+  all(sql`
+with redacted_audits as (
+    update audits set notes = ''
+    from forms
+    where audits."acteeId" = forms."acteeId"
+    and ${_trashedFilter(force, id)}
+  ), purge_audits as (
+    insert into audits ("action", "acteeId", "loggedAt")
+    select 'form.purge', "acteeId",  clock_timestamp()
+    from forms
+    where ${_trashedFilter(force, id)}
+  ), update_actees as (
+    update actees set "purgedAt" = clock_timestamp(),
+      "purgedName" = form_defs."name",
+      "details" = json_build_object('projectId', forms."projectId",
+                                    'formId', forms.id,
+                                    'xmlFormId', forms."xmlFormId",
+                                    'deletedAt', forms."deletedAt",
+                                    'version', form_defs."version")
+    from forms
+    left outer join form_defs on coalesce(forms."currentDefId", forms."draftDefId") = form_defs.id
+    where actees.id = forms."acteeId"
+    and ${_trashedFilter(force, id)}
+  ), deleted_forms as (
+    delete from forms
+    where ${_trashedFilter(force, id)}
+    returning *
+  )
+select "id", "xmlFormId", "projectId" from deleted_forms`)
+    .then((res) => Blobs.purgeUnattached()
+      .then(() => Promise.resolve(res)));
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -179,6 +179,66 @@ restore.audit = (form) => (log) => log('form.restore', form);
 
 
 ////////////////////////////////////////////////////////////////////////////////
+// PURGING SOFT-DELETED FORMS
+
+// The main ways we'd want to choose forms to purge are
+// 1. by their deletedAt date (30+ days in the past)
+//    (this would be the default behavior of a purge cron job)
+// 2. if deletedAt is set at all
+//    (useful to purge forms immediately for testing or other time sensitive scenarios)
+// 3. by a specific form id if deletedAt is also set (again for testing or potential future scenarios)
+
+const DAY_RANGE = 30;
+const _trashedFilter = (force, id) => {
+  const idFilter = (id
+    ? sql`and forms.id = ${id}`
+    : sql``);
+  return (force
+    ? sql`forms."deletedAt" is not null ${idFilter}`
+    : sql`forms."deletedAt" < current_date - cast(${DAY_RANGE} as int) ${idFilter}`);
+};
+
+// Purging steps
+// 1. Redact notes about forms from the audit table that reference a form
+//    (includes one kind of comment on a submission)
+// 2. Log the purge in the audit log with actor not set because purging isn't accessible through the api
+// 3. Update actees table for the specific form to leave some useful information behind
+// 4. Delete the forms and their resources from the database
+// 5. Purge unattached blobs
+const purge = (force = false, id = null) => ({ run, all, Blobs }) =>
+  run(sql`
+update audits set notes = ''
+from forms
+where audits."acteeId" = forms."acteeId"
+and ${_trashedFilter(force, id)}`)
+    .then(() => run(sql`
+insert into audits ("action", "acteeId", "loggedAt")
+select 'form.purge', "acteeId",  clock_timestamp()
+from forms
+where ${_trashedFilter(force, id)}`))
+    .then(() => run(sql`
+update actees set "purgedAt" = clock_timestamp(),
+  "purgedName" = form_defs."name",
+  "details" = json_build_object('projectId', forms."projectId",
+                                'formId', forms.id,
+                                'xmlFormId', forms."xmlFormId",
+                                'deletedAt', forms."deletedAt",
+                                'version', form_defs."version")
+from forms
+left outer join form_defs on coalesce(forms."currentDefId", forms."draftDefId") = form_defs.id
+where actees.id = forms."acteeId"
+and ${_trashedFilter(force, id)}`))
+    .then(() => all(sql`
+with deleted as (
+  delete from forms
+  where ${_trashedFilter(force, id)}
+returning *)
+select count(*) from deleted`))
+    .then((count) => Blobs.purgeUnattached()
+      .then(() => Promise.resolve(count[0].count)));
+
+
+////////////////////////////////////////////////////////////////////////////////
 // ENCRYPTION
 
 // takes a Key object and a suffix to add to the form version string.
@@ -379,7 +439,7 @@ order by actors."displayName" asc`)
 module.exports = {
   fromXls, _createNew, createNew, createVersion,
   publish, clearDraft,
-  _update, update, _updateDef, del, restore,
+  _update, update, _updateDef, del, restore, purge,
   setManagedKey,
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,

--- a/lib/task/purge.js
+++ b/lib/task/purge.js
@@ -1,0 +1,15 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { task } = require('./task');
+
+const purgeForms = task.withContainer(({ Forms }) => (force = false, formId = null) =>
+  Forms.purge(force, formId));
+
+module.exports = { purgeForms };

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -153,7 +153,7 @@ describe('query module form purge', () => {
         .then(() => container.oneFirst(sql`select count(*) from form_field_values`))
         .then((count) => count.should.eql(0)))));
 
-  describe('puring form submissions', () => {
+  describe('purging form submissions', () => {
     const withSimpleIds = (deprecatedId, instanceId) => testData.instances.simple.one
       .replace('one</instance', `${instanceId}</instanceID><deprecatedID>${deprecatedId}</deprecated`);
 

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -1,0 +1,256 @@
+const appPath = require('app-root-path');
+const should = require('should');
+const { sql } = require('slonik');
+const { testService } = require('../setup');
+const testData = require('../../data/xml');
+const { createReadStream } = require('fs');
+const { exhaust } = require(appPath + '/lib/worker/worker');
+
+
+describe('query module form purge', () => {
+  it('should purge a soft-deleted form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ])
+        .then((counts) => {
+          counts.should.eql([0, 0]);
+        })))));
+
+  it('should purge a form deleted over 30 days ago', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(() => container.run(sql`update forms set "deletedAt" = '1999-1-1' where id=1`))
+        .then(() => container.Forms.purge()) // purge forms deleted more than 30 days ago
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ])
+        .then((counts) => {
+          counts.should.eql([0, 0]);
+        })))));
+
+  it('should not purge a recently deleted form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(() => container.Forms.purge()) // purge forms deleted more than 30 days ago
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ])
+        .then((counts) => {
+          counts.should.eql([1, 1]);
+        })))));
+
+  it('should purge a deleted form by ID', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.withAttachments)
+          .set('Content-Type', 'application/xml')
+          .expect(200))
+        .then(() => container.Forms.getByProjectAndXmlFormId(1, 'withAttachments').then((o) => o.get()))
+        .then((ghostForm) => asAlice.delete('/v1/projects/1/withAttachments')
+          .then(() => container.Forms.purge(true, 1)) // force delete a single form
+          .then(() => Promise.all([
+            container.oneFirst(sql`select count(*) from forms where id=${ghostForm.id}`),
+            container.oneFirst(sql`select count(*) from forms where id=1`), // deleted form id
+          ])
+          .then((counts) => {
+            counts.should.eql([1, 0]);
+          }))))));
+
+  it('should log the purge action in the audit log', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      container.Forms.getByProjectAndXmlFormId(1, 'simple').then((o) => o.get()) // get the form before we delete it
+        .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200)
+          .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+          .then(() => container.Audits.getLatestByAction('form.purge'))
+          .then((audit) => {
+            audit.isDefined().should.equal(true);
+            audit.get().acteeId.should.equal(form.acteeId);
+          })))));
+
+  it('should update the actee table with purgedAt details', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      container.Forms.getByProjectAndXmlFormId(1, 'simple').then((o) => o.get()) // get the form before we delete it
+        .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200)
+          .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+          .then(() => container.one(sql`select * from actees where id = ${form.acteeId}`))
+          .then((res) => {
+            res.details.projectId.should.equal(1);
+            res.details.formId.should.equal(1);
+            res.details.version.should.equal('');
+            res.details.xmlFormId.should.equal('simple');
+            res.details.deletedAt.should.be.an.isoDate();
+            res.purgedName.should.equal('Simple');
+          })))));
+
+  it('should purge a form with multiple versions', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms/simple/draft')
+        .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="2"'))
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft/publish')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+          .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="3"'))
+          .set('Content-Type', 'application/xml')
+          .expect(200))
+        .then((form) => asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200))
+        .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from forms where id=1`),
+          container.oneFirst(sql`select count(*) from form_defs where "formId"=1`)
+        ]))
+        .then((counts) => counts.should.eql([0, 0])))));
+
+  it('should purge attachments (and blobs) of a form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send('this is goodone.csv')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
+          .expect(200))
+        .then(() => container.Forms.getByProjectAndXmlFormId(1, 'withAttachments').then((o) => o.get())
+        .then((ghostForm) => asAlice.delete('/v1/projects/1/forms/withAttachments')
+          .expect(200)
+          .then(() => container.Forms.purge(true))
+          .then(() => Promise.all([
+            container.oneFirst(sql`select count(*) from forms where id=${ghostForm.id}`),
+            container.oneFirst(sql`select count(*) from form_defs where "formId"=${ghostForm.id}`),
+            container.oneFirst(sql`select count(*) from form_attachments where "formId"=${ghostForm.id}`),
+            container.oneFirst(sql`select count(*) from blobs`)
+          ]))
+          .then((counts) => counts.should.eql([0, 0, 0, 0])))))));
+
+  it('should purge the select multiple values of a purged form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.selectMultiple)
+        .set('Content-Type', 'application/xml')
+        .then(() => asAlice.post('/v1/projects/1/forms/selectMultiple/submissions')
+          .set('Content-Type', 'application/xml')
+          .send(testData.instances.selectMultiple.one))
+        .then(() => exhaust(container))
+        .then(() => asAlice.delete('/v1/projects/1/forms/selectMultiple'))
+        .then(() => container.Forms.purge(true))
+        .then(() => container.oneFirst(sql`select count(*) from form_field_values`))
+        .then((count) => count.should.eql(0)))));
+
+  describe('puring form submissions', () => {
+    const withSimpleIds = (deprecatedId, instanceId) => testData.instances.simple.one
+      .replace('one</instance', `${instanceId}</instanceID><deprecatedID>${deprecatedId}</deprecated`);
+
+    it('should delete all defs of a submission', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.put('/v1/projects/1/forms/simple/submissions/one')
+            .send(withSimpleIds('one', 'two'))
+            .set('Content-Type', 'text/xml')
+            .expect(200))
+          .then(() => container.oneFirst(sql`select count(*) from submission_defs`)
+            .then((count) => { count.should.equal(2); }))
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.oneFirst(sql`select count(*) from submission_defs`)
+            .then((count) => { count.should.equal(0); })))));
+
+    it('should purge attachments and blobs associated with the submission', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+            .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+            .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+            .expect(201))
+          .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments')
+            .expect(200)
+            .then(({ body }) => {
+              body.should.eql([
+                { name: 'here_is_file2.jpg', exists: true },
+                { name: 'my_file1.mp4', exists: true }
+              ]);
+            }))
+          .then(() => asAlice.delete('/v1/projects/1/forms/binaryType'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.oneFirst(sql`select count(*) from submission_attachments`)
+            .then((count) => count.should.equal(0)))
+          .then(() => container.oneFirst(sql`select count(*) from blobs`)
+            .then((count) => count.should.equal(0))))));
+
+    it('should purge submission comments from comments table', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions/one/comments')
+            .send({ body: 'new comment here' })
+            .expect(200))
+          .then(() => container.oneFirst(sql`select count(*) from comments`)
+            .then((count) => count.should.equal(1)))
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.oneFirst(sql`select count(*) from comments`)
+            .then((count) => count.should.equal(0))))));
+
+    it('should purge submission comments from notes fields of audits table', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.patch('/v1/projects/1/forms/simple/submissions/one')
+            .send({ reviewState: 'approved' })
+            .set('X-Action-Notes', 'secret note')
+            .expect(200))
+          .then(() => container.Audits.getLatestByAction('submission.update')
+            .then((audit) => { audit.get().notes.should.equal('secret note'); }))
+          .then(() => asAlice.delete('/v1/projects/1/forms/simple'))
+          .then(() => container.Forms.purge(true))
+          .then(() => container.Audits.getLatestByAction('submission.update')
+            .then((audit) => { audit.get().notes.should.equal(''); })))));
+
+    it('should purge client audit log attachments', testService((service, container) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.clientAudits)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('audit.csv', createReadStream(appPath + '/test/data/audit.csv'), { filename: 'audit.csv' })
+            .attach('xml_submission_file', Buffer.from(testData.instances.clientAudits.one), { filename: 'data.xml' })
+            .expect(201)
+          .then(() => asAlice.delete('/v1/projects/1/forms/audits'))
+          .then(() => container.Forms.purge(true))
+          .then(() => Promise.all([
+            container.oneFirst(sql`select count(*) from client_audits`),
+            container.oneFirst(sql`select count(*) from blobs`)
+          ])
+          .then((count) => count.should.eql([0, 0])))))));
+  });
+});

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -1,0 +1,46 @@
+const appRoot = require('app-root-path');
+const should = require('should');
+const config = require('config');
+const { testServiceFullTrx } = require('../setup');
+const { sql } = require('slonik');
+const { connect } = require(appRoot + '/lib/model/migrate');
+const migrator = connect(config.get('test.database'));
+const testData = require('../../data/xml');
+const populateUsers = require('../fixtures/01-users.js');
+const populateForms = require('../fixtures/02-forms.js');
+
+
+const upToMigration = async (toName) => {
+  await migrator.raw('drop owned by current_user');
+  while (true) {
+    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
+    const migrations = await migrator.migrate.list({ directory: appRoot + '/lib/model/migrations' });
+    const applied = migrations[0];
+    const remaining = migrations[1];
+    if (toName === applied[applied.length - 1]) break;
+    if (remaining.length === 0) {
+      console.log("Could not find migration", toName);
+      break;
+    }
+  }
+}
+
+describe('database migrations', function() {
+  this.timeout(4000);
+
+  it('should purge deleted forms via migration', testServiceFullTrx(async (service, container) => {
+    await upToMigration('20220121-01-form-cascade-delete.js');
+
+    await populateUsers(container);
+    await populateForms(container);
+    
+    await service.login('alice', (asAlice) =>
+      asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200));
+
+    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
+
+    const count = await container.oneFirst(sql`select count(*) from forms`);
+    count.should.equal(1); // only the withrepeat base test should exist
+  }));
+});

--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -1,0 +1,64 @@
+const appRoot = require('app-root-path');
+const should = require('should');
+const { testTask } = require('../setup');
+const { purgeForms } = require(appRoot + '/lib/task/purge');
+const { setConfiguration } = require(appRoot + '/lib/task/config');
+
+// The basics of this task are tested here, including returning the count
+// of purged forms, but the full functionality is more thoroughly tested in 
+// test/integration/other/form-purging.js
+
+describe('task: purge deleted forms', () => {
+  it('should not purge recently deleted forms by default', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms())
+      .then((count) => {
+        count.should.equal(0);
+      }))));
+
+  it('should purge recently deleted form if forced', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true))
+      .then((count) => {
+        count.should.equal(1);
+      }))));
+
+  it('should return count for multiple forms purged', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true))
+      .then((count) => {
+        count.should.equal(2);
+      })))));
+
+  it('should not purge specific recently deleted form', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(false, 1))
+      .then((count) => {
+        count.should.equal(0);
+      }))));
+
+  it('should purge specific recently deleted form if forced', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true, 1))
+      .then((count) => {
+        count.should.equal(1);
+      }))));
+
+  it('should force purge only specific form', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true, 1))
+      .then((count) => {
+        count.should.equal(1);
+      })))));
+});
+


### PR DESCRIPTION
This PR enables the purging of soft-deleted forms and their associated resources (definitions, versions, submissions, attachments, comments, etc.)

Purging follows these steps:
- Redact notes about forms from the audit table that reference a form (includes one kind of comment on a submission)
- Log the purge in the audit log with actor not set
- Update actees table for the specific form to leave some useful information behind
- Delete the forms and their resources from the database
- Purge unattached blobs

Purging of a form will happen a few different ways:
- via a script run daily by a cron job that will purge forms deleted more than 30 days ago
- the migration described below that purges all old deleted forms
- when a form with only a draft is abandoned

This PR has a number of high-impact migrations:
- Cascaded delete constraints on all form-related database tables
- Purging all previously soft-deleted forms regardless of deletion date on upgrade (from a previous central version to this one)

(Note: This PR also used to be part of PR #431)

Not part of this PR:
- block 14 changes that deal with purging unneeded drafts, either when a form with only a draft is deleted, or when a draft is internally overwritten