### PR TITLE
New metrics: archived projects, unique roles

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -31,7 +31,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/submission",
         "formId": "odk-analytics",
-        "version": "2021.12.15.01"
+        "version": "2022.02.23.01"
       }
     }
   },

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -25,6 +25,10 @@ const metricsTemplate = {
       "recent": 0,
       "total": 0
     },
+    "num_archived_projects": {},
+    "num_unique_managers": {},
+    "num_unique_viewers": {},
+    "num_unique_collectors": {},
     "backups_configured": {},
     "database_size": {}
   },
@@ -77,7 +81,8 @@ const metricsTemplate = {
         "num_forms_with_audits": {
           "recent": 0,
           "total": 0
-        }
+        },
+        "num_reused_form_ids": 0
       },
       "submissions": {
         "num_submissions_received": {

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -235,7 +235,7 @@ group by fs."projectId"`);
 
 // This query checks the audit log for 'form.delete' actions
 // and joins with two sources: purged actees and soft-deleted forms
-// to produce a list of all deleted formId/xmlFormId/projectId entries.
+// to produce a list of all deleted xmlFormId/projectId entries.
 // The list of active forms is then compared against this
 // deleted forms list to see how many active forms reuse an xmlFormId.
 const countReusedFormIds = () => ({ all }) => all(sql`
@@ -244,8 +244,7 @@ from forms
 inner join (
   select
   coalesce(a."details"->>'xmlFormId', f."xmlFormId") as xml_form_id,
-  coalesce((a."details"->>'projectId')::int, f."projectId") as proj_id,
-  coalesce((a."details"->>'formId')::int, f."id") as form_id
+  coalesce((a."details"->>'projectId')::int, f."projectId") as proj_id
   from audits as au
   join actees as a on au."acteeId" = a."id"
   left join forms as f on au."acteeId" = f."acteeId"
@@ -255,11 +254,11 @@ inner join (
     when a."purgedAt" is not null then true
     else false
   end
-  group by (xml_form_id, form_id, proj_id)
+  group by (xml_form_id, proj_id)
 ) as deleted_form_ids
 on forms."xmlFormId" = deleted_form_ids."xml_form_id" and
    forms."projectId" = deleted_form_ids."proj_id"
-where forms.id <> deleted_form_ids."form_id"
+where forms."deletedAt" is null
 group by forms."projectId"`);
 
 // Submissions

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -244,7 +244,7 @@ from forms
 inner join (
   select
   coalesce(a."details"->>'xmlFormId', f."xmlFormId") as xml_form_id,
-  coalesce((a."details"->'projectId')::int, f."projectId") as proj_id,
+  coalesce((a."details"->>'projectId')::int, f."projectId") as proj_id,
   coalesce((a."details"->>'formId')::int, f."id") as form_id
   from audits as au
   join actees as a on au."acteeId" = a."id"

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -233,6 +233,35 @@ from (
 ) as fs
 group by fs."projectId"`);
 
+// This query checks the audit log for 'form.delete' actions
+// and joins with two sources: purged actees and soft-deleted forms
+// to produce a list of all deleted formId/xmlFormId/projectId entries.
+// The list of active forms is then compared against this
+// deleted forms list to see how many active forms reuse an xmlFormId.
+const countReusedFormIds = () => ({ all }) => all(sql`
+select count(*) as total, forms."projectId"
+from forms
+inner join (
+  select
+  coalesce(a."details"->>'xmlFormId', f."xmlFormId") as xml_form_id,
+  coalesce((a."details"->'projectId')::int, f."projectId") as proj_id,
+  coalesce((a."details"->>'formId')::int, f."id") as form_id
+  from audits as au
+  join actees as a on au."acteeId" = a."id"
+  left join forms as f on au."acteeId" = f."acteeId"
+  where au."action" = 'form.delete' and
+  case
+    when f.id is not null then f."deletedAt" is not null
+    when a."purgedAt" is not null then true
+    else false
+  end
+  group by (xml_form_id, form_id, proj_id)
+) as deleted_form_ids
+on forms."xmlFormId" = deleted_form_ids."xml_form_id" and
+   forms."projectId" = deleted_form_ids."proj_id"
+where forms.id <> deleted_form_ids."form_id"
+group by forms."projectId"`);
+
 // Submissions
 const countSubmissions = () => ({ all }) => all(sql`
 select f."projectId", count(s.id) as total,
@@ -320,13 +349,14 @@ const projectMetrics = () => (({ Analytics }) => Promise.all([
   Analytics.countForms(),
   Analytics.countFormFieldTypes(),
   Analytics.countFormsEncrypted(),
+  Analytics.countReusedFormIds(),
   Analytics.countSubmissions(),
   Analytics.countSubmissionReviewStates(),
   Analytics.countSubmissionsEdited(),
   Analytics.countSubmissionsComments(),
   Analytics.countSubmissionsByUserType()
 ]).then(([ userRoles, appUsers, deviceIds, pubLinks,
-  forms, formGeoRepeats, formsEncrypt,
+  forms, formGeoRepeats, formsEncrypt, reusedIds,
   subs, subStates, subEdited, subComments, subUsers ]) => {
   const projects = {};
 
@@ -379,6 +409,11 @@ const projectMetrics = () => (({ Analytics }) => Promise.all([
   for (const row of formsEncrypt) {
     const project = _getProject(projects, row.projectId);
     project.forms.num_forms_with_encryption = { total: row.total, recent: row.recent };
+  }
+
+  for (const row of reusedIds) {
+    const project = _getProject(projects, row.projectId);
+    project.forms.num_reused_form_ids = row.total;
   }
 
   // submissions
@@ -481,6 +516,7 @@ module.exports = {
   countFormsEncrypted,
   countFormFieldTypes,
   countPublicLinks,
+  countReusedFormIds,
   countSubmissions,
   countSubmissionReviewStates,
   countSubmissionsEdited,

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -71,6 +71,27 @@ select max(count) from (
   group by ff."formDefId"
 ) as "formFieldCounts"`);
 
+const archivedProjects = () => ({ one }) => one(sql`
+select count(*) as num_archived_projects from projects where archived is true`);
+
+const countUniqueManagers = () => ({ oneFirst }) => oneFirst(sql`
+select count(distinct a."actorId")
+from assignments as a
+join roles as r on r."id" = a."roleId"
+where r."system" = 'manager'`);
+
+const countUniqueViewers = () => ({ oneFirst }) => oneFirst(sql`
+select count(distinct a."actorId")
+from assignments as a
+join roles as r on r."id" = a."roleId"
+where r."system" = 'viewer'`);
+
+const countUniqueDataCollectors = () => ({ oneFirst }) => oneFirst(sql`
+select count(distinct a."actorId")
+from assignments as a
+join roles as r on r."id" = a."roleId"
+where r."system" = 'formfill'`);
+
 const databaseSize = () => ({ one }) => one(sql`
 select pg_database_size(current_database()) as database_size`);
 
@@ -408,14 +429,26 @@ const previewMetrics = () => (({ Analytics }) => Promise.all([
   Analytics.biggestForm(),
   Analytics.countAdmins(),
   Analytics.auditLogs(),
+  Analytics.archivedProjects(),
+  Analytics.countUniqueManagers(),
+  Analytics.countUniqueViewers(),
+  Analytics.countUniqueDataCollectors(),
   Analytics.projectMetrics()
-]).then(([db, backups, encrypt, bigForm, admins, audits, projMetrics]) => {
+]).then(([db, backups, encrypt, bigForm, admins, audits,
+  archived, managers, viewers, collectors, projMetrics]) => {
   const metrics = clone(metricsTemplate);
   // system
   for (const [key, value] of Object.entries(db))
     metrics.system[key] = value;
   for (const [key, value] of Object.entries(backups))
     metrics.system[key] = value;
+  for (const [key, value] of Object.entries(archived))
+    metrics.system[key] = value;
+
+  metrics.system.num_unique_managers = managers;
+  metrics.system.num_unique_viewers = viewers;
+  metrics.system.num_unique_collectors = collectors;
+
   for (const [key, value] of Object.entries(encrypt))
     metrics.system.num_projects_encryption[key] = value;
   metrics.system.num_questions_biggest_form = bigForm;
@@ -436,6 +469,7 @@ const getLatestAudit = () => ({ maybeOne }) => maybeOne(sql`select * from audits
   order by "loggedAt" desc limit 1`);
 
 module.exports = {
+  archivedProjects,
   auditLogs,
   backupsEnabled,
   biggestForm,
@@ -452,6 +486,9 @@ module.exports = {
   countSubmissionsEdited,
   countSubmissionsComments,
   countSubmissionsByUserType,
+  countUniqueDataCollectors,
+  countUniqueManagers,
+  countUniqueViewers,
   countUsersPerRole,
   encryptedProjects,
   previewMetrics,

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -414,7 +414,7 @@ describe('analytics task queries', () => {
       emptyRes.should.eql([]);
 
       // one purged form reused
-      await container.Forms.purge(force=true);
+      await container.Forms.purge(true);
       await createTestForm(service, container, testData.forms.simple, 1);
 
       // one deleted unpublished form reused (in the same project)
@@ -430,8 +430,8 @@ describe('analytics task queries', () => {
       // delete multiple times (only count 1 active form with reused id)
       const proj2 = await createTestProject(service, container, 'New Proj');
       await service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms')
-          .send(testData.forms.simple1)
+        asAlice.post(`/v1/projects/${proj2}/forms`)
+          .send(testData.forms.simple)
           .set('Content-Type', 'application/xml')
           .then(() => asAlice.delete(`/v1/projects/${proj2}/forms/simple`))
           .then(() => asAlice.post(`/v1/projects/${proj2}/forms?publish=true`)


### PR DESCRIPTION
Adds 5 new metrics:
1. number of total archived projects (no recent vs. total, just how many there are at the time of computing analytics)
2. number of unique project managers (if a user is a manager on multiple projects, this is only counted once. if a user has two different roles on different projects, each type of role is counted.)
3. same as above but for project viewers
4. same as above but for data collectors
5. number of reused form ids: will report how many active forms use an (`xmlFormid`) ID that was ever deleted or purged in the past.
    * this will give us a sense of whether people are reusing form IDs at all (which will they have to use form deletion to do).