### PR TITLE
new: API Get form/formXmlId/draft/dataset

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -11,7 +11,7 @@ const { sql } = require('slonik');
 const { raw } = require('slonik-sql-tag-raw');
 const { unjoiner } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
-const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either } = require('ramda');
+const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either, prop, reduceBy } = require('ramda');
 const { construct } = require('../../util/util');
 
 // It removes prefix from all the key of an object
@@ -145,4 +145,43 @@ ORDER BY form_fields."order"
 `)
   .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName }))); // TODO augment this field so it also has the property name
 
-module.exports = { createOrMerge, getById, getAllByProjectId, getFieldsByFormDefId };
+const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
+  WITH form AS (
+    SELECT * FROM forms WHERE "xmlFormId" = ${formDefId}
+  ),
+  ds AS (
+    SELECT id, name, CASE WHEN sum(formStatus) > 0 THEN 'Published' ELSE 'Draft' END status FROM (
+      SELECT d.id, d.name, all_dd."formDefId", CASE WHEN all_f."draftDefId" IS NULL THEN 1 ELSE 0 END formStatus 
+      FROM form f 
+      JOIN dataset_defs dd ON dd."formDefId" = f."draftDefId"  
+      JOIN datasets d ON d.id = dd."datasetId" 
+      JOIN dataset_defs all_dd ON all_dd."datasetId" = d.id 
+      JOIN forms all_f ON all_f."draftDefId" = all_dd."formDefId" OR all_f."currentDefId" = all_dd."formDefId" 
+    ) dsInfo
+    GROUP BY id, name
+  ),
+  properties AS (
+    SELECT dp.*, dpf.*, CASE WHEN pf."draftDefId" IS NULL THEN 1 ELSE 0 END pfStatus FROM ds_properties dp 
+    JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id 
+    JOIN forms pf ON pf."draftDefId" = dpf."formDefId" OR pf."currentDefId" = dpf."formDefId"  
+    JOIN ds ON ds.id = dp."datasetId"
+  ),
+  propertyStatus AS (
+    SELECT "datasetId", name, CASE WHEN sum(pfStatus) > 0 THEN 'Published' ELSE 'Draft' END status
+    FROM properties
+    GROUP BY "datasetId", name
+  )
+  SELECT ds.name "datasetName", p.name "propertyName" FROM form
+  CROSS JOIN ds
+  LEFT JOIN (
+    SELECT p.* FROM properties p 
+    JOIN propertyStatus ps ON ps.name = p.name AND ps."datasetId" = p."datasetId" AND ps.status = 'Draft'
+  ) p ON ds.id = p."datasetId" AND form."draftDefId" = p."formDefId"
+  WHERE p.name IS NOT NULL OR ds.status = 'Draft'
+`).then(reduceBy((acc, {propertyName}) => acc.concat(propertyName), [], prop('datasetName')))
+.then(r => Object.keys(r).map(k => ({datasetName:k, properties: r[k]})));
+
+module.exports = { 
+  createOrMerge, getById, getAllByProjectId, 
+  getFieldsByFormDefId, getDatasetDelta
+ };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -145,7 +145,7 @@ ORDER BY form_fields."order"
 `)
   .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName }))); // TODO augment this field so it also has the property name
 
-const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
+const getDatasetDiff = (formDefId) => ({ all }) => all(sql`
   WITH form AS (
     SELECT * FROM forms WHERE "xmlFormId" = ${formDefId}
   ),
@@ -186,5 +186,5 @@ const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
 
 module.exports = {
   createOrMerge, getById, getAllByProjectId,
-  getFieldsByFormDefId, getDatasetDelta
+  getFieldsByFormDefId, getDatasetDiff
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -181,7 +181,7 @@ const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
   ORDER BY p.name
 `)
 // AND ps.status = 'Draft'
-.then(reduceBy((acc, { propertyName, isPropertyNew }) => (propertyName ? acc.concat({name: propertyName, isNew: isPropertyNew}) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
+  .then(reduceBy((acc, { propertyName, isPropertyNew }) => (propertyName ? acc.concat({ name: propertyName, isNew: isPropertyNew }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
   .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: k.split(',')[1] === 'true', properties: r[k] })));
 
 module.exports = {

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -151,19 +151,19 @@ const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
   ),
   ds AS (
     SELECT id, name, CASE WHEN sum(formStatus) > 0 THEN 'Published' ELSE 'Draft' END status FROM (
-      SELECT d.id, d.name, all_dd."formDefId", CASE WHEN all_f."draftDefId" IS NULL THEN 1 ELSE 0 END formStatus 
+      SELECT d.id, d.name, all_dd."formDefId", CASE WHEN all_fd."publishedAt" IS NULL THEN 0 ELSE 1 END formStatus 
       FROM form f 
-      JOIN dataset_defs dd ON dd."formDefId" = f."draftDefId"  
+      JOIN dataset_form_defs dd ON dd."formDefId" = f."draftDefId"  
       JOIN datasets d ON d.id = dd."datasetId" 
-      JOIN dataset_defs all_dd ON all_dd."datasetId" = d.id 
-      JOIN forms all_f ON all_f."draftDefId" = all_dd."formDefId" OR all_f."currentDefId" = all_dd."formDefId" 
+      JOIN dataset_form_defs all_dd ON all_dd."datasetId" = d.id 
+      JOIN form_defs all_fd ON all_fd.id = all_dd."formDefId"
     ) dsInfo
     GROUP BY id, name
   ),
   properties AS (
-    SELECT dp.*, dpf.*, CASE WHEN pf."draftDefId" IS NULL THEN 1 ELSE 0 END pfStatus FROM ds_properties dp 
+    SELECT dp.*, dpf.*, CASE WHEN pfd."publishedAt" IS NULL THEN 0 ELSE 1 END pfStatus FROM ds_properties dp 
     JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id 
-    JOIN forms pf ON pf."draftDefId" = dpf."formDefId" OR pf."currentDefId" = dpf."formDefId"  
+    JOIN form_defs pfd ON pfd.id = dpf."formDefId" 
     JOIN ds ON ds.id = dp."datasetId"
   ),
   propertyStatus AS (
@@ -178,10 +178,10 @@ const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
     JOIN propertyStatus ps ON ps.name = p.name AND ps."datasetId" = p."datasetId" AND ps.status = 'Draft'
   ) p ON ds.id = p."datasetId" AND form."draftDefId" = p."formDefId"
   WHERE p.name IS NOT NULL OR ds.status = 'Draft'
-`).then(reduceBy((acc, {propertyName}) => acc.concat(propertyName), [], prop('datasetName')))
-.then(r => Object.keys(r).map(k => ({datasetName:k, properties: r[k]})));
+`).then(reduceBy((acc, { propertyName }) => (propertyName ? acc.concat(propertyName) : acc), [], prop('datasetName')))
+  .then(r => Object.keys(r).map(k => ({ datasetName: k, properties: r[k] })));
 
-module.exports = { 
-  createOrMerge, getById, getAllByProjectId, 
+module.exports = {
+  createOrMerge, getById, getAllByProjectId,
   getFieldsByFormDefId, getDatasetDelta
- };
+};

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -150,7 +150,7 @@ const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
     SELECT * FROM forms WHERE "xmlFormId" = ${formDefId}
   ),
   ds AS (
-    SELECT id, name, CASE WHEN sum(formStatus) > 0 THEN 'Published' ELSE 'Draft' END status FROM (
+    SELECT id, name, sum(formStatus) <= 0 "isNew" FROM (
       SELECT d.id, d.name, all_dd."formDefId", CASE WHEN all_fd."publishedAt" IS NULL THEN 0 ELSE 1 END formStatus 
       FROM form f 
       JOIN dataset_form_defs dd ON dd."formDefId" = f."draftDefId"  
@@ -167,19 +167,22 @@ const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
     JOIN ds ON ds.id = dp."datasetId"
   ),
   propertyStatus AS (
-    SELECT "datasetId", name, CASE WHEN sum(pfStatus) > 0 THEN 'Published' ELSE 'Draft' END status
+    SELECT "datasetId", name, sum(pfStatus) <= 0 "isNew"
     FROM properties
     GROUP BY "datasetId", name
   )
-  SELECT ds.name "datasetName", ds.status "datasetStatus", p.name "propertyName" FROM form
+  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew" FROM form
   CROSS JOIN ds
   LEFT JOIN (
-    SELECT p.* FROM properties p 
-    JOIN propertyStatus ps ON ps.name = p.name AND ps."datasetId" = p."datasetId" AND ps.status = 'Draft'
+    SELECT p.*, ps."isNew" "isNew" FROM properties p 
+    JOIN propertyStatus ps ON ps.name = p.name AND ps."datasetId" = p."datasetId" 
   ) p ON ds.id = p."datasetId" AND form."draftDefId" = p."formDefId"
-  WHERE p.name IS NOT NULL OR ds.status = 'Draft'
-`).then(reduceBy((acc, { propertyName }) => (propertyName ? acc.concat(propertyName) : acc), [], (row) => `${row.datasetName},${row.datasetStatus}`))
-  .then(r => Object.keys(r).map(k => ({ datasetName: k.split(',')[0], datasetStatus: k.split(',')[1], properties: r[k] })));
+  WHERE p.name IS NOT NULL OR ds."isNew"
+  ORDER BY p.name
+`)
+// AND ps.status = 'Draft'
+.then(reduceBy((acc, { propertyName, isPropertyNew }) => (propertyName ? acc.concat({name: propertyName, isNew: isPropertyNew}) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
+  .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: k.split(',')[1] === 'true', properties: r[k] })));
 
 module.exports = {
   createOrMerge, getById, getAllByProjectId,

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -11,7 +11,7 @@ const { sql } = require('slonik');
 const { raw } = require('slonik-sql-tag-raw');
 const { unjoiner } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
-const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either, prop, reduceBy } = require('ramda');
+const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either, reduceBy } = require('ramda');
 const { construct } = require('../../util/util');
 
 // It removes prefix from all the key of an object
@@ -171,15 +171,15 @@ const getDatasetDelta = (formDefId) => ({ all }) => all(sql`
     FROM properties
     GROUP BY "datasetId", name
   )
-  SELECT ds.name "datasetName", p.name "propertyName" FROM form
+  SELECT ds.name "datasetName", ds.status "datasetStatus", p.name "propertyName" FROM form
   CROSS JOIN ds
   LEFT JOIN (
     SELECT p.* FROM properties p 
     JOIN propertyStatus ps ON ps.name = p.name AND ps."datasetId" = p."datasetId" AND ps.status = 'Draft'
   ) p ON ds.id = p."datasetId" AND form."draftDefId" = p."formDefId"
   WHERE p.name IS NOT NULL OR ds.status = 'Draft'
-`).then(reduceBy((acc, { propertyName }) => (propertyName ? acc.concat(propertyName) : acc), [], prop('datasetName')))
-  .then(r => Object.keys(r).map(k => ({ datasetName: k, properties: r[k] })));
+`).then(reduceBy((acc, { propertyName }) => (propertyName ? acc.concat(propertyName) : acc), [], (row) => `${row.datasetName},${row.datasetStatus}`))
+  .then(r => Object.keys(r).map(k => ({ datasetName: k.split(',')[0], datasetStatus: k.split(',')[1], properties: r[k] })));
 
 module.exports = {
   createOrMerge, getById, getAllByProjectId,

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -22,5 +22,5 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form)) // what verb is required here? a new one
       .then(ensureFormDef)
-      .then(() => Datasets.getDatasetDelta(params.id))));
+      .then(() => Datasets.getDatasetDiff(params.id))));
 };

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -7,6 +7,8 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 const { getOrNotFound } = require('../util/promise');
+const { Form } = require('../model/frames');
+const { ensureFormDef } = require('../util/db');
 
 module.exports = (service, endpoint) => {
   service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
@@ -14,4 +16,11 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.read', project)) // TODO change the verb
       .then(() => Datasets.getAllByProjectId(params.id))));
+
+  service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets }, { params, auth }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('form.update', form)) // what verb is required here? a new one
+      .then(ensureFormDef)
+      .then(() => Datasets.getDatasetDelta(params.id))));
 };

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -232,6 +232,14 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then(ensureDef));
 
+  ////////////////////////////////////////
+  // DATASET RELATED ENDPOINTS
+  service.get('/projects/:projectId/forms/:id/draft/dataset', endpoint(({ Forms, Datasets }, { params, auth, query }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('form.update', form)) // what verb is required here? a new one
+      .then(ensureDef)
+      .then(() => Datasets.getDatasetDelta(params.id))));
 
   ////////////////////////////////////////
   // PRIMARY-FORM SPECIFIC ENDPOINTS

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -234,7 +234,7 @@ module.exports = (service, endpoint) => {
 
   ////////////////////////////////////////
   // DATASET RELATED ENDPOINTS
-  service.get('/projects/:projectId/forms/:id/draft/dataset', endpoint(({ Forms, Datasets }, { params, auth, query }) =>
+  service.get('/projects/:projectId/forms/:id/draft/dataset', endpoint(({ Forms, Datasets }, { params, auth }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form)) // what verb is required here? a new one

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -233,15 +233,6 @@ module.exports = (service, endpoint) => {
       .then(ensureDef));
 
   ////////////////////////////////////////
-  // DATASET RELATED ENDPOINTS
-  service.get('/projects/:projectId/forms/:id/draft/dataset', endpoint(({ Forms, Datasets }, { params, auth }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
-      .then(getOrNotFound)
-      .then((form) => auth.canOrReject('form.update', form)) // what verb is required here? a new one
-      .then(ensureDef)
-      .then(() => Datasets.getDatasetDelta(params.id))));
-
-  ////////////////////////////////////////
   // PRIMARY-FORM SPECIFIC ENDPOINTS
 
   service.patch('/projects/:projectId/forms/:id', endpoint(({ Forms }, { auth, params, body }) =>

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -11,11 +11,11 @@ const { inspect } = require('util');
 const { merge, pick, always } = require('ramda');
 const { sql } = require('slonik');
 const { raw } = require('slonik-sql-tag-raw');
-const { reject } = require('./promise');
+const { reject, rejectIf } = require('./promise');
 const Problem = require('./problem');
 const Option = require('./option');
 const { PartialPipe, mapStream } = require('./stream');
-const { construct } = require('./util');
+const { construct, noargs } = require('./util');
 const { isTrue, isFalse } = require('./http');
 
 
@@ -439,12 +439,14 @@ const postgresErrorToProblem = (x) => {
   return reject(error);
 };
 
+// To ensure the form we fetched successfully joined to the intended def.
+const ensureFormDef = rejectIf(((form) => form.def.id == null), noargs(Problem.user.notFound));
 
 module.exports = {
   connectionString, connectionObject,
   unjoiner, extender, equals, page, queryFuncs,
   insert, insertMany, updater, markDeleted, markUndeleted,
-  QueryOptions,
+  QueryOptions, ensureFormDef,
   postgresErrorToProblem
 };
 

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -113,7 +113,7 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
   });
 });
 
-describe.only('api: /projects/:id/forms/draft/dataset', () => {
+describe('api: /projects/:id/forms/draft/dataset', () => {
 
   it('should return all properties of dataset', testService(async (service) => {
     // Upload a form and then create a new draft version
@@ -128,6 +128,7 @@ describe.only('api: /projects/:id/forms/draft/dataset', () => {
             body.should.be.eql([
               {
                 datasetName: 'people',
+                datasetStatus: 'Draft',
                 properties: ['name', 'age']
               }
             ]);
@@ -169,6 +170,7 @@ describe.only('api: /projects/:id/forms/draft/dataset', () => {
             .then(({ body }) => {
               body.should.be.eql([{
                 datasetName: 'people',
+                datasetStatus: 'Published',
                 properties: ['firstName']
               }]);
             }))));
@@ -186,6 +188,7 @@ describe.only('api: /projects/:id/forms/draft/dataset', () => {
           .then(({ body }) => {
             body.should.be.eql([{
               datasetName: 'people',
+              datasetStatus: 'Draft',
               properties: []
             }]);
           })));

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -112,3 +112,24 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
     }));
   });
 });
+
+describe('api: /projects/:id/forms/draft/dataset', () => {
+  it('should return all properties of dataset', testService(async (service, { Datasets }) => {
+    // Upload a form and then create a new draft version
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft/dataset')
+          .expect(200)
+          .then(({ body }) => {            
+            body.should.be.eql([
+              {
+                datasetName: 'people',
+                properties: ['name', 'age']
+              }
+            ]);
+          })));
+  }));
+});

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -127,9 +127,12 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
           .then(({ body }) => {
             body.should.be.eql([
               {
-                datasetName: 'people',
-                datasetStatus: 'Draft',
-                properties: ['name', 'age']
+                name: 'people',
+                isNew: true,
+                properties: [
+                  { name: 'age', isNew: true },
+                  { name: 'name', isNew: true }
+                ]
               }
             ]);
           })));
@@ -149,6 +152,20 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
             .expect(200)
             .then(({ body }) => {
               body.should.be.eql([
+                {
+                  name: 'people',
+                  isNew: false,
+                  properties: [
+                    {
+                      name: 'age',
+                      isNew: false
+                    },
+                    {
+                      name: 'name',
+                      isNew: false
+                    }
+                  ]
+                }
               ]);
             }))));
   }));
@@ -169,9 +186,12 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
             .expect(200)
             .then(({ body }) => {
               body.should.be.eql([{
-                datasetName: 'people',
-                datasetStatus: 'Published',
-                properties: ['firstName']
+                name: 'people',
+                isNew: false,
+                properties: [
+                  { name: 'age', isNew: false },
+                  { name: 'firstName', isNew: true }
+                ]
               }]);
             }))));
   }));
@@ -187,8 +207,8 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
           .expect(200)
           .then(({ body }) => {
             body.should.be.eql([{
-              datasetName: 'people',
-              datasetStatus: 'Draft',
+              name: 'people',
+              isNew: true,
               properties: []
             }]);
           })));

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -122,7 +122,7 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
         .send(testData.forms.simpleEntity)
         .set('Content-Type', 'application/xml')
         .expect(200)
-        .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft/dataset')
+        .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft/dataset-diff')
           .expect(200)
           .then(({ body }) => {
             body.should.be.eql([
@@ -138,7 +138,7 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
           })));
   }));
 
-  it('should return nothing if dataset and all properties already exist', testService(async (service) => {
+  it('should return all properties with isNew to be false', testService(async (service) => {
     // Upload a form and then create a new draft version
     await service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms?publish=true')
@@ -148,7 +148,7 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
         .then(() => asAlice.post('/v1/projects/1/forms')
           .send(testData.forms.simpleEntity.replace(/simpleEntity/, 'simpleEntity2'))
           .expect(200)
-          .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity2/draft/dataset')
+          .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity2/draft/dataset-diff')
             .expect(200)
             .then(({ body }) => {
               body.should.be.eql([
@@ -170,7 +170,7 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
             }))));
   }));
 
-  it('should return properties delta only', testService(async (service) => {
+  it('should return all properties with appropriate value of isNew', testService(async (service) => {
     // Upload a form and then create a new draft version
     await service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms?publish=true')
@@ -182,7 +182,7 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
             .replace(/simpleEntity/, 'simpleEntity2')
             .replace(/saveto="name"/, 'saveto="firstName"'))
           .expect(200)
-          .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity2/draft/dataset')
+          .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity2/draft/dataset-diff')
             .expect(200)
             .then(({ body }) => {
               body.should.be.eql([{
@@ -203,7 +203,7 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
         .send(testData.forms.simpleEntity.replace(/entities:saveto="\w+"/g, ''))
         .set('Content-Type', 'application/xml')
         .expect(200)
-        .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft/dataset')
+        .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft/dataset-diff')
           .expect(200)
           .then(({ body }) => {
             body.should.be.eql([{

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -214,4 +214,17 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
           })));
   }));
 
+  it('should return empty array if there is no dataset defined', testService(async (service) => {
+    // Upload a form and then create a new draft version
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simple.replace(/simple/, 'simple2'))
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.get('/v1/projects/1/forms/simple2/draft/dataset-diff')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.eql([]);
+          })));
+  }));
 });


### PR DESCRIPTION
### Changes
Added a new API that return dataset information for a draft form
Endpoint: GET /v1/projects/1/forms/formXmlId/draft/dataset 
Returns an array of all the datasets and their properties that will be created by publishing the given draft form. If the dataset is already there then `properties` field will contained only properties delta i.e. only properties that will be created by publishing the given draft form. Response also returns `datasetStatus` ; possible values are 1) `Draft` means dataset will be created 2) `Published` means dataset is already there and given properties will be added.

This API will be consumed by frontend to display dialog box when user is publishing a draft form that has entityRelated definition.

#### What has been done to verify that this works as intended?
Integration tests

#### Why is this the best possible solution? Were any other approaches considered?
Alternative was to return current and future state of dataset definition and let frontend do the heavy lifting. Implemented approach does the comparison at database level and returns simple response that makes the life of frontend quite easy.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
none

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
In a separate PR

#### Before submitting this PR, please make sure you have:

- [X] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [NA] verified that any code from external sources are properly credited in comments