### PR TITLE
Check for pending migrations before running server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,12 @@ node_modules:
 migrations: node_modules
 	node -e 'const { withDatabase, migrate } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(migrate);'
 
+check-migrations: node_modules
+	node -e 'const { withDatabase, checkMigrations } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(checkMigrations);'
+
 base: node_modules migrations
 
-run: base
+run: base check-migrations
 	node lib/bin/run-server.js
 
 debug: base

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ migrations: node_modules
 check-migrations: node_modules
 	node -e 'const { withDatabase, checkMigrations } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(checkMigrations);'
 
-base: node_modules migrations
+base: node_modules migrations check-migrations
 
-run: base check-migrations
+run: base
 	node lib/bin/run-server.js
 
 debug: base

--- a/lib/model/migrate.js
+++ b/lib/model/migrate.js
@@ -25,5 +25,12 @@ const withDatabase = (config) => (mutator) => {
 // Given a database, initiates migrations on it.
 const migrate = (db) => db.migrate.latest({ directory: `${__dirname}/migrations` });
 
-module.exports = { connect, withDatabase, migrate };
+// Checks for pending migrations and returns an exit code of 1 if any are
+// still pending/unapplied (e.g. automatically running migrations just failed).
+const checkMigrations = (db) => db.migrate.list({ directory: `${__dirname}/migrations` })
+  .then((res) => (res[1].length === 0
+    ? process.exit(0)
+    : process.exit(1)));
+
+module.exports = { checkMigrations, connect, withDatabase, migrate };
 

--- a/lib/model/migrate.js
+++ b/lib/model/migrate.js
@@ -28,9 +28,10 @@ const migrate = (db) => db.migrate.latest({ directory: `${__dirname}/migrations`
 // Checks for pending migrations and returns an exit code of 1 if any are
 // still pending/unapplied (e.g. automatically running migrations just failed).
 const checkMigrations = (db) => db.migrate.list({ directory: `${__dirname}/migrations` })
-  .then((res) => (res[1].length === 0
-    ? process.exit(0)
-    : process.exit(1)));
+  .then((res) => {
+    if (res[1].length > 0)
+      process.exitCode = 1;
+  });
 
 module.exports = { checkMigrations, connect, withDatabase, migrate };
 


### PR DESCRIPTION
Adds a helper function for checking for pending migrations that returns an error exit code (1) if there are any pending migrations. This is used to prevent running the server after automatically applying migrations if there happened to be a problem with the migrations. See issues #461 and https://github.com/getodk/central/issues/258. 

This check has been added to the Makefile so the dev server won't run if there is a problem with the migrations, but it also needs to be used in `start-odk.sh` of the main central repo.

Here's an example non-make script (similar to `start-odk.sh`) that will exit before starting the server if the migration check fails:
  
    #!/bin/sh
    
    echo "pretending to work like start-odk.sh in the main central repo"
    
    node -e 'const { withDatabase, migrate } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(migrate);'
    
    node -e 'const { withDatabase, checkMigrations } = require("./lib/model/migrate"); withDatabase(require("config").get("default.database"))(checkMigrations);'
    
    if [ $? -eq 1 ]; then
      echo "migration error: there are still pending migrations... central will not run until fixed"
      exit 1
    fi
    
    node lib/bin/run-server.js
