### PR TITLE
Purge unneeded form draft definitions

### DIFF
--- a/lib/model/migrations/20220209-01-purge-unneeded-drafts.js
+++ b/lib/model/migrations/20220209-01-purge-unneeded-drafts.js
@@ -1,0 +1,30 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+// This migration permanently purges all unpublished (draft) form defs that
+// are no longer needed, e.g. a draft that was replaced by another draft without
+// ever being published, or a draft replaced by an ecrypted version when managed
+// encryption was turned on for a project. For these unneeded (unattached) draft
+// form defs, there is no reference on the form itself back to these form defs.
+
+// NOTE: copypasta alert! The following SQL also appears in 'purgeUnneededDrafts()'
+// of lib/model/query/forms.js
+
+
+const up = (db) =>
+  db.raw(`
+delete from form_defs
+using forms
+where form_defs."formId" = forms.id
+and form_defs."publishedAt" is null
+and form_defs.id is distinct from forms."draftDefId"`);
+
+const down = () => {};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20220209-01-purge-unneeded-drafts.js
+++ b/lib/model/migrations/20220209-01-purge-unneeded-drafts.js
@@ -13,7 +13,7 @@
 // encryption was turned on for a project. For these unneeded (unattached) draft
 // form defs, there is no reference on the form itself back to these form defs.
 
-// NOTE: copypasta alert! The following SQL also appears in 'purgeUnneededDrafts()'
+// NOTE: copypasta alert! The following SQL also appears in 'clearUnneededDrafts()'
 // of lib/model/query/forms.js
 
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -243,6 +243,32 @@ select count(*) from deleted_forms`)
     .then((count) => Blobs.purgeUnattached()
       .then(() => Promise.resolve(count)));
 
+////////////////////////////////////////////////////////////////////////////////
+// PURGING UNNEEDED DRAFTS
+
+// Automatically purge the drafts of forms when the drafts aren't needed anymore.
+// 1. when a new draft is uploaded to replace an existing draft
+// 2. when a project's managed encryption is turned on and every form and
+//    existing drafts are replaced with encrypted versions
+
+// These unneeded drafts are essentially unnatched to the form in any meaningful way, either
+// as a plublished version or as the current draft.
+
+const _draftFilter = (form, project) =>
+  (form
+    ? sql`and forms."id" = ${form.id}`
+    : (project
+      ? sql`and forms."projectId" = ${project.id}`
+      : sql``));
+
+const purgeUnneededDrafts = (form = null, project = null) => ({ run }) =>
+  run(sql`
+delete from form_defs
+using forms
+where form_defs."formId" = forms.id
+and form_defs."publishedAt" is null
+and form_defs.id != forms."draftDefId"
+${_draftFilter(form, project)}`);
 
 ////////////////////////////////////////////////////////////////////////////////
 // ENCRYPTION
@@ -446,6 +472,7 @@ module.exports = {
   fromXls, _createNew, createNew, createVersion,
   publish, clearDraft,
   _update, update, _updateDef, del, restore, purge,
+  purgeUnneededDrafts,
   setManagedKey,
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -261,13 +261,14 @@ const _draftFilter = (form, project) =>
       ? sql`and forms."projectId" = ${project.id}`
       : sql``));
 
+// NOTE: copypasta alert! The following SQL also appears in 20220209-01-purge-unneeded-drafts.js
 const purgeUnneededDrafts = (form = null, project = null) => ({ run }) =>
   run(sql`
 delete from form_defs
 using forms
 where form_defs."formId" = forms.id
 and form_defs."publishedAt" is null
-and form_defs.id != forms."draftDefId"
+and form_defs.id is distinct from forms."draftDefId"
 ${_draftFilter(form, project)}`);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -244,12 +244,14 @@ select count(*) from deleted_forms`)
       .then(() => Promise.resolve(count)));
 
 ////////////////////////////////////////////////////////////////////////////////
-// PURGING UNNEEDED DRAFTS
+// CLEARING UNNEEDED DRAFTS
 
-// Automatically purge the drafts of forms when the drafts aren't needed anymore.
+// Automatically hard-delete the drafts of forms when the drafts aren't needed anymore.
 // 1. when a new draft is uploaded to replace an existing draft
 // 2. when a project's managed encryption is turned on and every form and
 //    existing drafts are replaced with encrypted versions
+// 3. when delete is called directly on a draft (and a published version exists
+//    for that form)
 
 // These unneeded drafts are essentially unnatched to the form in any meaningful way, either
 // as a plublished version or as the current draft.
@@ -262,7 +264,7 @@ const _draftFilter = (form, project) =>
       : sql``));
 
 // NOTE: copypasta alert! The following SQL also appears in 20220209-01-purge-unneeded-drafts.js
-const purgeUnneededDrafts = (form = null, project = null) => ({ run }) =>
+const clearUnneededDrafts = (form = null, project = null) => ({ run }) =>
   run(sql`
 delete from form_defs
 using forms
@@ -473,7 +475,7 @@ module.exports = {
   fromXls, _createNew, createNew, createVersion,
   publish, clearDraft,
   _update, update, _updateDef, del, restore, purge,
-  purgeUnneededDrafts,
+  clearUnneededDrafts,
   setManagedKey,
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -109,7 +109,8 @@ module.exports = (service, endpoint) => {
         .then((partial) => Promise.all([
           Forms.createVersion(partial, form, false),
           Submissions.clearDraftSubmissions(form.id)
-        ])))
+        ]))
+        .then(() => Forms.purgeUnneededDrafts(form))) // remove drafts made obsolete by new draft
       .then(success)));
 
   service.post('/projects/:projectId/forms/:id/draft/publish', endpoint(({ Forms, Submissions }, { params, auth, query }) =>

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -110,7 +110,7 @@ module.exports = (service, endpoint) => {
           Forms.createVersion(partial, form, false),
           Submissions.clearDraftSubmissions(form.id)
         ]))
-        .then(() => Forms.purgeUnneededDrafts(form))) // remove drafts made obsolete by new draft
+        .then(() => Forms.clearUnneededDrafts(form))) // remove drafts made obsolete by new draft
       .then(success)));
 
   service.post('/projects/:projectId/forms/:id/draft/publish', endpoint(({ Forms, Submissions }, { params, auth, query }) =>
@@ -143,7 +143,7 @@ module.exports = (service, endpoint) => {
       .then(rejectIf(((form) => form.currentDefId == null), noargs(Problem.user.noPublishedVersion)))
       .then(rejectIf(((form) => form.draftDefId == null), noargs(Problem.user.notFound)))
       .then((form) => Promise.all([
-        Forms.clearDraft(form).then(Forms.purgeUnneededDrafts(form)),
+        Forms.clearDraft(form).then(() => Forms.clearUnneededDrafts(form)),
         Submissions.clearDraftSubmissions(form.id),
         Audits.log(auth.actor, 'form.update.draft.delete', form, { oldDraftDefId: form.draftDefId })
       ]))

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -143,8 +143,7 @@ module.exports = (service, endpoint) => {
       .then(rejectIf(((form) => form.currentDefId == null), noargs(Problem.user.noPublishedVersion)))
       .then(rejectIf(((form) => form.draftDefId == null), noargs(Problem.user.notFound)))
       .then((form) => Promise.all([
-        // TODO: for now we just cast away the draft to nothing. eventually probably sweep+delete.
-        Forms.clearDraft(form),
+        Forms.clearDraft(form).then(Forms.purgeUnneededDrafts(form)),
         Submissions.clearDraftSubmissions(form.id),
         Audits.log(auth.actor, 'form.update.draft.delete', form, { oldDraftDefId: form.draftDefId })
       ]))

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -48,7 +48,7 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.update', project))
       .then((project) => Projects.setManagedEncryption(project, body.passphrase, body.hint)
-        .then(() => Forms.purgeUnneededDrafts(null, project))) // remove obsolete unencrypted draft form defs
+        .then(() => Forms.clearUnneededDrafts(null, project))) // remove obsolete unencrypted draft form defs
       .then(success)));
 
   // really this should probably fit just below PATCH but it's  just  so   l o o o  o  n    g

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -43,11 +43,12 @@ module.exports = (service, endpoint) => {
         .then(success))));
 
   // TODO: when form versioning is opened to users, log the version changes here.
-  service.post('/projects/:id/key', endpoint(({ Projects }, { auth, params, body }) =>
+  service.post('/projects/:id/key', endpoint(({ Projects, Forms }, { auth, params, body }) =>
     Projects.getById(params.id)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.update', project))
-      .then((project) => Projects.setManagedEncryption(project, body.passphrase, body.hint))
+      .then((project) => Projects.setManagedEncryption(project, body.passphrase, body.hint)
+        .then(() => Forms.purgeUnneededDrafts(null, project))) // remove obsolete unencrypted draft form defs
       .then(success)));
 
   // really this should probably fit just below PATCH but it's  just  so   l o o o  o  n    g

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -1,9 +1,6 @@
 const { readFileSync } = require('fs');
 const appRoot = require('app-root-path');
 const should = require('should');
-const config = require('config');
-const superagent = require('superagent');
-const { DateTime } = require('luxon');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
@@ -83,44 +80,44 @@ describe('api: /projects/:id/forms (drafts)', () => {
                     }));
               })))));
 
-    it('should worker-process the draft form over to enketo', testService((service, container) =>
-      service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms/simple/draft')
-          .expect(200)
-          .then(({ body }) => {
-            should.not.exist(body.enketoId);
-          })
-          .then(() => exhaust(container))
-          .then(() => asAlice.get('/v1/projects/1/forms/simple/draft')
+      it('should worker-process the draft form over to enketo', testService((service, container) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms/simple/draft')
             .expect(200)
             .then(({ body }) => {
-              body.enketoId.should.equal('::abcdefgh');
-              should.not.exist(body.enketoOnceId);
-              global.enketoReceivedUrl.startsWith(container.env.domain).should.equal(true);
-              global.enketoReceivedUrl.should.match(/\/v1\/test\/[a-z0-9$!]{64}\/projects\/1\/forms\/simple\/draft/i);
-            })))));
-
-    it('should manage draft/published enketo tokens separately', testService((service, container) =>
-      service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms?publish=true')
-          .set('Content-Type', 'application/xml')
-          .send(testData.forms.simple2)
-          .expect(200)
-          .then(() => exhaust(container))
-          .then(() => {
-            global.enketoToken = '::ijklmnop';
-            return asAlice.post('/v1/projects/1/forms/simple2/draft')
+              should.not.exist(body.enketoId);
+            })
+            .then(() => exhaust(container))
+            .then(() => asAlice.get('/v1/projects/1/forms/simple/draft')
               .expect(200)
-              .then(() => exhaust(container))
-              .then(() => Promise.all([
-                asAlice.get('/v1/projects/1/forms/simple2')
-                  .expect(200)
-                  .then(({ body }) => { body.enketoId.should.equal('::abcdefgh'); }),
-                asAlice.get('/v1/projects/1/forms/simple2/draft')
-                  .expect(200)
-                  .then(({ body }) => { body.enketoId.should.equal('::ijklmnop'); })
-              ]));
-          }))));
+              .then(({ body }) => {
+                body.enketoId.should.equal('::abcdefgh');
+                should.not.exist(body.enketoOnceId);
+                global.enketoReceivedUrl.startsWith(container.env.domain).should.equal(true);
+                global.enketoReceivedUrl.should.match(/\/v1\/test\/[a-z0-9$!]{64}\/projects\/1\/forms\/simple\/draft/i);
+              })))));
+
+      it('should manage draft/published enketo tokens separately', testService((service, container) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms?publish=true')
+            .set('Content-Type', 'application/xml')
+            .send(testData.forms.simple2)
+            .expect(200)
+            .then(() => exhaust(container))
+            .then(() => {
+              global.enketoToken = '::ijklmnop';
+              return asAlice.post('/v1/projects/1/forms/simple2/draft')
+                .expect(200)
+                .then(() => exhaust(container))
+                .then(() => Promise.all([
+                  asAlice.get('/v1/projects/1/forms/simple2')
+                    .expect(200)
+                    .then(({ body }) => { body.enketoId.should.equal('::abcdefgh'); }),
+                  asAlice.get('/v1/projects/1/forms/simple2/draft')
+                    .expect(200)
+                    .then(({ body }) => { body.enketoId.should.equal('::ijklmnop'); })
+                ]));
+            }))));
 
       it('should replace the draft version', testService((service) =>
         service.login('alice', (asAlice) =>
@@ -361,7 +358,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
             .then(() => asAlice.post('/v1/projects/1/forms/simple/draft/publish?version=two')
               .expect(200))
             .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
-            .send(testData.forms.simple)
+              .send(testData.forms.simple)
               .set('Content-Type', 'application/xml')
               .expect(400)
               .then(({ body }) => {
@@ -526,8 +523,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                     .expect(200)
                     .then(({ body }) => {
                       body.name.should.equal('New Title');
-                    })
-                ))))));
+                    })))))));
 
         it('should not update form title with draft title when form already published', testService((service) =>
           service.login('alice', (asAlice) =>
@@ -548,8 +544,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                     .expect(200)
                     .then(({ body }) => {
                       body.name.should.equal('Simple 2');
-                    })
-                ))))));
+                    })))))));
 
         it('should not update form title from draft when form published and existing draft present', testService((service) =>
           service.login('alice', (asAlice) =>
@@ -569,7 +564,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                   .then(() => asAlice.get('/v1/projects/1/forms/simple2')
                     .expect(200)
                     .then(({ body }) => {
-                          body.name.should.equal('Simple 2');
+                      body.name.should.equal('Simple 2');
                     })
                     .then(() => asAlice.post('/v1/projects/1/forms/simple2/draft')
                       .send(withRenamedTitleAndVersion('An Even Newer Title', '2.3'))
@@ -663,23 +658,23 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 body.lastSubmission.should.be.a.recentIsoDate();
               })))));
 
-    it('should return the correct enketoId with extended draft', testService((service, container) =>
-      service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms?publish=true')
-          .set('Content-Type', 'application/xml')
-          .send(testData.forms.simple2)
-          .expect(200)
-          .then(() => exhaust(container))
-          .then(() => {
-            global.enketoToken = '::ijklmnop';
-            return asAlice.post('/v1/projects/1/forms/simple2/draft')
-              .expect(200)
-              .then(() => exhaust(container))
-              .then(() => asAlice.get('/v1/projects/1/forms/simple2/draft')
-                .set('X-Extended-Metadata', true)
+      it('should return the correct enketoId with extended draft', testService((service, container) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms?publish=true')
+            .set('Content-Type', 'application/xml')
+            .send(testData.forms.simple2)
+            .expect(200)
+            .then(() => exhaust(container))
+            .then(() => {
+              global.enketoToken = '::ijklmnop';
+              return asAlice.post('/v1/projects/1/forms/simple2/draft')
                 .expect(200)
-                .then(({ body }) => { body.enketoId.should.equal('::ijklmnop'); }));
-          }))));
+                .then(() => exhaust(container))
+                .then(() => asAlice.get('/v1/projects/1/forms/simple2/draft')
+                  .set('X-Extended-Metadata', true)
+                  .expect(200)
+                  .then(({ body }) => { body.enketoId.should.equal('::ijklmnop'); }));
+            }))));
 
       it('should not count nondraft submissions in its count', testService((service) =>
         service.login('alice', (asAlice) =>

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -768,6 +768,19 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 body.version.should.equal('');
               })))));
 
+      it('should purge the draft when it is deleted', testService((service, { oneFirst }) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms/simple/draft')
+            .send(testData.forms.simple)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.delete('/v1/projects/1/forms/simple/draft')
+              .expect(200))
+            .then(() => oneFirst(sql`select count(*) from form_defs where "formId" = 1 and "publishedAt" is null`)
+              .then((count) => {
+                count.should.equal(0); // one for the first published version and for the new draft
+              })))));
+
       it('should conflict if there is no published version', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms')

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -105,4 +105,121 @@ describe('database migrations', function() {
     count = await container.oneFirst(sql`select count(*) from blobs`);
     count.should.equal(0); // blobs should all be purged
   }));
+
+
+  it('should purge blobs of deleted forms', testServiceFullTrx(async (service, container) => {
+    // An earlier version of this migration [20220121-02-purge-deleted-forms.js]
+    // failed because it tried to purge blobs that were still being used as
+    // xlsBlobIds on active form definitons.
+    await upToMigration('20220121-01-form-cascade-delete.js');
+    await populateUsers(container);
+    await populateForms(container);
+
+    // xmlFormId of this xlsx form is 'simple2'
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
+        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        .expect(200)
+        .then(() => asAlice.delete('/v1/projects/1/forms/simple2') // Delete form
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/submission')
+          .set('X-OpenRosa-Version', '1.0')
+          .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+          .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+          .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+          .expect(201))
+        .then(() => asAlice.delete('/v1/projects/1/forms/binaryType') // Delete form
+          .expect(200)));
+
+    let count = await container.oneFirst(sql`select count(*) from blobs`);
+    count.should.equal(3); // xls blob and two file blobs
+
+    // running migration 20220121-02-purge-deleted-forms.js
+    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
+
+    count = await container.oneFirst(sql`select count(*) from blobs`);
+    count.should.equal(0); // blobs should all be purged
+  }));
+
+  it('should not purge form defs (published and active drafts)', testServiceFullTrx(async (service, container) => {
+    // 20220209-01-purge-unneeded-drafts.js
+    await upToMigration('20220121-02-purge-deleted-forms.js');
+    await populateUsers(container);
+    await populateForms(container);
+
+    // Creating form defs that should still be there after the purge
+    // 1. published defs (withrepeat) (1)
+    // 2. published def and new draft of simple (2)
+    // 3. just a new draft of simple2 (1)
+    // 4. defs in a managed encryption project (3)
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms/simple/draft')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects')
+          .set('Content-Type', 'application/json')
+          .send({ name: 'New Encrypted Proj' })
+          .expect(200)
+          .then(({ body }) => body.id))
+        .then((newProjId) => asAlice.post(`/v1/projects/${newProjId}/forms?publish=true`)
+          .send(testData.forms.simple)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.post(`/v1/projects/${newProjId}/forms/simple/draft`)
+            .expect(200))
+          .then(() => asAlice.post(`/v1/projects/${newProjId}/key`)
+            .send({ passphrase: 'supersecret', hint: 'it is a secret' })
+            .expect(200))));
+
+    const before = await container.oneFirst(sql`select count(*) from form_defs`);
+    before.should.equal(7);
+
+    // running migration 20220209-01-purge-unneeded-drafts.js
+    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
+
+    const after = await container.oneFirst(sql`select count(*) from form_defs`);
+    after.should.equal(before); // no defs purged
+  }));
+
+  it('should purge unneeded form draft defs', testServiceFullTrx(async (service, container) => {
+    // 20220209-01-purge-unneeded-drafts.js
+    await upToMigration('20220121-02-purge-deleted-forms.js');
+    await populateUsers(container);
+    await populateForms(container);
+
+    // There isn't a way to get the code to make unneeded drafts anymore
+    // so we are trying to do it manually
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms/simple/draft')
+        .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="2"'))
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft/publish')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+          .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="3"'))
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms/simple/draft/publish')
+            .expect(200)))
+        .then(() => container.run(sql`update form_defs set "publishedAt" = null where "formId" = 1 and "version" = '2'`)));
+
+    const before = await container.oneFirst(sql`select count(*) from form_defs`);
+    before.should.equal(4);
+
+    // running migration 20220209-01-purge-unneeded-drafts.js
+    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
+
+    const after = await container.oneFirst(sql`select count(*) from form_defs`);
+    after.should.equal(before - 1); // one purged
+  }));
+
 });

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -106,7 +106,7 @@ describe('database migrations', function() {
     count.should.equal(0); // blobs should all be purged
   }));
 
-  it('should not purge form defs (published and active drafts)', testServiceFullTrx(async (service, container) => {
+  it('should not purge certain form defs that are either published or active drafts', testServiceFullTrx(async (service, container) => {
     // 20220209-01-purge-unneeded-drafts.js
     await upToMigration('20220121-02-purge-deleted-forms.js');
     await populateUsers(container);
@@ -156,7 +156,8 @@ describe('database migrations', function() {
     await populateForms(container);
 
     // There isn't a way to get the code to make unneeded drafts anymore
-    // so we are trying to do it manually
+    // so we are trying to do it manually by taking one of the intermediate
+    // (but not current) published defs and setting its publishedAt value to null.
     await service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms/simple/draft')
         .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="2"'))

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -106,46 +106,6 @@ describe('database migrations', function() {
     count.should.equal(0); // blobs should all be purged
   }));
 
-
-  it('should purge blobs of deleted forms', testServiceFullTrx(async (service, container) => {
-    // An earlier version of this migration [20220121-02-purge-deleted-forms.js]
-    // failed because it tried to purge blobs that were still being used as
-    // xlsBlobIds on active form definitons.
-    await upToMigration('20220121-01-form-cascade-delete.js');
-    await populateUsers(container);
-    await populateForms(container);
-
-    // xmlFormId of this xlsx form is 'simple2'
-    await service.login('alice', (asAlice) =>
-      asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
-        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-        .expect(200)
-        .then(() => asAlice.delete('/v1/projects/1/forms/simple2') // Delete form
-          .expect(200))
-        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
-          .set('Content-Type', 'application/xml')
-          .send(testData.forms.binaryType)
-          .expect(200))
-        .then(() => asAlice.post('/v1/projects/1/submission')
-          .set('X-OpenRosa-Version', '1.0')
-          .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
-          .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
-          .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
-          .expect(201))
-        .then(() => asAlice.delete('/v1/projects/1/forms/binaryType') // Delete form
-          .expect(200)));
-
-    let count = await container.oneFirst(sql`select count(*) from blobs`);
-    count.should.equal(3); // xls blob and two file blobs
-
-    // running migration 20220121-02-purge-deleted-forms.js
-    await migrator.migrate.up({ directory: appRoot + '/lib/model/migrations' });
-
-    count = await container.oneFirst(sql`select count(*) from blobs`);
-    count.should.equal(0); // blobs should all be purged
-  }));
-
   it('should not purge form defs (published and active drafts)', testServiceFullTrx(async (service, container) => {
     // 20220209-01-purge-unneeded-drafts.js
     await upToMigration('20220121-02-purge-deleted-forms.js');


### PR DESCRIPTION
If a user does something that makes a particular Draft Form unneeded, it should be immediately hard-deleted from the database.

There are three scenarios for this:
1. Uploading a new Draft while there is currently a draft, which replaces the existing one
2. Enabling Project Managed Encryption, which replaces all existing drafts
3. Deleting a draft directly (only when there is a published version already on the form)