### PR TITLE
Circleci node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ machine:
 jobs:
   build:
     docker:
-      - image: circleci/node:14.17.5
+      - image: circleci/node:14.17.6
       - image: circleci/postgres:9.6-alpine-ram
         environment:
           POSTGRES_PASSWORD: odktest


### PR DESCRIPTION
Ref https://github.com/getodk/central/blob/master/service.dockerfile#L1

Should tests be run against the same version used in production?