### PR TITLE
enforce-node-version: ignore lint violation

### DIFF
--- a/lib/bin/enforce-node-version.js
+++ b/lib/bin/enforce-node-version.js
@@ -1,4 +1,4 @@
-const semver = require('semver');
+const semver = require('semver'); // eslint-disable-line import/no-extraneous-dependencies
 const pkg = require('../../package.json');
 
 const expected = pkg.engines.node;


### PR DESCRIPTION
Ignores lint violation:

```
lib/bin/enforce-node-version.js
  1:16  error  'semver' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
```

An alternative fix might be to move `enforce-node-version.js` to a directory specific to dev-only scripts.