### PR TITLE
check-file-headers: use git ls-files to simplify ignore list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - checkout
-      - run: node lib/bin/check-file-headers.js
+      - run: make check-file-headers
       - run: npm ci
       - run: node lib/bin/create-docker-databases.js
       - run: make test-full

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,7 @@ stop-docker-postgres:
 .PHONY: rm-docker-postgres
 rm-docker-postgres: stop-docker-postgres
 	docker rm odk-postgres || true
+
+.PHONY: check-file-headers
+check-file-headers:
+	git ls-files | node lib/bin/check-file-headers.js

--- a/lib/bin/check-file-headers.js
+++ b/lib/bin/check-file-headers.js
@@ -19,50 +19,40 @@ const header = `// Copyright 2017 ODK Central Developers
 // except according to the terms contained in the LICENSE file.
 `;
 
-// This might not be the full list in local development: .gitignore includes
-// other files. However, this list should be sufficient for CircleCI.
-const skip = new Set([
-  '.circleci',
-  '.git',
-  '.github',
-  'config',
-  'docs',
+const skip = [
+  'test/',
   'lib/bin/.eslintrc.js',
   'lib/util/quarantine/pkcs7.js',
-  'node_modules',
-  'test',
-  '.eslintrc.json',
-  '.gitignore',
-  '.npmrc',
-  'CONTRIBUTING.md',
-  'LICENSE',
-  'Makefile',
-  'NOTICE',
-  'README.md',
-  'package-lock.json',
-  'package.json'
-]);
+];
 
-let missing = false;
-const checkDir = (dirPath) => {
-  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
-    const entryPath = dirPath === '.' ? entry.name : `${dirPath}/${entry.name}`;
-    if (!skip.has(entryPath)) {
-      if (entry.isDirectory()) {
-        checkDir(entryPath);
-      } else {
-        const contents = fs.readFileSync(entryPath).toString();
-        const withConsistentYear = contents.replace(/(Copyright 20)\d\d/, '$117');
-        if (!withConsistentYear.startsWith(header)) {
-          console.error(entryPath);
-          missing = true;
-        }
-      }
+let stdin = '';
+process.stdin.resume();
+process.stdin.on('data', (data) => {
+  stdin += data.toString();
+});
+process.stdin.on('end', () => {
+  const files = stdin
+    .split('\n')
+    .filter(f => f.endsWith('.js'))
+    .filter(f => !skip.some(skipEntry => {
+      if (skipEntry.endsWith('.js')) return f === skipEntry;
+      if (skipEntry.endsWith('/')) return f.startsWith(skipEntry);
+      throw new Error(`Invalid skip entry: '${skipEntry}'`);
+    }));
+
+  let missing = false;
+
+  for (const entryPath of files) {
+    const contents = fs.readFileSync(entryPath).toString();
+    const withConsistentYear = contents.replace(/(Copyright 20)\d\d/, '$117');
+    if (!withConsistentYear.startsWith(header)) {
+      console.error(entryPath);
+      missing = true;
     }
   }
-};
-checkDir('.');
-if (missing) {
-  console.error('\nThe files above do not have the expected file header.');
-  process.exit(1);
-}
+
+  if (missing) {
+    console.error('\nThe files above do not have the expected file header.');
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
Originally written in https://github.com/getodk/central-backend/pull/612, to avoid updating the check-file-headers ignore list with benchmarker `node_mdoules` directory.

Simplify diff by ignoring whitespace: https://github.com/getodk/central-backend/pull/619/files?w=1