### PR TITLE
Change to project list query to get verbs when also getting form lists

### DIFF
--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -128,6 +128,10 @@ Project.Extended = class extends Frame.define(
   }
 };
 
+Project.Verbs = Frame.define(
+  'verbs', readable
+);
+
 class PublicLink extends Frame.define(
   table('public_links'), aux(Actor),
   'actorId',                            'createdBy',

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -94,15 +94,16 @@ ${extend|| sql`
     on field_keys."projectId"=projects.id`}
 ${(actorId == null) ? sql`` : sql`
 inner join
-  (select id, assignment.verbs from projects
+  (select id, min("roleId") as "bestRole" from projects
     inner join
       (select "acteeId", role.id as "roleId", role.verbs from assignments
         inner join (select id, verbs from roles where verbs ? 'project.read') as role
           on role.id=assignments."roleId"
         where "actorId"=${actorId}) as assignment
       on assignment."acteeId" in ('*', 'project', projects."acteeId")
-    order by assignment."roleId" limit 1) as filtered
-  on filtered.id=projects.id`}
+    group by id) as filtered
+on filtered.id=projects.id
+inner join (select id, verbs from roles) as roles_no_name on roles_no_name.id = "bestRole" `}
 where "deletedAt" is null and ${equals(options.condition)}
 order by coalesce(archived, false) asc, name asc`);
 

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -97,7 +97,7 @@ inner join
   (select id, min("roleId") as "bestRole" from projects
     inner join
       (select "acteeId", role.id as "roleId", role.verbs from assignments
-        inner join (select id, verbs from roles where verbs ? 'project.read') as role
+        inner join (select id, verbs from roles where verbs ?& array['project.read', 'form.list']) as role
           on role.id=assignments."roleId"
         where "actorId"=${actorId}) as assignment
       on assignment."acteeId" in ('*', 'project', projects."acteeId")
@@ -134,7 +134,8 @@ const getAllByAuthWithForms = (auth, queryOptions = QueryOptions.none) => ({ Pro
           // Update "extended" fields on project even if not extended, because
           // such data can be calculated from formList.
           proj.forms += 1;
-          if (formForApi.lastSubmission > proj.lastSubmission)
+          if (proj.lastSubmission == null ||
+            (formForApi.lastSubmission != null && formForApi.lastSubmission > proj.lastSubmission))
             proj.lastSubmission = formForApi.lastSubmission;
         }
       }

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -96,12 +96,12 @@ ${(actorId == null) ? sql`` : sql`
 inner join
   (select id, assignment.verbs from projects
     inner join
-      (select "acteeId", role.verbs from assignments
+      (select "acteeId", role.id as "roleId", role.verbs from assignments
         inner join (select id, verbs from roles where verbs ? 'project.read') as role
           on role.id=assignments."roleId"
         where "actorId"=${actorId}) as assignment
       on assignment."acteeId" in ('*', 'project', projects."acteeId")
-    group by id, assignment.verbs) as filtered
+    order by assignment."roleId" limit 1) as filtered
   on filtered.id=projects.id`}
 where "deletedAt" is null and ${equals(options.condition)}
 order by coalesce(archived, false) asc, name asc`);

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -73,7 +73,7 @@ setManagedEncryption.audit = (project) => (log) => log('project.update', project
 ////////////////////////////////////////////////////////////////////////////////
 // GETTER
 
-const _get = extender(Project)(Project.Extended)((fields, extend, options, actorId) => sql`
+const _getSql = ((fields, extend, options, actorId) => sql`
 select ${fields} from projects
 ${extend|| sql`
   left outer join
@@ -94,20 +94,25 @@ ${extend|| sql`
     on field_keys."projectId"=projects.id`}
 ${(actorId == null) ? sql`` : sql`
 inner join
-  (select id from projects
+  (select id, assignment.verbs from projects
     inner join
-      (select "acteeId" from assignments
-        inner join (select id from roles where verbs ? 'project.read') as role
+      (select "acteeId", role.verbs from assignments
+        inner join (select id, verbs from roles where verbs ? 'project.read') as role
           on role.id=assignments."roleId"
         where "actorId"=${actorId}) as assignment
       on assignment."acteeId" in ('*', 'project', projects."acteeId")
-    group by id) as filtered
+    group by id, assignment.verbs) as filtered
   on filtered.id=projects.id`}
 where "deletedAt" is null and ${equals(options.condition)}
 order by coalesce(archived, false) asc, name asc`);
 
+const _getWithoutVerbs = extender(Project)(Project.Extended)(_getSql);
+const _getWithVerbs = extender(Project, Project.Verbs)(Project.Extended)(_getSql);
+const _get = (exec, options, verbs, actorId) =>
+  ((verbs === true) ? _getWithVerbs : _getWithoutVerbs)(exec, options, actorId);
+
 const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
-  _get(all, options, auth.actor.map((actor) => actor.id).orElse(-1));
+  _get(all, options, true, auth.actor.map((actor) => actor.id).orElse(-1));
 
 const getById = (id, options = QueryOptions.none) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ id }));
@@ -119,10 +124,18 @@ const getAllByAuthWithForms = (auth, queryOptions = QueryOptions.none) => ({ Pro
   ])
     .then(([ projects, forms ]) => {
       const projectsWithForms = projects.reduce((acc, proj) =>
-        ({ ...acc, [proj.id]: { ...proj.forApi(), formList: [] } }), {});
+        ({ ...acc, [proj.id]: { ...proj.forApi(), formList: [], forms: 0, lastSubmission: null } }), {});
       for (const form of forms) {
-        if (form.projectId in projectsWithForms)
-          projectsWithForms[form.projectId].formList.push(form.forApi());
+        if (form.projectId in projectsWithForms) {
+          const formForApi = form.forApi();
+          const proj = projectsWithForms[form.projectId];
+          proj.formList.push(formForApi);
+          // Update "extended" fields on project even if not extended, because
+          // such data can be calculated from formList.
+          proj.forms += 1;
+          if (formForApi.lastSubmission > proj.lastSubmission)
+            proj.lastSubmission = formForApi.lastSubmission;
+        }
       }
       return Object.values(projectsWithForms);
     });

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -59,6 +59,20 @@ describe('api: /projects', () => {
                 body[0].name.should.equal('Default Project');
               }))))));
 
+    it('should return the verbs of the more permissive assignment if multiply assigned', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/users/current').expect(200).then(({ body }) => body.id)
+          .then((aliceId) => asAlice.post('/v1/projects/1/assignments/manager/' + aliceId)
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1')
+              .set('X-Extended-Metadata', 'true')
+              .expect(200)
+              .then(({ body }) => {
+                body.verbs.length.should.be.greaterThan(39);
+                body.should.be.a.Project();
+                body.name.should.equal('Default Project');
+              }))))));
+
     it('should order projects appropriately', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects')
@@ -1190,6 +1204,7 @@ describe('api: /projects?forms=true', () => {
           body.length.should.equal(1);
           body[0].should.be.a.Project();
           const { formList, verbs } = body[0];
+          // verbs seems to have 1 more verb than it should - one is duplicated
           verbs.length.should.be.greaterThan(40);
           formList.length.should.equal(2);
           const form = formList[0];


### PR DESCRIPTION
The verbs (permissions) for a given user on each individual project are needed to construct links in the project list frontend page. (E.g. project viewer form links go straight to a form's submission page, and data collector links should either be disabled or go directly to enketo.) 

Previously, the project list query for this endpoint used an auth check to hide draft forms for certain levels of users, and that same auth query was able to be used to get the project verbs as well.

Additionally, there is a change that if a non-extended project list is requested, data (like the form count `forms` and `lastSubmission` date) that can be calculated by the form list will be automatically filled in.