### PR TITLE
server name not needed now that user has hostname information.

### DIFF
--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -14,15 +14,13 @@ const { sql } = require('slonik');
 const { timebound, resolve } = require('../util/promise');
 const defaultJobMap = require('./jobs').jobs;
 
-const hostname = require('os').hostname();
-
 // TODO: domain catch/restart? << investigated and seems unlikely.
 
 // we'd love to report to sentry, but it's much more important that we don't fail
 // in our error handling code. so we will do anything to pass this and move on.
 const reporter = (Sentry) => (err) => {
   /* eslint-disable */ // i don't like anything it suggests here.
-  try { Sentry.captureException(err, { server_name: hostname }); }
+  try { Sentry.captureException(err); }
   catch (ierr) {
     try { process.stderr.write(inspect(err) + '\n'); process.stderr.write(inspect(ierr) + '\n'); }
     catch (_) { /* too scared to try anything at this point */ }


### PR DESCRIPTION
Not sure if we use server_name else where, but I checked central and central-frontend and didn't see it.