### PR TITLE
Makefile: use eslint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 /coverage/
 .nyc_output/
 .idea/
+/.eslintcache

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test-coverage: node_modules
 	node node_modules/.bin/nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --exit --recursive test
 
 lint:
-	node node_modules/.bin/eslint lib
+	node node_modules/.bin/eslint --cache lib
 
 run-multi: base
 	node node_modules/naught/lib/main.js start --worker-count 4 lib/bin/run-server.js


### PR DESCRIPTION
docs: https://eslint.org/docs/latest/user-guide/command-line-interface#--cache

This should speed up `make lint`, and any targets which depend on it (...which seems to be none of them!)

### Without cache

```
$ time make lint
node node_modules/.bin/eslint lib

real	0m5.331s
user	0m7.761s
sys	0m0.229s

$ time make lint
node node_modules/.bin/eslint lib

real	0m5.254s
user	0m7.701s
sys	0m0.212s

$ time make lint
node node_modules/.bin/eslint lib

real	0m5.250s
user	0m7.683s
sys	0m0.216s
```

### With cache

Note that on the first run, cache will need to be built.

```
$ time make lint
node node_modules/.bin/eslint --cache lib

real	0m5.531s
user	0m7.962s
sys	0m0.246s

$ time make lint
node node_modules/.bin/eslint --cache lib

real	0m0.598s
user	0m0.657s
sys	0m0.049s

$ time make lint
node node_modules/.bin/eslint --cache lib

real	0m0.609s
user	0m0.643s
sys	0m0.075s
```