### PR TITLE
In-depth project + form queries

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -777,6 +777,17 @@ This endpoint supports retrieving extended metadata; provide a header `X-Extende
 
     + Attributes (array[Extended Project])
 
+### Listing Projects with nested Forms [GET /v1/projects?forms=true]
+
+_(introduced: Version 1.5)_
+
+This endpoint works similarly to the Project listing endpoint above, except it also returns the Forms that the authenticated Actor is allowed to see, with those Forms nested within their corresponding Project under a new parameter `formList`. The returned Forms will match structure of Forms requested with extended metadata (including additional `lastSubmission` timestamp and `submissions` and `reviewStates` counts).
+
++ Response 200 (application/json)
+    This is the standard response:
+
+    + Attributes (array[Project With Forms])
+
 ### Creating a Project [POST /v1/projects]
 
 To create a Project, the only information you must supply (via POST body) is the desired name of the Project.
@@ -1088,7 +1099,7 @@ Currently, there are no paging or filtering options, so listing `Form`s will get
 
 As of version 1.2, Forms that are unpublished (that only carry a draft and have never been published) will appear with full metadata detail. Previously, certain details like `name` were omitted. You can determine that a Form is unpublished by checking the `publishedAt` value: it will be `null` for unpublished forms.
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that each Form has and the `lastSubmission` most recent submission timestamp, as well as the Actor the Form was `createdBy`.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of Submissions that each Form has, the `reviewStates` object of counts of Submissions with specific review states, the `lastSubmission` most recent submission timestamp, as well as the Actor the Form was `createdBy`.
 
 + Response 200 (application/json)
     This is the standard response, if Extended Metadata is not requested:
@@ -4002,6 +4013,7 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 
 ## Extended Form (Form)
 + submissions: `10` (number, required) - The number of `Submission`s that have been submitted to this `Form`.
++ reviewStates: (Review State Counts, required) - Additional counts of the number of submissions in various states of review.
 + lastSubmission: `2018-04-18T03:04:51.695Z` (string, optional) - ISO date format. The timestamp of the most recent submission, if any.
 + createdBy: (Actor, optional) - The full information of the Actor who created this Form.
 + excelContentType: (string, optional) - If the Form was created by uploading an Excel file, this field contains the MIME type of that file.
@@ -4051,6 +4063,9 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 + forms: `7` (number, required) - The number of forms within this Project.
 + lastSubmission: `2018-04-18T03:04:51.695Z` (string, optional) - ISO date format. The timestamp of the most recent submission to any form in this project, if any.
 
+## Project With Forms (Project)
++ formList: (array[Extended Form], required) - The extended Forms associated with this Project that are visible to the authenticated Actor.
+
 ## Public Link (Actor)
 + token: `d1!E2GVHgpr4h9bpxxtqUJ7EVJ1Q$Dusm2RBXg8XyVJMCBCbvyE8cGacxUx3bcUT` (string, optional) - If present, this is the Token to include as the `st` query parameter for this `Public Link`. If not present, this `Public Link` has been revoked.
 + once: `false` (boolean, optional) - If set to `true`, an Enketo [single submission survey](https://blog.enketo.org/single-submission-surveys/) will be created instead of a standard one, limiting respondents to a single submission each.
@@ -4093,6 +4108,11 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 ## Extended Submission (Submission)
 + submitter (Actor, required) - The full details of the `Actor` that submitted this `Submission`.
 + formVersion: `1.0` (string, optional) - The version of the form the submission was initially created against. Only returned with specific Submission Version requests.
+
+## Review State Counts (object)
++ received: `3` (number, required) - The number of submissions receieved with no other review state.
++ hasIssues: `2` (number, required) - The number of submissions marked as having issues.
++ edited: `1` (number, required) - The number of edited submissions.
 
 ## Submission Attachment (object)
 + name: `myfile.mp3` (string, required) - The name of the file as specified in the Submission XML.

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -140,11 +140,19 @@ Form.Partial = class extends Form {};
 
 Form.Extended = class extends Frame.define(
   'submissions',        readable,       'lastSubmission', readable,
-  'excelContentType',   readable
+  'excelContentType',   readable,
+  // counts of submissions in various review states
+  'receivedCount',                      'hasIssuesCount',
+  'editedCount'
 ) {
   forApi() {
     return {
       submissions: this.submissions || 0,
+      reviewStates: {
+        received: this.receivedCount || 0,
+        hasIssues: this.hasIssuesCount || 0,
+        edited: this.editedCount || 0
+      },
       lastSubmission: this.lastSubmission,
       excelContentType: this.excelContentType
     };

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -379,7 +379,7 @@ where "acteeId"=${acteeId} and "deletedAt" is null`)
   .then(map(_unjoiner));
 
 // there are many combinations of required fields here so we compose our own extender variant.
-const _getSql = ((fields, extend, options, version, deleted = false) => sql`
+const _getSql = ((fields, extend, options, version, deleted = false, actorId) => sql`
 select ${fields} from forms
 left outer join form_defs on ${versionJoinCondition(version)}
 ${extend|| sql`
@@ -397,13 +397,30 @@ ${extend|| sql`
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
     on form_defs."xlsBlobId"=xls.id`}
+${(actorId == null) ? sql`` : sql`
+inner join
+  (select id, max(assignment."showDraft") as "showDraft" from projects
+    inner join
+      (select "acteeId", 0 as "showDraft" from assignments
+        inner join (select id from roles where verbs ? 'form.read') as role
+          on role.id=assignments."roleId"
+        where "actorId"=${actorId}
+      union all
+      select "acteeId", 1 as "showDraft" from assignments
+        inner join (select id from roles where verbs ? 'form.update') as role
+          on role.id=assignments."roleId"
+        where "actorId"=${actorId}) as assignment
+      on assignment."acteeId" in ('*', 'project', projects."acteeId")
+    group by id) as filtered
+  on filtered.id=forms."projectId"`}
 where ${equals(options.condition)} and forms."deletedAt" is ${deleted ? sql`not` : sql``} null
+${(actorId == null) ? sql`` : sql`and (form_defs."publishedAt" is not null or filtered."showDraft" = 1)`}
 order by coalesce(form_defs.name, "xmlFormId") asc`);
 
 const _getWithoutXml = extender(Form, Form.Def)(Form.Extended, Actor.into('createdBy'))(_getSql);
 const _getWithXml = extender(Form, Form.Def, Form.Xml)(Form.Extended, Actor.into('createdBy'))(_getSql);
-const _get = (exec, options, xml, version, deleted) =>
-  ((xml === true) ? _getWithXml : _getWithoutXml)(exec, options, version, deleted);
+const _get = (exec, options, xml, version, deleted, actorId) =>
+  ((xml === true) ? _getWithXml : _getWithoutXml)(exec, options, version, deleted, actorId);
 
 const getByProjectId = (projectId, xml, version, options = QueryOptions.none, deleted = false) => ({ all }) =>
   _get(all, options.withCondition({ projectId }), xml, version, deleted);
@@ -411,6 +428,8 @@ const getByProjectAndXmlFormId = (projectId, xmlFormId, xml, version, options = 
   _get(maybeOne, options.withCondition({ projectId, xmlFormId }), xml, version, deleted);
 const getByProjectAndNumericId = (projectId, id, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ projectId, 'forms.id': id }), xml, version, deleted);
+const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
+  _get(all, options, null, null, false, auth.actor.map((actor) => actor.id).orElse(-1));
 
 ////////////////////////////////////////////////////////////////////////////////
 // SCHEMA
@@ -486,6 +505,7 @@ module.exports = {
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,
   getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
+  getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
   lockDefs, getAllSubmitters
 };

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -384,7 +384,11 @@ select ${fields} from forms
 left outer join form_defs on ${versionJoinCondition(version)}
 ${extend|| sql`
   left outer join
-    (select "formId", count(id)::integer as "submissions", max("createdAt") as "lastSubmission" from submissions
+    (select "formId", count(id)::integer as "submissions", max("createdAt") as "lastSubmission",
+      count(case when submissions."reviewState" is null then 1 else null end) as "receivedCount",
+      count(case when submissions."reviewState" = 'hasIssues' then 1 else null end) as "hasIssuesCount",
+      count(case when submissions."reviewState" = 'edited' then 1 else null end) as "editedCount"
+      from submissions
       where draft=${version === Form.DraftVersion} and "deletedAt" is null
       group by "formId") as submission_stats
     on forms.id=submission_stats."formId"

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -112,9 +112,25 @@ const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
 const getById = (id, options = QueryOptions.none) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ id }));
 
+const getAllByAuthWithForms = (auth, queryOptions = QueryOptions.none) => ({ Projects, Forms }) =>
+  Promise.all([
+    Projects.getAllByAuth(auth, queryOptions),
+    Forms.getAllByAuth(auth, QueryOptions.extended)
+  ])
+    .then(([ projects, forms ]) => {
+      const projectsWithForms = projects.reduce((acc, proj) =>
+        ({ ...acc, [proj.id]: { ...proj.forApi(), formList: [] } }), {});
+      for (const form of forms) {
+        if (form.projectId in projectsWithForms)
+          projectsWithForms[form.projectId].formList.push(form.forApi());
+      }
+      return Object.values(projectsWithForms);
+    });
+
 module.exports = {
   create, update, del,
   setManagedEncryption,
-  getAllByAuth, getById
+  getAllByAuth, getById,
+  getAllByAuthWithForms
 };
 

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -9,13 +9,16 @@
 
 const { Form, Project } = require('../model/frames');
 const { getOrNotFound, getOrReject, reject } = require('../util/promise');
-const { success } = require('../util/http');
+const { isTrue, success } = require('../util/http');
 const { QueryOptions } = require('../util/db');
 const Problem = require('../util/problem');
 
 module.exports = (service, endpoint) => {
-  service.get('/projects', endpoint(({ Projects }, { auth, queryOptions }) =>
-    Projects.getAllByAuth(auth, queryOptions)));
+  // specify ?forms=true to get formList of forms nested within projects
+  service.get('/projects', endpoint(({ Projects }, { auth, query, queryOptions }) =>
+    (isTrue(query.forms)
+      ? Projects.getAllByAuthWithForms(auth, queryOptions)
+      : Projects.getAllByAuth(auth, queryOptions))));
 
   service.post('/projects', endpoint(({ Projects }, { auth, body }) =>
     auth.canOrReject('project.create', Project.species)

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -178,9 +178,8 @@ should.Assertion.add('ExtendedForm', function() {
 
   this.obj.should.be.a.Form();
   Object.keys(this.obj).should.containDeep([ 'submissions', 'lastSubmission', 'reviewStates' ]);
-  if (this.obj.submissions != null) this.obj.submissions.should.be.a.Number();
-  if (this.obj.reviewStates != null)
-    Object.keys(this.obj.reviewStates).should.containDeep([ 'received', 'hasIssues', 'edited']);
+  this.obj.submissions.should.be.a.Number();
+  Object.keys(this.obj.reviewStates).should.containDeep([ 'received', 'hasIssues', 'edited']);
   if (this.obj.lastSubmission != null) this.obj.lastSubmission.should.be.an.isoDate();
 });
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -177,8 +177,10 @@ should.Assertion.add('ExtendedForm', function() {
   this.params = { operator: 'to be a ExtendedForm' };
 
   this.obj.should.be.a.Form();
-  Object.keys(this.obj).should.containDeep([ 'submissions', 'lastSubmission' ]);
+  Object.keys(this.obj).should.containDeep([ 'submissions', 'lastSubmission', 'reviewStates' ]);
   if (this.obj.submissions != null) this.obj.submissions.should.be.a.Number();
+  if (this.obj.reviewStates != null)
+    Object.keys(this.obj.reviewStates).should.containDeep([ 'received', 'hasIssues', 'edited']);
   if (this.obj.lastSubmission != null) this.obj.lastSubmission.should.be.an.isoDate();
 });
 

--- a/test/integration/api/forms/list.js
+++ b/test/integration/api/forms/list.js
@@ -45,6 +45,9 @@ describe('api: /projects/:id/forms (listing forms)', () => {
               body.forEach((form) => form.should.be.an.ExtendedForm());
               const simple = body.find((form) => form.xmlFormId === 'simple');
               simple.submissions.should.equal(1);
+              simple.reviewStates.received.should.equal(1);
+              simple.reviewStates.hasIssues.should.equal(0);
+              simple.reviewStates.edited.should.equal(0);
               simple.lastSubmission.should.be.a.recentIsoDate();
             })))));
   });

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1237,7 +1237,7 @@ describe('api: /projects?forms=true', () => {
         .expect(200)
         .then(({ body }) => asAlice.post(`/v1/projects/${body.id}/forms?publish=true`)
           .set('Content-Type', 'application/xml')
-          .send(testData.forms.simple)
+          .send(testData.forms.simple2)
           .expect(200)
           .then(() => asAlice.post(`/v1/projects/${body.id}/forms`)
             .set('Content-Type', 'application/xml')
@@ -1251,7 +1251,7 @@ describe('api: /projects?forms=true', () => {
             body.length.should.equal(2);
             body[0].formList.length.should.equal(2);
             body[1].formList.length.should.equal(1);
-            body[1].formList[0].name.should.equal('Simple');
+            body[1].formList[0].name.should.equal('Simple 2');
           }))))));
   });
 });


### PR DESCRIPTION
This PR is to be used by the frontend for the new Project list page (the Central homepage) in Block 15, where forms and key details about each form are shown on that page.

This backend PR makes two key changes:
1. It extends what an "Extended" Form is to also include counts of Submissions in specific review states, such as 'edited', 'hasIssues', and 'received' (the default state for new Submissions)
2. It adds a query parameter `?forms=true` to the Project listing API call to get a list of Forms (extended with the fields described above) associated with each project that are visible to the authenticated Actor. 
    - Actors that are admins or managers of Projects will be able to see all the Forms of a Project including drafts, while Actors who are data collectors will only be able to see the published Forms.