### PR TITLE
Allow navigating to enketo for form submission editing

### DIFF
--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -231,7 +231,6 @@ module.exports = (service, endpoint) => {
       // transaction. but it doesn't feel like this case is likely to ever be hit. so just
       // reject if we haven't pushed to enketo for .. some probably bad unrelated reason.
       .then(rejectIf(((form) => form.enketoId == null), noargs(Problem.user.enketoNotReady)))
-      .then(rejectIf(((form) => form.state !== 'open'), noargs(Problem.user.editingClosingOrClosed)))
       .then((form) => Submissions.getCurrentDefByIds(params.projectId, params.formId, params.instanceId, false)
         .then(getOrNotFound)
         .then((def) => SubmissionAttachments.getCurrentForSubmissionId(form.id, def.submissionId, false)

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -153,8 +153,6 @@ const problems = {
 
     enketoNotReady: problem(409.11, () => 'The form you tried to access is not ready for web use yet. Please wait some time and try again.'),
 
-    editingClosingOrClosed: problem(409.12, () => 'You are trying to edit a submission of a Form that is in Closing or Closed state. In this version of Central, you can only edit the submissions of Open Forms. We will fix this in a future version for Central.'),
-
     enketoEditRateLimit: problem(409.13, () => 'You must wait one minute before trying to edit a submission a second time.')
   },
   internal: {

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1086,7 +1086,18 @@ describe('api: /forms/:id/submissions', () => {
           .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/edit')
             .expect(409)))));
 
-    it('should reject if the form is closing', testService((service, { run }) =>
+    it('should redirect to the edit_url for an open form', testService((service, { run }) =>
+      run(sql`update forms set "enketoId"='myenketoid'`)
+        .then(() => service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms/simple/submissions')
+            .send(testData.instances.simple.one)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/edit')
+              .expect(302)
+              .then(({ text }) => { text.should.equal('Found. Redirecting to https://enketo/edit/url'); }))))));
+
+    it('should redirect to the edit_url for a closing form', testService((service, { run }) =>
       run(sql`update forms set "enketoId"='myenketoid'`)
         .then(() => service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms/simple/submissions')
@@ -1097,19 +1108,19 @@ describe('api: /forms/:id/submissions', () => {
               .send({ state: 'closing' })
               .expect(200))
             .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/edit')
-              .expect(409)
-              .then(({ body }) => {
-                body.code.should.equal(409.12);
-                /trying to edit a submission of a Form that is in Closing or Closed/.test(body.message).should.equal(true);
-              }))))));
+              .expect(302)
+              .then(({ text }) => { text.should.equal('Found. Redirecting to https://enketo/edit/url'); }))))));
 
-    it('should redirect to the edit_url', testService((service, { run }) =>
+    it('should redirect to the edit_url for a closed form', testService((service, { run }) =>
       run(sql`update forms set "enketoId"='myenketoid'`)
         .then(() => service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms/simple/submissions')
             .send(testData.instances.simple.one)
             .set('Content-Type', 'application/xml')
             .expect(200)
+            .then(() => asAlice.patch('/v1/projects/1/forms/simple')
+              .send({ state: 'closed' })
+              .expect(200))
             .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/edit')
               .expect(302)
               .then(({ text }) => { text.should.equal('Found. Redirecting to https://enketo/edit/url'); }))))));


### PR DESCRIPTION
Address case 17 & 18 of https://github.com/getodk/central-backend/issues/469#issuecomment-1184672088

Should not be merged before https://github.com/getodk/central-backend/pull/530; maybe the two PRs should be combined.

### TODO

- [x] update `/projects/:projectId/forms/:formId/submissions/:instanceId/edit` to allow loading submission
- [ ] update `/projects/:projectId/formList` to include closing & closed forms _when appropriate_