### PR TITLE
worker: prevent blocking on audit table

### DIFF
--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -69,7 +69,7 @@ with q as
       and ("lastFailure" is null or "lastFailure" < (now() - interval '10 minutes'))
     order by "loggedAt" asc
     limit 1
-    for update)
+    for update skip locked)
 update audits set claimed=clock_timestamp() from q where audits.id=q.id returning *`)
   .then(head);
 


### PR DESCRIPTION
It looks like this code should be skipping locked rows, as in its current form it looks like it falls prey to this:

> If two are started at exactly the same moment, the subSELECTs for each will be processed first. (It’s not that simple, but we can pretend for this purpose. Don’t rely on subqueries executing in any particular order for correctness). Each one scans for a row with [supplied `WHERE` query]. Both find the same row and attempt to lock it. One succeeds, one waits on the other one’s lock.

https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/