### PR TITLE
Updated changelog for block 15 and added missing tests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,18 @@ Finally, **system information and configuration** is available via a set of spec
 
 Here major and breaking changes to the API are listed by version.
 
+### ODK Central v1.5
+
+ODK Central v1.5 adds editable Project descriptions as well as more detailed information about Forms and Submissions when listing Projects (via the API and shown in new Project and Form lists on Frontend).
+
+**Added**:
+
+* New `description` field returned for each [Project](/reference/project-management/projects) that can be set or updated through `POST`/`PATCH`/`PUT` on `/projects/…`
+    * Note that for the `PUT` request, the Project's description must be included in the request. [Read more](/reference/project-management/projects/deep-updating-project-and-form-details).
+* [Form extended metadata](/reference/forms/individual-form/getting-form-details) now includes a `reviewStates` object of counts of Submissions with specific review states.
+    * e.g. `{ received: 12, edited: 5, hasIssues: 3 }`
+* New `?forms=true` option on [Project Listing](/reference/project-management/projects/listing-projects-with-nested-forms) that includes a `formList` field containing a list of extended Forms (and the review state counts described above) associated with that Project.
+
 ### ODK Central v1.4
 
 ODK Central v1.4 enables additional CSV export options and creates an API-manageable 30 day permanent purge system for deleted Forms. Previously, deleted Forms were made inaccessible but the data was not purged from the database.

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,14 +34,14 @@ Here major and breaking changes to the API are listed by version.
 
 ### ODK Central v1.5
 
-ODK Central v1.5 adds editable Project descriptions as well as more detailed information about Forms and Submissions when listing Projects (via the API and shown in new Project and Form lists on Frontend).
+ODK Central v1.5 adds editable Project descriptions as well as more detailed information about Forms and Submissions when listing Projects.
 
 **Added**:
 
 * New `description` field returned for each [Project](/reference/project-management/projects) that can be set or updated through `POST`/`PATCH`/`PUT` on `/projects/…`
     * Note that for the `PUT` request, the Project's description must be included in the request. [Read more](/reference/project-management/projects/deep-updating-project-and-form-details).
 * [Form extended metadata](/reference/forms/individual-form/getting-form-details) now includes a `reviewStates` object of counts of Submissions with specific review states.
-    * e.g. `{ received: 12, edited: 5, hasIssues: 3 }`
+    * e.g. `{"received":12, "hasIssues":2, "edited":3}`
 * New `?forms=true` option on [Project Listing](/reference/project-management/projects/listing-projects-with-nested-forms) that includes a `formList` field containing a list of extended Forms (and the review state counts described above) associated with that Project.
 
 ### ODK Central v1.4

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -212,6 +212,19 @@ describe('api: /projects', () => {
             return asAlice.get(`/v1/projects/${body.id}`).expect(200);
           }))));
 
+    it('should create the given project with a description', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects')
+          .set('Content-Type', 'application/json')
+          .send({ name: 'Test Project', description: 'Test Description' })
+          .expect(200)
+          .then(({ body }) => {
+            body.name.should.equal('Test Project');
+            body.description.should.equal('Test Description');
+            body.should.be.a.Project();
+            return asAlice.get(`/v1/projects/${body.id}`).expect(200);
+          }))));
+
     it('should create an audit log entry', testService((service, { Audits, Projects, one }) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects')
@@ -364,11 +377,12 @@ describe('api: /projects', () => {
       service.login('alice', (asAlice) =>
         asAlice.patch('/v1/projects/1')
           .set('Content-Type', 'application/json')
-          .send({ name: 'New Test Name', archived: true })
+          .send({ name: 'New Test Name', archived: true, description: 'New Description' })
           .expect(200)
           .then(({ body }) => {
             body.should.be.a.Project();
             body.name.should.equal('New Test Name');
+            body.description.should.equal('New Description');
             body.archived.should.equal(true);
           })
           // paranoia:
@@ -376,6 +390,7 @@ describe('api: /projects', () => {
             .expect(200)
             .then(({ body }) => {
               body.name.should.equal('New Test Name');
+              body.description.should.equal('New Description');
               body.archived.should.equal(true);
             })))));
 


### PR DESCRIPTION
Added 1.5 change log to API docs...

But as I was writing about the new description field, realized that while the `PUT` endpoint is tested, the more basic Project endpoints didn't seem to have description-related tests.