### PR TITLE
bug: allow user to both splitSelectMultiples and $filter.

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -112,8 +112,8 @@ inner join
   on defs.id=form_field_values."submissionDefId"
 inner join
   (select * from submissions
-    where "deletedAt" is null and draft=${draft}) as subs
-  on subs.id=defs."submissionId"
+    where "deletedAt" is null and draft=${draft}) as submissions
+  on submissions.id=defs."submissionId"
 where
   form_field_values."formId"=${formId} and
   ${odataFilter(options.filter)}


### PR DESCRIPTION
This PR addresses an error seen on [Sentry](https://sentry.io/organizations/getodk/issues/2703129106/?environment=production):

```
error: missing FROM-clause entry for table "submissions"
```

The issue is that the `odataFilter()` function references a table named `submissions`, which means that a query that uses `odataFilter()` must have a table or subquery named `submissions`. However, `Submissions.getSelectMultipleValuesForExport()` does not: the subquery there is named `subs`.

I considered a few different solutions, but opted simply for renaming `subs` to `submissions`. That pattern is used in other queries in the `Submissions`, `SubmissionAttachments`, and `ClientAudits` query modules.

I also did a quick check of other queries that use `odataFilter()`. All seem to have a table or subquery named `submissions`.