### PR TITLE
migrations: handle async errors in scripts

### DIFF
--- a/lib/bin/.eslintrc.js
+++ b/lib/bin/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: '../../.eslintrc.json',
+  rules: {
+    'no-console': 'off',
+  },
+};

--- a/lib/bin/check-migrations.js
+++ b/lib/bin/check-migrations.js
@@ -1,3 +1,10 @@
 const { withDatabase, checkMigrations } = require('../model/migrate');
 
-withDatabase(require('config').get('default.database'))(checkMigrations);
+(async () => {
+  try {
+    await withDatabase(require('config').get('default.database'))(checkMigrations);
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+})();

--- a/lib/bin/run-migrations.js
+++ b/lib/bin/run-migrations.js
@@ -1,3 +1,10 @@
 const { withDatabase, migrate } = require('../model/migrate');
 
-withDatabase(require('config').get('default.database'))(migrate);
+(async () => {
+  try {
+    await withDatabase(require('config').get('default.database'))(migrate);
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
Closes #509

Example

```shell
$ make migrations 2>&1
node lib/bin/enforce-node-version.js
node lib/bin/run-migrations.js
Error: The migration directory is corrupt, the following files are missing: 20220121-01-form-cascade-delete.js
make: *** [Makefile:15: migrations] Error 1
```