### PR TITLE
Use npx in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export PATH := ./node_modules/.bin:$(PATH)
-
 default: base
 
 node_modules: package.json
@@ -31,26 +29,26 @@ debug: base
 
 .PHONY: test
 test: lint
-	env BCRYPT=no mocha --recursive --exit
+	env BCRYPT=no npx mocha --recursive --exit
 .PHONY: test-full
 test-full: lint
-	mocha --recursive --exit
+	npx mocha --recursive --exit
 
 .PHONY: test-integration
 test-integration: node_version
-	mocha --recursive test/integration --exit
+	npx mocha --recursive test/integration --exit
 
 .PHONY: test-unit
 test-unit: node_version
-	mocha --recursive test/unit --exit
+	npx mocha --recursive test/unit --exit
 
 .PHONY: test-coverage
 test-coverage: node_version
-	nyc -x "**/migrations/**" --reporter=lcov _mocha --exit --recursive test
+	npx nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --exit --recursive test
 
 .PHONY: lint
 lint: node_version
-	eslint --cache --max-warnings 0 .
+	npx eslint --cache --max-warnings 0 .
 
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres


### PR DESCRIPTION
Some of the makefile commands aren't working on some machines. This PR uses npx in the makefile so that those commands will work on all machines.

#### What has been done to verify that this works as intended?

`make lint` and `make test` now run on my machine.

#### Why is this the best possible solution? Were any other approaches considered?

See the [commit message](https://github.com/getodk/central-backend/pull/579/commits/42d799a284171e543971c97328cd042e07f2e414) for related notes. Another approach would have been to revert #524. However, I think #524 provided a nice improvement in the readability of the makefile, so I didn't want to revert it entirely.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Not user-facing.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No changes required.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments