### PR TITLE
package.json: order dev dependencies alphabetically

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "eslint-plugin-import": "~2.25",
     "mocha": "~9",
     "nock": "~12",
-    "nyc": "~15",
     "node-mocks-http": "~1.6",
+    "nyc": "~15",
     "semver": "^7.3.7",
     "should": "~13",
-    "supertest": "~3",
     "streamtest": "~1.2",
+    "supertest": "~3",
     "tmp": "~0.2"
   }
 }


### PR DESCRIPTION
`npm` re-orders these every time a dev dependency is added or removed.  Making the change permanently would save a bit of fiddling when changing dependencies.