### PR TITLE
new: API GET /projects/id/datasets

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -65,6 +65,7 @@ module.exports = (container) => {
   require('../resources/backup')(service, endpoint);
   require('../resources/comments')(service, endpoint);
   require('../resources/analytics')(service, endpoint);
+  require('../resources/datasets')(service, endpoint);
 
   ////////////////////////////////////////////////////////////////////////////////
   // POSTRESOURCE HANDLERS

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -50,7 +50,12 @@ const isNilOrEmpty = either(isNil, isEmpty);
 
 ////////////////////////////////////////////////////////////////////////////////
 // SQL Queries
-const _getAllByProjectId = (projectId) => sql`select ${Dataset.fieldlist} from datasets WHERE "projectId" = ${projectId}`;
+const _getAllByProjectId = (projectId) => sql`
+  SELECT DISTINCT d.* FROM datasets d 
+  JOIN dataset_defs dd ON d.id = dd."datasetId" 
+  JOIN form_defs fd ON fd.id = dd."formDefId" 
+  WHERE fd."publishedAt" IS NOT NULL AND d."projectId" = ${projectId}
+`;
 
 const _insertDatasetDef = (dataset, withDsDefsCTE) => sql`
   WITH ds AS (

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -1,0 +1,17 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+const { getOrNotFound } = require('../util/promise');
+
+module.exports = (service, endpoint) => {
+  service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
+    Projects.getById(params.id, queryOptions)
+      .then(getOrNotFound)
+      .then((project) => auth.canOrReject('project.read', project)) // TODO change the verb
+      .then(() => Datasets.getAllByProjectId(params.id))));
+};

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -32,6 +32,12 @@ module.exports = (service, endpoint) => {
         ? auth.verbsOn(project).then((verbs) => Object.assign({ verbs }, project.forApi()))
         : project))));
 
+  service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
+    Projects.getById(params.id, queryOptions)
+      .then(getOrNotFound)
+      .then((project) => auth.canOrReject('project.read', project)) // TODO change the verb
+      .then(() => Datasets.getAllByProjectId(params.id))));
+
   service.patch('/projects/:id', endpoint(({ Projects }, { auth, body, params }) =>
     Projects.getById(params.id)
       .then(getOrNotFound)

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -32,12 +32,6 @@ module.exports = (service, endpoint) => {
         ? auth.verbsOn(project).then((verbs) => Object.assign({ verbs }, project.forApi()))
         : project))));
 
-  service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
-    Projects.getById(params.id, queryOptions)
-      .then(getOrNotFound)
-      .then((project) => auth.canOrReject('project.read', project)) // TODO change the verb
-      .then(() => Datasets.getAllByProjectId(params.id))));
-
   service.patch('/projects/:id', endpoint(({ Projects }, { auth, body, params }) =>
     Projects.getById(params.id)
       .then(getOrNotFound)

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1,0 +1,39 @@
+const { testService } = require('../setup');
+const testData = require('../../data/xml');
+
+describe('projects/:id/datasets GET', () => {
+  it('should return the datasets of Default project', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() =>
+          asAlice.get('/v1/projects/1/datasets')
+            .expect(200)
+            .then(({ body }) => {
+              body.map(({ id, ...d }) => d).should.eql([
+                { name: 'people', projectId: 1, revisionNumber: 0 }
+              ]);
+            })))));
+
+  it('should not return draft datasets', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity
+            .replace(/simpleEntity/, 'simpleEntity2')
+            .replace(/people/, 'student'))
+          .expect(200)
+          .then(() =>
+            asAlice.get('/v1/projects/1/datasets')
+              .expect(200)
+              .then(({ body }) => {
+                body.map(({ id, ...d }) => d).should.eql([
+                  { name: 'student', projectId: 1, revisionNumber: 0 }
+                ]);
+              }))))));
+});

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1274,18 +1274,37 @@ describe('api: /projects', () => {
     it('should return the datasets of Default project', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.simpleEntity)
-        .set('Content-Type', 'application/xml')
-        .expect(200)
-        .then(() => 
-          asAlice.get('/v1/projects/1/datasets')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
           .expect(200)
-          .then(({ body }) => {
-            body.map(({id, ...d}) => d).should.eql([
-              {name: 'people', projectId: 1, revisionNumber: 0}
-            ]);
-          }))
-        )));      
+          .then(() =>
+            asAlice.get('/v1/projects/1/datasets')
+              .expect(200)
+              .then(({ body }) => {
+                body.map(({ id, ...d }) => d).should.eql([
+                  { name: 'people', projectId: 1, revisionNumber: 0 }
+                ]);
+              })))));
+
+    it('should not return draft datasets', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+            .send(testData.forms.simpleEntity
+              .replace(/simpleEntity/, 'simpleEntity2')
+              .replace(/people/, 'student'))
+            .expect(200)
+            .then(() =>
+              asAlice.get('/v1/projects/1/datasets')
+                .expect(200)
+                .then(({ body }) => {
+                  body.map(({ id, ...d }) => d).should.eql([
+                    { name: 'student', projectId: 1, revisionNumber: 0 }
+                  ]);
+                }))))));
   });
 });
 

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1269,6 +1269,24 @@ describe('api: /projects', () => {
                 .then((o) => { o.isDefined().should.equal(false); })
             ])))))));
   });
+
+  describe('/:id/datasets GET', () => {
+    it('should return the datasets of Default project', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => 
+          asAlice.get('/v1/projects/1/datasets')
+          .expect(200)
+          .then(({ body }) => {
+            body.map(({id, ...d}) => d).should.eql([
+              {name: 'people', projectId: 1, revisionNumber: 0}
+            ]);
+          }))
+        )));      
+  });
 });
 
 


### PR DESCRIPTION
Created new API that returns all datasets of a given project.
Endpoint: `/v1/projects/id/datasets`
Response contains only published datasets, by published I mean the corresponding form has been published

#### What has been done to verify that this works as intended?
Integration tests

#### Why is this the best possible solution? Were any other approaches considered?
hmmm

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
Will do it in a separate PR

#### Before submitting this PR, please make sure you have:

- [X] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [NA] verified that any code from external sources are properly credited in comments