### PR TITLE
improve: increase bodyParser limit so that large payload is accepted.

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -24,7 +24,7 @@ module.exports = (container) => {
   // automatically parse JSON if it is marked as such. otherwise, just pull the
   // plain-text body contents.
   const bodyParser = require('body-parser');
-  service.use(bodyParser.json({ type: 'application/json' }));
+  service.use(bodyParser.json({ type: 'application/json', limit: '250kb' }));
 
   // apache request commonlog.
   const morgan = require('morgan');


### PR DESCRIPTION
For a project with 1,500 forms and 14 app users, an attempt to update app user access resulted in a 500 error. From the log:

```
ClientError [PayloadTooLargeError]: request entity too large
    at readStream (/usr/odk/node_modules/raw-body/index.js:155:17)
    at getRawBody (/usr/odk/node_modules/raw-body/index.js:108:12)
    at read (/usr/odk/node_modules/body-parser/lib/read.js:77:3)
    at jsonParser (/usr/odk/node_modules/body-parser/lib/types/json.js:134:5)
    at Layer.handle [as handle_request] (/usr/odk/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/odk/node_modules/express/lib/router/index.js:317:13)
    at /usr/odk/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/usr/odk/node_modules/express/lib/router/index.js:335:12)
    at next (/usr/odk/node_modules/express/lib/router/index.js:275:10)
    at Domain.<anonymous> (/usr/odk/node_modules/@sentry/node/dist/handlers.js:321:13)
    at Domain.run (domain.js:373:15)
    at sentryRequestMiddleware (/usr/odk/node_modules/@sentry/node/dist/handlers.js:294:15)
    at Layer.handle [as handle_request] (/usr/odk/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/odk/node_modules/express/lib/router/index.js:317:13)
    at /usr/odk/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/usr/odk/node_modules/express/lib/router/index.js:335:12) {
  expected: 102557,
  length: 102557,
  limit: 102400,
  type: 'entity.too.large',
  expose: true,
  statusCode: 413,
  status: 413
}
```

When I took a look at the payload of the PUT request to /v1/projects/:id, it was 141 kB. This exceeds the default `bodyParser` [limit](https://github.com/expressjs/body-parser#limit) of 100 kB. After the limit was increased, the request was successful. The goal of this PR is to increase the limit so that that change can go out with v1.4.

A couple of other notes about this case:

- `bodyParser` is throwing an error with a `status` property of 413, but Backend is returning a 500. I think Backend knows how to handle some other `bodyParser` errors, but not this type. (I'll file an issue about that.)
- This error does not appear in Sentry — not sure why.
  - Is it expected that `sentryRequestMiddleware` appears in the stack trace?