### PR TITLE
Makefile: make node_modules depend on package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test
 default: base
 
-node_modules:
+node_modules: package.json
 	npm install
 
 migrations: node_modules


### PR DESCRIPTION
If I've understood correctly, this means that a change in `package.json` should trigger a re-run of `make node_modules` on the next invocation of `make`.

This should be helpful e.g. when switching to a branch with different dependencies.