### PR TITLE
new: Added hasDataset field on GET extended form

### DIFF
--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -175,7 +175,7 @@ Form.Def = Frame.define(
   'sha256',      readable,              'draftToken',   readable,
   'enketoId',    readable,              'createdAt',
   'publishedAt', readable,              'xlsBlobId',
-  'name',        readable,              
+  'name',        readable
 );
 Form.Xml = Frame.define(into('xml'), 'xml');
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -144,11 +144,12 @@ Form.Extended = class extends Frame.define(
   'excelContentType',   readable,
   // counts of submissions in various review states
   'receivedCount',                      'hasIssuesCount',
-  'editedCount'
+  'editedCount',                        'hasDataset',  readable
 ) {
   forApi() {
     return {
       submissions: this.submissions || 0,
+      hasDataset: this.hasDataset || false,
       reviewStates: {
         received: this.receivedCount || 0,
         hasIssues: this.hasIssuesCount || 0,
@@ -174,7 +175,7 @@ Form.Def = Frame.define(
   'sha256',      readable,              'draftToken',   readable,
   'enketoId',    readable,              'createdAt',
   'publishedAt', readable,              'xlsBlobId',
-  'name',        readable,              'managesEntities',  readable
+  'name',        readable,              
 );
 Form.Xml = Frame.define(into('xml'), 'xml');
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -174,7 +174,7 @@ Form.Def = Frame.define(
   'sha256',      readable,              'draftToken',   readable,
   'enketoId',    readable,              'createdAt',
   'publishedAt', readable,              'xlsBlobId',
-  'name',        readable
+  'name',        readable,              'managesEntities',  readable
 );
 Form.Xml = Frame.define(into('xml'), 'xml');
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -144,12 +144,12 @@ Form.Extended = class extends Frame.define(
   'excelContentType',   readable,
   // counts of submissions in various review states
   'receivedCount',                      'hasIssuesCount',
-  'editedCount',                        'hasDataset',  readable
+  'editedCount',                        'entityRelated',  readable
 ) {
   forApi() {
     return {
       submissions: this.submissions || 0,
-      hasDataset: this.hasDataset || false,
+      entityRelated: this.entityRelated || false,
       reviewStates: {
         received: this.receivedCount || 0,
         hasIssues: this.hasIssuesCount || 0,

--- a/lib/model/migrations/20220803-01-create-entities-schema.js
+++ b/lib/model/migrations/20220803-01-create-entities-schema.js
@@ -36,19 +36,12 @@ const up = async (db) => {
     dsPropertyFields.foreign(['formDefId', 'path']).references(['formDefId', 'path']).inTable('form_fields');
     dsPropertyFields.unique(['dsPropertyId', 'formDefId', 'path']);
   });
-
-  await db.schema.table('form_defs', (t) => {
-    t.boolean('managesEntities');
-  });
 };
 
 const down = async (db) => {
   await db.schema.dropTable('ds_property_fields');
   await db.schema.dropTable('ds_properties');
-  await db.schema.dropTable('datasets');
-  await db.schema.table('form_defs', (t) => {
-    t.dropColumn('managesEntities');
-  });
+  await db.schema.dropTable('datasets');  
 };
 
 module.exports = { up, down };

--- a/lib/model/migrations/20220803-01-create-entities-schema.js
+++ b/lib/model/migrations/20220803-01-create-entities-schema.js
@@ -7,8 +7,8 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const up = (db) =>
-  db.schema.createTable('datasets', (datasets) => {
+const up = async (db) => {
+  await db.schema.createTable('datasets', (datasets) => {
     datasets.increments('id').primary();
     datasets.text('name').notNull();
     datasets.integer('projectId').notNull();
@@ -16,28 +16,39 @@ const up = (db) =>
 
     datasets.foreign('projectId').references('projects.id');
     datasets.unique(['name', 'projectId']);
-  }).then(() =>
-    db.schema.createTable('ds_properties', (dsProperties) => {
-      dsProperties.increments('id').primary();
-      dsProperties.text('name').notNull();
-      dsProperties.integer('datasetId').notNull();
+  });
 
-      dsProperties.foreign('datasetId').references('datasets.id');
-      dsProperties.unique(['name', 'datasetId']);
-    })).then(() =>
-    db.schema.createTable('ds_property_fields', (dsPropertyFields) => {
-      dsPropertyFields.integer('dsPropertyId');
-      dsPropertyFields.integer('formDefId');
-      dsPropertyFields.text('path');
+  await db.schema.createTable('ds_properties', (dsProperties) => {
+    dsProperties.increments('id').primary();
+    dsProperties.text('name').notNull();
+    dsProperties.integer('datasetId').notNull();
 
-      dsPropertyFields.foreign('dsPropertyId').references('ds_properties.id');
-      dsPropertyFields.foreign(['formDefId', 'path']).references(['formDefId', 'path']).inTable('form_fields');
-      dsPropertyFields.unique(['dsPropertyId', 'formDefId', 'path']);
-    }));
+    dsProperties.foreign('datasetId').references('datasets.id');
+    dsProperties.unique(['name', 'datasetId']);
+  });
 
-const down = (db) =>
-  db.schema.dropTable('ds_property_fields')
-    .then(() => db.schema.dropTable('ds_properties')
-      .then(() => db.schema.dropTable('datasets')));
+  await db.schema.createTable('ds_property_fields', (dsPropertyFields) => {
+    dsPropertyFields.integer('dsPropertyId');
+    dsPropertyFields.integer('formDefId');
+    dsPropertyFields.text('path');
+
+    dsPropertyFields.foreign('dsPropertyId').references('ds_properties.id');
+    dsPropertyFields.foreign(['formDefId', 'path']).references(['formDefId', 'path']).inTable('form_fields');
+    dsPropertyFields.unique(['dsPropertyId', 'formDefId', 'path']);
+  });
+
+  await db.schema.table('form_defs', (t) => {
+    t.boolean('managesEntities');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.dropTable('ds_property_fields');
+  await db.schema.dropTable('ds_properties');
+  await db.schema.dropTable('datasets');
+  await db.schema.table('form_defs', (t) => {
+    t.dropColumn('managesEntities');
+  });
+};
 
 module.exports = { up, down };

--- a/lib/model/migrations/20220803-01-create-entities-schema.js
+++ b/lib/model/migrations/20220803-01-create-entities-schema.js
@@ -41,7 +41,7 @@ const up = async (db) => {
 const down = async (db) => {
   await db.schema.dropTable('ds_property_fields');
   await db.schema.dropTable('ds_properties');
-  await db.schema.dropTable('datasets');  
+  await db.schema.dropTable('datasets');
 };
 
 module.exports = { up, down };

--- a/lib/model/migrations/20220830-01-create-dataset_def.js
+++ b/lib/model/migrations/20220830-01-create-dataset_def.js
@@ -1,0 +1,25 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+    await db.schema.createTable('dataset_defs', (t) => {
+        t.integer('datasetId').notNull();
+        t.integer('formDefId').notNull();
+
+        t.foreign('datasetId').references('datasets.id');
+        t.foreign('formDefId').references('form_defs.id');
+        t.unique(['datasetId', 'formDefId']);
+    });
+};
+
+const down = async (db) => {
+    await db.schema.dropTable('dataset_defs');
+};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20220830-01-create-dataset_def.js
+++ b/lib/model/migrations/20220830-01-create-dataset_def.js
@@ -8,18 +8,18 @@
 // except according to the terms contained in the LICENSE file.
 
 const up = async (db) => {
-    await db.schema.createTable('dataset_defs', (t) => {
-        t.integer('datasetId').notNull();
-        t.integer('formDefId').notNull();
+  await db.schema.createTable('dataset_defs', (t) => {
+    t.integer('datasetId').notNull();
+    t.integer('formDefId').notNull();
 
-        t.foreign('datasetId').references('datasets.id');
-        t.foreign('formDefId').references('form_defs.id');
-        t.unique(['datasetId', 'formDefId']);
-    });
+    t.foreign('datasetId').references('datasets.id');
+    t.foreign('formDefId').references('form_defs.id');
+    t.unique(['datasetId', 'formDefId']);
+  });
 };
 
 const down = async (db) => {
-    await db.schema.dropTable('dataset_defs');
+  await db.schema.dropTable('dataset_defs');
 };
 
 module.exports = { up, down };

--- a/lib/model/migrations/20220830-01-create-dataset_form_def.js
+++ b/lib/model/migrations/20220830-01-create-dataset_form_def.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const up = async (db) => {
-  await db.schema.createTable('dataset_defs', (t) => {
+  await db.schema.createTable('dataset_form_defs', (t) => {
     t.integer('datasetId').notNull();
     t.integer('formDefId').notNull();
 
@@ -19,7 +19,7 @@ const up = async (db) => {
 };
 
 const down = async (db) => {
-  await db.schema.dropTable('dataset_defs');
+  await db.schema.dropTable('dataset_form_defs');
 };
 
 module.exports = { up, down };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -100,14 +100,6 @@ const _getByIdSql = ((fields, datasetId) => sql`
 
 // Creates or merges dataset, properties and field mapping.
 // Expects dataset:Frame and array of field:Frame auxed with property `name`
-// Returns dataset:Frame and array of properties:Frame if there are newly created
-// so that this can be shown on frontend.
-// Few scenarios:
-// 1) If dataset, properties and mapping already exists then return nothing.
-// 2) If there's difference between existing properties and given fields then only
-//    newly created properties are returned.
-// 3) If given field mapping is different then existing mapping then new mapping is
-//    created but nothing is return.
 const createOrMerge = (dataset, fields) => ({ all }) =>
   all(_createOrMerge(dataset, fields));
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -107,7 +107,7 @@ const _getByIdSql = ((fields, datasetId) => sql`
 
 
 // Creates or merges dataset, properties and field mapping.
-// Expects dataset:Frame and array of field:Frame auxed with property `name`
+// Expects dataset:Frame auxed with `formDefId` and array of field:Frame auxed with `propertyName`
 const createOrMerge = (dataset, fields) => ({ all }) =>
   all(_createOrMerge(dataset, fields));
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -8,6 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
+const { raw } = require('slonik-sql-tag-raw');
 const { unjoiner } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
 const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either } = require('ramda');
@@ -51,17 +52,24 @@ const isNilOrEmpty = either(isNil, isEmpty);
 // SQL Queries
 const _getAllByProjectId = (projectId) => sql`select ${Dataset.fieldlist} from datasets WHERE "projectId" = ${projectId}`;
 
-const _createDatasetSql = dataset => sql`
-INSERT INTO datasets VALUES 
-(nextval(pg_get_serial_sequence('datasets', 'id')), ${dataset.name}, ${dataset.projectId}, 0) 
-ON CONFLICT ON CONSTRAINT datasets_name_projectid_unique 
-DO UPDATE SET "revisionNumber" = datasets."revisionNumber" + 1`;
-
-const _createOrMerge = (dataset, fields) => (isNilOrEmpty(fields) ? _createDatasetSql(dataset) : sql`
-WITH ds AS (
-    ${_createDatasetSql(dataset)} 
+const _insertDatasetDef = (dataset, withDsDefsCTE) => sql`
+  WITH ds AS (
+    INSERT INTO datasets VALUES 
+    (nextval(pg_get_serial_sequence('datasets', 'id')), ${dataset.name}, ${dataset.projectId}, 0) 
+    ON CONFLICT ON CONSTRAINT datasets_name_projectid_unique 
+    DO UPDATE SET "revisionNumber" = datasets."revisionNumber" + 1
     RETURNING *
-),
+  )
+  ${raw(withDsDefsCTE ? ', ds_defs AS (': '')}
+    INSERT INTO dataset_defs
+    SELECT ds.id, ${dataset.aux.formDefId} FROM ds
+    ON CONFLICT ON CONSTRAINT dataset_defs_datasetid_formdefid_unique 
+    DO NOTHING
+  ${raw(withDsDefsCTE ? '),' : '')}
+`;
+
+const _createOrMerge = (dataset, fields) => (isNilOrEmpty(fields) ? _insertDatasetDef(dataset, false) : sql`
+${_insertDatasetDef(dataset, true)}
 fields("propertyName", "formDefId", path) AS (VALUES      
   ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.formDefId, p.path], sql`,`)} )`), sql`,`)}
 ),

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -61,9 +61,9 @@ const _insertDatasetDef = (dataset, withDsDefsCTE) => sql`
     RETURNING *
   )
   ${raw(withDsDefsCTE ? ', ds_defs AS (': '')}
-    INSERT INTO dataset_defs
+    INSERT INTO dataset_form_defs
     SELECT ds.id, ${dataset.aux.formDefId} FROM ds
-    ON CONFLICT ON CONSTRAINT dataset_defs_datasetid_formdefid_unique 
+    ON CONFLICT ON CONSTRAINT dataset_form_defs_datasetid_formdefid_unique 
     DO NOTHING
   ${raw(withDsDefsCTE ? '),' : '')}
 `;

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -45,8 +45,8 @@ const _createNew = (form, def, project, publish) => ({ oneFirst, Actees, Forms }
   Actees.provision('form', project)
     .then((actee) => oneFirst(sql`
 with def as
-  (insert into form_defs ("formId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt")
-  values (nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null})
+  (insert into form_defs ("formId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt", "managesEntities")
+  values (nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null}, ${def.managesEntities})
   returning *),
 form as
   (insert into forms (id, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "createdAt")
@@ -64,7 +64,7 @@ const createNew = (partial, project, publish = false) => ({ run, Datasets, FormA
     getDataset(partial.xml)
   ])
     // eslint-disable-next-line no-unused-vars
-    .then(([ keyId, fields, dataset ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
+    .then(([ keyId, fields, dataset ]) => Forms._createNew(partial, partial.def.with({ keyId, managesEntities: dataset.isDefined() }), project, publish)
       .then((savedForm) => {
         const ids = { formId: savedForm.id, formDefId: savedForm.def.id };
         return Promise.all([
@@ -106,43 +106,44 @@ const createVersion = (partial, form, publish = false) => ({ run, one, Datasets,
   if (form.xmlFormId !== partial.xmlFormId)
     return reject(Problem.user.unexpectedValue({ field: 'xmlFormId', value: partial.xmlFormId, reason: 'does not match the form you are updating' }));
 
-  return Promise.all([
-    // ensure the encryption key exists, then make sure our new def is in the
-    // database, and mark it as either draft or current.
-    partial.aux.key.map(Keys.ensure).orElse(resolve(null))
-      .then((keyId) => partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId }))
-      .then((def) => ((publish === true)
-        ? def.with({ publishedAt: new Date(), xml: partial.xml })
-        : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
-      .then(compose(one, insert))
-      .then(ignoringResult((savedDef) => ((publish === true)
-        ? Forms._update(form, { currentDefId: savedDef.id })
-        : Forms._update(form, { draftDefId: savedDef.id })))),
-    getDataset(partial.xml),
-    // process the form schema locally while everything happens
-    getFormFields(partial.xml)
-  ])
-    .then(([ savedDef, dataset, fields ]) => {
-      // deal with fields for a moment; we just need to attach a bunch of ids
-      // to them for storage.
-      const ids = { formId: form.id, formDefId: savedDef.id };
-      const fieldsForInsert = new Array(fields.length);
-      for (let i = 0; i < fields.length; i += 1)
-        fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
+  return getDataset(partial.xml).then(dataset =>
+    Promise.all([
+      // ensure the encryption key exists, then make sure our new def is in the
+      // database, and mark it as either draft or current.
+      partial.aux.key.map(Keys.ensure).orElse(resolve(null))
+        .then((keyId) => partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId }))
+        .then((def) => ((publish === true)
+          ? def.with({ publishedAt: new Date(), xml: partial.xml })
+          : def.with({ draftToken: _getDraftToken(form), xml: partial.xml }))
+          .with({ managesEntities: dataset.isDefined() }))
+        .then(compose(one, insert))
+        .then(ignoringResult((savedDef) => ((publish === true)
+          ? Forms._update(form, { currentDefId: savedDef.id })
+          : Forms._update(form, { draftDefId: savedDef.id })))),
+      // process the form schema locally while everything happens
+      getFormFields(partial.xml)
+    ])
+      .then(([ savedDef, fields ]) => {
+        // deal with fields for a moment; we just need to attach a bunch of ids
+        // to them for storage.
+        const ids = { formId: form.id, formDefId: savedDef.id };
+        const fieldsForInsert = new Array(fields.length);
+        for (let i = 0; i < fields.length; i += 1)
+          fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
 
-      return Promise.all([
-        run(insertMany(fieldsForInsert)),
-        FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
-      ])
-        .then(() => {
-          if (dataset.isDefined())
-            return Datasets.createOrMerge(
-              new Dataset({ name: dataset.get(), projectId: form.projectId }),
-              fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName }))
-            );
-        })
-        .then(always(savedDef));
-    });
+        return Promise.all([
+          run(insertMany(fieldsForInsert)),
+          FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
+        ])
+          .then(() => {
+            if (dataset.isDefined())
+              return Datasets.createOrMerge(
+                new Dataset({ name: dataset.get(), projectId: form.projectId }),
+                fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName }))
+              );
+          })
+          .then(always(savedDef));
+      }));
 };
 createVersion.audit = (newDef, partial, form, _, publish) => (log) => ((publish === true)
   ? log('form.update.publish', form, { oldDefId: form.currentDefId, newDefId: newDef.id })

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -74,7 +74,7 @@ const createNew = (partial, project, publish = false) => ({ run, Datasets, FormA
           .then(() => {
             if (dataset.isDefined())
               return Datasets.createOrMerge(
-                new Dataset({ name: dataset.get(), projectId: project.id }, {formDefId: savedForm.def.id} ),
+                new Dataset({ name: dataset.get(), projectId: project.id }, { formDefId: savedForm.def.id }),
                 fields.filter((field) => (field.propertyName)).map((field) => new Form.Field(field, { propertyName: field.propertyName }))
               );
           })
@@ -106,43 +106,43 @@ const createVersion = (partial, form, publish = false) => ({ run, one, Datasets,
   if (form.xmlFormId !== partial.xmlFormId)
     return reject(Problem.user.unexpectedValue({ field: 'xmlFormId', value: partial.xmlFormId, reason: 'does not match the form you are updating' }));
 
-  return getDataset(partial.xml).then(dataset =>
-    Promise.all([
-      // ensure the encryption key exists, then make sure our new def is in the
-      // database, and mark it as either draft or current.
-      partial.aux.key.map(Keys.ensure).orElse(resolve(null))
-        .then((keyId) => partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId }))
-        .then((def) => (publish === true)
-          ? def.with({ publishedAt: new Date(), xml: partial.xml })
-          : def.with({ draftToken: _getDraftToken(form), xml: partial.xml }))
-        .then(compose(one, insert))
-        .then(ignoringResult((savedDef) => ((publish === true)
-          ? Forms._update(form, { currentDefId: savedDef.id })
-          : Forms._update(form, { draftDefId: savedDef.id })))),
-      // process the form schema locally while everything happens
-      getFormFields(partial.xml)
-    ])
-      .then(([ savedDef, fields ]) => {
-        // deal with fields for a moment; we just need to attach a bunch of ids
-        // to them for storage.
-        const ids = { formId: form.id, formDefId: savedDef.id };
-        const fieldsForInsert = new Array(fields.length);
-        for (let i = 0; i < fields.length; i += 1)
-          fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
+  return Promise.all([
+    // ensure the encryption key exists, then make sure our new def is in the
+    // database, and mark it as either draft or current.
+    partial.aux.key.map(Keys.ensure).orElse(resolve(null))
+      .then((keyId) => partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId }))
+      .then((def) => ((publish === true)
+        ? def.with({ publishedAt: new Date(), xml: partial.xml })
+        : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
+      .then(compose(one, insert))
+      .then(ignoringResult((savedDef) => ((publish === true)
+        ? Forms._update(form, { currentDefId: savedDef.id })
+        : Forms._update(form, { draftDefId: savedDef.id })))),
+    getDataset(partial.xml),
+    // process the form schema locally while everything happens
+    getFormFields(partial.xml)
+  ])
+    .then(([ savedDef, dataset, fields ]) => {
+      // deal with fields for a moment; we just need to attach a bunch of ids
+      // to them for storage.
+      const ids = { formId: form.id, formDefId: savedDef.id };
+      const fieldsForInsert = new Array(fields.length);
+      for (let i = 0; i < fields.length; i += 1)
+        fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
 
-        return Promise.all([
-          run(insertMany(fieldsForInsert)),
-          FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
-        ])
-          .then(() => {
-            if (dataset.isDefined())
-              return Datasets.createOrMerge(
-                new Dataset({ name: dataset.get(), projectId: form.projectId }, {formDefId: savedDef.id}),
-                fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName }))
-              );
-          })
-          .then(always(savedDef));
-      }));
+      return Promise.all([
+        run(insertMany(fieldsForInsert)),
+        FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
+      ])
+        .then(() => {
+          if (dataset.isDefined())
+            return Datasets.createOrMerge(
+              new Dataset({ name: dataset.get(), projectId: form.projectId }, { formDefId: savedDef.id }),
+              fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName }))
+            );
+        })
+        .then(always(savedDef));
+    });
 };
 createVersion.audit = (newDef, partial, form, _, publish) => (log) => ((publish === true)
   ? log('form.update.publish', form, { oldDefId: form.currentDefId, newDefId: newDef.id })

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -417,7 +417,7 @@ ${extend|| sql`
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
     on form_defs."xlsBlobId"=xls.id
-  left outer join (select "formDefId", count(1) > 0 "hasDataset" from dataset_defs group by "formDefId") as dd
+  left outer join (select "formDefId", count(1) > 0 "entityRelated" from dataset_form_defs group by "formDefId") as dd
     on form_defs.id = dd."formDefId"`}
 ${(actorId == null) ? sql`` : sql`
 inner join

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -45,8 +45,8 @@ const _createNew = (form, def, project, publish) => ({ oneFirst, Actees, Forms }
   Actees.provision('form', project)
     .then((actee) => oneFirst(sql`
 with def as
-  (insert into form_defs ("formId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt", "managesEntities")
-  values (nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null}, ${def.managesEntities})
+  (insert into form_defs ("formId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt")
+  values (nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null})
   returning *),
 form as
   (insert into forms (id, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "createdAt")
@@ -64,7 +64,7 @@ const createNew = (partial, project, publish = false) => ({ run, Datasets, FormA
     getDataset(partial.xml)
   ])
     // eslint-disable-next-line no-unused-vars
-    .then(([ keyId, fields, dataset ]) => Forms._createNew(partial, partial.def.with({ keyId, managesEntities: dataset.isDefined() }), project, publish)
+    .then(([ keyId, fields, dataset ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
       .then((savedForm) => {
         const ids = { formId: savedForm.id, formDefId: savedForm.def.id };
         return Promise.all([
@@ -74,7 +74,7 @@ const createNew = (partial, project, publish = false) => ({ run, Datasets, FormA
           .then(() => {
             if (dataset.isDefined())
               return Datasets.createOrMerge(
-                new Dataset({ name: dataset.get(), projectId: project.id }),
+                new Dataset({ name: dataset.get(), projectId: project.id }, {formDefId: savedForm.def.id} ),
                 fields.filter((field) => (field.propertyName)).map((field) => new Form.Field(field, { propertyName: field.propertyName }))
               );
           })
@@ -112,10 +112,9 @@ const createVersion = (partial, form, publish = false) => ({ run, one, Datasets,
       // database, and mark it as either draft or current.
       partial.aux.key.map(Keys.ensure).orElse(resolve(null))
         .then((keyId) => partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId }))
-        .then((def) => ((publish === true)
+        .then((def) => (publish === true)
           ? def.with({ publishedAt: new Date(), xml: partial.xml })
           : def.with({ draftToken: _getDraftToken(form), xml: partial.xml }))
-          .with({ managesEntities: dataset.isDefined() }))
         .then(compose(one, insert))
         .then(ignoringResult((savedDef) => ((publish === true)
           ? Forms._update(form, { currentDefId: savedDef.id })
@@ -138,7 +137,7 @@ const createVersion = (partial, form, publish = false) => ({ run, one, Datasets,
           .then(() => {
             if (dataset.isDefined())
               return Datasets.createOrMerge(
-                new Dataset({ name: dataset.get(), projectId: form.projectId }),
+                new Dataset({ name: dataset.get(), projectId: form.projectId }, {formDefId: savedDef.id}),
                 fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName }))
               );
           })
@@ -417,7 +416,9 @@ ${extend|| sql`
     on forms."acteeId"=audits."acteeId"
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
-    on form_defs."xlsBlobId"=xls.id`}
+    on form_defs."xlsBlobId"=xls.id
+  left outer join (select "formDefId", count(1) > 0 "hasDataset" from dataset_defs group by "formDefId") as dd
+    on form_defs.id = dd."formDefId"`}
 ${(actorId == null) ? sql`` : sql`
 inner join
   (select id, max(assignment."showDraft") as "showDraft" from projects

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -43,7 +43,14 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
           .then(({ body }) => {
             body.should.be.a.Form();
             body.xmlFormId.should.equal('simpleEntity');
-            body.managesEntities.should.equal(true);
+
+            return asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
+              .set('X-Extended-Metadata', 'true')
+              .expect(200)
+              .then(({ body }) => {
+                body.should.be.a.Form();
+                body.hasDataset.should.equal(true);
+              });
           }))));
 
     it('should accept entity form and save dataset with no binds', testService((service) => {
@@ -87,9 +94,10 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
           .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
             .expect(200)
             .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
+              .set('X-Extended-Metadata', 'true')
               .expect(200)
               .then(({ body }) => {
-                body.managesEntities.should.equal(true);
+                body.hasDataset.should.equal(true);
               }))));
 
       // Get all datasets by projectId

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -47,9 +47,9 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
             return asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
               .set('X-Extended-Metadata', 'true')
               .expect(200)
-              .then(({ body }) => {
-                body.should.be.a.Form();
-                body.hasDataset.should.equal(true);
+              .then(({ body: getBody }) => {
+                getBody.should.be.a.Form();
+                getBody.hasDataset.should.equal(true);
               });
           }))));
 

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -43,6 +43,7 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
           .then(({ body }) => {
             body.should.be.a.Form();
             body.xmlFormId.should.equal('simpleEntity');
+            body.managesEntities.should.equal(true);
           }))));
 
     it('should accept entity form and save dataset with no binds', testService((service) => {
@@ -84,7 +85,12 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
           .set('Content-Type', 'application/xml')
           .expect(200)
           .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
-            .expect(200)));
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
+              .expect(200)
+              .then(({ body }) => {
+                body.managesEntities.should.equal(true);
+              }))));
 
       // Get all datasets by projectId
       const datasetId = await Datasets.getAllByProjectId(1)

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -49,7 +49,7 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
               .expect(200)
               .then(({ body: getBody }) => {
                 getBody.should.be.a.Form();
-                getBody.hasDataset.should.equal(true);
+                getBody.entityRelated.should.equal(true);
               });
           }))));
 
@@ -97,7 +97,7 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
               .set('X-Extended-Metadata', 'true')
               .expect(200)
               .then(({ body }) => {
-                body.hasDataset.should.equal(true);
+                body.entityRelated.should.equal(true);
               }))));
 
       // Get all datasets by projectId

--- a/test/integration/model/query/dataset.js
+++ b/test/integration/model/query/dataset.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-dynamic-require */
 const appRoot = require('app-root-path');
 const { Form } = require('../../../../lib/model/frames');
+const { QueryOptions } = require('../../../../lib/util/db');
 const { testService } = require(appRoot + '/test/integration/setup');
 const { Dataset } = require(appRoot + '/lib/model/frames/dataset');
 const testData = require(appRoot + '/test/data/xml');
@@ -13,7 +14,7 @@ describe('datasets', () => {
   describe('create', () => {
     it('should create a dataset', testService(async (service, { Datasets, Forms }) => {
 
-      const ds = new Dataset({ name: 'people', projectId: 1 });
+      const ds = new Dataset({ name: 'people', projectId: 1 }, {formDefId: 1});
 
       const fields = [
         new Form.Field({ formDefId: 1, path: '/name' }, { propertyName: 'p1' }),
@@ -65,7 +66,7 @@ describe('datasets', () => {
   describe('get fields', () => {
     it('should get the fields for a specific form def (needed for parsing a submission)', testService(async (service, { Datasets }) => {
 
-      const ds = new Dataset({ name: 'people', projectId: 1 });
+      const ds = new Dataset({ name: 'people', projectId: 1 }, {formDefId: 1});
       const fields = [
         new Form.Field({ formDefId: 1, path: '/name' }, { propertyName: 'p1' }),
         new Form.Field({ formDefId: 1, path: '/age' }, { propertyName: 'p2' })

--- a/test/integration/model/query/dataset.js
+++ b/test/integration/model/query/dataset.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-dynamic-require */
 const appRoot = require('app-root-path');
 const { Form } = require('../../../../lib/model/frames');
-const { QueryOptions } = require('../../../../lib/util/db');
 const { testService } = require(appRoot + '/test/integration/setup');
 const { Dataset } = require(appRoot + '/lib/model/frames/dataset');
 const testData = require(appRoot + '/test/data/xml');
@@ -14,7 +13,7 @@ describe('datasets', () => {
   describe('create', () => {
     it('should create a dataset', testService(async (service, { Datasets, Forms }) => {
 
-      const ds = new Dataset({ name: 'people', projectId: 1 }, {formDefId: 1});
+      const ds = new Dataset({ name: 'people', projectId: 1 }, { formDefId: 1 });
 
       const fields = [
         new Form.Field({ formDefId: 1, path: '/name' }, { propertyName: 'p1' }),
@@ -66,7 +65,7 @@ describe('datasets', () => {
   describe('get fields', () => {
     it('should get the fields for a specific form def (needed for parsing a submission)', testService(async (service, { Datasets }) => {
 
-      const ds = new Dataset({ name: 'people', projectId: 1 }, {formDefId: 1});
+      const ds = new Dataset({ name: 'people', projectId: 1 }, { formDefId: 1 });
       const fields = [
         new Form.Field({ formDefId: 1, path: '/name' }, { propertyName: 'p1' }),
         new Form.Field({ formDefId: 1, path: '/age' }, { propertyName: 'p2' })


### PR DESCRIPTION
Added dataset_form_defs table that maintains relationship between datasets and form definitions
Added `entityRelated` flag in /forms/:id API, this flag will help frontend to know which forms has associated dataset i.e. it creates, updates or delete entities

#### What has been done to verify that this works as intended?
Updated integration tests

#### Why is this the best possible solution? Were any other approaches considered?
I could have used ds_property_fields table to check if there's a mapping for a given form definition but that would not work for those forms which are related to a dataset without creating any properties.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
GET form APIs now return `entityRelated` flag, ensure frontend doesn't break with this new flag

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
next PR

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [NA] verified that any code from external sources are properly credited in comments