### PR TITLE
improve: add ability to configure maximumPoolSize.

### DIFF
--- a/lib/external/slonik.js
+++ b/lib/external/slonik.js
@@ -15,6 +15,7 @@ const timestamptzTypeParser = { name: 'timestamptz', parse: (x) => new Date(x) }
 
 const slonikPool = (config) => createPool(connectionString(config), {
   captureStackTrace: false,
+  maximumPoolSize: config.maximumPoolSize ?? 10,
   typeParsers: [
     createDateTypeParser(),
     createBigintTypeParser(),

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -23,7 +23,7 @@ const { isTrue, isFalse } = require('./http');
 // DATABASE CONFIG
 
 const validateConfig = (config) => {
-  const { host, port, database, user, password, ssl, ...unsupported } = config;
+  const { host, port, database, user, password, ssl, maximumPoolSize, ...unsupported } = config;
 
   if (ssl != null && ssl !== true)
     return Problem.internal.invalidDatabaseConfig({ reason: 'If ssl is specified, its value can only be true.' });
@@ -51,14 +51,17 @@ const connectionString = (config) => {
 const connectionObject = (config) => {
   const problem = validateConfig(config);
   if (problem != null) throw problem;
-  // Slonik seems to specify `false` for `rejectUnauthorized` whenever SSL is
-  // specified:
-  // https://github.com/gajus/slonik/issues/159#issuecomment-891089466. We do
-  // the same here so that Knex will connect to the database in the same way as
-  // Slonik.
-  return config.ssl === true
-    ? { ...config, ssl: { rejectUnauthorized: false } }
-    : config;
+  // We ignore maximumPoolSize when using Knex.
+  const { maximumPoolSize, ...knexConfig } = config;
+  if (knexConfig.ssl === true) {
+    // Slonik seems to specify `false` for `rejectUnauthorized` whenever SSL is
+    // specified:
+    // https://github.com/gajus/slonik/issues/159#issuecomment-891089466. We do
+    // the same here so that Knex will connect to the database in the same way
+    // as Slonik.
+    knexConfig.ssl = { rejectUnauthorized: false };
+  }
+  return knexConfig;
 };
 
 

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -74,6 +74,17 @@ describe('util/db', () => {
       result.should.throw();
     });
 
+    it('should allow (but ignore) maximumPoolSize', () => {
+      const result = connectionString({
+        host: 'localhost',
+        database: 'foo',
+        user: 'bar',
+        password: 'baz',
+        maximumPoolSize: 42
+      });
+      result.should.equal('postgres://bar:baz@localhost/foo');
+    });
+
     it('should throw for an unsupported option', () => {
       const result = () => connectionString({
         host: 'localhost',
@@ -158,6 +169,22 @@ describe('util/db', () => {
         ssl: { rejectUnauthorized: false }
       });
       result.should.throw();
+    });
+
+    it('should allow (but ignore) maximumPoolSize', () => {
+      const result = connectionObject({
+        host: 'localhost',
+        database: 'foo',
+        user: 'bar',
+        password: 'baz',
+        maximumPoolSize: 42
+      });
+      result.should.eql({
+        host: 'localhost',
+        database: 'foo',
+        user: 'bar',
+        password: 'baz'
+      });
     });
 
     it('should throw for an unsupported option', () => {


### PR DESCRIPTION
This PR adds the ability to configure `maximumPoolSize` for Slonik. See #476 for more on why it could be useful to change the pool size. We originally planned to set `maximumPoolSize` to a constant, but ultimately decided to make it configurable. With this PR, the user can specify `maximumPoolSize` in their database config; it defaults to 10. We use the database config to connect to both Slonik and Knex, but we only need to use `maximumPoolSize` with Slonik: Knex has its own approach to pooling. That means that part of the work of this PR is forwarding `maximumPoolSize` on to Slonik but not Knex.