### PR TITLE
improve #468: no send email if no account exists

### DIFF
--- a/lib/formats/mail.js
+++ b/lib/formats/mail.js
@@ -41,10 +41,6 @@ const messages = {
   accountReset: message('ODK Central account password reset', '<html>Hello!<p>A password reset has been requested for this email address.</p><p>If this message is unexpected, simply ignore it. Otherwise, please visit the following link to set your password and claim your account:</p><p><a href="{{{domain}}}/#/account/claim?token={{token}}">{{{domain}}}/#/account/claim?token={{token}}</a></p><p>The link is valid for 24 hours. After that, you will have to request a new one by resetting your password:</p><p><a href="{{{domain}}}/#/reset-password">{{{domain}}}/#/reset-password</a></p></html>'),
 
   // Notifies an email address that a password reset has been initiated, but that
-  // no account exists at this address.
-  accountResetFailure: message('ODK Central account password reset', '<html>Hello!<p>A password reset has been requested for this email address, but no account exists with this address.</p><p>If this message is unexpected, simply ignore it. Otherwise, please double check the email address given for your account, and try resetting your password again:</p><p><a href="{{{domain}}}/#/reset-password">{{{domain}}}/#/reset-password</a></p></html>'),
-
-  // Notifies an email address that a password reset has been initiated, but that
   // the account that we know about has been deleted.
   accountResetDeleted: message('ODK Central account password reset', '<html>Hello!<p>A password reset has been requested for this email address, but the account has been deleted.</p><p>If this message is unexpected, simply ignore it. Otherwise, please double check the email address given for your account, and try contacting your ODK system administrator.</p></html>'),
 

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -55,7 +55,7 @@ module.exports = (service, endpoint) => {
         .orElseGet(() => Users.emailEverExisted(body.email)
           .then((existed) => ((existed === true)
             ? mail(body.email, 'accountResetDeleted')
-            : mail(body.email, 'accountResetFailure'))))
+            : reject(Problem.user.noAccount()))))
         .then(success))));
 
   // TODO: some standard URL structure for RPC-style methods.

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -55,7 +55,7 @@ module.exports = (service, endpoint) => {
         .orElseGet(() => Users.emailEverExisted(body.email)
           .then((existed) => ((existed === true)
             ? mail(body.email, 'accountResetDeleted')
-            : reject(Problem.user.noAccount()))))
+            : resolve())))
         .then(success))));
 
   // TODO: some standard URL structure for RPC-style methods.

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -119,9 +119,6 @@ const problems = {
     // deprecated id does not exist.
     deprecatedIdNotFound: problem(404.5, ({ deprecatedId }) => `You tried to update an existing submission, but we can't find that submission to update (${deprecatedId})`),
 
-    // no account found for the provided email address.
-    noAccount: problem(404.6, () => 'No account exists with the provided email address'),
-
     // { allowed: [ acceptable formats ], got }
     unacceptableFormat: problem(406.1, ({ allowed }) => `Requested format not acceptable; this resource allows: ${allowed.join()}.`),
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -119,6 +119,9 @@ const problems = {
     // deprecated id does not exist.
     deprecatedIdNotFound: problem(404.5, ({ deprecatedId }) => `You tried to update an existing submission, but we can't find that submission to update (${deprecatedId})`),
 
+    // no account found for the provided email address.
+    noAccount: problem(404.6, () => 'No account exists with the provided email address'),
+
     // { allowed: [ acceptable formats ], got }
     unacceptableFormat: problem(406.1, ({ allowed }) => `Requested format not acceptable; this resource allows: ${allowed.join()}.`),
 

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -192,8 +192,7 @@ describe('api: /users', () => {
     it('should not send any email if no account exists', testService((service) =>
       service.post('/v1/users/reset/initiate')
         .send({ email: 'winnifred@getodk.org' })
-        .expect(404)
-        .then(({ body }) => body.should.eql({"message":"No account exists with the provided email address","code":404.6}))
+        .expect(200)
         .then(() => {
           global.inbox.length.should.equal(0);
         })));

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -189,16 +189,13 @@ describe('api: /users', () => {
   });
 
   describe('/reset/initiate POST', () => {
-    it('should send an email with a helpful message if no account exists', testService((service) =>
+    it('should not send any email if no account exists', testService((service) =>
       service.post('/v1/users/reset/initiate')
         .send({ email: 'winnifred@getodk.org' })
-        .expect(200)
+        .expect(404)
+        .then(({ body }) => body.should.eql({"message":"No account exists with the provided email address","code":404.6}))
         .then(() => {
-          const email = global.inbox.pop();
           global.inbox.length.should.equal(0);
-          email.to.should.eql([{ address: 'winnifred@getodk.org', name: '' }]);
-          email.subject.should.equal('ODK Central account password reset');
-          email.html.should.match(/no account exists/);
         })));
 
     it('should send a specific email if an account existed but was deleted', testService((service) =>


### PR DESCRIPTION
- Updated `/users/reset/initiate` API such that it does not send any email if no account is found and returns 404
- Updated integration test to validate the change
- Performed manual testing to see how error appears on UI

![image](https://user-images.githubusercontent.com/447837/163635963-6354f6f3-a643-49f1-b2a9-03ad8c972c4c.png)
