### PR TITLE
Add default enketo config suitable for development

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -17,7 +17,10 @@
       "host": "localhost",
       "port": 5000
     },
-    "enketo": {},
+    "enketo": {
+      "url": "http://localhost:8005/-",
+      "apiKey": "enketorules"
+    },
     "env": {
       "domain": "http://localhost:8989",
       "sysadminAccount": "no-reply@getodk.org"


### PR DESCRIPTION
As per settings in https://github.com/getodk/central-frontend/blob/master/docs/enketo.md.

I think this change would be helpful for developers because:

* this brings backend, frontend & enketo-express 1 step closer to working out-of-the-box for developers
* it means backend repo is not constantly dirty when working with enketo
* it removes the risk of accidentally committing these changes
* it removes the risk of accidentally overriding these changes.  This can be particularly frustrating, as the error message(s) relating to missing enketo config can be cryptic and hard to resolve if unfamiliar.