### PR TITLE
db.stream(): add timeout

### DIFF
--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -239,7 +239,23 @@ const queryFuncs = (db, obj) => {
     for (let i = 0; i < xs.length; i += 1) result[i] = f(xs[i]);
     return result;
   };
-  obj.stream = (s) => new Promise((resolve, reject1) => db.stream(s, resolve).catch(reject1));
+  obj.stream = (s) => new Promise((resolve, reject1) => db.stream(s, stream => {
+    const streamTimeout = setTimeout(() => {
+      // TODO should probably be stream.destroy(new Error('Stream timed out')), but
+      // stream.destroy(error) may currently throw other issues:
+      // * slonik with #347 unpatched: terminates process with: Emitted 'error' event on Transform instance at
+      // * slonik with #347 patched:   there are intermittent issues with this too TODO add link to the underlying pg issue
+      // see: https://github.com/gajus/slonik/issues/347
+      stream.destroy();
+    }, 30_000); // REVIEW this was picked arbitrarily, but seems to work ok in testing.   It should probably be a bigger number than HTTP request timeout etc; it might be important to check production response times for successful, long-lived requests and make this timeout bigger than those
+
+    stream.on('close', () => {
+      clearTimeout(streamTimeout);
+    });
+
+    resolve(stream);
+  }).catch(reject1));
+
   obj.stream.map = (f) => (strm) => PartialPipe.of(strm, mapStream(({ row }) => f(row)));
   /* eslint-enable no-param-reassign */
 };

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -247,7 +247,7 @@ const queryFuncs = (db, obj) => {
       // * slonik with #347 patched:   there are intermittent issues with this too TODO add link to the underlying pg issue
       // see: https://github.com/gajus/slonik/issues/347
       stream.destroy();
-    }, 30_000); // REVIEW this was picked arbitrarily, but seems to work ok in testing.   It should probably be a bigger number than HTTP request timeout etc; it might be important to check production response times for successful, long-lived requests and make this timeout bigger than those
+    }, 30000); // REVIEW this was picked arbitrarily, but seems to work ok in testing.   It should probably be a bigger number than HTTP request timeout etc; it might be important to check production response times for successful, long-lived requests and make this timeout bigger than those
 
     stream.on('close', () => {
       clearTimeout(streamTimeout);


### PR DESCRIPTION
Possible fix for https://github.com/getodk/central-backend/issues/565.

Without fixing https://github.com/gajus/slonik/issues/347 (e.g. with https://github.com/gajus/slonik/pull/360), this will still result in hanging connections sometimes, but is still a significant improvement vs current `master`.