### PR TITLE
new: link and unlink dataset to a form

### DIFF
--- a/lib/formats/openrosa.js
+++ b/lib/formats/openrosa.js
@@ -12,6 +12,7 @@
 
 const { mergeRight } = require('ramda');
 const { parse, render } = require('mustache');
+const { md5sum } = require('../util/crypto');
 
 ////////////////////////////////////////////////////////////////////////////////
 // SETUP
@@ -61,20 +62,22 @@ const formList = (data) => formListTemplate(mergeRight(data, {
 const formManifestTemplate = template(200, `<?xml version="1.0" encoding="UTF-8"?>
   <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
   {{#attachments}}
-    {{#blobId}}
+    {{#hasSource}}
     <mediaFile>
       <filename>{{name}}</filename>
-      <hash>md5:{{aux.openRosa.md5}}</hash>
+      <hash>md5:{{md5}}</hash>
       <downloadUrl>{{{domain}}}{{{basePath}}}/attachments/{{urlName}}</downloadUrl>
     </mediaFile>
-    {{/blobId}}
+    {{/hasSource}}
   {{/attachments}}
   </manifest>`);
 
 // use the above template but encode all attachment names for output.
 const formManifest = (data) => formManifestTemplate(mergeRight(data, {
   attachments: data.attachments.map((attachment) =>
-    attachment.with({ urlName: encodeURIComponent(attachment.name) }))
+    attachment.with({ hasSource: attachment.blobId || attachment.datasetId,
+      md5: attachment.blobId ? attachment.aux.openRosa.md5 : md5sum(attachment.aux.openRosa.dsUpdatedAt ?? '1970-01-01'),
+      urlName: encodeURIComponent(attachment.name) }))
 }));
 
 // Returns a generic error message with a nature of error. We do this not via the

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -106,7 +106,7 @@ Form.Attachment = class extends Frame.define(
   'updatedAt',    readable
 ) {
   forApi() {
-    const data = { name: this.name, type: this.type, exists: (this.blobId != null) };
+    const data = { name: this.name, type: this.type, blobExists: this.blobId != null, datasetExists: this.datasetId != null };
     if (this.updatedAt != null) data.updatedAt = this.updatedAt;
     return data;
   }

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -101,8 +101,9 @@ const { Form } = require('./frames/form');
 Form.Attachment = class extends Frame.define(
   table('form_attachments'),
   'formId',                             'formDefId',
-  'blobId',                             'name',         readable,
-  'type',       readable,               'updatedAt',    readable
+  'blobId',                             'datasetId',
+  'name',         readable,             'type',       readable,
+  'updatedAt',    readable
 ) {
   forApi() {
     const data = { name: this.name, type: this.type, exists: (this.blobId != null) };

--- a/lib/model/migrations/20220829-01-create-entities-defs.js
+++ b/lib/model/migrations/20220829-01-create-entities-defs.js
@@ -15,6 +15,7 @@ const up = (db) =>
     entities.text('label').notNull();
     entities.dateTime('createdAt');
     entities.integer('createdBy').notNull();
+    entities.dateTime('updatedAt');
 
     entities.foreign('datasetId').references('datasets.id');
     entities.foreign('createdBy').references('actors.id');

--- a/lib/model/migrations/20220921-01-attach-dataset-to-form.js
+++ b/lib/model/migrations/20220921-01-attach-dataset-to-form.js
@@ -19,10 +19,11 @@ const up = async (db) => {
 };
 
 const down = async (db) => {
+  await db.raw('ALTER TABLE form_attachments DROP CONSTRAINT "check_blobId_or_datasetId_is_null"');
+
   await db.schema.table('form_attachments', (t) => {
     t.dropColumn('datasetId');
   });
-  await db.raw('ALTER TABLE form_attachments DROP CONSTRAINT check_blobId_or_datasetId_is_null');
 };
 
 module.exports = { up, down };

--- a/lib/model/migrations/20220921-01-attach-dataset-to-form.js
+++ b/lib/model/migrations/20220921-01-attach-dataset-to-form.js
@@ -1,0 +1,23 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.schema.table('form_attachments', (t) => {
+    t.integer('datasetId');
+    t.foreign('datasetId').references('datasets.id');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.table('form_attachments', (t) => {
+    t.dropColumn('datasetId');
+  });
+};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20220921-01-attach-dataset-to-form.js
+++ b/lib/model/migrations/20220921-01-attach-dataset-to-form.js
@@ -11,13 +11,18 @@ const up = async (db) => {
   await db.schema.table('form_attachments', (t) => {
     t.integer('datasetId');
     t.foreign('datasetId').references('datasets.id');
+
   });
+  await db.raw(`ALTER TABLE form_attachments 
+    ADD CONSTRAINT "check_blobId_or_datasetId_is_null"
+    CHECK (("blobId" IS NULL) OR ("datasetId" IS NULL));`);
 };
 
 const down = async (db) => {
   await db.schema.table('form_attachments', (t) => {
     t.dropColumn('datasetId');
   });
+  await db.raw('ALTER TABLE form_attachments DROP CONSTRAINT check_blobId_or_datasetId_is_null');
 };
 
 module.exports = { up, down };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -27,7 +27,8 @@ const makeHierarchy = reduce((result, item) => {
   const property = new Dataset.Property(pickFrameFields(Dataset.Property, item)).forApi();
   const propertyField = new Dataset.PropertyField(pickFrameFields(Dataset.PropertyField, item)).forApi();
 
-  return { ...result,
+  return {
+    ...result,
     [dataset.id]: {
       ...dataset,
       properties: !property.id ? { ...(result[dataset.id]?.properties || {}) } : {
@@ -40,7 +41,8 @@ const makeHierarchy = reduce((result, item) => {
           ]
         }
       }
-    } };
+    }
+  };
 }, {});
 
 const asArray = compose(map(d => ({ ...d, properties: Object.values(d.properties) })), Object.values);
@@ -65,7 +67,7 @@ const _insertDatasetDef = (dataset, withDsDefsCTE) => sql`
     DO UPDATE SET "revisionNumber" = datasets."revisionNumber" + 1
     RETURNING *
   )
-  ${raw(withDsDefsCTE ? ', ds_defs AS (': '')}
+  ${raw(withDsDefsCTE ? ', ds_defs AS (' : '')}
     INSERT INTO dataset_form_defs
     SELECT ds.id, ${dataset.aux.formDefId} FROM ds
     ON CONFLICT ON CONSTRAINT dataset_form_defs_datasetid_formdefid_unique 
@@ -203,9 +205,13 @@ const getDatasetDiff = (formDefId) => ({ all }) => all(sql`
   .then(reduceBy((acc, { propertyName, isPropertyNew }) => (propertyName ? acc.concat({ name: propertyName, isNew: isPropertyNew }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
   .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: k.split(',')[1] === 'true', properties: r[k] })));
 
+  const getByProjectAndName = (projectId, name) => ({ maybeOne }) => maybeOne(sql`
+SELECT * FROM datasets WHERE "projectId" = ${projectId} AND name = ${name}`)
+  .then(map(construct(Dataset)));
+
 module.exports = {
   createOrMerge,
   getById, getAllByProjectId, getByName,
   getFieldsByFormDefId,
-  getDatasetDiff
+  getDatasetDiff, getByProjectAndName
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -205,7 +205,7 @@ const getDatasetDiff = (formDefId) => ({ all }) => all(sql`
   .then(reduceBy((acc, { propertyName, isPropertyNew }) => (propertyName ? acc.concat({ name: propertyName, isNew: isPropertyNew }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
   .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: k.split(',')[1] === 'true', properties: r[k] })));
 
-  const getByProjectAndName = (projectId, name) => ({ maybeOne }) => maybeOne(sql`
+const getByProjectAndName = (projectId, name) => ({ maybeOne }) => maybeOne(sql`
 SELECT * FROM datasets WHERE "projectId" = ${projectId} AND name = ${name}`)
   .then(map(construct(Dataset)));
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -20,7 +20,6 @@ const { unjoiner, insertMany } = require('../../util/db');
 const { ignoringResult, resolve } = require('../../util/promise');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
-const Problem = require('../../util/problem');
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -99,10 +98,9 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
 ////////////////////////////////////////////////////////////////////////////////
 // CRUD
 
-const update = (_, fa, blobId, datasetId = null) => ({ run }) =>
-  (blobId && datasetId ? Problem.internal.invalidParameters('blobId and datasetId can\'t be set simultaneously') : run(sql`
+const update = (_, fa, blobId, datasetId = null) => ({ run }) => run(sql`
   update form_attachments set "blobId"=${blobId}, "datasetId"=${datasetId}, "updatedAt"=clock_timestamp()
-    where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}`));
+    where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}`);
 update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attachment.update', form,
   { formDefId: form.draftDefId, name: fa.name, oldBlobId: fa.blobId, newBlobId: blobId, oldDatasetId: fa.datasetId, newDatasetId: datasetId });
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -20,6 +20,7 @@ const { unjoiner, insertMany } = require('../../util/db');
 const { ignoringResult, resolve } = require('../../util/promise');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
+const Problem = require('../../util/problem');
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -28,7 +29,7 @@ const Option = require('../../util/option');
 // deal with itemsets.csv in both createNew and createVersion by hijacking the incoming
 // data and patching in a new blobId.
 // TODO: this is absolutely awful.
-const itemsetsHack = (Blobs, itemsets) => ([ expected, extant ]) => {
+const itemsetsHack = (Blobs, itemsets) => ([expected, extant]) => {
   if (itemsets == null) return resolve(expected);
   const target = expected.find((a) => a.name === 'itemsets.csv');
   if (target == null) return resolve(expected);
@@ -55,7 +56,7 @@ const itemsetsHack = (Blobs, itemsets) => ([ expected, extant ]) => {
 
 const createNew = (xml, form, itemsets) => ({ Blobs, run }) =>
   expectedFormAttachments(xml)
-    .then((expected) => [ expected ])
+    .then((expected) => [expected])
     .then(itemsetsHack(Blobs, itemsets))
     .then((expected) => {
       const ids = { formId: form.id, formDefId: form.def.id };
@@ -73,7 +74,7 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
       ? form.currentDefId : (form.draftDefId || form.currentDefId)),
   ])
     .then(ignoringResult(itemsetsHack(Blobs, itemsets)))
-    .then(([ expecteds, extants ]) => {
+    .then(([expecteds, extants]) => {
       // deal with attachments. match up extant ones with now-expected ones,
       // and in general save the expected attachments into the database.
       const lookup = {}; // sigh javascript.
@@ -98,11 +99,12 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
 ////////////////////////////////////////////////////////////////////////////////
 // CRUD
 
-const update = (_, fa, blobId) => ({ run }) => run(sql`
-update form_attachments set "blobId"=${blobId}, "updatedAt"=clock_timestamp()
-  where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}`);
-update.audit = (form, fa, blobId) => (log) => log('form.attachment.update', form,
-  { formDefId: form.draftDefId, name: fa.name, oldBlobId: fa.blobId, newBlobId: blobId });
+const update = (_, fa, blobId, datasetId = null) => ({ run }) =>
+  (blobId && datasetId ? Problem.internal.invalidParameters('blobId and datasetId can\'t be set simultaneously') : run(sql`
+  update form_attachments set "blobId"=${blobId}, "datasetId"=${datasetId}, "updatedAt"=clock_timestamp()
+    where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}`));
+update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attachment.update', form,
+  { formDefId: form.draftDefId, name: fa.name, oldBlobId: fa.blobId, newBlobId: blobId, oldDatasetId: fa.datasetId, newDatasetId: datasetId });
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -117,10 +119,13 @@ select * from form_attachments where "formDefId"=${formDefId} and "name"=${name}
   .then(map(construct(Form.Attachment)));
 
 // TODO: bad name
-const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('openRosa'), 'md5'));
+const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('openRosa'), 'md5', 'dsUpdatedAt'));
 const getAllByFormDefIdForOpenRosa = (formDefId) => ({ all }) => all(sql`
 select ${_unjoinMd5.fields} from form_attachments
   left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
+  left outer join (
+    select d.id, max(e."updatedAt") "dsUpdatedAt" from datasets d left outer join entities e on d.id = e."datasetId" group by d.id
+  ) as ds on form_attachments."datasetId"=ds.id
   where "formDefId"=${formDefId}`)
   .then(map(_unjoinMd5));
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -98,9 +98,10 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
 ////////////////////////////////////////////////////////////////////////////////
 // CRUD
 
-const update = (_, fa, blobId, datasetId = null) => ({ run }) => run(sql`
+const update = (_, fa, blobId, datasetId = null) => ({ one }) => one(sql`
   update form_attachments set "blobId"=${blobId}, "datasetId"=${datasetId}, "updatedAt"=clock_timestamp()
-    where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}`);
+    where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}
+    returning *`).then(construct(Form.Attachment));
 update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attachment.update', form,
   { formDefId: form.draftDefId, name: fa.name, oldBlobId: fa.blobId, newBlobId: blobId, oldDatasetId: fa.datasetId, newDatasetId: datasetId });
 

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -12,7 +12,7 @@ const { getOrNotFound } = require('../util/promise');
 const { Form } = require('../model/frames');
 const { ensureFormDef } = require('../util/db');
 const { streamEntityCsvs } = require('../data/entity');
-const { contentDisposition } = require('../util/http');
+const { contentDisposition, success } = require('../util/http');
 
 module.exports = (service, endpoint) => {
   service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
@@ -42,7 +42,7 @@ module.exports = (service, endpoint) => {
             return streamEntityCsvs(entities, dataset.properties);
           })))));
 
-  service.post('/projects/:projectId/forms/:id/draft/attachments/:name/link-dataset', endpoint(({ Datasets, FormAttachments, Forms }, { auth, params }) =>
+  service.patch('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Datasets, FormAttachments, Forms }, { auth, params, body }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
@@ -50,14 +50,6 @@ module.exports = (service, endpoint) => {
         Datasets.getByProjectAndName(params.projectId, params.name.replace(/\.csv$/, '')).then(getOrNotFound),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
       ])
-        .then(([dataset, attachment]) => FormAttachments.update(form, attachment, null, dataset.id))
-        .then(success))));
-
-  service.post('/projects/:projectId/forms/:id/draft/attachments/:name/unlink-dataset', endpoint(({ FormAttachments, Forms }, { auth, params }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
-      .then(getOrNotFound)
-      .then((form) => auth.canOrReject('form.update', form))
-      .then((form) => FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
-        .then(attachment => FormAttachments.update(form, attachment, null, null))
+        .then(([dataset, attachment]) => FormAttachments.update(form, attachment, null, body.dataset ? dataset.id : null))
         .then(success))));
 };

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -12,7 +12,7 @@ const { getOrNotFound } = require('../util/promise');
 const { Form } = require('../model/frames');
 const { ensureFormDef } = require('../util/db');
 const { streamEntityCsvs } = require('../data/entity');
-const { contentDisposition, success } = require('../util/http');
+const { contentDisposition } = require('../util/http');
 
 module.exports = (service, endpoint) => {
   service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
@@ -50,6 +50,5 @@ module.exports = (service, endpoint) => {
         Datasets.getByProjectAndName(params.projectId, params.name.replace(/\.csv$/, '')).then(getOrNotFound),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
       ])
-        .then(([dataset, attachment]) => FormAttachments.update(form, attachment, null, body.dataset ? dataset.id : null))
-        .then(success))));
+        .then(([dataset, attachment]) => FormAttachments.update(form, attachment, null, body.dataset ? dataset.id : null)))));
 };

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -41,4 +41,23 @@ module.exports = (service, endpoint) => {
             response.append('Content-Type', 'text/csv');
             return streamEntityCsvs(entities, dataset.properties);
           })))));
+
+  service.post('/projects/:projectId/forms/:id/draft/attachments/:name/link-dataset', endpoint(({ Datasets, FormAttachments, Forms }, { auth, params }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('form.update', form))
+      .then((form) => Promise.all([
+        Datasets.getByProjectAndName(params.projectId, params.name.replace(/\.csv$/, '')).then(getOrNotFound),
+        FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
+      ])
+        .then(([dataset, attachment]) => FormAttachments.update(form, attachment, null, dataset.id))
+        .then(success))));
+
+  service.post('/projects/:projectId/forms/:id/draft/attachments/:name/unlink-dataset', endpoint(({ FormAttachments, Forms }, { auth, params }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('form.update', form))
+      .then((form) => FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
+        .then(attachment => FormAttachments.update(form, attachment, null, null))
+        .then(success))));
 };

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -285,7 +285,7 @@ module.exports = (service, endpoint) => {
         Blob.fromStream(request, headers['content-type']).then((blob) => Blobs.ensure(blob)),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
       ])
-        .then(([ blobId, attachment ]) => FormAttachments.update(form, attachment, blobId))
+        .then(([ blobId, attachment ]) => FormAttachments.update(form, attachment, blobId, null))
         .then(success))));
 
   service.delete('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ FormAttachments, Forms }, { params, auth }) =>
@@ -294,8 +294,8 @@ module.exports = (service, endpoint) => {
       .then((form) => auth.canOrReject('form.update', form))
       .then((form) => FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name)
         .then(getOrNotFound)
-        .then(rejectIf(((attachment) => attachment.blobId == null), noargs(Problem.user.notFound)))
-        .then((attachment) => FormAttachments.update(form, attachment, null))
+        .then(rejectIf(((attachment) => attachment.blobId == null && attachment.datasetId == null), noargs(Problem.user.notFound)))
+        .then((attachment) => FormAttachments.update(form, attachment, null, null))
         .then(success))));
 
 

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -490,11 +490,6 @@ const postgresErrorToProblem = (x) => {
     if (match != null) {
       return reject(Problem.user.valueTooLong({ maxLength }));
     }
-  } else if (error.code === '23514') {
-    const match = /check_blobId_or_datasetId_is_null/.exec(error.message);
-    if (match != null) {
-      return reject(Problem.internal.invalidParameters('blobId and datasetId can\'t be set simultaneously'));
-    }
   }
 
   debugger; // automatically trip the debugger if it's attached.

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -490,6 +490,11 @@ const postgresErrorToProblem = (x) => {
     if (match != null) {
       return reject(Problem.user.valueTooLong({ maxLength }));
     }
+  } else if (error.code === '23514') {
+    const match = /check_blobId_or_datasetId_is_null/.exec(error.message);
+    if (match != null) {
+      return reject(Problem.internal.invalidParameters('blobId and datasetId can\'t be set simultaneously'));
+    }
   }
 
   debugger; // automatically trip the debugger if it's attached.

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -193,6 +193,8 @@ const problems = {
     // returned in case no external ODK Analytics service is configured.
     analyticsNotConfigured: problem(501.9, () => 'This ODK Central has not been configured to report Analytics. Please contact your server administrator.'),
 
+    invalidParameters: problem(501.10, (details) => `Invalid parameters passed. ${details}`),
+
     // used internally when a task fails to complete in a reasonable length of time.
     timeout: problem(502.1, () => 'The task took too long to run.'),
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -193,7 +193,7 @@ const problems = {
     // returned in case no external ODK Analytics service is configured.
     analyticsNotConfigured: problem(501.9, () => 'This ODK Central has not been configured to report Analytics. Please contact your server administrator.'),
 
-    invalidParameters: problem(501.10, (details) => `Invalid parameters passed. ${details}`),
+    invalidParameters: problem(501.11, (details) => `Invalid parameters passed. ${details}`),
 
     // used internally when a task fails to complete in a reasonable length of time.
     timeout: problem(502.1, () => 'The task took too long to run.'),

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1,5 +1,6 @@
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
+const config = require('config');
 
 describe('projects/:id/datasets GET', () => {
   it('should return the datasets of Default project', testService((service) =>
@@ -36,4 +37,69 @@ describe('projects/:id/datasets GET', () => {
                   { name: 'student', projectId: 1, revisionNumber: 0 }
                 ]);
               }))))));
+});
+
+describe('projects/:id/forms/:formId/draft/attachment/link-dataset POST', () => {
+  it('should link dataset to form and returns in manifest', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/people/, 'goodone')))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/link-dataset')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
+          .expect(200))
+        .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/manifest')
+          .set('X-OpenRosa-Version', '1.0')
+          .expect(200)
+          .then(({ text }) => {
+            const domain = config.get('default.env.domain');
+            text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
+  <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    <mediaFile>
+      <filename>goodone.csv</filename>
+      <hash>md5:0c0fb6b2ee7dbb235035f7f6fdcfe8fb</hash>
+      <downloadUrl>${domain}/v1/projects/1/forms/withAttachments/attachments/goodone.csv</downloadUrl>
+    </mediaFile>
+  </manifest>`);
+          })))));
+
+  it('should match dataset name with attachment name', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/link-dataset')
+          .expect(404)))));
+});
+
+describe('projects/:id/forms/:formId/draft/attachment/unlink-dataset POST', () => {
+  it('should unlink dataset and should not return in manifest', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/people/, 'goodone')))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/link-dataset')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/unlink-dataset')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
+          .expect(200))
+        .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/manifest')
+          .set('X-OpenRosa-Version', '1.0')
+          .expect(200)
+          .then(({ text }) => {
+            text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
+  <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+  </manifest>`);
+          })))));
 });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -225,6 +225,6 @@ describe('Check only blobId or datasetId is set', () => {
         .then(([form, dataset]) => FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodone.csv').then(getOrNotFound)
           .then((attachment) => FormAttachments.update(form, attachment, 1, dataset.id)
             .catch(error => {
-              error.problemCode.should.be.equal(501.11);
+              error.constraint.should.be.equal('check_blobId_or_datasetId_is_null');
             }))))));
 });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1,6 +1,10 @@
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
 const config = require('config');
+const { Form } = require('../../../lib/model/frames');
+const { getOrNotFound } = require('../../../lib/util/promise');
+
+// TODO merge with test/integration/api/forms/dataset.js
 
 describe('projects/:id/datasets GET', () => {
   it('should return the datasets of Default project', testService((service) =>
@@ -39,7 +43,7 @@ describe('projects/:id/datasets GET', () => {
               }))))));
 });
 
-describe('projects/:id/forms/:formId/draft/attachment/link-dataset POST', () => {
+describe('projects/:id/forms/:formId/draft/attachment/:name PATCH', () => {
   it('should link dataset to form and returns in manifest', testService((service) =>
     service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms')
@@ -48,7 +52,47 @@ describe('projects/:id/forms/:formId/draft/attachment/link-dataset POST', () => 
         .expect(200)
         .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
           .send(testData.forms.simpleEntity.replace(/people/, 'goodone')))
-        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/link-dataset')
+        .then(() => asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send({ dataset: true })
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
+          .expect(200))
+        .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/attachments')
+          .expect(200)
+          .then(({ body }) => {
+            body[0].name.should.equal('goodone.csv');
+            body[0].datasetExists.should.equal(true);
+            body[0].updatedAt.should.be.a.recentIsoDate();
+          }))
+        .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/manifest')
+          .set('X-OpenRosa-Version', '1.0')
+          .expect(200)
+          .then(({ text }) => {
+            const domain = config.get('default.env.domain');
+            text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
+  <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    <mediaFile>
+      <filename>goodone.csv</filename>
+      <hash>md5:0c0fb6b2ee7dbb235035f7f6fdcfe8fb</hash>
+      <downloadUrl>${domain}/v1/projects/1/forms/withAttachments/attachments/goodone.csv</downloadUrl>
+    </mediaFile>
+  </manifest>`);
+          })))));
+
+  it('should override blob and link dataset', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/people/, 'goodone')))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send('test,csv\n1,2')
+          .set('Content-Type', 'text/csv')
+          .expect(200))
+        .then(() => asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send({ dataset: true })
           .expect(200))
         .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
           .expect(200))
@@ -67,20 +111,7 @@ describe('projects/:id/forms/:formId/draft/attachment/link-dataset POST', () => 
   </manifest>`);
           })))));
 
-  it('should match dataset name with attachment name', testService((service) =>
-    service.login('alice', (asAlice) =>
-      asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.withAttachments)
-        .set('Content-Type', 'application/xml')
-        .expect(200)
-        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.simpleEntity))
-        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/link-dataset')
-          .expect(404)))));
-});
-
-describe('projects/:id/forms/:formId/draft/attachment/unlink-dataset POST', () => {
-  it('should unlink dataset and should not return in manifest', testService((service) =>
+  it('should unlink dataset from the form', testService((service) =>
     service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms')
         .send(testData.forms.withAttachments)
@@ -88,9 +119,54 @@ describe('projects/:id/forms/:formId/draft/attachment/unlink-dataset POST', () =
         .expect(200)
         .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
           .send(testData.forms.simpleEntity.replace(/people/, 'goodone')))
-        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/link-dataset')
+        .then(() => asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send({ dataset: true })
           .expect(200))
-        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv/unlink-dataset')
+        .then(() => asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send({ dataset: false })
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
+          .expect(200))
+        .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/attachments')
+          .expect(200)
+          .then(({ body }) => {
+            body[0].name.should.equal('goodone.csv');
+            body[0].datasetExists.should.equal(false);
+            body[0].updatedAt.should.be.a.recentIsoDate();
+          }))
+        .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/manifest')
+          .set('X-OpenRosa-Version', '1.0')
+          .expect(200)
+          .then(({ text }) => {
+            text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
+  <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+  </manifest>`);
+          })))));
+
+  it('should return error if dataset is not found', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send({ dataset: true })
+          .expect(404)))));
+});
+
+describe('projects/:id/forms/:formId/draft/attachment/:name DELETE', () => {
+  it('should unlink dataset from the form', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/people/, 'goodone')))
+        .then(() => asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send({ dataset: true })
+          .expect(200))
+        .then(() => asAlice.delete('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
           .expect(200))
         .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
           .expect(200))
@@ -102,4 +178,29 @@ describe('projects/:id/forms/:formId/draft/attachment/unlink-dataset POST', () =
   <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
   </manifest>`);
           })))));
+});
+
+describe('Check only blobId or datasetId is set', () => {
+  // this scenario will never happen by just using APIs, adding this test for safety
+  it('should throw problem 501.11 if both are being set', testService((service, { Forms, FormAttachments, Datasets }) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.withAttachments)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/people/, 'goodone')))
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send('test,csv\n1,2')
+          .set('Content-Type', 'text/csv')
+          .expect(200))
+        .then(() => Promise.all([
+          Forms.getByProjectAndXmlFormId(1, 'withAttachments', false, Form.DraftVersion).then(getOrNotFound),
+          Datasets.getByProjectAndName(1, 'goodone').then(getOrNotFound)
+        ]))
+        .then(([form, dataset]) => FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodone.csv').then(getOrNotFound)
+          .then((attachment) => FormAttachments.update(form, attachment, 1, dataset.id)
+            .catch(error => {
+              error.problemCode.should.be.equal(501.11);
+            }))))));
 });

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -416,8 +416,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
               .expect(200)
               .then(({ body }) => {
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', exists: false },
-                  { name: 'goodtwo.mp3', type: 'audio', exists: false }
+                  { name: 'goodone.csv', type: 'file', blobExists: false, datasetExists: false },
+                  { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
                 ]);
               })))));
 
@@ -450,8 +450,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', exists: true },
-                  { name: 'greattwo.mp3', type: 'audio', exists: false }
+                  { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
+                  { name: 'greattwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
                 ]);
               })))));
 
@@ -482,8 +482,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', exists: true },
-                  { name: 'greattwo.mp3', type: 'audio', exists: false }
+                  { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
+                  { name: 'greattwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
                 ]);
               })))));
 
@@ -946,8 +946,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', exists: true },
-                  { name: 'goodtwo.mp3', type: 'audio', exists: false }
+                  { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
+                  { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
                 ]);
               })))));
 

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -1149,7 +1149,9 @@ describe('api: /projects/:id/forms (drafts)', () => {
                       formDefId: form.draftDefId,
                       name: attachment.name,
                       oldBlobId: null,
-                      newBlobId: attachment.blobId
+                      newBlobId: attachment.blobId,
+                      oldDatasetId: null,
+                      newDatasetId: attachment.datasetId
                     });
 
                     return asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
@@ -1167,7 +1169,9 @@ describe('api: /projects/:id/forms (drafts)', () => {
                           formDefId: form.draftDefId,
                           name: attachment.name,
                           oldBlobId: attachment.blobId,
-                          newBlobId: attachment2.blobId
+                          newBlobId: attachment2.blobId,
+                          oldDatasetId: attachment.datasetId,
+                          newDatasetId: attachment2.datasetId
                         });
                       });
                   }))))));
@@ -1248,7 +1252,9 @@ describe('api: /projects/:id/forms (drafts)', () => {
                         formDefId: form.draftDefId,
                         name: 'goodone.csv',
                         oldBlobId: attachment.blobId,
-                        newBlobId: null
+                        newBlobId: null,
+                        oldDatasetId: attachment.datasetId,
+                        newDatasetId: null
                       });
                     }))))));
 

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -786,8 +786,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                 .expect(200)
                 .then(({ body }) => {
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', exists: false },
-                    { name: 'goodtwo.mp3', type: 'audio', exists: false }
+                    { name: 'goodone.csv', type: 'file', blobExists: false, datasetExists: false },
+                    { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
                   ]);
                 })))));
 
@@ -812,8 +812,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                   delete body[0].updatedAt;
 
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', exists: true },
-                    { name: 'goodtwo.mp3', type: 'audio', exists: false }
+                    { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
+                    { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
                   ]);
                 })))));
 
@@ -835,7 +835,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                 .expect(200)
                 .then(({ body }) => {
                   body[0].name.should.equal('goodone.csv'); // sanity
-                  body[0].exists.should.equal(true);
+                  body[0].blobExists.should.equal(true);
                   body[0].updatedAt.should.be.a.recentIsoDate();
                 })))));
 
@@ -861,7 +861,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                   .set('X-Extended-Metadata', 'true')
                   .expect(200)
                   .then((secondListing) => {
-                    secondListing.body[0].exists.should.equal(false);
+                    secondListing.body[0].blobExists.should.equal(false);
                     secondListing.body[0].updatedAt.should.be.a.recentIsoDate();
 
                     const firstUpdatedAt = DateTime.fromISO(firstListing.body[0].updatedAt);

--- a/test/integration/api/forms/versions.js
+++ b/test/integration/api/forms/versions.js
@@ -354,8 +354,8 @@ describe('api: /projects/:id/forms (versions)', () => {
                   delete body[0].updatedAt;
 
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', exists: true },
-                    { name: 'goodtwo.mp3', type: 'audio', exists: false }
+                    { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
+                    { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
                   ]);
                 })))));
 


### PR DESCRIPTION
### Changes:
- Added a new endpoint `PATCH /projects/:id/forms/:formId/draft/attachment/:name`, it expects following request body:`{ dataset: <boolean> }` and returns attachment object
- Updated `GET /projects/:id/forms/:formId/attachments`, it now returns `blobExists` (previously `exists`) and `datasetExists`
- `form_attachments` table has a new column `datasetId`, a constraint is added that makes sure that only `blobId` or `datasetId` is filled

Note: `PATCH ../attachment/:name`, `POST ../attachment` and `DELETE ..attachment` tries to perform requested action aggressively, which means existing `blobId` will be set to null if link dataset request is received using PATCH and similarly `datasetId` will be set to null if blob is uploaded using POST, and DELETE sets both to null.

#### What has been done to verify that this works as intended?
Integration test

#### Why is this the best possible solution? Were any other approaches considered?
Had discussions with the team and decided to implement PATCH endpoint for linking dataset to a form

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
`exists` field has been renamed to `blobExists`, frontend should make the appropriate changes

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
In a separate PR

#### Before submitting this PR, please make sure you have:

- [X] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [NA] verified that any code from external sources are properly credited in comments