### PR TITLE
Makefile: make lint depend on node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-unit: node_modules
 test-coverage: node_modules
 	node node_modules/.bin/nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --exit --recursive test
 
-lint:
+lint: node_modules
 	node node_modules/.bin/eslint lib
 
 run-multi: base


### PR DESCRIPTION
I think `lint` should depend on `node_modules` as the `eslint` binary is inside the `node_modules` directory.