### PR TITLE
make: don't re-run `npm install` unnecessarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ default: base
 
 node_modules: package.json
 	npm install
+	touch node_modules
 
 .PHONY: node_version
 node_version: node_modules


### PR DESCRIPTION
For me this knocks 5-6 seconds off every re-run of `make test`, `make run` etc.