### PR TITLE
bug: fix splitSelectMultiples for draft submissions.

### DIFF
--- a/lib/model/container.js
+++ b/lib/model/container.js
@@ -35,8 +35,9 @@ const queryModuleBuilder = (definition, container) => {
       // query modules can additionally declare an audit logging coroutine. handle them here.
       if ((fn.audit != null) && (container != null)) {
         const isAuthenticated = (container.context != null) && (container.context.auth != null) && container.context.auth.isAuthenticated;
+        const bypassAuth = (container.task === true || fn.audit.logEvenIfAnonymous === true);
 
-        if (isAuthenticated || container.task === true) {
+        if (isAuthenticated || bypassAuth) {
           const actor = isAuthenticated ? container.context.auth.actor.orNull() : null;
           const logger = (action, actee, details) => container.Audits.log(actor, action, actee, details);
           return (fn.audit.withResult === true)

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -429,6 +429,8 @@ const getStructuralFields = (formDefId) => ({ all }) =>
 //
 // used by the export deleted fields option, this gives all fields we know about
 // for a form, across all its published versions.
+//
+// N.B. will only return published form fields! do not use this to try to get draft fields.
 const getMergedFields = (formId) => ({ all }) => all(sql`
 select form_fields.* from form_fields
 inner join

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -56,6 +56,7 @@ select ins.*, def.id as "submissionDefId" from ins, def;`)
 createNew.audit = (submission, _, form) => (log) =>
   log('submission.create', form, { submissionId: submission.id, instanceId: submission.instanceId });
 createNew.audit.withResult = true;
+createNew.audit.logEvenIfAnonymous = true; // so that test submissions are fully logged.
 
 const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn = null) => ({ one, context }) => {
   const actorId = context.auth.actor.map((actor) => actor.id).orNull();
@@ -75,6 +76,7 @@ ${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, devic
 
 createVersion.audit = (partial, deprecated, form) => (log) =>
   log('submission.update.version', form, { submissionId: deprecated.submissionId, instanceId: partial.instanceId });
+createNew.audit.logEvenIfAnonymous = true; // so that test submissions are fully logged.
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -145,6 +147,10 @@ const getByIds = (projectId, xmlFormId, instanceId, draft, options = QueryOption
 
 const getAllForFormByIds = (projectId, xmlFormId, draft, options = QueryOptions.none) => ({ all }) =>
   _get(all, options, projectId, xmlFormId, draft);
+
+const getById = (submissionId) => ({ maybeOne }) =>
+  maybeOne(sql`select * from submissions where id=${submissionId} and "deletedAt" is null`)
+    .then(map(construct(Submission)));
 
 const countByFormId = (formId, draft, options = QueryOptions.none) => ({ oneFirst }) => oneFirst(sql`
 select count(*) from submissions
@@ -281,7 +287,7 @@ module.exports = {
   createNew, createVersion,
   update, clearDraftSubmissions,
   setSelectMultipleValues, getSelectMultipleValuesForExport,
-  getByIds, getAllForFormByIds, countByFormId, verifyVersion,
+  getByIds, getAllForFormByIds, getById, countByFormId, verifyVersion,
   getDefById, getCurrentDefByIds, getAnyDefByFormAndInstanceId, getDefsByFormAndLogicalId, getDefBySubmissionAndInstanceId, getRootForInstanceId,
   streamForExport, getForExport
 };

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -76,7 +76,7 @@ ${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, devic
 
 createVersion.audit = (partial, deprecated, form) => (log) =>
   log('submission.update.version', form, { submissionId: deprecated.submissionId, instanceId: partial.instanceId });
-createNew.audit.logEvenIfAnonymous = true; // so that test submissions are fully logged.
+createVersion.audit.logEvenIfAnonymous = true; // so that test submissions are fully logged.
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/worker/submission.js
+++ b/lib/worker/submission.js
@@ -15,7 +15,7 @@ const updateSelectMultipleValues = ({ Forms, Submissions }, event) =>
     Submissions.getDefBySubmissionAndInstanceId(event.details.submissionId, event.details.instanceId)
   ])
     .then(([ mform, mdef ]) => mform.map((form) => mdef.map((def) =>
-      Forms.getMergedFields(form.id).then((fields) =>
+      Forms.getFields(def.formDefId).then((fields) =>
         getSelectMultipleResponses(fields.filter((field) => field.selectMultiple === true), def.xml)
           .then((pairs) => Submissions.setSelectMultipleValues(form.id, def.id, pairs))))));
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -2235,6 +2235,18 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                 done();
               })))))));
 
+    it('should not log the action in the audit log', testService((service) =>
+      service.login('alice', (asAlice) =>
+         asAlice.post('/v1/projects/1/forms/simple/draft')
+           .expect(200)
+           .then(() => asAlice.get('/v1/projects/1/forms/simple/draft/submissions.csv.zip')
+             .expect(200))
+           .then(() => asAlice.get('/v1/audits?action=form.submission.export')
+             .expect(200)
+             .then(({ body }) => {
+               body.length.should.equal(0);
+             })))));
+
     it('should split select multiple values submitted over /test/ if ?splitSelectMultiples=true', testService((service, container) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms')

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -2235,17 +2235,34 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                 done();
               })))))));
 
-    it('should not log the action in the audit log', testService((service) =>
+    it('should split select multiple values submitted over /test/ if ?splitSelectMultiples=true', testService((service, container) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms/simple/draft')
-          .expect(200)
-          .then(() => asAlice.get('/v1/projects/1/forms/simple/draft/submissions.csv.zip')
-            .expect(200))
-          .then(() => asAlice.get('/v1/audits?action=form.submission.export')
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.selectMultiple)
+          .then(() => asAlice.get('/v1/projects/1/forms/selectMultiple/draft')
             .expect(200)
-            .then(({ body }) => {
-              body.length.should.equal(0);
-            })))));
+            .then(({ body }) => body.draftToken)
+            .then((token) => service.post(`/v1/test/${token}/projects/1/forms/selectMultiple/draft/submission`)
+              .set('Content-Type', 'application/xml')
+              .set('X-OpenRosa-Version', '1.0')
+              .attach('xml_submission_file', Buffer.from(testData.instances.selectMultiple.one), { filename: 'data.xml' })
+              .then(() => service.post(`/v1/test/${token}/projects/1/forms/selectMultiple/draft/submission`)
+                .set('Content-Type', 'application/xml')
+                .set('X-OpenRosa-Version', '1.0')
+                .attach('xml_submission_file', Buffer.from(testData.instances.selectMultiple.two), { filename: 'data.xml' }))))
+          .then(() => exhaust(container))
+          .then(() => new Promise((done) =>
+            zipStreamToFiles(asAlice.get('/v1/projects/1/forms/selectMultiple/draft/submissions.csv.zip?splitSelectMultiples=true'), (result) => {
+              result.filenames.should.containDeep([ 'selectMultiple.csv' ]);
+              const lines = result['selectMultiple.csv'].split('\n');
+              lines[0].should.equal('SubmissionDate,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+              lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+                .should.equal(',b,0,1,m x,1,1,0,0,two,,,0,0,,,,0,');
+              lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+                .should.equal(',a b,1,1,x y z,0,1,1,1,one,,,0,0,,,,0,');
+              done();
+            }))))));
   });
 
   describe('GET', () => {


### PR DESCRIPTION
* we now just get the fields for the form def in question rather than
  try to merge them all. we did the latter for paranoia+compatibility
  with deletedFields = true.
* but theoretically nobody can be filling out data their form version
  doesn't ask for, so it should cover all the values in the instance.