### PR TITLE
Create streams only after Promise.all()

### DIFF
--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -64,12 +64,11 @@ module.exports = (service, endpoint) => {
           const options = QueryOptions.fromODataRequest(params, query);
           return Promise.all([
             Forms.getFields(form.def.id),
-            Submissions.streamForExport(form.id, draft, undefined, options),
             ((params.table === 'Submissions') && options.hasPaging())
               ? Submissions.countByFormId(form.id, draft, options) : resolve(null)
           ])
-            .then(([ fields, stream, count ]) =>
-              json(rowStreamToOData(fields, params.table, env.domain, originalUrl, query, stream, count)));
+            .then(([ fields, count ]) => Submissions.streamForExport(form.id, draft, undefined, options)
+              .then((stream) => json(rowStreamToOData(fields, params.table, env.domain, originalUrl, query, stream, count))));
         })));
   };
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -7,7 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { always, identity } = require('ramda');
+const { always, identity, call } = require('ramda');
 const multer = require('multer');
 const sanitize = require('sanitize-filename');
 const { Blob, Form, Submission } = require('../model/frames');
@@ -269,20 +269,20 @@ module.exports = (service, endpoint) => {
             const options = QueryOptions.fromSubmissionCsvRequest(query);
             return Promise.all([
               (options.deletedFields === true) ? Forms.getMergedFields(form.id) : Forms.getFields(form.def.id),
-              Submissions.streamForExport(form.id, draft, keys, options),
               (options.splitSelectMultiples !== true) ? null : Submissions.getSelectMultipleValuesForExport(form.id, draft, options),
-              SubmissionAttachments.streamForExport(form.id, draft, keys, options),
-              ClientAudits.streamForExport(form.id, draft, keys, options),
               draft ? null : Audits.log(auth.actor, 'form.submission.export', form)
-            ]).then(([ fields, rows, selectValues, attachments, clientAudits ]) => {
+            ]).then(([ fields, selectValues ]) => {
               const filename = sanitize(form.xmlFormId);
               response.append('Content-Disposition', contentDisposition(`${filename}.zip`));
               response.append('Content-Type', 'application/zip');
               return zipStreamFromParts(
                 // TODO: not 100% sure that these streams close right on crash.
-                streamBriefcaseCsvs(rows, fields, form.xmlFormId, selectValues, decryptor, false, options),
-                streamAttachments(attachments, decryptor),
-                streamClientAudits(clientAudits, form, decryptor)
+                () => Submissions.streamForExport(form.id, draft, keys, options)
+                  .then((rows) => streamBriefcaseCsvs(rows, fields, form.xmlFormId, selectValues, decryptor, false, options)),
+                () => SubmissionAttachments.streamForExport(form.id, draft, keys, options)
+                  .then((attachments) => streamAttachments(attachments, decryptor)),
+                () => ClientAudits.streamForExport(form.id, draft, keys, options)
+                  .then((clientAudits) => streamClientAudits(clientAudits, form, decryptor))
               );
             });
           }));
@@ -295,18 +295,18 @@ module.exports = (service, endpoint) => {
           const options = QueryOptions.fromSubmissionCsvRequest(query);
           return Promise.all([
             (options.deletedFields === true) ? Forms.getMergedFields(form.id) : Forms.getFields(form.def.id),
-            Submissions.streamForExport(form.id, draft, Object.keys(passphrases), options),
             (options.splitSelectMultiples !== true) ? null : Submissions.getSelectMultipleValuesForExport(form.id, draft, options),
             Keys.getDecryptor(passphrases),
             draft ? null : Audits.log(auth.actor, 'form.submission.export', form)
           ])
-            .then(([ fields, rows, selectValues, decryptor ]) => {
+            .then(([ fields, selectValues, decryptor ]) => {
               const filename = sanitize(form.xmlFormId);
               const extension = (rootOnly === true) ? 'csv' : 'csv.zip';
               response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
               response.append('Content-Type', (rootOnly === true) ? 'text/csv' : 'application/zip');
-              const envelope = (rootOnly === true) ? identity : zipStreamFromParts;
-              return envelope(streamBriefcaseCsvs(rows, fields, form.xmlFormId, selectValues, decryptor, rootOnly, options));
+              const envelope = (rootOnly === true) ? call : zipStreamFromParts;
+              return envelope(() => Submissions.streamForExport(form.id, draft, Object.keys(passphrases), options)
+                .then((rows) => streamBriefcaseCsvs(rows, fields, form.xmlFormId, selectValues, decryptor, rootOnly, options)));
             });
         });
 

--- a/lib/util/zip.js
+++ b/lib/util/zip.js
@@ -14,6 +14,7 @@
 const { Readable } = require('stream');
 const { PartialPipe } = require('./stream');
 const archiver = require('archiver');
+const { resolve } = require('./promise');
 
 // Returns an object that can add files to an archive, without having that archive
 // object directly nor knowing what else is going into it. Call append() to add a
@@ -36,8 +37,7 @@ const zipPart = () => {
 // if the final component in the pipeline emitted the error, archiver would then
 // emit it again, but if it was an intermediate component archiver wouldn't know
 // about it. by manually aborting, we always emit the error and archiver never does.
-const zipStreamFromParts = (...zipParts) => {
-  let completed = 0;
+const zipStreamFromParts = (...zipPartFns) => {
   const resultStream = archiver('zip', { zlib: { level: 9 } });
 
   // track requested callbacks and call them when they are fully added to the zip.
@@ -47,29 +47,35 @@ const zipStreamFromParts = (...zipParts) => {
     if (cb != null) cb();
   });
 
-  for (const part of zipParts) {
-    part.stream.on('data', ({ stream, options, cb }) => {
-      const s = (stream instanceof PartialPipe)
-        ? stream.pipeline((err) => { resultStream.emit('error', err); resultStream.abort(); })
-        : stream;
+  const next = () => {
+    if (zipPartFns.length === 0) {
+      resultStream.finalize();
+      return;
+    }
 
-      if (cb == null) {
-        resultStream.append(s, options);
-      } else {
-        // using the String object will result in still an empty comment, but allows
-        // separate instance equality check when the entry is recorded.
-        const sentinel = new String(); // eslint-disable-line no-new-wrappers
-        callbacks.set(sentinel, cb);
-        resultStream.append(s, Object.assign(options, { comment: sentinel }));
-      }
-    });
-    part.stream.on('error', (err) => { resultStream.emit('error', err); });
-    part.stream.on('end', () => { // eslint-disable-line no-loop-func
-      completed += 1;
-      if (completed === zipParts.length)
-        resultStream.finalize();
-    });
-  }
+    resolve(zipPartFns.shift()())
+      .then((part) => {
+        part.stream.on('data', ({ stream, options, cb }) => {
+          const s = (stream instanceof PartialPipe)
+            ? stream.pipeline((err) => { resultStream.emit('error', err); resultStream.abort(); })
+            : stream;
+
+          if (cb == null) {
+            resultStream.append(s, options);
+          } else {
+            // using the String object will result in still an empty comment, but allows
+            // separate instance equality check when the entry is recorded.
+            const sentinel = new String(); // eslint-disable-line no-new-wrappers
+            callbacks.set(sentinel, cb);
+            resultStream.append(s, Object.assign(options, { comment: sentinel }));
+          }
+        });
+        part.stream.on('error', (err) => { resultStream.emit('error', err); });
+        part.stream.on('end', next);
+      })
+      .catch((err) => { resultStream.emit('error', err); });
+  };
+  next();
 
   return resultStream;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5985,26 +5985,26 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slonik": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/slonik/-/slonik-23.6.0.tgz",
-      "integrity": "sha512-4SqZ4U9NVd6OYIsMKN2wrNbmXQqiifu54M3SP33XjXcJ8qsk2NBiwGwSGIeuW5QtRqnfNHBdgdQsNfrfMFKlag==",
+      "version": "npm:@getodk/slonik@23.6.0-1",
+      "resolved": "https://registry.npmjs.org/@getodk/slonik/-/slonik-23.6.0-1.tgz",
+      "integrity": "sha512-dZwX3lQBLkXPOfZB/RQvJ41xGWRskP4VV8eX/0y2X0DcGa43BcQwWQayEJNI8PYL6V4cse6LulPnVDdDIFSRDQ==",
       "requires": {
         "concat-stream": "^2.0.0",
         "delay": "^5.0.0",
         "es6-error": "^4.1.1",
         "get-stack-trace": "^2.0.3",
-        "hyperid": "^2.1.0",
+        "hyperid": "2.1.0",
         "is-plain-object": "^5.0.0",
         "iso8601-duration": "^1.3.0",
         "pg": "^8.5.1",
         "pg-connection-string": "^2.4.0",
         "pg-copy-streams": "^5.1.1",
-        "pg-copy-streams-binary": "^2.0.1",
+        "pg-copy-streams-binary": "2.0.1",
         "pg-cursor": "^2.5.2",
         "postgres-array": "^3.0.1",
         "postgres-interval": "^3.0.0",
-        "roarr": "^4.0.11",
-        "serialize-error": "^8.0.1",
+        "roarr": "4.0.11",
+        "serialize-error": "8.0.1",
         "through2": "^4.0.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prompt": "~1",
     "ramda": "~0",
     "sanitize-filename": "~1",
-    "slonik": "~23",
+    "slonik": "npm:@getodk/slonik@23.6.0-1",
     "slonik-sql-tag-raw": "1.0.3",
     "tmp-promise": "~3",
     "uuid": "~3",

--- a/test/unit/data/attachments.js
+++ b/test/unit/data/attachments.js
@@ -12,7 +12,7 @@ describe('.zip attachments streaming', () => {
       { row: { instanceId: 'subone', name: 'secondfile.ext', content: 'this is my second file' } },
       { row: { instanceId: 'subtwo', name: 'thirdfile.ext', content: 'this is my third file' } }
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (err, result) => {
+    zipStreamToFiles(zipStreamFromParts(() => streamAttachments(inStream)), (err, result) => {
       if(err) return done(err);
 
       result.filenames.should.eql([
@@ -35,7 +35,7 @@ describe('.zip attachments streaming', () => {
       { row: { instanceId: 'subone', name: '../secondfile.ext', content: 'this is my second file' } },
       { row: { instanceId: 'subone', name: './.secondfile.ext', content: 'this is my duplicate second file' } },
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (err, result) => {
+    zipStreamToFiles(zipStreamFromParts(() => streamAttachments(inStream)), (err, result) => {
       if(err) return done(err);
 
       result.filenames.should.eql([
@@ -52,7 +52,7 @@ describe('.zip attachments streaming', () => {
     const inStream = streamTest.fromObjects([
       { row: { instanceId: 'subone', name: 'firstfile.ext.enc', content: 'this is my first file' } }
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (err, result) => {
+    zipStreamToFiles(zipStreamFromParts(() => streamAttachments(inStream)), (err, result) => {
       if(err) return done(err);
 
       result.filenames.should.eql([ 'media/firstfile.ext.enc' ]);
@@ -64,7 +64,7 @@ describe('.zip attachments streaming', () => {
     const inStream = streamTest.fromObjects([
       { row: { instanceId: 'subone', name: 'firstfile.ext.enc', content: 'this is my first file' } }
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream, () => {})), (err, result) => {
+    zipStreamToFiles(zipStreamFromParts(() => streamAttachments(inStream, () => {})), (err, result) => {
       if(err) return done(err);
 
       result.filenames.should.eql([ 'media/firstfile.ext' ]);

--- a/test/unit/data/attachments.js
+++ b/test/unit/data/attachments.js
@@ -12,7 +12,9 @@ describe('.zip attachments streaming', () => {
       { row: { instanceId: 'subone', name: 'secondfile.ext', content: 'this is my second file' } },
       { row: { instanceId: 'subtwo', name: 'thirdfile.ext', content: 'this is my third file' } }
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (result) => {
+    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([
         'media/firstfile.ext', 
         'media/secondfile.ext', 
@@ -33,7 +35,9 @@ describe('.zip attachments streaming', () => {
       { row: { instanceId: 'subone', name: '../secondfile.ext', content: 'this is my second file' } },
       { row: { instanceId: 'subone', name: './.secondfile.ext', content: 'this is my duplicate second file' } },
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (result) => {
+    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([
         'media/firstfile.ext',
         'media/..secondfile.ext',
@@ -48,7 +52,9 @@ describe('.zip attachments streaming', () => {
     const inStream = streamTest.fromObjects([
       { row: { instanceId: 'subone', name: 'firstfile.ext.enc', content: 'this is my first file' } }
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (result) => {
+    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'media/firstfile.ext.enc' ]);
       done();
     });
@@ -58,7 +64,9 @@ describe('.zip attachments streaming', () => {
     const inStream = streamTest.fromObjects([
       { row: { instanceId: 'subone', name: 'firstfile.ext.enc', content: 'this is my first file' } }
     ]);
-    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream, () => {})), (result) => {
+    zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream, () => {})), (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'media/firstfile.ext' ]);
       done();
     });

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -60,7 +60,9 @@ describe('.csv.zip briefcase output @slow', () => {
       instance('three', '<name>Chelsea</name><age>38</age><hometown>San Francisco, CA</hometown>')
     ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -82,7 +84,7 @@ describe('.csv.zip briefcase output @slow', () => {
     }]);
 
     // not hanging is the assertion here:
-    callAndParse(inStream, testData.forms.simple, 'simple', () => { done(); });
+    callAndParse(inStream, testData.forms.simple, 'simple', (err) => { done(err); });
   });
 
   it('should attach submitter information if present', (done) => {
@@ -111,7 +113,9 @@ describe('.csv.zip briefcase output @slow', () => {
       withSubmitter(15, 'lito', instance('three', '<name>Chelsea</name><age>38</age><hometown>San Francisco, CA</hometown>'))
     ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -149,7 +153,9 @@ describe('.csv.zip briefcase output @slow', () => {
       withAttachments(3, 3, instance('three', '<name>Chelsea</name><age>38</age><hometown>San Francisco, CA</hometown>'))
     ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -186,7 +192,9 @@ describe('.csv.zip briefcase output @slow', () => {
       { ...instance('two', '<name>Bob</name><age>34</age><hometown>Portland, OR</hometown>'), reviewState: 'rejected' }
     ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -221,7 +229,9 @@ describe('.csv.zip briefcase output @slow', () => {
       { ...instance('one', 'missing'), xml: 'missing', deviceId: 'test device' }
     ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -255,7 +265,9 @@ describe('.csv.zip briefcase output @slow', () => {
     data.aux.edit.count = 3;
     const inStream = streamTest.fromObjects([ data ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -291,7 +303,9 @@ describe('.csv.zip briefcase output @slow', () => {
     two.aux.exports.formVersion = 'updated';
     const inStream = streamTest.fromObjects([ one, two ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -326,7 +340,9 @@ describe('.csv.zip briefcase output @slow', () => {
       instance('one', '<name>&#171;Alice&#187;</name><age>30</age><hometown>Seattle, WA</hometown>'),
     ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,hometown,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -362,7 +378,9 @@ describe('.csv.zip briefcase output @slow', () => {
       instance('three', '<name>Chelsea</name><age>38</age><location></location>')
     ]);
 
-    callAndParse(inStream, formXml, 'mytestform', (result) => {
+    callAndParse(inStream, formXml, 'mytestform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'mytestform.csv' ]);
       result['mytestform.csv'].should.equal(
 `SubmissionDate,name,age,location-Latitude,location-Longitude,location-Altitude,location-Accuracy,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -381,7 +399,9 @@ describe('.csv.zip briefcase output @slow', () => {
     ]);
 
     fieldsFor(testData.forms.selectMultiple).then((fields) => {
-      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] })), (result) => {
+      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] })), (err, result) => {
+        if(err) return done(err);
+
         result.filenames.should.eql([ 'selectMultiple.csv' ]);
         result['selectMultiple.csv'].should.equal(
 `SubmissionDate,q1,q1/x,q1/y,q1/z,g1-q2,g1-q2/m,g1-q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -429,7 +449,9 @@ describe('.csv.zip briefcase output @slow', () => {
       instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><home><type>House</type><address><city>San Francisco, CA</city><street>99 Mission Ave</street></address></home>'),
     ]);
 
-    callAndParse(inStream, formXml, 'structuredform', (result) => {
+    callAndParse(inStream, formXml, 'structuredform', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.eql([ 'structuredform.csv' ]);
       result['structuredform.csv'].should.equal(
 `SubmissionDate,meta-instanceID,name,home-type,home-address-street,home-address-city,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -478,7 +500,9 @@ describe('.csv.zip briefcase output @slow', () => {
     ]);
 
     fieldsFor(formXml).then((fields) => {
-      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'structuredform', undefined, undefined, false, { groupPaths: false })), (result) => {
+      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'structuredform', undefined, undefined, false, { groupPaths: false })), (err, result) => {
+        if(err) return done(err);
+
         result.filenames.should.eql([ 'structuredform.csv' ]);
         result['structuredform.csv'].should.equal(
 `SubmissionDate,instanceID,name,type,street,city,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -498,7 +522,9 @@ describe('.csv.zip briefcase output @slow', () => {
     ]);
 
     fieldsFor(testData.forms.selectMultiple).then((fields) => {
-      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] }, undefined, false, { groupPaths: false })), (result) => {
+      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] }, undefined, false, { groupPaths: false })), (err, result) => {
+        if(err) return done(err);
+
         result.filenames.should.eql([ 'selectMultiple.csv' ]);
         result['selectMultiple.csv'].should.equal(
 `SubmissionDate,q1,q1/x,q1/y,q1/z,q2,q2/m,q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -565,7 +591,9 @@ describe('.csv.zip briefcase output @slow', () => {
       instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><age>38</age><children><child><name>Candace</name><age>2</age></child></children>'),
     ]);
 
-    callAndParse(inStream, formXml, 'singlerepeat', (result) => {
+    callAndParse(inStream, formXml, 'singlerepeat', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'singlerepeat.csv', 'singlerepeat-child.csv' ]);
       result['singlerepeat.csv'].should.equal(
 `SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -627,7 +655,9 @@ Candace,2,three,three/children/child[1]
     const inStream = streamTest.fromObjects(
       (new Array(127)).fill(null).map(_ => instance(uuid(), `<orx:meta><orx:instanceID>${uuid()}</orx:instanceID></orx:meta><name>${uuid()}</name><children><child><name>${uuid()}</name></child></children>`)));
 
-    callAndParse(inStream, formXml, 'singlerepeat', (result) => {
+    callAndParse(inStream, formXml, 'singlerepeat', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'singlerepeat.csv', 'singlerepeat-child.csv' ]);
       result['singlerepeat.csv'].split('\n').length.should.equal(129);
       result['singlerepeat-child.csv'].split('\n').length.should.equal(129);
@@ -702,7 +732,9 @@ Candace,2,three,three/children/child[1]
       instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><age>38</age><children><child><name>Candace</name><toy><name>Millennium Falcon</name></toy><toy><name>X-Wing</name></toy><toy><name>Pod racer</name></toy><age>2</age></child></children>'),
     ]);
 
-    callAndParse(inStream, formXml, 'multirepeat', (result) => {
+    callAndParse(inStream, formXml, 'multirepeat', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'multirepeat.csv', 'multirepeat-child.csv', 'multirepeat-toy.csv' ]);
       result['multirepeat.csv'].should.equal(
 `SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -762,7 +794,9 @@ Pod racer,three/children/child[1],three/children/child[1]/toy[3]
       instance('one', '<name>Alice</name><children><name>Bob</name></children><children><name>Chelsea</name></children><children-status>Living at home</children-status>')
     ]);
 
-    callAndParse(inStream, formXml, 'pathprefix', (result) => {
+    callAndParse(inStream, formXml, 'pathprefix', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'pathprefix.csv', 'pathprefix-children.csv' ]);
       result['pathprefix.csv'].should.equal(
 `SubmissionDate,name,children-status,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -851,7 +885,9 @@ Chelsea,one,one/children[2]
       aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 }, exports: { formVersion: '' } }
     }]);
 
-    callAndParse(inStream, formXml, 'all-data-types', (result) => {
+    callAndParse(inStream, formXml, 'all-data-types', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'all-data-types.csv' ]);
       result['all-data-types.csv'].should.equal(
 `SubmissionDate,some_string,some_int,some_decimal,some_date,some_time,some_date_time,some_geopoint-Latitude,some_geopoint-Longitude,some_geopoint-Altitude,some_geopoint-Accuracy,some_geotrace,some_geoshape,some_barcode,meta-instanceID,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -978,7 +1014,9 @@ Chelsea,one,one/children[2]
       aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 }, exports: { formVersion: '' } }
     }]);
 
-    callAndParse(inStream, formXml, 'nested-repeats', (result) => {
+    callAndParse(inStream, formXml, 'nested-repeats', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'nested-repeats.csv', 'nested-repeats-g1.csv', 'nested-repeats-g2.csv', 'nested-repeats-g3.csv' ]);
       result['nested-repeats.csv'].should.equal(
 `SubmissionDate,meta-instanceID,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
@@ -1064,7 +1102,9 @@ some text 3.1.4,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b/g1[3]/g2[1],uuid:0a1b8
       instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><jobs><entry><name>Instantaneous Food</name></entry></jobs><friends><entry><name>Ferrence</name></entry><entry><name>Mick</name></entry></friends>'),
     ]);
 
-    callAndParse(inStream, formXml, 'ambiguous', (result) => {
+    callAndParse(inStream, formXml, 'ambiguous', (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'ambiguous.csv', 'ambiguous-entry~1.csv', 'ambiguous-entry~2.csv' ]);
       result['ambiguous.csv'].should.equal(
 `SubmissionDate,meta-instanceID,name,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -28,7 +28,7 @@ const withAttachments = (present, expected, row) => ({ ...row, aux: { ...row.aux
 
 const callAndParse = (inStream, formXml, xmlFormId, callback) => {
   fieldsFor(formXml).then((fields) => {
-    zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, xmlFormId)), callback);
+    zipStreamToFiles(zipStreamFromParts(() => streamBriefcaseCsvs(inStream, fields, xmlFormId)), callback);
   });
 };
 
@@ -399,7 +399,7 @@ describe('.csv.zip briefcase output @slow', () => {
     ]);
 
     fieldsFor(testData.forms.selectMultiple).then((fields) => {
-      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] })), (err, result) => {
+      zipStreamToFiles(zipStreamFromParts(() => streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] })), (err, result) => {
         if(err) return done(err);
 
         result.filenames.should.eql([ 'selectMultiple.csv' ]);
@@ -500,7 +500,7 @@ describe('.csv.zip briefcase output @slow', () => {
     ]);
 
     fieldsFor(formXml).then((fields) => {
-      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'structuredform', undefined, undefined, false, { groupPaths: false })), (err, result) => {
+      zipStreamToFiles(zipStreamFromParts(() => streamBriefcaseCsvs(inStream, fields, 'structuredform', undefined, undefined, false, { groupPaths: false })), (err, result) => {
         if(err) return done(err);
 
         result.filenames.should.eql([ 'structuredform.csv' ]);
@@ -522,7 +522,7 @@ describe('.csv.zip briefcase output @slow', () => {
     ]);
 
     fieldsFor(testData.forms.selectMultiple).then((fields) => {
-      zipStreamToFiles(zipStreamFromParts(streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] }, undefined, false, { groupPaths: false })), (err, result) => {
+      zipStreamToFiles(zipStreamFromParts(() => streamBriefcaseCsvs(inStream, fields, 'selectMultiple', { '/q1': [ 'x', 'y', 'z' ], '/g1/q2': [ 'm', 'n' ] }, undefined, false, { groupPaths: false })), (err, result) => {
         if(err) return done(err);
 
         result.filenames.should.eql([ 'selectMultiple.csv' ]);

--- a/test/unit/util/zip.js
+++ b/test/unit/util/zip.js
@@ -13,7 +13,9 @@ describe('zipPart streamer', () => {
     const part = zipPart();
 
     let closed = false;
-    zipStreamToFiles(zipStreamFromParts(part), (result) => {
+    zipStreamToFiles(zipStreamFromParts(part), (err, result) => {
+      if(err) return done(err);
+
       closed = true;
       done();
     });
@@ -26,7 +28,7 @@ describe('zipPart streamer', () => {
   it('should close the archive successfully given no files', (done) => {
     const part = zipPart();
     // no assertions other than verifying that done is called.
-    zipStreamToFiles(zipStreamFromParts(part), () => done());
+    zipStreamToFiles(zipStreamFromParts(part), (err) => done(err));
     part.finalize();
   });
 
@@ -93,7 +95,9 @@ describe('zipPart streamer', () => {
     const part1 = zipPart();
     const part2 = zipPart();
 
-    zipStreamToFiles(zipStreamFromParts(part1, part2), (result) => {
+    zipStreamToFiles(zipStreamFromParts(part1, part2), (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([
         'x/test1.file',
         'x/test2.file',
@@ -122,7 +126,9 @@ describe('zipPart streamer', () => {
     const part1 = zipPart();
     const part2 = zipPart();
 
-    zipStreamToFiles(zipStreamFromParts(part1, part2), (result) => {
+    zipStreamToFiles(zipStreamFromParts(part1, part2), (err, result) => {
+      if(err) return done(err);
+
       result.filenames.should.containDeep([ 'test1.file', 'test2.file' ]);
       result['test1.file'].should.equal('test static');
       result['test2.file'].should.equal('a!test!stream!');

--- a/test/util/zip.js
+++ b/test/util/zip.js
@@ -52,5 +52,7 @@ const zipStreamToFiles = (zipStream, callback) => {
   });
 };
 
-module.exports = { zipStreamToFiles };
+const pZipStreamToFiles = (zipStream) => new Promise((resolve) => zipStreamToFiles(zipStream, resolve));
+
+module.exports = { zipStreamToFiles, pZipStreamToFiles };
 


### PR DESCRIPTION
Part of a possible solution for #482, copied in part from changes in #564. See the commit message of the fourth commit for notes. The first commit is from #604. I've also cherry-picked from #542 and #553 in order to prevent a conflict with the `master` branch: this PR touches some of the same files as those PRs. When reviewing this PR, I recommend focusing on the fourth commit.

#### What has been done to verify that this works as intended?

In addition to tests, I've deployed this PR to the QA server and followed the reproduction steps in #482. I was successfully able to send 10 concurrent requests. When I sent 11 concurrent requests, one quickly resulted in an error response ("Completely unhandled exception: timeout exceeded when trying to connect"). That is expected given that the maximum number of database connections is 10. However, what's exciting is that after the 11 responses, there was no database connection leak. 🎉

I still want to write a couple more tests to get at the Promise-related behavior of `zipStreamFromParts()` that I've introduced.

#### Why is this the best possible solution? Were any other approaches considered?

I'm actually not sure that this is the best solution or that we want to ship this with v1.5.3. I've created this PR in part so that we can consider this solution further. See https://github.com/getodk/central-backend/pull/604#issuecomment-1244913740 for the three options we've been discussing for v1.5.3.

The main alternative to this solution is a utility function like the one at https://github.com/getodk/central-backend/issues/482#issuecomment-1126784318. In most places, I think this solution is clearer to reason about than what we would get with a utility function. I think the main exception is `zipStreamFromParts()`, which has become more complicated. I also think a utility function could be more performant (though I doubt by much). That said, some of the changes that #564 makes are similar to those here, so we might be heading in this direction for multiple reasons.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The hope is that this PR fixes connection leak issues. However, there's a risk of regression with each of the three streaming endpoints that the PR modifies. I think running @alxndrsn's benchmarker against this PR would help us gain confidence.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments