### PR TITLE
bug #478: decode html entities in form title

### DIFF
--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -31,10 +31,11 @@ const { Key } = require('./key');
 const { md5sum, shasum, sha256sum, digestWith, generateVersionSuffix } = require('../../util/crypto');
 const { resolve } = require('../../util/promise');
 const { pipethrough, consumerToPiper, consumeAndBuffer } = require('../../util/stream');
-const { blankStringToNull, decodeHtml } = require('../../util/util');
+const { blankStringToNull } = require('../../util/util');
 const { traverseXml, findOne, root, node, attr, text } = require('../../util/xml');
 const Option = require('../../util/option');
 const Problem = require('../../util/problem');
+const { decodeXML } = require('entities'); 
 
 /* eslint-disable no-multi-spaces */
 
@@ -109,7 +110,7 @@ class Form extends Frame.define(
         .orThrow(Problem.user.missingParameter({ field: 'formId' }));
 
       const version = versionText.orElse('');
-      const name = nameText.map(decodeHtml).orNull();
+      const name = nameText.map(decodeXML).orNull();
       const key = pubKey.map((k) => new Key({ public: k }));
       return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version, name }), key });
     });

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -35,7 +35,7 @@ const { blankStringToNull } = require('../../util/util');
 const { traverseXml, findOne, root, node, attr, text } = require('../../util/xml');
 const Option = require('../../util/option');
 const Problem = require('../../util/problem');
-const { decodeXML } = require('entities'); 
+const { decodeXML } = require('entities');
 
 /* eslint-disable no-multi-spaces */
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -31,7 +31,7 @@ const { Key } = require('./key');
 const { md5sum, shasum, sha256sum, digestWith, generateVersionSuffix } = require('../../util/crypto');
 const { resolve } = require('../../util/promise');
 const { pipethrough, consumerToPiper, consumeAndBuffer } = require('../../util/stream');
-const { blankStringToNull } = require('../../util/util');
+const { blankStringToNull, decodeHtml } = require('../../util/util');
 const { traverseXml, findOne, root, node, attr, text } = require('../../util/xml');
 const Option = require('../../util/option');
 const Problem = require('../../util/problem');
@@ -109,7 +109,7 @@ class Form extends Frame.define(
         .orThrow(Problem.user.missingParameter({ field: 'formId' }));
 
       const version = versionText.orElse('');
-      const name = nameText.orNull();
+      const name = nameText.map(decodeHtml).orNull();
       const key = pubKey.map((k) => new Key({ public: k }));
       return new Form.Partial({ xmlFormId, name }, { def: new Form.Def({ version, name }), key });
     });

--- a/lib/model/query/comments.js
+++ b/lib/model/query/comments.js
@@ -8,7 +8,6 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { map } = require('ramda');
 const { Actor, Comment } = require('../frames');
 const { extender, insert, QueryOptions } = require('../../util/db');
 const { construct } = require('../../util/util');

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -32,14 +32,6 @@ const blankStringToNull = (x) => ((x === '') ? null : x);
 const sanitizeOdataIdentifier = (name) =>
   name.replace(/^([^a-z_])/i, '_$1').replace(/([^a-z0-9_]+)/gi, '_');
 
-
-// Decodes html entities into plain text
-// greedy approach, only converting entities that are return by xlsform to xform conversion process
-const decodeHtml = (input) =>
-  input.replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
-
 ////////////////////////////////////////
 // OBJECTS
 
@@ -82,7 +74,7 @@ const construct = (Type) => (x, y) => new Type(x, y);
 
 module.exports = {
   noop, noargs,
-  isBlank, isPresent, blankStringToNull, sanitizeOdataIdentifier, decodeHtml,
+  isBlank, isPresent, blankStringToNull, sanitizeOdataIdentifier,
   printPairs, without, pickAll,
   construct
 };

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -33,6 +33,13 @@ const sanitizeOdataIdentifier = (name) =>
   name.replace(/^([^a-z_])/i, '_$1').replace(/([^a-z0-9_]+)/gi, '_');
 
 
+// Decodes html entities into plain text
+// greedy approach, only converting entities that are return by xlsform to xform conversion process
+const decodeHtml = (input) =>
+  input.replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+
 ////////////////////////////////////////
 // OBJECTS
 
@@ -75,7 +82,7 @@ const construct = (Type) => (x, y) => new Type(x, y);
 
 module.exports = {
   noop, noargs,
-  isBlank, isPresent, blankStringToNull, sanitizeOdataIdentifier,
+  isBlank, isPresent, blankStringToNull, sanitizeOdataIdentifier, decodeHtml,
   printPairs, without, pickAll,
   construct
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,7 +769,7 @@
     "append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
     },
     "append-transform": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,7 +769,7 @@
     "append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
     },
     "append-transform": {
       "version": "2.0.0",

--- a/test/integration/api/comments.js
+++ b/test/integration/api/comments.js
@@ -35,10 +35,10 @@ describe('api: /submissions/:id/comments', () => {
           .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions/one/comments')
             .send({ body: 'new comment here' })
             .expect(200))
-            .then(({ body }) => {
-              body.should.be.a.Comment();
-              body.body.should.equal('new comment here');
-            })
+          .then(({ body }) => {
+            body.should.be.a.Comment();
+            body.body.should.equal('new comment here');
+          })
           .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/comments')
             .expect(200)
             .then(({ body }) => {

--- a/test/integration/api/forms/list.js
+++ b/test/integration/api/forms/list.js
@@ -394,7 +394,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
                 })
             ]))))));
 
-    it.only('should encode html entities in the response', testService((service) =>
+    it('should encode html entities in the response', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms?publish=true')
           .send(testData.forms.simple.replace('<h:title>Simple</h:title>', '<h:title>Crate &amp; Barrel</h:title>').replace('id="simple"', 'id="htmlEntities"'))

--- a/test/integration/api/forms/list.js
+++ b/test/integration/api/forms/list.js
@@ -393,5 +393,19 @@ describe('api: /projects/:id/forms (listing forms)', () => {
   </xforms>`);
                 })
             ]))))));
+
+    it.only('should encode html entities in the response', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simple.replace('<h:title>Simple</h:title>', '<h:title>Crate &amp; Barrel</h:title>').replace('id="simple"','id="htmlEntities"'))
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.get('/v1/projects/1/formList')
+            .set('X-OpenRosa-Version', '1.0')
+            .expect(200)
+            .then(({ text }) => {
+              text.should.containEql('<name>Crate &amp; Barrel</name>');
+              text.should.not.containEql('<name>Crate &amp;amp; Barrel</name>');              
+            })))));
   });
 });

--- a/test/integration/api/forms/list.js
+++ b/test/integration/api/forms/list.js
@@ -397,7 +397,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
     it.only('should encode html entities in the response', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.simple.replace('<h:title>Simple</h:title>', '<h:title>Crate &amp; Barrel</h:title>').replace('id="simple"','id="htmlEntities"'))
+          .send(testData.forms.simple.replace('<h:title>Simple</h:title>', '<h:title>Crate &amp; Barrel</h:title>').replace('id="simple"', 'id="htmlEntities"'))
           .set('Content-Type', 'application/xml')
           .expect(200)
           .then(() => asAlice.get('/v1/projects/1/formList')
@@ -405,7 +405,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
             .expect(200)
             .then(({ text }) => {
               text.should.containEql('<name>Crate &amp; Barrel</name>');
-              text.should.not.containEql('<name>Crate &amp;amp; Barrel</name>');              
+              text.should.not.containEql('<name>Crate &amp;amp; Barrel</name>');
             })))));
   });
 });

--- a/test/unit/model/frames/form.js
+++ b/test/unit/model/frames/form.js
@@ -76,6 +76,13 @@ describe('Form', () => {
         partial.aux.key.isDefined().should.equal(false);
       });
     });
+
+    it('should decode form title', () => {
+      const xml = '<html><head><title>Crate &amp; Barrel</title><model><instance><data id="mycoolform"><field/></data></instance></model></head></html>';
+      return Form.fromXml(xml).then((partial) => {
+        partial.name.should.equal('Crate & Barrel');
+      });
+    });
   });
 });
 

--- a/test/unit/util/util.js
+++ b/test/unit/util/util.js
@@ -62,6 +62,6 @@ describe('util/util', () => {
       (blankStringToNull(' ') === ' ').should.equal(true);
     });
   });
-  
+
 });
 

--- a/test/unit/util/util.js
+++ b/test/unit/util/util.js
@@ -62,12 +62,6 @@ describe('util/util', () => {
       (blankStringToNull(' ') === ' ').should.equal(true);
     });
   });
-
-  describe('decodeHtml', () => {
-    const { decodeHtml } = util;
-    it('should replace html entities', () => {
-      (decodeHtml('Crate &amp; Barrel &lt;empty&gt;')).should.equal('Crate & Barrel <empty>');
-    });
-  });
+  
 });
 

--- a/test/unit/util/util.js
+++ b/test/unit/util/util.js
@@ -62,5 +62,12 @@ describe('util/util', () => {
       (blankStringToNull(' ') === ' ').should.equal(true);
     });
   });
+
+  describe('decodeHtml', () => {
+    const { decodeHtml } = util;
+    it('should replace html entities', () => {
+      (decodeHtml('Crate &amp; Barrel &lt;empty&gt;')).should.equal('Crate & Barrel <empty>');
+    });
+  });
 });
 


### PR DESCRIPTION
Closes #478 

### Change
I have decoded only title before saving it in database

### Verification
Created unit tests
Manually tested in ODK Collect and Enketo to ensure that change is not breaking functionality there

### Alternative
I could have decoded the title in GET APIs after retrieving the data from DB but there are few of them. 
Other option was to change the `text()` function but I am afraid of ripple effect it might create across the application