### PR TITLE
Include lint in make test & test-full targets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "global-require": "off",
     "implicit-arrow-linebreak": "off",
     "import/newline-after-import": "off",
+    "import/no-extraneous-dependencies": "off",
     "import/order": "off",
     "lines-between-class-members": "off",
     "max-classes-per-file": "off",
@@ -22,6 +23,7 @@
     "no-multiple-empty-lines": "off",
     "no-nested-ternary": "off",
     "no-restricted-syntax": "off",
+    "no-shadow": "off",
     "no-underscore-dangle": "off",
     "nonblock-statement-body-position": "off",
     "object-curly-newline": [ "error", {
@@ -31,6 +33,7 @@
     "object-property-newline": "off",
     "operator-linebreak": "off",
     "padded-blocks": "off",
+    "prefer-destructuring": "off",
     "prefer-object-spread": "off",
     "prefer-template": "off",
     "space-infix-ops": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,6 @@
     "global-require": "off",
     "implicit-arrow-linebreak": "off",
     "import/newline-after-import": "off",
-    "import/no-extraneous-dependencies": "off",
     "import/order": "off",
     "lines-between-class-members": "off",
     "max-classes-per-file": "off",
@@ -23,7 +22,6 @@
     "no-multiple-empty-lines": "off",
     "no-nested-ternary": "off",
     "no-restricted-syntax": "off",
-    "no-shadow": "off",
     "no-underscore-dangle": "off",
     "nonblock-statement-body-position": "off",
     "object-curly-newline": [ "error", {
@@ -33,7 +31,6 @@
     "object-property-newline": "off",
     "operator-linebreak": "off",
     "padded-blocks": "off",
-    "prefer-destructuring": "off",
     "prefer-object-spread": "off",
     "prefer-template": "off",
     "space-infix-ops": "off",

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ debug: base
 	node --debug --inspect lib/bin/run-server.js
 
 .PHONY: test
-test: node_version
+test: lint
 	env BCRYPT=no mocha --recursive --exit
 .PHONY: test-full
-test-full: node_version
+test-full: lint
 	mocha --recursive --exit
 
 .PHONY: test-integration


### PR DESCRIPTION
Closes #505

I have disabled 3 more eslint rules in this PR because these rules are currently violated on `master`.  If the violations need fixing, I'd suggest doing this separately.