### PR TITLE
Addressing xlsBlobId issue in form and blob purging

### DIFF
--- a/lib/model/migrations/20220121-02-purge-deleted-forms.js
+++ b/lib/model/migrations/20220121-02-purge-deleted-forms.js
@@ -13,7 +13,15 @@
 // forms, but since there was no way to access forms deleted prior to this release, we
 // are removing old deleted forms.
 
-// Purging steps
+// NOTE: copypasta alert!
+// The following purge queries are roughly the same as in the form and blob
+// query modules, with the first roughly matching Forms.purge() (except where
+// this migration only looks for deleted forms regardless of deletedAt date`)
+// and the second exactly matching Blobs.purgeUnattached(). If this migration
+// changes, changes will also likely need to be made in lib/model/query/forms.js
+// and lib/model/query/blobs.js.
+//
+// The Purging steps are the same:
 // 1. Redact notes about forms from the audit table that reference a form
 //    (includes one kind of comment on a submission)
 // 2. Log the purge in the audit log with actor not set because purging isn't accessible through the api

--- a/lib/model/migrations/20220121-02-purge-deleted-forms.js
+++ b/lib/model/migrations/20220121-02-purge-deleted-forms.js
@@ -58,10 +58,12 @@ delete from blobs
   left join client_audits as ca on ca."blobId" = b.id
   left join submission_attachments as sa on sa."blobId" = b.id
   left join form_attachments as fa on fa."blobId" = b.id
+  left join form_defs as fd on fd."xlsBlobId" = b.id
 where (blobs.id = b.id and
   ca."blobId" is null and
   sa."blobId" is null and
-  fa."blobId" is null)`));
+  fa."blobId" is null and
+  fd."xlsBlobId" is null)`));
 
 const down = () => {};
 

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -31,6 +31,10 @@ const getById = (blobId) => ({ maybeOne }) =>
   maybeOne(sql`select * from blobs where id=${blobId}`)
     .then(map(construct(Blob)));
 
+// NOTE: copypasta alert!
+// The migration 20220121-02-purge-deleted-forms.js also contains a version
+// of the following purge blob query, and if it changes here, it should likely
+// change there, too.
 const purgeUnattached = () => ({ all }) =>
   all(sql`
 delete from blobs

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -38,10 +38,12 @@ delete from blobs
   left join client_audits as ca on ca."blobId" = b.id
   left join submission_attachments as sa on sa."blobId" = b.id
   left join form_attachments as fa on fa."blobId" = b.id
+  left join form_defs as fd on fd."xlsBlobId" = b.id
 where (blobs.id = b.id and
   ca."blobId" is null and
   sa."blobId" is null and
-  fa."blobId" is null)`);
+  fa."blobId" is null and
+  fd."xlsBlobId" is null)`);
 
 module.exports = { ensure, getById, purgeUnattached };
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -198,6 +198,11 @@ const _trashedFilter = (force, id) => {
     : sql`forms."deletedAt" < current_date - cast(${DAY_RANGE} as int) ${idFilter}`);
 };
 
+// NOTE: copypasta alert!
+// The migration 20220121-02-purge-deleted-forms.js also contains a version
+// of the following purge form query, and if it changes here, it should likely
+// change there, too.
+
 // Purging steps
 // 1. Redact notes about forms from the audit table that reference a form
 //    (includes one kind of comment on a submission)

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -1,0 +1,16 @@
+const { createReadStream, readFileSync } = require('fs');
+const appPath = require('app-root-path');
+const { sql } = require('slonik');
+const { testService } = require('../setup');
+
+describe('blob query module', () => {
+  it('should not try to purge blobs that are still referenced', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(readFileSync(appPath + '/test/data/simple.xlsx'))
+        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        .expect(200)
+        .then(() => container.Blobs.purgeUnattached())
+        .then(() => container.oneFirst(sql`select count(*) from blobs`))
+        .then((count) => count.should.equal(1)))));
+});

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -1,6 +1,7 @@
 const { createReadStream, readFileSync } = require('fs');
 const appPath = require('app-root-path');
 const { sql } = require('slonik');
+const testData = require('../../data/xml');
 const { testService } = require('../setup');
 
 describe('blob query module', () => {
@@ -13,4 +14,35 @@ describe('blob query module', () => {
         .then(() => container.Blobs.purgeUnattached())
         .then(() => container.oneFirst(sql`select count(*) from blobs`))
         .then((count) => count.should.equal(1)))));
+
+  it('should handle blob collisions and not purge still attached blobs', testService((service, container) =>
+    // One one instance of the form, two files are uploaded
+    // On another instance of the form (different id), one file is uploaded
+    // and it creates another reference to one of the blobs.
+    // When the first form with two blob references is deleted and purged,
+    // one of the blobs should get purged and the other should stay.
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.binaryType)
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/submission')
+          .set('X-OpenRosa-Version', '1.0')
+          .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+          .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+          .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+          .expect(201))
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType.replace('id="binaryType"', 'id="binaryType2"'))
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/submission')
+          .set('X-OpenRosa-Version', '1.0')
+          .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.one.replace('id="binaryType"', 'id="binaryType2"')), { filename: 'data.xml' })
+          .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+          .expect(201))
+        .then(() => asAlice.delete('/v1/projects/1/forms/binaryType'))
+        .then(() => container.Forms.purge(true))
+        .then(() => container.oneFirst(sql`select count(*) from blobs`))
+        .then((count) => count.should.equal(1))))); //
 });

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -5,7 +5,7 @@ const testData = require('../../data/xml');
 const { testService } = require('../setup');
 
 describe('blob query module', () => {
-  it('should not try to purge blobs that are still referenced', testService((service, container) =>
+  it('should not purge xls blob that is still referenced', testService((service, container) =>
     service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms?publish=true')
         .send(readFileSync(appPath + '/test/data/simple.xlsx'))

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -1,3 +1,4 @@
+const { readFileSync } = require('fs');
 const appRoot = require('app-root-path');
 const should = require('should');
 const config = require('config');
@@ -38,9 +39,70 @@ describe('database migrations', function() {
       asAlice.delete('/v1/projects/1/forms/simple')
         .expect(200));
 
+    // running migration 20220121-02-purge-deleted-forms.js
     await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
 
     const count = await container.oneFirst(sql`select count(*) from forms`);
     count.should.equal(1); // only the withrepeat base test should exist
+  }));
+
+  it('should not purge blobs that are still referenced', testServiceFullTrx(async (service, container) => {
+    // An earlier version of this migration [20220121-02-purge-deleted-forms.js]
+    // failed because it tried to purge blobs that were still being used as
+    // xlsBlobIds on active form definitons.
+    await upToMigration('20220121-01-form-cascade-delete.js');
+    await populateUsers(container);
+    await populateForms(container);
+
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
+        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        .expect(200));
+
+    // running migration 20220121-02-purge-deleted-forms.js
+    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
+
+    const count = await container.oneFirst(sql`select count(*) from blobs`);
+    count.should.equal(1); // the xls blob should still exist
+  }));
+
+  it('should purge blobs of deleted forms', testServiceFullTrx(async (service, container) => {
+    // An earlier version of this migration [20220121-02-purge-deleted-forms.js]
+    // failed because it tried to purge blobs that were still being used as
+    // xlsBlobIds on active form definitons.
+    await upToMigration('20220121-01-form-cascade-delete.js');
+    await populateUsers(container);
+    await populateForms(container);
+
+    // xmlFormId of this xlsx form is 'simple2'
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
+        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        .expect(200)
+        .then(() => asAlice.delete('/v1/projects/1/forms/simple2') // Delete form
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/submission')
+          .set('X-OpenRosa-Version', '1.0')
+          .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+          .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+          .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+          .expect(201))
+        .then(() => asAlice.delete('/v1/projects/1/forms/binaryType') // Delete form
+          .expect(200)));
+
+    let count = await container.oneFirst(sql`select count(*) from blobs`);
+    count.should.equal(3); // xls blob and two file blobs
+
+    // running migration 20220121-02-purge-deleted-forms.js
+    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
+
+    count = await container.oneFirst(sql`select count(*) from blobs`);
+    count.should.equal(0); // blobs should all be purged
   }));
 });


### PR DESCRIPTION
This error came up while applying the form purging migration on the QA server on Feb 2, 2022, and it turns out to be an issue in the regular blob purging SQL as well. That code checks for blobs with no references and tries to delete them, but it wasn't considering the reference to `xlsBlobId` in the `form_defs` table, so it was trying (and failing) to delete blobs that shouldn't have been deleted. 

      service_1             | migration file "20220121-02-purge-deleted-forms.js" failed
      service_1             | migration failed with error:
      service_1             | delete from blobs
      service_1             |   using blobs as b
      service_1             |   left join client_audits as ca on ca."blobId" = b.id
      service_1             |   left join submission_attachments as sa on sa."blobId" = b.id
      service_1             |   left join form_attachments as fa on fa."blobId" = b.id
      service_1             | where (blobs.id = b.id and
      service_1             |   ca."blobId" is null and
      service_1             |   sa."blobId" is null and
      service_1             |   fa."blobId" is null) - update or delete on table "blobs" violates foreign key constraint "form_defs_xlsblobid_foreign" on table "form_defs"