### PR TITLE
move test reinit to mocha's after hooks

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -77,7 +77,7 @@ before(initialize);
 
 let mustReinitAfter;
 beforeEach(() => {
-  if(mustReinitAfter) throw new Error(`Failed to reinitalize after previous test: '${mustReinitAfter}'`);
+  if(mustReinitAfter) throw new Error(`Failed to reinitalize after previous test: '${mustReinitAfter}'.  You may need to increase your mocha timeout.`);
 });
 afterEach(async () => {
   if(mustReinitAfter) {

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -72,9 +72,19 @@ const initialize = () => migrator
   .raw('drop owned by current_user')
   .then(() => migrator.migrate.latest({ directory: appRoot + '/lib/model/migrations' }))
   .then(() => withDefaults({ db, bcrypt }).transacting(populate));
-const reinit = (f) => (x) => { initialize().then(() => f(x)); };
 
 before(initialize);
+
+let mustReinitAfter;
+beforeEach(() => {
+  if(mustReinitAfter) throw new Error('Previous test did not complete re-initialization.');
+});
+afterEach(async () => {
+  if(mustReinitAfter) {
+    await initialize();
+    mustReinitAfter = false;
+  }
+});
 
 // augments a supertest object with a `.as(user, cb)` method, where user may be the
 // name of a fixture user or an object with email/password. the user will be logged
@@ -121,9 +131,10 @@ const testService = (test) => () => new Promise((resolve, reject) => {
 // for some tests we explicitly need to make concurrent requests, in which case
 // the transaction butchering we do for testService will not work. for these cases,
 // we offer testServiceFullTrx:
-const testServiceFullTrx = (test) => () => new Promise((resolve, reject) =>
-  test(augment(request(service(baseContainer))), baseContainer)
-    .then(reinit(resolve), reinit(reject)));
+const testServiceFullTrx = (test) => () => {
+  mustReinitAfter = true;
+  return test(augment(request(service(baseContainer))), baseContainer);
+};
 
 // for some tests we just want a container, without any of the webservice stuffs between.
 // this is that, with the same transaction trickery as a normal test.
@@ -135,8 +146,10 @@ const testContainer = (test) => () => new Promise((resolve, reject) => {
 });
 
 // complete the square of options:
-const testContainerFullTrx = (test) => () => new Promise((resolve, reject) =>
-  test(baseContainer).then(reinit(resolve), reinit(reject)));
+const testContainerFullTrx = (test) => () => {
+  mustReinitAfter = true;
+  return test(baseContainer);
+};
 
 // called to get a container context per task. ditto all // from testService.
 // here instead our weird hijack work involves injecting our own constructed

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -77,7 +77,7 @@ before(initialize);
 
 let mustReinitAfter;
 beforeEach(() => {
-  if(mustReinitAfter) throw new Error('Previous test did not complete re-initialization.');
+  if(mustReinitAfter) throw new Error(`Failed to reinitalize after previous test: '${mustReinitAfter}'`);
 });
 afterEach(async () => {
   if(mustReinitAfter) {
@@ -131,8 +131,8 @@ const testService = (test) => () => new Promise((resolve, reject) => {
 // for some tests we explicitly need to make concurrent requests, in which case
 // the transaction butchering we do for testService will not work. for these cases,
 // we offer testServiceFullTrx:
-const testServiceFullTrx = (test) => () => {
-  mustReinitAfter = true;
+const testServiceFullTrx = (test) => function() {
+  mustReinitAfter = this.test.fullTitle();
   return test(augment(request(service(baseContainer))), baseContainer);
 };
 
@@ -146,8 +146,8 @@ const testContainer = (test) => () => new Promise((resolve, reject) => {
 });
 
 // complete the square of options:
-const testContainerFullTrx = (test) => () => {
-  mustReinitAfter = true;
+const testContainerFullTrx = (test) => function() {
+  mustReinitAfter = this.test.fullTitle();
   return test(baseContainer);
 };
 


### PR DESCRIPTION
Closes #499

This will fail the whole suite fast if `initialize()` times out in a single test.  IMO this is helpful, as otherwise the state of the database is unpredictable for subsequent tests.

Example failure:

```
  1 failing

  1) "before each" hook for "should reject forms created while project managed encryption is being enabled @slow":
     Error: Failed to reinitalize after previous test: 'managed encryption lock management should reject keyless forms in keyed projects @slow'.  You may need to increase your mocha timeout.
      at Context.<anonymous> (test/integration/setup.js:80:29)
      at processImmediate (internal/timers.js:464:21)
```
