### PR TITLE
improve: move ensureDef to util/db.js to eliminate code duplication

### DIFF
--- a/lib/model/frame.js
+++ b/lib/model/frame.js
@@ -10,8 +10,10 @@
 const { raw } = require('slonik-sql-tag-raw');
 const { pick, without } = require('ramda');
 const uuid = require('uuid/v4');
-const { pickAll } = require('../util/util');
+const { pickAll, noargs } = require('../util/util');
 const Option = require('../util/option');
+const { rejectIf } = require('../util/promise');
+const Problem = require('../util/problem');
 
 const _forApi = (v) => ((v instanceof Option)
   ? v.map((w) => w.forApi()).orNull()
@@ -151,5 +153,8 @@ class Frame {
 // make sure the basic Frame is usable for simple tasks by giving it a def.
 Frame.def = { fields: [], readable: [], hasCreatedAt: false, hasUpdatedAt: false };
 
-module.exports = { Frame, table, from, into, aux, species, embedded, readable, writable };
+// util func to ensure the frame we fetched successfully joined to the intended def.
+const ensureDef = rejectIf(((f) => f.def.id == null), noargs(Problem.user.notFound));
+
+module.exports = { Frame, table, from, into, aux, species, embedded, readable, writable, ensureDef };
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -10,7 +10,8 @@
 const path = require('path');
 const { identity } = require('ramda');
 const { Blob, Form } = require('../model/frames');
-const { QueryOptions, ensureFormDef } = require('../util/db');
+const { ensureDef } = require('../model/frame');
+const { QueryOptions } = require('../util/db');
 const { isTrue, xml, binary } = require('../util/http');
 const Problem = require('../util/problem');
 const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
@@ -112,7 +113,7 @@ module.exports = (service, endpoint) => {
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then((form) => (isPresent(query.version)
         // we've been asked to change the form def version before publish.
         // we will do so by getting and patching the xml, and creating a new draft
@@ -220,12 +221,12 @@ module.exports = (service, endpoint) => {
   formResource('/projects/:projectId/forms/:id/versions/:version', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, params.version, options)
       .then(getOrNotFound)
-      .then(ensureFormDef));
+      .then(ensureDef));
 
   formResource('/projects/:projectId/forms/:id/draft', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, Form.DraftVersion, options)
       .then(getOrNotFound)
-      .then(ensureFormDef));
+      .then(ensureDef));
 
 
   ////////////////////////////////////////
@@ -312,7 +313,7 @@ module.exports = (service, endpoint) => {
   service.get('/test/:key/projects/:projectId/forms/:id/draft/formList', endpoint.openRosa(({ Forms, FormAttachments, env }, { params, originalUrl }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then(checkFormToken(params.key))
       .catch(Problem.translate(Problem.user.notFound, noargs(Problem.user.failedDraftAccess)))
       // TODO: this is really awful. extra request to munge in a value.
@@ -327,7 +328,7 @@ module.exports = (service, endpoint) => {
   service.get('/test/:key/projects/:projectId/forms/:id/draft/manifest', endpoint.openRosa(({ FormAttachments, Forms, env }, { params, originalUrl }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then(checkFormToken(params.key))
       .then((form) => FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id)
         .then((attachments) =>
@@ -336,14 +337,14 @@ module.exports = (service, endpoint) => {
   service.get('/test/:key/projects/:projectId/forms/:id/draft.xml', endpoint(({ Forms }, { params }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then(checkFormToken(params.key))
       .then((form) => xml(form.xml))));
 
   service.get('/test/:key/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Blobs, FormAttachments, Forms }, { params }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then(checkFormToken(params.key))
       .then((form) => FormAttachments.getByFormDefIdAndName(form.def.id, params.name)
         .then(getOrNotFound)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -10,7 +10,7 @@
 const path = require('path');
 const { identity } = require('ramda');
 const { Blob, Form } = require('../model/frames');
-const { QueryOptions } = require('../util/db');
+const { QueryOptions, ensureFormDef } = require('../util/db');
 const { isTrue, xml, binary } = require('../util/http');
 const Problem = require('../util/problem');
 const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
@@ -26,11 +26,6 @@ const excelMimeTypes = {
   xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 };
-
-// util func to ensure the form we fetched successfully joined to the intended def.
-// TODO: copied to resources/submissions
-const ensureDef = rejectIf(((form) => form.def.id == null), noargs(Problem.user.notFound));
-
 
 module.exports = (service, endpoint) => {
   // This forms list can also be used to get a list of just the soft-deleted forms by adding ?deleted=true
@@ -117,7 +112,7 @@ module.exports = (service, endpoint) => {
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then((form) => (isPresent(query.version)
         // we've been asked to change the form def version before publish.
         // we will do so by getting and patching the xml, and creating a new draft
@@ -225,12 +220,12 @@ module.exports = (service, endpoint) => {
   formResource('/projects/:projectId/forms/:id/versions/:version', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, params.version, options)
       .then(getOrNotFound)
-      .then(ensureDef));
+      .then(ensureFormDef));
 
   formResource('/projects/:projectId/forms/:id/draft', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, Form.DraftVersion, options)
       .then(getOrNotFound)
-      .then(ensureDef));
+      .then(ensureFormDef));
 
 
   ////////////////////////////////////////
@@ -317,7 +312,7 @@ module.exports = (service, endpoint) => {
   service.get('/test/:key/projects/:projectId/forms/:id/draft/formList', endpoint.openRosa(({ Forms, FormAttachments, env }, { params, originalUrl }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then(checkFormToken(params.key))
       .catch(Problem.translate(Problem.user.notFound, noargs(Problem.user.failedDraftAccess)))
       // TODO: this is really awful. extra request to munge in a value.
@@ -332,7 +327,7 @@ module.exports = (service, endpoint) => {
   service.get('/test/:key/projects/:projectId/forms/:id/draft/manifest', endpoint.openRosa(({ FormAttachments, Forms, env }, { params, originalUrl }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then(checkFormToken(params.key))
       .then((form) => FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id)
         .then((attachments) =>
@@ -341,14 +336,14 @@ module.exports = (service, endpoint) => {
   service.get('/test/:key/projects/:projectId/forms/:id/draft.xml', endpoint(({ Forms }, { params }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then(checkFormToken(params.key))
       .then((form) => xml(form.xml))));
 
   service.get('/test/:key/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Blobs, FormAttachments, Forms }, { params }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then(checkFormToken(params.key))
       .then((form) => FormAttachments.getByFormDefIdAndName(form.def.id, params.name)
         .then(getOrNotFound)

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -8,8 +8,9 @@
 // except according to the terms contained in the LICENSE file.
 
 const { Form } = require('../model/frames');
+const { ensureDef } = require('../model/frame');
 const { getOrNotFound, resolve } = require('../util/promise');
-const { QueryOptions, ensureFormDef } = require('../util/db');
+const { QueryOptions } = require('../util/db');
 const { contentType, xml, json } = require('../util/http');
 const Problem = require('../util/problem');
 const { serviceDocumentFor, edmxFor, rowStreamToOData, singleRowToOData, selectFields, getTableFromOriginalUrl } = require('../formats/odata');
@@ -80,13 +81,13 @@ module.exports = (service, endpoint) => {
   odataResource('/projects/:projectId/forms/:id.svc', false, (Forms, auth, params) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.PublishedVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then((form) => auth.canOrReject('submission.read', form)));
 
   odataResource('/projects/:projectId/forms/:id/draft.svc', true, (Forms, auth, params) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then((form) => auth.canOrReject('submission.read', form)));
 };
 

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -8,11 +8,10 @@
 // except according to the terms contained in the LICENSE file.
 
 const { Form } = require('../model/frames');
-const { getOrNotFound, resolve, rejectIf } = require('../util/promise');
-const { QueryOptions } = require('../util/db');
+const { getOrNotFound, resolve } = require('../util/promise');
+const { QueryOptions, ensureFormDef } = require('../util/db');
 const { contentType, xml, json } = require('../util/http');
 const Problem = require('../util/problem');
-const { noargs } = require('../util/util');
 const { serviceDocumentFor, edmxFor, rowStreamToOData, singleRowToOData, selectFields, getTableFromOriginalUrl } = require('../formats/odata');
 
 module.exports = (service, endpoint) => {
@@ -78,18 +77,16 @@ module.exports = (service, endpoint) => {
   ////////////////////////////////////////////////////////////////////////////////
   // REIFY ODATA RESOURCES
 
-  const ensureDef = rejectIf((form) => form.def.id == null, noargs(Problem.user.notFound));
-
   odataResource('/projects/:projectId/forms/:id.svc', false, (Forms, auth, params) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.PublishedVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then((form) => auth.canOrReject('submission.read', form)));
 
   odataResource('/projects/:projectId/forms/:id/draft.svc', true, (Forms, auth, params) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then((form) => auth.canOrReject('submission.read', form)));
 };
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -11,9 +11,10 @@ const { always, identity } = require('ramda');
 const multer = require('multer');
 const sanitize = require('sanitize-filename');
 const { Blob, Form, Submission } = require('../model/frames');
+const { ensureDef } = require('../model/frame');
 const { createdMessage } = require('../formats/openrosa');
 const { getOrNotFound, getOrReject, rejectIf, reject } = require('../util/promise');
-const { QueryOptions, ensureFormDef } = require('../util/db');
+const { QueryOptions } = require('../util/db');
 const { success, xml, isFalse, contentDisposition, binary, redirect, url } = require('../util/http');
 const Problem = require('../util/problem');
 const { streamBriefcaseCsvs } = require('../data/briefcase');
@@ -120,7 +121,7 @@ module.exports = (service, endpoint) => {
   openRosaSubmission('/projects/:projectId/submission', false, (auth, { projectId }, xmlFormId, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, xmlFormId, false, version)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then((form) => auth.canOrReject('submission.create', form)));
 
   // draft-testing submission path:
@@ -131,7 +132,7 @@ module.exports = (service, endpoint) => {
 
     return Forms.getByProjectAndXmlFormId(params.projectId, xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then((form) => auth.canOrReject('submission.create', form));
   });
 
@@ -142,7 +143,7 @@ module.exports = (service, endpoint) => {
 
     return Forms.getByProjectAndXmlFormId(params.projectId, xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then(rejectIf(
         ((form) => (params.key !== form.def.draftToken) || isBlank(form.def.draftToken)),
         () => Problem.user.notFound()
@@ -205,7 +206,7 @@ module.exports = (service, endpoint) => {
   restSubmission('/projects/:projectId/forms/:formId', false, ({ projectId, formId }, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, formId, false, version) // TODO: okay so this is exactly the same as the func above..
       .then(getOrNotFound)
-      .then(ensureFormDef)
+      .then(ensureDef)
       .then(rejectIf(
         (form) => !form.acceptsSubmissions(),
         () => Problem.user.notAcceptingSubmissions()
@@ -214,7 +215,7 @@ module.exports = (service, endpoint) => {
   restSubmission('/projects/:projectId/forms/:formId/draft', true, ({ projectId, formId }, Forms) =>
     Forms.getByProjectAndXmlFormId(projectId, formId, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef));
+      .then(ensureDef));
 
   ////////////////////////////////////////////////////////////////////////////////
   // SUBMISSION EDIT / UPDATE
@@ -502,6 +503,6 @@ module.exports = (service, endpoint) => {
   dataOutputs('/projects/:projectId/forms/:formId/draft/submissions', true, (params, Forms) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.formId, undefined, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureFormDef));
+      .then(ensureDef));
 };
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -13,7 +13,7 @@ const sanitize = require('sanitize-filename');
 const { Blob, Form, Submission } = require('../model/frames');
 const { createdMessage } = require('../formats/openrosa');
 const { getOrNotFound, getOrReject, rejectIf, reject } = require('../util/promise');
-const { QueryOptions } = require('../util/db');
+const { QueryOptions, ensureFormDef } = require('../util/db');
 const { success, xml, isFalse, contentDisposition, binary, redirect, url } = require('../util/http');
 const Problem = require('../util/problem');
 const { streamBriefcaseCsvs } = require('../data/briefcase');
@@ -30,10 +30,6 @@ const multipart = multer({ storage: multer.memoryStorage() });
 // formbody things:
 const bodyParser = require('body-parser');
 const formParser = bodyParser.urlencoded({ extended: false });
-
-// util func to ensure the form we fetched successfully joined to the intended def.
-// TODO: copied from resources/forms
-const ensureDef = rejectIf(((form) => form.def.id == null), () => Problem.user.notFound());
 
 // util funcs for openRosaSubmission below, mostly just moving baked logic/data off for perf.
 const missingXmlProblem = Problem.user.missingMultipartField({ field: 'xml_submission_file' });
@@ -124,7 +120,7 @@ module.exports = (service, endpoint) => {
   openRosaSubmission('/projects/:projectId/submission', false, (auth, { projectId }, xmlFormId, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, xmlFormId, false, version)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then((form) => auth.canOrReject('submission.create', form)));
 
   // draft-testing submission path:
@@ -135,7 +131,7 @@ module.exports = (service, endpoint) => {
 
     return Forms.getByProjectAndXmlFormId(params.projectId, xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then((form) => auth.canOrReject('submission.create', form));
   });
 
@@ -146,7 +142,7 @@ module.exports = (service, endpoint) => {
 
     return Forms.getByProjectAndXmlFormId(params.projectId, xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then(rejectIf(
         ((form) => (params.key !== form.def.draftToken) || isBlank(form.def.draftToken)),
         () => Problem.user.notFound()
@@ -209,7 +205,7 @@ module.exports = (service, endpoint) => {
   restSubmission('/projects/:projectId/forms/:formId', false, ({ projectId, formId }, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, formId, false, version) // TODO: okay so this is exactly the same as the func above..
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then(ensureFormDef)
       .then(rejectIf(
         (form) => !form.acceptsSubmissions(),
         () => Problem.user.notAcceptingSubmissions()
@@ -218,7 +214,7 @@ module.exports = (service, endpoint) => {
   restSubmission('/projects/:projectId/forms/:formId/draft', true, ({ projectId, formId }, Forms) =>
     Forms.getByProjectAndXmlFormId(projectId, formId, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef));
+      .then(ensureFormDef));
 
   ////////////////////////////////////////////////////////////////////////////////
   // SUBMISSION EDIT / UPDATE
@@ -506,6 +502,6 @@ module.exports = (service, endpoint) => {
   dataOutputs('/projects/:projectId/forms/:formId/draft/submissions', true, (params, Forms) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.formId, undefined, Form.DraftVersion)
       .then(getOrNotFound)
-      .then(ensureDef));
+      .then(ensureFormDef));
 };
 

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -11,11 +11,11 @@ const { inspect } = require('util');
 const { mergeRight, pick, always } = require('ramda');
 const { sql } = require('slonik');
 const { raw } = require('slonik-sql-tag-raw');
-const { reject } = require('./promise');
+const { reject, rejectIf } = require('./promise');
 const Problem = require('./problem');
 const Option = require('./option');
 const { PartialPipe, mapStream } = require('./stream');
-const { construct } = require('./util');
+const { construct, noargs } = require('./util');
 const { isTrue, isFalse } = require('./http');
 
 const { Transform } = require('stream');
@@ -498,11 +498,14 @@ const postgresErrorToProblem = (x) => {
 };
 
 
+// util func to ensure the form we fetched successfully joined to the intended def.
+const ensureFormDef = rejectIf(((form) => form.def.id == null), noargs(Problem.user.notFound));
+
 module.exports = {
   connectionString, connectionObject,
   unjoiner, extender, equals, page, queryFuncs,
   insert, insertMany, updater, markDeleted, markUndeleted,
-  QueryOptions,
+  QueryOptions, ensureFormDef,
   postgresErrorToProblem
 };
 

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -11,11 +11,11 @@ const { inspect } = require('util');
 const { mergeRight, pick, always } = require('ramda');
 const { sql } = require('slonik');
 const { raw } = require('slonik-sql-tag-raw');
-const { reject, rejectIf } = require('./promise');
+const { reject } = require('./promise');
 const Problem = require('./problem');
 const Option = require('./option');
 const { PartialPipe, mapStream } = require('./stream');
-const { construct, noargs } = require('./util');
+const { construct } = require('./util');
 const { isTrue, isFalse } = require('./http');
 
 const { Transform } = require('stream');
@@ -498,14 +498,11 @@ const postgresErrorToProblem = (x) => {
 };
 
 
-// util func to ensure the form we fetched successfully joined to the intended def.
-const ensureFormDef = rejectIf(((form) => form.def.id == null), noargs(Problem.user.notFound));
-
 module.exports = {
   connectionString, connectionObject,
   unjoiner, extender, equals, page, queryFuncs,
   insert, insertMany, updater, markDeleted, markUndeleted,
-  QueryOptions, ensureFormDef,
+  QueryOptions,
   postgresErrorToProblem
 };
 


### PR DESCRIPTION
Code Refactor: moved ensureDef to util/db.js as ensureFormDef to eliminate code duplication

#### What has been done to verify that this works as intended?
All tests are passing

#### Why is this the best possible solution? Were any other approaches considered?
NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
NA

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
NA

#### Before submitting this PR, please make sure you have:

- [X] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments