### PR TITLE
Handle ConnectionError thrown by Slonik stream()

### DIFF
--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -239,7 +239,7 @@ const queryFuncs = (db, obj) => {
     for (let i = 0; i < xs.length; i += 1) result[i] = f(xs[i]);
     return result;
   };
-  obj.stream = (s) => new Promise((resolve) => db.stream(s, resolve));
+  obj.stream = (s) => new Promise((resolve, reject) => db.stream(s, resolve).catch(reject));
   obj.stream.map = (f) => (strm) => PartialPipe.of(strm, mapStream(({ row }) => f(row)));
   /* eslint-enable no-param-reassign */
 };


### PR DESCRIPTION
Closes #479 

@matthew-white I can't see any concerns about double-resolution/rejection of the promises in either [`slonik` `23.6.0`](https://github.com/gajus/slonik/blob/v23.6.0/src/connectionMethods/stream.ts#L44-L79) or [`slonik` `master`](https://github.com/gajus/slonik/blob/master/src/connectionMethods/stream.ts#L35-L80)