### PR TITLE
Update package-lock slonik version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "prompt": "~1",
         "ramda": "~0",
         "sanitize-filename": "~1",
-        "slonik": "^23.6.2",
+        "slonik": "23.6.2",
         "slonik-sql-tag-raw": "1.0.3",
         "tmp-promise": "~3",
         "uuid": "~3",


### PR DESCRIPTION
Every time `npm install` runs on my machine, it makes this change to `package-lock.json`.

Is anyone else seeing the same behaviour?  If so, perhaps we can make the change permanent.