### PR TITLE
Task and command line tool for purging forms

### DIFF
--- a/lib/bin/purge-forms.js
+++ b/lib/bin/purge-forms.js
@@ -1,0 +1,25 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+//
+// This script checks for (soft-)deleted forms and purges any that were deleted
+// over 30 days ago.
+
+const { run } = require('../task/task');
+const { purgeForms } = require('../task/purge');
+
+const cli = require('cli');
+const cliArgs = {
+  force: [ 'f', 'Force any soft-deleted form to be purged right away.', 'bool', false ],
+  formId: [ 'i', 'Purge a specific form based on its id.', 'int' ]
+};
+cli.parse(cliArgs);
+
+cli.main((args, options) =>
+  run(purgeForms(options.force, options.formId)
+    .then((count) => `Forms purged: ${count}`)));

--- a/lib/task/purge.js
+++ b/lib/task/purge.js
@@ -1,0 +1,15 @@
+// Copyright 2021 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { task } = require('./task');
+
+const purgeForms = task.withContainer(({ Forms }) => (force = false, formId = null) =>
+  Forms.purge(force, formId));
+
+module.exports = { purgeForms };

--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -1,0 +1,64 @@
+const appRoot = require('app-root-path');
+const should = require('should');
+const { testTask } = require('../setup');
+const { purgeForms } = require(appRoot + '/lib/task/purge');
+const { setConfiguration } = require(appRoot + '/lib/task/config');
+
+// The basics of this task are tested here, including returning the count
+// of purged forms, but the full functionality is more thoroughly tested in 
+// test/integration/other/form-purging.js
+
+describe('task: purge deleted forms', () => {
+  it('should not purge recently deleted forms by default', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms())
+      .then((count) => {
+        count.should.equal(0);
+      }))));
+
+  it('should purge recently deleted form if forced', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true))
+      .then((count) => {
+        count.should.equal(1);
+      }))));
+
+  it('should return count for multiple forms purged', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true))
+      .then((count) => {
+        count.should.equal(2);
+      })))));
+
+  it('should not purge specific recently deleted form', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(false, 1))
+      .then((count) => {
+        count.should.equal(0);
+      }))));
+
+  it('should purge specific recently deleted form if forced', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true, 1))
+      .then((count) => {
+        count.should.equal(1);
+      }))));
+
+  it('should force purge only specific form', testTask(({ Forms }) =>
+    Forms.getByProjectAndXmlFormId(1, 'simple')
+      .then((form) => Forms.del(form.get())
+      .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
+      .then((form) => Forms.del(form.get())
+      .then(() => purgeForms(true, 1))
+      .then((count) => {
+        count.should.equal(1);
+      })))));
+});
+


### PR DESCRIPTION
This is a command line tool for purging forms that a daily cron job will use. It can also be used to force purge specific forms.

```
$ node lib/bin/purge-forms.js --help
Usage:
  purge-forms.js [OPTIONS] [ARGS]

Options:
  -f, --force BOOL       Force any soft-deleted form to be purged right away.
  -i, --formId NUMBER   Purge a specific form based on its id.
  -h, --help             Display help and usage details
```

(Originally part of PR #431.)