### PR TITLE
improve: increase maximum pool size.

### DIFF
--- a/lib/external/slonik.js
+++ b/lib/external/slonik.js
@@ -15,6 +15,7 @@ const timestamptzTypeParser = { name: 'timestamptz', parse: (x) => new Date(x) }
 
 const slonikPool = (config) => createPool(connectionString(config), {
   captureStackTrace: false,
+  maximumPoolSize: 32,
   typeParsers: [
     createDateTypeParser(),
     createBigintTypeParser(),


### PR DESCRIPTION
By default, Slonik [limits](https://github.com/gajus/slonik#api) the database connection pool to 10 connections. However, 10 seems to be on the low side. Right now if a request is unable to acquire a connection, there is usually an unhandled Slonik `ConnectionError` and a 500 response.

We have also observed that in some cases, trying to create a connection when the pool is full results in a connection leak. We're going to try to solve that issue more systematically, but for now, increasing the pool size should make it less likely that that issue comes up.

There has been some discussion about what number to choose instead of 10. In one Slack discussion, @issa-tseng wrote:

> 10 is lowish. but for a 1GB server it's probably about right. 20-25 is probably a reasonable default. maybe even 30.

@yanokwa wrote:

> AWS max_db_connection is 83 on DO […] its 100.

We decided on 32 partly with the thought that it's the JDBC default.

I have tried this change on the QA server. When `maximumPoolSize` was 10, I observed that there could be up to 9 concurrent requests for a large OData feed. After changing the max to 32, I observed that there could be up to 31 concurrent requests. So it looks like Central is able to utilize the new max.

This commit branches off of v1.4.2 in case we want to try to release it as a patch.