### PR TITLE
Parse Form XML to get dataset name and validate entity element

### DIFF
--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -143,6 +143,30 @@ const getFormFields = (xml) => {
       new Set(stripNamespacesFromPaths(getList(repeats))), new Set(stripNamespacesFromPaths(getList(selectMultiples)))));
 };
 
+// Here we are looking for an <entity> element following the dataset-registrating
+// form spec. If we find one, we want to validate it and extract the name of the
+// dataset.
+//
+// Like with getFormFields above, we assume the form is otherwise valid.
+//
+// TODO later: validate entities namespace (look up and enforce prefix)
+const getDataset = (xml) => {
+  const metaNode = findOne(root('html'), node('head'), node('model'), node('instance'), node(), node('meta'));
+  return traverseXml(xml, [
+    metaNode(findOne(root(), node('entity'))(tree())),
+    metaNode(findOne(root(), and(node('entity'), hasAttr('dataset')))(attr('dataset'))),
+    metaNode(findOne(root(), node('entity'), node('create'))(node())),
+    metaNode(findOne(root(), node('entity'), node('label'))(node())),
+  ]).then(([ entity, dataset, create, label ]) => {
+    if (entity.isEmpty())
+      return Option.none();
+    // if the entity block exists, check that dataset and other children exist
+    if (dataset.isEmpty() || create.isEmpty() || label.isEmpty())
+      throw Problem.user.invalidEntityForm();
+    return dataset.get();
+  });
+};
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // SCHEMA STACK
@@ -552,6 +576,7 @@ const setVersion = _versionSplicer(true);
 
 module.exports = {
   getFormFields,
+  getDataset,
   SchemaStack,
   sanitizeFieldsForOdata,
   expectedFormAttachments, merge,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -11,7 +11,7 @@ const { sql } = require('slonik');
 const { map, compose, always } = require('ramda');
 const { Frame, into } = require('../frame');
 const { Actor, Blob, Form } = require('../frames');
-const { getFormFields, merge } = require('../../data/schema');
+const { getFormFields, getDataset, merge } = require('../../data/schema');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, ignoringResult } = require('../../util/promise');
@@ -60,11 +60,15 @@ select id from form`))
 const createNew = (partial, project, publish = false) => ({ run, FormAttachments, Forms, Keys }) =>
   Promise.all([
     partial.aux.key.map(Keys.ensure).orElse(resolve(null)),
-    getFormFields(partial.xml)
+    getFormFields(partial.xml),
+    getDataset(partial.xml)
   ])
-    .then(([ keyId, fields ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
+    // eslint-disable-next-line no-unused-vars
+    .then(([ keyId, fields, dataset ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
       .then((savedForm) => {
         const ids = { formId: savedForm.id, formDefId: savedForm.def.id };
+        // TODO (entities): `dataset` is either Option.none or a string of the dataset name
+        // and can now be used to update dataset info in the database.
         return Promise.all([
           FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets),
           run(insertMany(fields.map((field) => new Form.Field(Object.assign(field, ids)))))

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -96,6 +96,8 @@ const problems = {
 
     valueOutOfRangeForType: problem(400.22, ({ value, type }) => `Provided value '${value}' is out of range for type '${type}'`),
 
+    invalidEntityForm: problem(400.23, () => 'The entity definition within the form is invalid.'),
+
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),
 

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -331,6 +331,30 @@ module.exports = {
       <select ref="/data/g1/q2"><label>two</label></select>
     </group>
   </h:body>
+</h:html>`,
+
+    simpleEntity: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model>
+      <instance>
+        <data id="simpleEntity">
+          <name/>
+          <age/>
+          <hometown/>
+          <meta>
+            <entities:entity entities:dataset="people">
+              <entities:create/>
+              <entities:label/>
+            </entities:entity>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" entities:saveto="name"/>
+      <bind nodeset="/data/age" type="int" entities:saveto="age"/>
+      <bind nodeset="/data/hometown" type="string"/>
+    </model>
+  </h:head>
 </h:html>`
   },
   instances: {
@@ -411,6 +435,20 @@ module.exports = {
       one: instance('selectMultiple', 'one', '<q1>a b</q1><g1><q2>x y z</q2>'),
       two: instance('selectMultiple', 'two', '<q1>b</q1><g1><q2>m x</q2>'),
       three: instance('selectMultiple', 'three', '<q1> b c</q1>')
+    },
+    simpleEntity: {
+      one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="2">
+      <meta>
+        <instanceID>one</instanceID>
+        <entities:entity dataset="people">
+          <entities:id/>
+          <entities:create/>
+          <entities:label>Alice (88)</entities:label>
+        </entities:entity>
+      </meta>
+      <name>Alice</name>
+      <age>88</age>
+    </data>`
     }
   }
 };

--- a/test/integration/api/forms/entity.js
+++ b/test/integration/api/forms/entity.js
@@ -1,0 +1,22 @@
+const { testService } = require('../../setup');
+const testData = require('../../../data/xml');
+
+describe('api: /projects/:id/forms (entity-handling)', () => {
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // FORM CREATION RELATED TO ENTITIES
+  ////////////////////////////////////////////////////////////////////////////////
+
+  describe('parse form def to get entity def', () => {
+    it('should return the created form upon success', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.a.Form();
+            body.xmlFormId.should.equal('simpleEntity');
+          }))));
+	});
+});

--- a/test/integration/api/forms/entity.js
+++ b/test/integration/api/forms/entity.js
@@ -18,5 +18,5 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
             body.should.be.a.Form();
             body.xmlFormId.should.equal('simpleEntity');
           }))));
-	});
+  });
 });

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -6,7 +6,9 @@ const { getFormFields, getDataset, sanitizeFieldsForOdata, SchemaStack, merge, e
 const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
 // eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
+// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
+// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
 
 describe('form schema', () => {
@@ -1843,7 +1845,7 @@ describe('form schema', () => {
         </h:head>
       </h:html>`;
       // Problem.user.invalidEntityForm
-      return getDataset(xml).should.be.rejectedWith(Problem, { problemCode: 400.22 });
+      return getDataset(xml).should.be.rejectedWith(Problem, { problemCode: 400.23 });
     });
 
     it('should run but find no dataset on non-entity forms', () =>


### PR DESCRIPTION
Makes progress on entity-based data collection!

This PR focuses on validating the `<entity>` element (defined in a [new Form spec](https://docs.google.com/document/d/1-O_wT0JZZFaWvzHl_krrzERJcnrdGMKP55ZZ_hxV0gU/edit#)) of Form XML as it is uploaded, and extracting the dataset name. 

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

I experimented with some other things in this PR #517 that I'm going to close.

I first tried a separate XML parse pass to extract entity information, just to get a feel for how it would work. This new PR responds to some code suggestions on the previous PR. I wasn't yet clear on when or where this code would run when a form was uploaded, and we discussed how maybe the entity extraction should happen during an existing form parsing pass and not on its own.

I tried incorporating the entity-extraction in the main XML parse pass (`Form.fromXml`), which would have been okay, but feels like a core piece of code that I don't want to change too much. I noticed that `getFormFields(xml)` is doing another XML parse pass to get field information and wanted to follow that pattern more. I ended up with a separate function `getDataset(xml)` for parsing the entity dataset name out of the form, which is also where I've put the entity validation logic (that didn't exist in the previous PR). 

Next part of the plan is to extract the entity properties from the bindings in `getFormFields`. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No obvious user-facing changes in this PR, just more information extracted internally and made available to future pieces of code.

This _does_ parse the form XML an additional time (but is only looking for a small piece of information about entities so that it can be validated) so uploading a new form may become a tiny bit slower. Hopefully this is an imperceptible change, though. 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No changes to the API, but this functionality is based on Form spec changes.
