### PR TITLE
Do not automatically create a Default Project

### DIFF
--- a/lib/model/migrations/20181206-01-add-projects.js
+++ b/lib/model/migrations/20181206-01-add-projects.js
@@ -9,59 +9,48 @@
 
 const uuid = require('uuid/v4');
 
-const up = (db) =>
+const up = async (db) => {
   // first create the projects table itself.
-  db.schema.createTable('projects', (projects) => {
+  await db.schema.createTable('projects', (projects) => {
     projects.increments('id');
     projects.text('name').notNull();
     projects.string('acteeId', 36).notNull().unique();
     projects.dateTime('createdAt');
     projects.dateTime('updatedAt');
     projects.dateTime('deletedAt');
-  })
+  });
+
+  // first add projectId column to forms
+  await db.schema.table('forms', (forms) => {
+    forms.integer('projectId');
+  });
 
   // and create the project actee species.
-    .then(() => db.insert({ id: 'project', species: 'species' }).into('actees'))
+  await db.insert({ id: 'project', species: 'species' }).into('actees');
 
   // create a default project if forms already exist
-    .then(() => db.count('*').from('forms').where({ deletedAt: null }).limit(1)
-      .then(([{ count }]) => {
-        if (Number(count) > 0) {
-          const name = 'Forms you made before projects existed';
-          return db.insert({ id: uuid(), species: 'project' }).into('actees').returning('id')
-            .then(([ id ]) =>
-              db.insert({ name, acteeId: id, createdAt: new Date() }).into('projects').returning('*'));
-        }
-      }))
+  const [{ count }] = await db.count('*').from('forms').limit(1);
+  if (Number(count) > 0) {
+    const name = 'Forms you made before projects existed';
+    const [ id ] = await db.insert({ id: uuid(), species: 'project' }).into('actees').returning('id');
+    const [ project ] = await db.insert({ name, acteeId: id, createdAt: new Date() }).into('projects').returning('*');
+    await db.update({ projectId: project.id }).into('forms');
+  }
 
-  // now create a project_id column in forms.
-    .then((projects) =>
-      // first add projectId column to forms
-      db.schema.table('forms', (forms) => {
-        forms.integer('projectId');
-      })
-        .then(() => {
-          // projects may or may not be set (from project insertion step above)
-          // if set, it will be a list of one project [{ id: 1, name: ... }]
-          if (projects) {
-            const newProjId = projects[0].id;
-            return db.update({ projectId: newProjId }).into('forms');
-          }
-        }))
+  // and only now actually make the projectId field required and set up the
+  // appropriate foreign key things.
+  await db.schema.table('forms', (forms) => {
+    forms.integer('projectId').notNull().alter();
+    forms.foreign('projectId').references('projects.id');
+    // and also switch around the xmlFormId uniqueness requirements to be per project:
+    forms.dropUnique([ 'xmlFormId', 'version' ]);
+    forms.unique([ 'xmlFormId', 'version', 'projectId' ]);
+  });
 
-    // and only now actually make the projectId field required and set up the
-    // appropriate foreign key things.
-    .then(() =>
-      db.schema.table('forms', (forms) => {
-        forms.integer('projectId').notNull().alter();
-        forms.foreign('projectId').references('projects.id');
-        // and also switch around the xmlFormId uniqueness requirements to be per project:
-        forms.dropUnique([ 'xmlFormId', 'version' ]);
-        forms.unique([ 'xmlFormId', 'version', 'projectId' ]);
-      }))
-
-    .then(() => db.raw('drop index forms_xmlformid_deletedat_unique'))
-    .then(() => db.raw('create unique index forms_projectid_xmlformid_deletedat_unique on forms ("projectId", "xmlFormId") where "deletedAt" is null;'));
+  // redo index
+  await db.raw('drop index forms_xmlformid_deletedat_unique');
+  await db.raw('create unique index forms_projectid_xmlformid_deletedat_unique on forms ("projectId", "xmlFormId") where "deletedAt" is null;');
+};
 
 
 // NOT GUARANTEED TO SUCCEED! if post-up-migration the same xmlFormId has been

--- a/lib/model/migrations/20181206-01-add-projects.js
+++ b/lib/model/migrations/20181206-01-add-projects.js
@@ -23,27 +23,31 @@ const up = (db) =>
   // and create the project actee species.
     .then(() => db.insert({ id: 'project', species: 'species' }).into('actees'))
 
-  // then create a default project. depending on whether forms already exist,
-  // the project's name will vary.
-    .then(() => Promise.all([
-      db.count('*').from('forms').where({ deletedAt: null }).limit(1)
-        .then(([{ count }]) => count),
-      db.insert({ id: uuid(), species: 'project' }).into('actees').returning('id')
-        .then(([ id ]) => id)
-    ])
-      .then(([ count, acteeId ]) => {
-        const name = (Number(count) > 0) ? 'Forms you made before projects existed' : 'Default Project';
-        return db.insert({ name, acteeId, createdAt: new Date() }).into('projects').returning('*');
+  // create a default project if forms already exist
+    .then(() => db.count('*').from('forms').where({ deletedAt: null }).limit(1)
+      .then(([{ count }]) => {
+        if (Number(count) > 0) {
+          const name = 'Forms you made before projects existed';
+          return db.insert({ id: uuid(), species: 'project' }).into('actees').returning('id')
+            .then(([ id ]) =>
+              db.insert({ name, acteeId: id, createdAt: new Date() }).into('projects').returning('*'));
+        }
       }))
 
   // now create a project_id column in forms.
-    .then(([ project ]) =>
+    .then((projects) =>
+      // first add projectId column to forms
       db.schema.table('forms', (forms) => {
         forms.integer('projectId');
       })
-
-      // and assign all extant forms to that project.
-        .then(() => db.update({ projectId: project.id }).into('forms')))
+        .then(() => {
+          // projects may or may not be set (from project insertion step above)
+          // if set, it will be a list of one project [{ id: 1, name: ... }]
+          if (projects) {
+            const newProjId = projects[0].id;
+            return db.update({ projectId: newProjId }).into('forms');
+          }
+        }))
 
     // and only now actually make the projectId field required and set up the
     // appropriate foreign key things.

--- a/lib/model/migrations/20181212-01-add-roles.js
+++ b/lib/model/migrations/20181212-01-add-roles.js
@@ -74,12 +74,17 @@ const up = async (db) => {
       .where({ type: 'user' })
   ).into('assignments');
 
-  const [{ acteeId: defaultProjectActeeId }] = await db.select('acteeId').from('projects').where({ id: 1 });
-  await db.insert(
-    db.select(db.raw('id as "actorId", ? as "roleId", ? as "acteeId"', [ appUserRoleId, defaultProjectActeeId ]))
-      .from('actors')
-      .where({ type: 'field_key' })
-  ).into('assignments');
+  // there may or may not be a project here depending on if any forms existed before
+  const [ defaultProj ] = await db.select('acteeId').from('projects').where({ id: 1 });
+
+  if (defaultProj) { 
+    const defaultProjectActeeId = defaultProj.acteeId;
+    await db.insert(
+      db.select(db.raw('id as "actorId", ? as "roleId", ? as "acteeId"', [ appUserRoleId, defaultProjectActeeId ]))
+        .from('actors')
+        .where({ type: 'field_key' })
+    ).into('assignments');
+  }
   /* eslint-enable */
 };
 

--- a/test/integration/fixtures/01-users.js
+++ b/test/integration/fixtures/01-users.js
@@ -1,8 +1,10 @@
 const appRoot = require('app-root-path');
-const { User, Actor } = require(appRoot + '/lib/model/frames');
+const { User, Actor, Project } = require(appRoot + '/lib/model/frames');
 const { mapSequential } = require(appRoot + '/test/util/util');
 
 module.exports = ({ Assignments, Users, Projects, bcrypt }) => {
+  const proj = new Project({ name: 'Default Project' });
+
   const users = [
     new User({ email: 'alice@getodk.org', password: 'alice' }, { actor: new Actor({ type: 'user', displayName: 'Alice' }) }),
     new User({ email: 'bob@getodk.org', password: 'bob' }, { actor: new Actor({ type: 'user', displayName: 'Bob' }) }),
@@ -11,9 +13,10 @@ module.exports = ({ Assignments, Users, Projects, bcrypt }) => {
 
   // hash the passwords, create our three test users, then add grant Alice and Bob their rights.
   const withPasswords = Promise.all(users.map((user) =>
-    bcrypt.hash(user.password).then((password) => user.with({ password }))))
+    bcrypt.hash(user.password).then((password) => user.with({ password }))));
 
-  return withPasswords
+  return Projects.create(proj)
+    .then(() => withPasswords)
     .then((users) => mapSequential(users, Users.create))
     .then(([ alice, bob, chelsea ]) => Promise.all([
       Assignments.grantSystem(alice.actor, 'admin', '*'),

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -219,7 +219,7 @@ describe('datbase migrations: removing default project', function() {
   }));
 
   it('should not make a default project if no forms', testServiceFullTrx(async (service, container) => {
-    // before 20181206-01-add-projects.js
+    // up to and including this default project migration
     await upToMigration('20181206-01-add-projects.js');
 
     // check projects and forms


### PR DESCRIPTION
I wanted to give this a shot... of changing the migrations that create default projects. Default projects get created in an old migration `20181206-01-add-projects.js` and removing that behavior from the migration in the first place seemed cleaner than trying to undo that behavior later by trying to remove the default project or something else more risky.

It turned out to be a bit more complicated than that, though.
1) default project creation should still happen in the case that forms exist (without projects) at the time of running the migration.
2) a later roles migration `20181212-01-add-roles.js` assumes that a project exists.
3) the text fixture data assumes that a default project exists.

I think I addressed these three issues and tested them (with migration tests that don't use any server code and should continue to work going forward... see issue #466). 

Here's what a fresh database (with all migrations applied) looks like through the latest frontend, with and without admin privileges:
<img width="1603" alt="Screen Shot 2022-03-14 at 2 22 01 PM" src="https://user-images.githubusercontent.com/76205/158264981-1abb0c60-fcbb-4e37-9795-7ab7f8ac7d6d.png">
<img width="1603" alt="Screen Shot 2022-03-14 at 2 22 21 PM" src="https://user-images.githubusercontent.com/76205/158264997-0538f5cb-5f10-45cb-af7d-e0169621c237.png">

Leaving PR as a draft for now in case a different approach comes to mind.