### PR TITLE
Destroy streams created in rejected Promise.all()

### DIFF
--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -13,6 +13,7 @@ const { QueryOptions } = require('../util/db');
 const { contentType, xml, json } = require('../util/http');
 const Problem = require('../util/problem');
 const { noargs } = require('../util/util');
+const { allWithStreams } = require('../util/stream');
 const { serviceDocumentFor, edmxFor, rowStreamToOData, singleRowToOData } = require('../formats/odata');
 
 module.exports = (service, endpoint) => {
@@ -62,7 +63,7 @@ module.exports = (service, endpoint) => {
       getForm(Forms, auth, params)
         .then((form) => {
           const options = QueryOptions.fromODataRequest(params, query);
-          return Promise.all([
+          return allWithStreams([
             Forms.getFields(form.def.id),
             Submissions.streamForExport(form.id, draft, undefined, options),
             ((params.table === 'Submissions') && options.hasPaging())

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -23,6 +23,7 @@ const { diffSubmissions } = require('../data/submission');
 const { resolve } = require('../util/promise');
 const { isBlank, noargs } = require('../util/util');
 const { zipStreamFromParts } = require('../util/zip');
+const { allWithStreams } = require('../util/stream');
 
 // multipart things:
 const multipart = multer({ storage: multer.memoryStorage() });
@@ -267,7 +268,7 @@ module.exports = (service, endpoint) => {
           .then((decryptor) => {
             const keys = Object.keys(passphrases);
             const options = QueryOptions.fromSubmissionCsvRequest(query);
-            return Promise.all([
+            return allWithStreams([
               (options.deletedFields === true) ? Forms.getMergedFields(form.id) : Forms.getFields(form.def.id),
               Submissions.streamForExport(form.id, draft, keys, options),
               (options.splitSelectMultiples !== true) ? null : Submissions.getSelectMultipleValuesForExport(form.id, draft, options),
@@ -293,7 +294,7 @@ module.exports = (service, endpoint) => {
         .then((form) => auth.canOrReject('submission.read', form))
         .then((form) => {
           const options = QueryOptions.fromSubmissionCsvRequest(query);
-          return Promise.all([
+          return allWithStreams([
             (options.deletedFields === true) ? Forms.getMergedFields(form.id) : Forms.getFields(form.def.id),
             Submissions.streamForExport(form.id, draft, Object.keys(passphrases), options),
             (options.splitSelectMultiples !== true) ? null : Submissions.getSelectMultipleValuesForExport(form.id, draft, options),

--- a/lib/util/stream.js
+++ b/lib/util/stream.js
@@ -106,11 +106,50 @@ class PartialPipe {
   pipe(out) { return reduce(((x, y) => x.pipe(y)), this.streams[0], this.streams.slice(1)).pipe(out); }
 }
 
+// allWithStreams() is very similar to Promise.all() and returns the same
+// result. The key difference is that if `values` contains a stream or a promise
+// that resolves to a stream, then the fate of the stream will be tied to the
+// fate of each promise within `values`. If any promise is rejected, then the
+// stream will be destroyed.
+const allWithStreams = (values) => {
+  // If/when a promise is rejected, we will need to destroy any streams that we
+  // have already seen (streamsBeforeError), as well as remember to destroy any
+  // streams that we see later (based on anyError).
+  let anyError = false;
+  const streamsBeforeError = [];
+  const handleStream = (stream) => {
+    if (anyError)
+      stream.destroy();
+    else
+      streamsBeforeError.push(stream);
+  };
+
+  for (const value of values) {
+    Promise.resolve(value)
+      .then((result) => {
+        if (result instanceof PartialPipe) {
+          for (const stream of result.streams) handleStream(stream);
+        } else if (typeof result === 'object' && result != null &&
+          typeof result.pipe === 'function') {
+          handleStream(result);
+        }
+      })
+      .catch(() => { // eslint-disable-line no-loop-func
+        for (const stream of streamsBeforeError) stream.destroy();
+        // Avoid keeping the destroyed streams in memory.
+        streamsBeforeError.splice(0);
+        anyError = true;
+      });
+  }
+  return Promise.all(values);
+};
+
 module.exports = {
   mapStream,
   consumeAndBuffer, pipethrough, pipethroughAndBuffer,
   splitStream,
   consumerToPiper,
-  PartialPipe
+  PartialPipe,
+  allWithStreams
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5985,26 +5985,26 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slonik": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/slonik/-/slonik-23.6.0.tgz",
-      "integrity": "sha512-4SqZ4U9NVd6OYIsMKN2wrNbmXQqiifu54M3SP33XjXcJ8qsk2NBiwGwSGIeuW5QtRqnfNHBdgdQsNfrfMFKlag==",
+      "version": "npm:@getodk/slonik@23.6.0-1",
+      "resolved": "https://registry.npmjs.org/@getodk/slonik/-/slonik-23.6.0-1.tgz",
+      "integrity": "sha512-dZwX3lQBLkXPOfZB/RQvJ41xGWRskP4VV8eX/0y2X0DcGa43BcQwWQayEJNI8PYL6V4cse6LulPnVDdDIFSRDQ==",
       "requires": {
         "concat-stream": "^2.0.0",
         "delay": "^5.0.0",
         "es6-error": "^4.1.1",
         "get-stack-trace": "^2.0.3",
-        "hyperid": "^2.1.0",
+        "hyperid": "2.1.0",
         "is-plain-object": "^5.0.0",
         "iso8601-duration": "^1.3.0",
         "pg": "^8.5.1",
         "pg-connection-string": "^2.4.0",
         "pg-copy-streams": "^5.1.1",
-        "pg-copy-streams-binary": "^2.0.1",
+        "pg-copy-streams-binary": "2.0.1",
         "pg-cursor": "^2.5.2",
         "postgres-array": "^3.0.1",
         "postgres-interval": "^3.0.0",
-        "roarr": "^4.0.11",
-        "serialize-error": "^8.0.1",
+        "roarr": "4.0.11",
+        "serialize-error": "8.0.1",
         "through2": "^4.0.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prompt": "~1",
     "ramda": "~0",
     "sanitize-filename": "~1",
-    "slonik": "~23",
+    "slonik": "npm:@getodk/slonik@23.6.0-1",
     "slonik-sql-tag-raw": "1.0.3",
     "tmp-promise": "~3",
     "uuid": "~3",


### PR DESCRIPTION
Closes #482. See the commit message of the second commit for additional notes.

#### What has been done to verify that this works as intended?

I deployed this PR to the QA server and followed the reproduction steps in #482. As today and as expected, 9/10 concurrent requests were successful. However, unlike today, there was no database connection leak after the 10 responses.

We're not sure yet that we're going to ship this PR (see the next section). If we decide to, then I'll write unit tests of `allWithStreams()`.

#### Why is this the best possible solution? Were any other approaches considered?

We want to add stream timeout functionality along the lines of #599/#604. However, we also want some way to destroy streams as soon as we know they can be. https://github.com/getodk/central-backend/pull/604#issuecomment-1244913740 mentions two options along those lines. This PR represents option 1, while #608 represents option 2.

I first tried running with option 2. However, when @alxndrsn ran the benchmarker against #608, the [results](https://github.com/getodk/central-backend/pull/604#issuecomment-1248671496) were lackluster. I've pushed this PR in part so that @alxndrsn can run the benchmarker against it. If the PR is more performant than #608 (as I think we expect), then we'll probably want to ship it (as part of either v1.5.3 or v2022.3).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The hope is that this PR fixes connection leak issues. However, there's a risk of regression with each of the three streaming endpoints that the PR modifies. I think that if the results from the benchmarker are good, that should help us gain confidence in the PR.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments