### PR TITLE
README: add extra step to db setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ First, create a database and user in Postgres. Either use the same settings as t
 ```sql
 CREATE USER jubilant WITH PASSWORD 'jubilant';
 CREATE DATABASE jubilant_test with owner=jubilant encoding=UTF8;
+\c jubilant_test;
+CREATE EXTENSION IF NOT EXISTS CITEXT;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE DATABASE jubilant with owner=jubilant encoding=UTF8;
 \c jubilant;
 CREATE EXTENSION IF NOT EXISTS CITEXT;


### PR DESCRIPTION
Without this, I see the following error when running `make test`:

```bash
$ make test
env BCRYPT=no node node_modules/mocha/bin/mocha --recursive --exit


migration file "20181011-make-email-case-insensitive.js" failed
migration failed with error: create extension if not exists CITEXT - permission denied to create extension "citext"
  1) "before all" hook: initialize in "{root}"

  0 passing (548ms)
  1 failing

  1) "before all" hook: initialize in "{root}":
     error: create extension if not exists CITEXT - permission denied to create extension "citext"
      at Parser.parseErrorMessage (node_modules/pg-protocol/dist/parser.js:278:15)
      at Parser.handlePacket (node_modules/pg-protocol/dist/parser.js:126:29)
      at Parser.parse (node_modules/pg-protocol/dist/parser.js:39:38)
      at Socket.<anonymous> (node_modules/pg-protocol/dist/index.js:10:42)
      at Socket.emit (domain.js:475:12)
      at addChunk (internal/streams/readable.js:293:12)
      at readableAddChunk (internal/streams/readable.js:267:9)
      at Socket.Readable.push (internal/streams/readable.js:206:10)
      at TCP.onStreamRead (internal/stream_base_commons.js:188:23)



make: *** [Makefile:22: test] Error 1
$
```

To recreate, try:

```sql
ALTER USER jubilant WITH nosuperuser;
```