### PR TITLE
First pass of parsing entity xml

### DIFF
--- a/lib/data/entities.js
+++ b/lib/data/entities.js
@@ -1,0 +1,54 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { traverseXml, findOne, findAll, and, root, node, hasAttr, attr } = require('../util/xml');
+const { submissionXmlToFieldStream } = require('./submission');
+const { Form } = require('../model/frames');
+const { construct } = require('../util/util');
+
+// turn Option[Array[Option[x]]] into Array[x]; used just below in getFormFields
+const getList = (x) => x.map((xs) => xs.map((y) => y.orElse({}))).orElse([]);
+
+const getEntityDef = (xml) => {
+  const modelNode = findOne(root('html'), node('head'), node('model'));
+  return traverseXml(xml, [
+    modelNode(findOne(node('meta'), and(node('entity'), hasAttr('dataset')))(attr('dataset'))),
+    modelNode(findAll(root(), and(node('bind'), hasAttr('ref')))(attr()))
+  ]).then(([entity, bindings]) => {
+    if (entity.isEmpty()) return null;
+    const dataset = entity.get();
+    const mapping = getList(bindings)
+      .filter((bind) => ('entities:ref' in bind))
+      .map((bind) => ({
+        path: bind.nodeset.replace(/^(\/data)/, ''),
+        entity_prop: bind['entities:ref']
+      }));
+    return { dataset, mapping };
+  });
+};
+
+const getEntityFromSub = (fields, xml) => new Promise((resolve, reject) => {
+  const values = {};
+  const allFields = fields.concat([
+    { path: '/meta/entity/label', entity_prop: 'label' },
+    { path: '/meta/entity/create', entity_prop: 'create' },
+    { path: '/meta/entity/id', entity_prop: 'entity_id' }
+  ]);
+  const stream = submissionXmlToFieldStream(allFields.map(construct(Form.Field)), xml);
+  stream.on('error', reject);
+  stream.on('data', ({ field, text }) => {
+    values[field.entity_prop] = text;
+  });
+  stream.on('end', () => { resolve(values); });
+});
+
+module.exports = {
+  getEntityDef,
+  getEntityFromSub
+};

--- a/lib/data/entities.js
+++ b/lib/data/entities.js
@@ -48,7 +48,21 @@ const getEntityFromSub = (fields, xml) => new Promise((resolve, reject) => {
   stream.on('end', () => { resolve(values); });
 });
 
+const getEntityUsingFields = (fields, xml) => new Promise((resolve, reject) => {
+  const values = {};
+  const stream = submissionXmlToFieldStream(fields.map(construct(Form.Field)), xml);
+  stream.on('error', reject);
+  stream.on('data', ({ field, text }) => {
+    if (field.path === '/meta/entity/label')
+      values.label = text;
+    else if (field.entity_prop != null)
+      values[field.entity_prop] = text;
+  });
+  stream.on('end', () => { resolve(values); });
+});
+
 module.exports = {
   getEntityDef,
-  getEntityFromSub
+  getEntityFromSub,
+  getEntityUsingFields
 };

--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -78,6 +78,7 @@ const _recurseFormFields = (instance, bindings, repeats, selectMultiples, envelo
       const binding = bindings.find((bind) => absolutify(bind.nodeset, envelope) === bindingPath);
       if (binding != null) {
         field.type = binding.type || 'unknown'; // binding should have a type.
+        field.entity_prop = binding['entities:ref'] || null;
       } else if (tag.children != null) {
         // if we have no binding node but we have children, assume this is a
         // structural node with no repeat or direct data binding; recurse.

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -32,7 +32,7 @@ const { md5sum, shasum, sha256sum, digestWith, generateVersionSuffix } = require
 const { resolve } = require('../../util/promise');
 const { pipethrough, consumerToPiper, consumeAndBuffer } = require('../../util/stream');
 const { blankStringToNull } = require('../../util/util');
-const { traverseXml, findOne, root, node, attr, text } = require('../../util/xml');
+const { traverseXml, findAll, findOne, and, root, node, attr, hasAttr, text, tree } = require('../../util/xml');
 const Option = require('../../util/option');
 const Problem = require('../../util/problem');
 
@@ -43,6 +43,8 @@ const DraftVersion = Symbol('draft version');
 const PublishedVersion = Symbol('published version');
 const AllVersions = Symbol('all versions');
 
+// turn Option[Array[Option[x]]] into Array[x]; used just below in getFormFields
+const getList = (x) => x.map((xs) => xs.map((y) => y.orElse({}))).orElse([]);
 
 ////////////////////////////////////////////////////////////////////////////////
 // PRIMARY FORM
@@ -99,19 +101,36 @@ class Form extends Frame.define(
   // which is a Form property and so a plain object is returned.
   static fromXml(xml) {
     const dataNode = findOne(root('html'), node('head'), node('model'), node('instance'), node());
+    const modelNode = findOne(root('html'), node('head'), node('model'));
     const parse = (input) => traverseXml(input, [
       dataNode(attr('id')),
       dataNode(attr('version')),
       findOne(root('html'), node('head'), node('title'))(text()),
-      findOne(root('html'), node('head'), node('model'), node('submission'))(attr('base64RsaPublicKey'))
-    ]).then(([ idText, versionText, nameText, pubKey ]) => {
+      findOne(root('html'), node('head'), node('model'), node('submission'))(attr('base64RsaPublicKey')),
+      dataNode(tree()),
+      dataNode(findOne(node('meta'), and(node('entity'), hasAttr('dataset')))(attr('dataset'))),
+      modelNode(findAll(root(), and(node('bind'), hasAttr('ref')))(attr()))
+    ]).then(([ idText, versionText, nameText, pubKey, dataNodeElem, entity, bindings ]) => {
       const xmlFormId = idText.map(blankStringToNull)
         .orThrow(Problem.user.missingParameter({ field: 'formId' }));
+
+      let entityStuff = null;
+      if (!entity.isEmpty()) {
+        const dataNodeName = dataNodeElem.get().name;
+        const dataset = entity.get();
+        const mapping = getList(bindings)
+          .filter((bind) => ('entities:ref' in bind)) // just namespace hacks for now
+          .map((bind) => ({
+            path: bind.nodeset.replace(`/${dataNodeName}`, ''), // help, this feels like not the best way
+            entity_prop: bind['entities:ref']
+          }));
+        entityStuff = { dataset, mapping };
+      }
 
       const version = versionText.orElse('');
       const name = nameText.orNull();
       const key = pubKey.map((k) => new Key({ public: k }));
-      return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version, name }), key });
+      return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version, name }), key, entityStuff });
     });
 
     return (typeof xml === 'string')

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -12,6 +12,7 @@ const { map, compose, always } = require('ramda');
 const { Frame, into } = require('../frame');
 const { Actor, Blob, Form } = require('../frames');
 const { getFormFields, merge } = require('../../data/schema');
+const { getEntityDef } = require('../../data/entities');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, ignoringResult } = require('../../util/promise');
@@ -60,14 +61,23 @@ select id from form`))
 const createNew = (partial, project, publish = false) => ({ run, FormAttachments, Forms, Keys }) =>
   Promise.all([
     partial.aux.key.map(Keys.ensure).orElse(resolve(null)),
-    getFormFields(partial.xml)
+    getFormFields(partial.xml),
+    getEntityDef(partial.xml)
   ])
-    .then(([ keyId, fields ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
+    // eslint-disable-next-line no-unused-vars
+    .then(([ keyId, fields, moreEntityStuff ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
       .then((savedForm) => {
+        // entity dict of { dataset, mappings } is in both
+        // partial.aux.entityStuff and moreEntityStuff
+        // can also get field -> entity prop mappings in getFormFields
+        //   field.entity_prop
         const ids = { formId: savedForm.id, formDefId: savedForm.def.id };
         return Promise.all([
           FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets),
           run(insertMany(fields.map((field) => new Form.Field(Object.assign(field, ids)))))
+          // could add entity stuff per field in the above Form.Field query?
+          // or could do it separately - handle formFields differently form entityFields.
+          // also need to link form and dataset.
         ])
           .then(always(savedForm));
       }));

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -331,6 +331,30 @@ module.exports = {
       <select ref="/data/g1/q2"><label>two</label></select>
     </group>
   </h:body>
+</h:html>`,
+
+    simpleEntity: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model>
+      <instance>
+        <data id="form">
+          <name/>
+          <age/>
+          <hometown/>
+          <meta>
+            <entities:entity entities:dataset="people">
+              <entities:create/>
+              <entities:label/>
+            </entities:entity>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" entities:ref="full_name"/>
+      <bind nodeset="/data/age" type="int" entities:ref="age"/>
+      <bind nodeset="/data/hometown" type="select1"/>
+    </model>
+  </h:head>
 </h:html>`
   },
   instances: {
@@ -409,6 +433,20 @@ module.exports = {
       one: instance('selectMultiple', 'one', '<q1>a b</q1><g1><q2>x y z</q2>'),
       two: instance('selectMultiple', 'two', '<q1>b</q1><g1><q2>m x</q2>'),
       three: instance('selectMultiple', 'three', '<q1> b c</q1>')
+    },
+    simpleEntity: {
+      one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simple_entity" version="2">
+      <meta>
+        <instanceID>one</instanceID>
+        <entities:entity dataset="people">
+          <entities:id/>
+          <entities:create/>
+          <entities:label>Betty (94)</entities:label>
+        </entities:entity>
+      </meta>
+      <name>Betty</name>
+      <age>94</age>
+    </data>`
     }
   }
 };

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -338,7 +338,7 @@ module.exports = {
   <h:head>
     <model>
       <instance>
-        <data id="form">
+        <data id="simpleEntity">
           <name/>
           <age/>
           <hometown/>
@@ -435,7 +435,7 @@ module.exports = {
       three: instance('selectMultiple', 'three', '<q1> b c</q1>')
     },
     simpleEntity: {
-      one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simple_entity" version="2">
+      one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="2">
       <meta>
         <instanceID>one</instanceID>
         <entities:entity dataset="people">

--- a/test/integration/api/forms/entities.js
+++ b/test/integration/api/forms/entities.js
@@ -1,0 +1,40 @@
+const { readFileSync } = require('fs');
+const appRoot = require('app-root-path');
+const should = require('should');
+const config = require('config');
+const superagent = require('superagent');
+const { DateTime } = require('luxon');
+const { testService } = require('../../setup');
+const testData = require('../../../data/xml');
+const { exhaust } = require(appRoot + '/lib/worker/worker');
+
+describe('api: /projects/:id/forms (entity-handling)', () => {
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // FORM CREATION RELATED TO ENTITIES
+  ////////////////////////////////////////////////////////////////////////////////
+
+  describe('parse form def to get entity def', () => {
+    it('should return the created form upon success', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.a.Form();
+            body.xmlFormId.should.equal('simpleEntity');
+          }))));
+
+    it('should still work on non-entity forms', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.a.Form();
+            body.xmlFormId.should.equal('simple2');
+          }))));
+  });
+});

--- a/test/unit/data/entities.js
+++ b/test/unit/data/entities.js
@@ -1,0 +1,143 @@
+const appRoot = require('app-root-path');
+const { getEntityDef, getEntityFromSub } = require(appRoot + '/lib/data/entities');
+const testData = require(appRoot + '/test/data/xml');
+const should = require('should');
+
+describe('entity parsing', () => {
+  describe('entity form def spec', () => {
+    it('should extract name and entity field mappings', async () => {
+      const entityDef = await getEntityDef(testData.forms.simpleEntity);
+      entityDef.should.eql({
+        dataset: 'people',
+        mapping: [
+          { path: '/name', entity_prop: 'full_name' },
+          { path: '/age', entity_prop: 'age' }
+        ]
+      });
+    });
+
+    it('should map nested fields to entity properties through binds', async () => {
+      const xml = `
+      <?xml version="1.0"?>
+      <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+        <h:head>
+          <model>
+            <instance>
+              <data id="form">
+                <name/>
+                <location_info>
+                  <location_name/>
+                  <location_gps/>
+                  <location_image/>
+                </location_info>
+                <meta>
+                  <entity entities:dataset="people_places">
+                    <entities:create/>
+                    <entities:label/>
+                  </entity>
+                </meta>
+              </data>
+            </instance>
+            <bind nodeset="/data/name" type="string" entities:ref="full_name"/>
+            <bind nodeset="/data/location_info/location_name" type="string" entities:ref="location"/>
+          </model>
+        </h:head>
+      </h:html>`;
+      const entityDef = await getEntityDef(xml);
+      entityDef.should.eql({
+        dataset: 'people_places',
+        mapping: [
+          { path: '/name', entity_prop: 'full_name' },
+          { path: '/location_info/location_name', entity_prop: 'location' }
+        ]
+      });
+    });
+
+    it('should return null entity if entity not defined in form', async () => {
+      const entityDef = await getEntityDef(testData.forms.simple);
+      should.not.exist(entityDef);
+    });
+
+    describe('entities: namespace prefix', () => {
+      it.skip('should fail if entities namespace missing on entity', async () => {
+        const xml = `
+        <?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+          <h:head>
+            <model>
+              <instance>
+                <data id="form">
+                  <meta>
+                    <entity entities:dataset="people">
+                    </entity>
+                  </meta>
+                </data>
+              </instance>
+            </model>
+          </h:head>
+        </h:html>`;
+        const entityDef = await getEntityDef(xml);
+        entityDef.should.eql({});
+      });
+
+      it.skip('should fail if entities namespace missing on dataset', async () => {
+        const xml = `
+        <?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+          <h:head>
+            <model>
+              <instance>
+                <data id="form">
+                  <meta>
+                    <entities:entity dataset="people">
+                    </entity>
+                  </meta>
+                </data>
+              </instance>
+            </model>
+          </h:head>
+        </h:html>`;
+        const entityDef = await getEntityDef(xml);
+        entityDef.should.eql({});
+      });
+
+      it('should require entities namespace prefix on refs to be included', async () => {
+        const xml = `<?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+          <h:head>
+            <model>
+              <instance>
+                <data id="form">
+                  <name/>
+                  <age/>
+                  <meta>
+                    <entities:entity entities:dataset="people">
+                    </entities:entity>
+                  </meta>
+                </data>
+              </instance>
+              <bind nodeset="/data/name" type="string" ref="full_name"/>
+              <bind nodeset="/data/age" type="string" entities:ref="age"/>
+            </model>
+          </h:head>
+        </h:html>`;
+        const entityDef = await getEntityDef(xml);
+        entityDef.should.eql({
+          dataset: 'people',
+          mapping: [
+            { path: '/age', entity_prop: 'age' }
+          ]
+        });
+      });
+    });
+  });
+
+  describe('entity submission', () => {
+    it('should get entity properties out of submission', async () => {
+      const entityDef = await getEntityDef(testData.forms.simpleEntity);
+      const fields = entityDef.mapping;
+      const data = await getEntityFromSub(fields, testData.instances.simpleEntity.one);
+      data.should.eql({ label: 'Betty (94)', full_name: 'Betty', age: '94' });
+    });
+  });
+});

--- a/test/unit/data/entities.js
+++ b/test/unit/data/entities.js
@@ -1,6 +1,7 @@
 const appRoot = require('app-root-path');
-const { getEntityDef, getEntityFromSub } = require(appRoot + '/lib/data/entities');
+const { getEntityDef, getEntityFromSub, getEntityUsingFields } = require(appRoot + '/lib/data/entities');
 const testData = require(appRoot + '/test/data/xml');
+const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
 const should = require('should');
 
 describe('entity parsing', () => {
@@ -137,6 +138,12 @@ describe('entity parsing', () => {
       const entityDef = await getEntityDef(testData.forms.simpleEntity);
       const fields = entityDef.mapping;
       const data = await getEntityFromSub(fields, testData.instances.simpleEntity.one);
+      data.should.eql({ label: 'Betty (94)', full_name: 'Betty', age: '94' });
+    });
+
+    it('should get entity props out of submission another way using fields', async () => {
+      const fields = await fieldsFor(testData.forms.simpleEntity);
+      const data = await getEntityUsingFields(fields, testData.instances.simpleEntity.one);
       data.should.eql({ label: 'Betty (94)', full_name: 'Betty', age: '94' });
     });
   });


### PR DESCRIPTION
Key issues to work out:

1. **Unified parsing of form defs**

Ideally, entity parsing happens at the same time a form def is uploaded and parsed for the existing reasons (extracting form fields and their types). The form def data comes in from the request stream and is processed as as stream.

2. **Namespaces and namespace prefixes**

We're trying to support a new entities namespace: `xmlns:entities="http://www.opendatakit.org/xforms/entities"`. The prefix could be anything, not just `entities:` But given the stream reading issues above, it's tricky (but probably not impossible) to read and check for namespace mappings at the beginning of the stream and use them later. We might need to get into the core _Iteratee_ code (`lib/util/xml.js`) to do this. This might look like tracking the namespace mappings once we see them and being able to use them in node processing, i.e. looking for `entity/create` nodes of any namespace but then confirming the namespace on that node. Or we could take a different approach to this whole issue, like with a convention prefix. 


3. **Double-checking the meaning of `ref`/`saveTo` attributes on `bind`**

Related to namespace issues above, we were discussing what to call the attribute in a `bind` statement that specifies the entity prop that a form field maps to, and how critical having the `entities` namespace is. The latest notes in the spec now have this being called `saveTo`. 