### PR TITLE
improve 417: correct the response body for PUT submission

### DIFF
--- a/lib/model/frames/submission.js
+++ b/lib/model/frames/submission.js
@@ -90,7 +90,7 @@ Submission.Def = Frame.define(
   'localKey',                           'encDataAttachmentName',
   'signature',                          'createdAt',    readable,
   'instanceName', readable,             'instanceId',   readable,
-  'current',      readable,             'xml',
+  'current',                            'xml',
   'root',                               'deviceId',     readable,
   'userAgent',    readable,
   embedded('submitter')

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -65,13 +65,14 @@ const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn
 
   // we already do transactions but it just feels nice to have the cte do it all at once.
   return one(sql`
-with logical as (update submissions set "reviewState"='edited', "updatedAt"=clock_timestamp()
-  where id=${deprecated.submissionId})
+with logical as (update submissions set "reviewState"='edited', "updatedAt"=clock_timestamp() 
+  where id=${deprecated.submissionId} returning "reviewState","updatedAt")
 , upd as (update submission_defs set current=false where "submissionId"=${deprecated.submissionId})
-${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, deviceId, userAgent)}`)
+, def as (${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, deviceId, userAgent)})
+select def.*, logical.* from def, logical`)
     // TODO/HACK: lame that we are reconstructing this this way.
-    .then((saved) => new Submission({ instanceId: partial.instanceId },
-      { def: new Submission.Def(saved), xml: new Submission.Xml({ xml: partial.xml }) }));
+    .then(({reviewState, updatedAt, ...savedDef}) =>  new Submission({ instanceId: partial.instanceId, reviewState, updatedAt },
+      { def: new Submission.Def(savedDef), xml: new Submission.Xml({ xml: partial.xml }) }));
 };
 
 createVersion.audit = (partial, deprecated, form) => (log) =>


### PR DESCRIPTION
I have changed the sql so that it returns reviewState and updatedAt. Also removed the `readable` attribute from `current` field. 

In `lib/model/frames/submission.js` file, I see several HACK/TODO tags around constructor of submission. @issa-tseng can you please share some details around that, what should be the ideal way to create submission object?