### PR TITLE
bug #450: handle brackets in unique violation

### DIFF
--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -336,7 +336,7 @@ const postgresErrorToProblem = (x) => {
   if (error.code === '23502') { // not_null_violation
     return reject(Problem.user.missingParameter({ field: error.column }));
   } else if (error.code === '23505') { // unique_violation
-    const match = /^Key \(([^)]+)\)=\(([^)]+)\) already exists.$/.exec(error.detail);
+    const match = /^Key \(([^)]+)\)=\((.+)\) already exists.$/.exec(error.detail);
     if (match != null) {
       const [ , rawFields, rawValues ] = match;
       return reject(Problem.user.uniquenessViolation({

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -460,6 +460,15 @@ returning *`);
       });
     });
 
+    it('recognizes and parses unique_violation when value contains brackets', (done) => { // github #450
+      postgresErrorToProblem(errorWith({ code: '23505', detail: 'Key ("projectId", "xmlFormId")=(3, my_form (1)) already exists.' })).catch((result) => {
+        result.problemCode.should.equal(409.3);
+        result.problemDetails.fields.should.eql([ 'projectId', 'xmlFormId' ]);
+        result.problemDetails.values.should.eql([ '3', 'my_form (1)' ]);
+        done();
+      });
+    });
+
     it('recognizes undefined_column', (done) => {
       postgresErrorToProblem(errorWith({ code: '42703', message: 'column "test" of relation "aa" does not exist' })).catch((result) => {
         result.problemCode.should.equal(400.4);


### PR DESCRIPTION
This pull request fixes bug #450 (Return Problem if duplicate value contains `)` )

# Changes:
- fixed the regex for parsing postgres' error message
- added unit test to verify the change

I have run all unit tests and manually tested unique violation by uploading duplicate form

![image](https://user-images.githubusercontent.com/447837/162783089-ba9f437c-d10f-413f-a566-5ba5d7ad518a.png)
