### PR TITLE
Disallow passwords that are too short

### DIFF
--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -41,6 +41,8 @@ const setManagedEncryption = (project, passphrase, hint) => ({ Forms, Keys, Proj
     return reject(Problem.user.alreadyActive({ feature: 'managed encryption' }));
   if (isBlank(passphrase))
     return reject(Problem.user.missingParameter({ field: 'passphrase' }));
+  if (passphrase.length < 10)
+    return reject(Problem.user.passwordTooShort());
 
   // generate a common version suffix for all forms we are about to munge.
   const suffix = generateVersionSuffix();

--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -11,6 +11,8 @@ const { sql } = require('slonik');
 const { map } = require('ramda');
 const { Actor, User } = require('../frames');
 const { unjoiner, page, equals, QueryOptions } = require('../../util/db');
+const { reject } = require('../../util/promise');
+const Problem = require('../../util/problem');
 
 const create = (user) => ({ Actors }) => Actors.createSubtype(user);
 create.audit = (user) => (log) => log('user.create', user.actor, { data: user });
@@ -31,7 +33,9 @@ const update = (user, data) => ({ run, one }) => {
 update.audit = (user, data) => (log) => log('user.update', user.actor, { data: data.with(data.actor) });
 
 const updatePassword = (user, cleartext) => ({ run, bcrypt }) =>
-  bcrypt.hash(cleartext)
+  (cleartext.length < 10
+    ? reject(Problem.user.passwordTooShort())
+    : bcrypt.hash(cleartext))
     .then((hash) => run(sql`update users set password=${hash} where "actorId"=${user.actor.id}`));
 updatePassword.audit = (user) => (log) => log('user.update', user.actor, { data: { password: true } });
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -92,7 +92,7 @@ const problems = {
 
     expectedDeprecation: problem(400.19, () => 'This PUT endpoint expects a deprecatedID metadata tag pointing at the current version instanceID. I cannot find that tag in your request.'),
 
-    passwordTooShort: problem(400.21, () => 'The password provided does not meet the required length.'),
+    passwordTooShort: problem(400.21, () => 'The password or passphrase provided does not meet the required length.'),
 
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -92,6 +92,8 @@ const problems = {
 
     expectedDeprecation: problem(400.19, () => 'This PUT endpoint expects a deprecatedID metadata tag pointing at the current version instanceID. I cannot find that tag in your request.'),
 
+    passwordTooShort: problem(400.21, () => 'The password provided does not meet the required length.'),
+
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),
 

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -530,7 +530,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
       it('should return encrypted form keyId', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/key')
-            .send({ passphrase: 'encryptme' })
+            .send({ passphrase: 'supersecret' })
             .expect(200)
             .then(() => asAlice.get('/v1/projects/1/forms/simple')
               .expect(200)

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -415,6 +415,12 @@ describe('api: /projects', () => {
           .send({ passphrase: '' })
           .expect(400))));
 
+    it('should reject if passphrase is too short', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/key')
+          .send({ passphrase: 'x' })
+          .expect(400))));
+
     it('should reject if managed encryption is already active', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/key')

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -48,7 +48,7 @@ const withSimpleIds = (deprecatedId, instanceId) => testData.instances.simple.on
 const createTestUser = (service, container, name, role, projectId, recent = true) =>
   service.login('alice', (asAlice) =>
     asAlice.post('/v1/users')
-      .send({ email: `${name}@getodk.org`, password: name })
+      .send({ email: `${name}@getodk.org`, password: `${name}slongpassword` }) // password has to be >10 chars
       .then(({ body }) => ((role === 'admin')
         ? asAlice.post(`/v1/assignments/admin/${body.id}`)
         : asAlice.post(`/v1/projects/${projectId}/assignments/${role}/${body.id}`))

--- a/test/integration/task/account.js
+++ b/test/integration/task/account.js
@@ -8,7 +8,7 @@ const { User } = require(appRoot + '/lib/model/frames');
 describe('task: accounts', () => {
   describe('createUser', () => {
     it('should create a user account', testTask(({ Users }) =>
-      createUser('testuser@getodk.org', 'aoeu')
+      createUser('testuser@getodk.org', 'aoeuidhtns')
         .then((result) => {
           result.email.should.equal('testuser@getodk.org');
           return Users.getByEmail('testuser@getodk.org')
@@ -16,7 +16,7 @@ describe('task: accounts', () => {
         })));
 
     it('should log an audit entry', testTask(({ Audits, Users }) =>
-      createUser('testuser@getodk.org', 'aoeu')
+      createUser('testuser@getodk.org', 'aoeuidhtns')
         .then((result) => Promise.all([
           Users.getByEmail('testuser@getodk.org').then((o) => o.get()),
           Audits.getLatestByAction('user.create').then((o) => o.get())
@@ -28,11 +28,16 @@ describe('task: accounts', () => {
         })));
 
     it('should set the password if given', testTask(({ Users, bcrypt }) =>
-      createUser('testuser@getodk.org', 'aoeu')
+      createUser('testuser@getodk.org', 'aoeuidhtns')
         .then(() => Users.getByEmail('testuser@getodk.org'))
         .then(getOrNotFound)
-        .then((user) => bcrypt.verify('aoeu', user.password))
+        .then((user) => bcrypt.verify('aoeuidhtns', user.password))
         .then((verified) => verified.should.equal(true))));
+
+
+    it('should complain if the password is too short', testTask(({ Users, bcrypt }) =>
+      createUser('testuser@getodk.org', 'short')
+        .catch((problem) => problem.problemCode.should.equal(400.21))));
   });
 
   describe('promoteUser', () => {
@@ -67,23 +72,28 @@ describe('task: accounts', () => {
   describe('setUserPassword', () => {
     it('should set a user password', testTask(({ Users, bcrypt }) =>
       Users.create(User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }))
-        .then(() => setUserPassword('testuser@getodk.org', 'aoeu'))
+        .then(() => setUserPassword('testuser@getodk.org', 'aoeuidhtns'))
         .then(() => Users.getByEmail('testuser@getodk.org'))
         .then(getOrNotFound)
-        .then((user) => bcrypt.verify('aoeu', user.password))
+        .then((user) => bcrypt.verify('aoeuidhtns', user.password))
         .then((verified) => verified.should.equal(true))));
+
+    it('should complain about a password that is too short', testTask(({ Users, bcrypt }) =>
+      Users.create(User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }))
+        .then(() => setUserPassword('testuser@getodk.org', 'aoeu'))
+        .catch((problem) => problem.problemCode.should.equal(400.21))));
 
     it('should log an audit entry', testTask(({ Audits, Users }) =>
       Users.create(User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }))
-        .then(() => setUserPassword('testuser@getodk.org', 'aoeu'))
+        .then(() => setUserPassword('testuser@getodk.org', 'aoeuidhtns'))
         .then(() => Promise.all([
           Audits.getLatestByAction('user.update').then((o) => o.get()),
           Users.getByEmail('testuser@getodk.org').then((o) => o.get())
         ])
-        .then(([ log, user ]) => {
-          log.acteeId.should.equal(user.actor.acteeId);
-          log.details.data.should.eql({ password: true });
-        }))));
+          .then(([ log, user ]) => {
+            log.acteeId.should.equal(user.actor.acteeId);
+            log.details.data.should.eql({ password: true });
+          }))));
   });
 });
 


### PR DESCRIPTION
Complain if a user tries to set a password that is too short (<10 chars) on several API endpoints and in the central CLI. Includes creating and updating a user password and specifying a passphrase when enabling managed encryption on a project.