### PR TITLE
Add Dataset verbs and add Dataset count to Project extended metadata

### DIFF
--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -125,11 +125,16 @@ const Project = Frame.define(
 );
 Project.Extended = class extends Frame.define(
   'forms',      readable,               'lastSubmission', readable,
-  'appUsers',   readable
+  'appUsers',   readable,               'datasets', readable
 ) {
   // default these properties to 0, since sql gives null if they're 0.
   forApi() {
-    return { forms: this.forms || 0, appUsers: this.appUsers || 0, lastSubmission: this.lastSubmission };
+    return {
+      forms: this.forms || 0,
+      appUsers: this.appUsers || 0,
+      datasets: this.datasets || 0,
+      lastSubmission: this.lastSubmission
+    };
   }
 };
 

--- a/lib/model/migrations/20221003-01-add-dataset-verbs.js
+++ b/lib/model/migrations/20221003-01-add-dataset-verbs.js
@@ -7,11 +7,6 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-// backup.create and backup.terminate will be combined into a single verb,
-// config.set. If a role permitted backup.create but not backup.terminate (or
-// vice versa), that role will now permit both. However, that shouldn't be an
-// issue, because the two verbs should go hand-in-hand.
-
 const { without } = require('ramda');
 
 /* eslint-disable no-await-in-loop */
@@ -26,7 +21,7 @@ const up = async (db) => {
 };
 
 const down = async (db) => {
-  // grant rights.
+  // revoke rights.
   for (const system of [ 'admin', 'manager', 'viewer' ]) {
     const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
     const newVerbs = without([ 'dataset.list', 'dataset.read' ], verbs);

--- a/lib/model/migrations/20221003-01-add-dataset-verbs.js
+++ b/lib/model/migrations/20221003-01-add-dataset-verbs.js
@@ -15,7 +15,7 @@ const up = async (db) => {
   // grant rights.
   for (const system of [ 'admin', 'manager', 'viewer' ]) {
     const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
-    const newVerbs = verbs.concat([ 'dataset.list', 'dataset.read' ]);
+    const newVerbs = verbs.concat([ 'dataset.list', 'entity.list' ]);
     await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
   }
 };
@@ -24,7 +24,7 @@ const down = async (db) => {
   // revoke rights.
   for (const system of [ 'admin', 'manager', 'viewer' ]) {
     const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
-    const newVerbs = without([ 'dataset.list', 'dataset.read' ], verbs);
+    const newVerbs = without([ 'dataset.list', 'entity.list' ], verbs);
     await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
   }
 };

--- a/lib/model/migrations/20221003-01-add-dataset-verbs.js
+++ b/lib/model/migrations/20221003-01-add-dataset-verbs.js
@@ -1,0 +1,50 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+// backup.create and backup.terminate will be combined into a single verb,
+// config.set. If a role permitted backup.create but not backup.terminate (or
+// vice versa), that role will now permit both. However, that shouldn't be an
+// issue, because the two verbs should go hand-in-hand.
+
+const { without } = require('ramda');
+
+/* eslint-disable no-await-in-loop */
+
+const up = async (db) => {
+  // grant rights.
+  for (const system of [ 'admin', 'manager', 'viewer' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = verbs.concat([ 'dataset.list', 'dataset.read' ]);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+
+  for (const system of [ 'admin', 'manager' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = verbs.concat([ 'dataset.create', 'dataset.update' ]);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+};
+
+const down = async (db) => {
+  // grant rights.
+  for (const system of [ 'admin', 'manager', 'viewer' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = without([ 'dataset.list', 'dataset.read' ], verbs);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+
+  for (const system of [ 'admin', 'manager' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = without([ 'dataset.create', 'dataset.update' ], verbs);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+};
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20221003-01-add-dataset-verbs.js
+++ b/lib/model/migrations/20221003-01-add-dataset-verbs.js
@@ -23,12 +23,6 @@ const up = async (db) => {
     const newVerbs = verbs.concat([ 'dataset.list', 'dataset.read' ]);
     await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
   }
-
-  for (const system of [ 'admin', 'manager' ]) {
-    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
-    const newVerbs = verbs.concat([ 'dataset.create', 'dataset.update' ]);
-    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
-  }
 };
 
 const down = async (db) => {
@@ -36,12 +30,6 @@ const down = async (db) => {
   for (const system of [ 'admin', 'manager', 'viewer' ]) {
     const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
     const newVerbs = without([ 'dataset.list', 'dataset.read' ], verbs);
-    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
-  }
-
-  for (const system of [ 'admin', 'manager' ]) {
-    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
-    const newVerbs = without([ 'dataset.create', 'dataset.update' ], verbs);
     await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
   }
 };

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -94,8 +94,8 @@ ${extend|| sql`
     on field_keys."projectId"=projects.id
   left outer join
     (select "projectId", count("id")::integer as "datasets" from datasets
-      group by "projectId") as datasetCounts
-    on datasetCounts."projectId"=projects.id`}
+      group by "projectId") as dataset_counts
+    on dataset_counts."projectId"=projects.id`}
 ${(actorId == null) ? sql`` : sql`
 inner join
   (select id, array_agg(distinct verb) as verbs from projects

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -91,7 +91,11 @@ ${extend|| sql`
       inner join (select id from actors where "deletedAt" is null) as actors
         on actors.id=field_keys."actorId"
       group by "projectId") as field_keys
-    on field_keys."projectId"=projects.id`}
+    on field_keys."projectId"=projects.id
+  left outer join
+    (select "projectId", count("id")::integer as "datasets" from datasets
+      group by "projectId") as datasetCounts
+    on datasetCounts."projectId"=projects.id`}
 ${(actorId == null) ? sql`` : sql`
 inner join
   (select id, array_agg(distinct verb) as verbs from projects

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -16,7 +16,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
     Projects.getById(params.id, queryOptions)
       .then(getOrNotFound)
-      .then((project) => auth.canOrReject('project.read', project)) // TODO change the verb
+      .then((project) => auth.canOrReject('dataset.list', project))
       .then(() => Datasets.getAllByProjectId(params.id))));
 
   service.get('/projects/:projectId/datasets/:name/download', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -9,8 +9,6 @@
 
 const sanitize = require('sanitize-filename');
 const { getOrNotFound } = require('../util/promise');
-const { Form } = require('../model/frames');
-const { ensureFormDef } = require('../util/db');
 const { streamEntityCsvs } = require('../data/entity');
 const { contentDisposition } = require('../util/http');
 
@@ -20,13 +18,6 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.read', project)) // TODO change the verb
       .then(() => Datasets.getAllByProjectId(params.id))));
-
-  service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets }, { params, auth }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
-      .then(getOrNotFound)
-      .then((form) => auth.canOrReject('form.update', form)) // what verb is required here? a new one
-      .then(ensureFormDef)
-      .then(() => Datasets.getDatasetDiff(params.id))));
 
   service.get('/projects/:projectId/datasets/:name/download', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
     Projects.getById(params.projectId) // TODO: different lookup/auth scheme for datasets

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -20,10 +20,11 @@ module.exports = (service, endpoint) => {
       .then(() => Datasets.getAllByProjectId(params.id))));
 
   service.get('/projects/:projectId/datasets/:name/download', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
-    Projects.getById(params.projectId) // TODO: different lookup/auth scheme for datasets
+    Projects.getById(params.projectId)
       .then(getOrNotFound)
-      .then((project) => auth.canOrReject('project.read', project))
+      .then((project) => auth.canOrReject('dataset.read', project))
       .then(() => Datasets.getByName(params.name, params.projectId)
+        //.then(getOrNotFound) // TODO: change dataset query to return option so this can be used
         .then((dataset) => Entities.streamForExport(dataset.id)
           .then((entities) => {
             const filename = sanitize(dataset.name);

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -23,7 +23,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name/download', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
-      .then((project) => auth.canOrReject('dataset.read', project))
+      .then((project) => auth.canOrReject('entity.list', project))
       .then(() => Datasets.getByName(params.name, params.projectId)
         //.then(getOrNotFound) // TODO: change dataset query to return option so this can be used
         .then((dataset) => Entities.streamForExport(dataset.id)

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -8,6 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const sanitize = require('sanitize-filename');
+const { Form } = require('../model/frames');
 const { getOrNotFound } = require('../util/promise');
 const { streamEntityCsvs } = require('../data/entity');
 const { contentDisposition } = require('../util/http');

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -10,7 +10,7 @@
 const path = require('path');
 const { identity } = require('ramda');
 const { Blob, Form } = require('../model/frames');
-const { QueryOptions } = require('../util/db');
+const { ensureFormDef, QueryOptions } = require('../util/db');
 const { isTrue, xml, binary } = require('../util/http');
 const Problem = require('../util/problem');
 const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
@@ -135,6 +135,18 @@ module.exports = (service, endpoint) => {
         : resolve(form)))
       .then(((form) => Promise.all([ Forms.publish(form), Submissions.clearDraftSubmissions(form.id) ])))
       .then(success)));
+
+  // Entity/Dataset-specific endpoint that is used to show how publishing
+  // a form will change any datasets mentioned in the form.
+  // Even though there are dataset-related permissions, we will use the form modification verbs
+  // for authentication because it seems weird to mix the ability/inability to alter a dataset
+  // with the ability to modify forms -- they should just be the same.
+  service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets }, { params, auth }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('form.update', form)) // use form verb
+      .then(ensureFormDef)
+      .then(() => Datasets.getDatasetDiff(params.id))));
 
   service.delete('/projects/:projectId/forms/:id/draft', endpoint(({ Audits, Forms, Submissions }, { params, auth }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -138,15 +138,28 @@ module.exports = (service, endpoint) => {
 
   // Entity/Dataset-specific endpoint that is used to show how publishing
   // a form will change any datasets mentioned in the form.
-  // Even though there are dataset-related permissions, we will use the form modification verbs
-  // for authentication because it seems weird to mix the ability/inability to alter a dataset
-  // with the ability to modify forms -- they should just be the same.
+  // Even though there are dataset-related permissions, we will use a combination of dataset access and
+  // form modification verbs for authentication. Though form.update and dataset.list will likely be part
+  // of the same role for now, we can imagine a future where they are different and want to use the combined
+  // authentication strength.
+  //
+  // e.g.
+  // Someone can list all datasets but can't read forms so they shouldn't be able to get info about the form
+  // through this endpoint.
+  // Or they can modify forms but not access datasets so they shouldn't be able to get info about the datasets
+  // through this endpoint.
+  //
+  // We are not considering a separate 'dataset.update' verb right now because it seems weird to mix the
+  // ability/inability to alter a dataset with the ability to modify forms -- they should just be the same.
   service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets }, { params, auth }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
-      .then((form) => auth.canOrReject('form.update', form)) // use form verb
-      .then(ensureFormDef)
-      .then(() => Datasets.getDatasetDiff(params.id))));
+      .then((form) => Promise.all([
+        auth.canOrReject('form.update', form),
+        auth.canOrReject('dataset.list', form) // We can use the form actee here and the auth check will implicitly look up the project
+      ]))
+      .then(([form, ]) => ensureFormDef(form))
+      .then(() => Datasets.getDatasetDiff(params.id)))); // TODO: change this query to also use project ID
 
   service.delete('/projects/:projectId/forms/:id/draft', endpoint(({ Audits, Forms, Submissions }, { params, auth }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -140,8 +140,9 @@ module.exports = (service, endpoint) => {
   // a form will change any datasets mentioned in the form.
   // Even though there are dataset-related permissions, we will use a combination of dataset access and
   // form modification verbs for authentication. Though form.update and dataset.list will likely be part
-  // of the same role for now, we can imagine a future where they are different and want to use the combined
-  // authentication strength.
+  // of the same role, we want to use the combined authentication strength. One scenario where they are
+  // different is if a user has been assigned a higher auth role on a specific form but not a project,
+  // which can be done through the API: projects/.../forms/.../assignments
   //
   // e.g.
   // Someone can list all datasets but can't read forms so they shouldn't be able to get info about the form
@@ -151,13 +152,21 @@ module.exports = (service, endpoint) => {
   //
   // We are not considering a separate 'dataset.update' verb right now because it seems weird to mix the
   // ability/inability to alter a dataset with the ability to modify forms -- they should just be the same.
-  service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets }, { params, auth }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
-      .then(getOrNotFound)
-      .then((form) => Promise.all([
-        auth.canOrReject('form.update', form),
-        auth.canOrReject('dataset.list', form) // We can use the form actee here and the auth check will implicitly look up the project
-      ]))
+  service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
+    Promise.all([
+      Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion),
+      Projects.getById(params.projectId)
+    ])
+      .then(([form, project]) =>
+        Promise.all([
+          getOrNotFound(form),
+          getOrNotFound(project),
+        ]))
+      .then(([form, project]) =>
+        Promise.all([
+          auth.canOrReject('form.update', form),
+          auth.canOrReject('dataset.list', project)
+        ]))
       .then(([form, ]) => ensureFormDef(form))
       .then(() => Datasets.getDatasetDiff(params.id)))); // TODO: change this query to also use project ID
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -54,6 +54,40 @@ describe('projects/:id/datasets', () => {
                   ]);
                 }))))));
   });
+
+  describe('GET: dataset download', () => {
+    it('should reject if the user cannot access dataset', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => service.login('chelsea', (asChelsea) =>
+            asChelsea.get('/v1/projects/1/datasets/people/download')
+              .expect(403))))));
+
+    it('should let the user download the dataset (even if 0 entity rows)', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.get('/v1/projects/1/datasets/people/download')
+            .expect(200)
+            .then(({ text }) => {
+              text.should.equal('name,label,name,age\n');
+            })))));
+
+    // TODO: right now this returns 500 internal server error
+    it.skip('should reject if dataset does not exist', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200)
+          .then(() => asAlice.get('/v1/projects/1/datasets/nonexistent/download')
+            .expect(404)))));
+  });
 });
 
 describe('projects/:id/forms/:formId/draft/attachment/:name PATCH', () => {

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -125,6 +125,23 @@ describe('api: /projects/:id/forms/draft/dataset', () => {
           asChelsea.get('/v1/projects/1/forms/simpleEntity/draft/dataset-diff')
             .expect(403))))));
 
+  it('should reject if user can modify form but not list datasets on project', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => service.login('chelsea', (asChelsea) =>
+          asChelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body)))
+        .then((chelsea) =>
+          asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/manager/${chelsea.id}`)
+            .expect(200))
+        .then(() => service.login('chelsea', (asChelsea) =>
+          asChelsea.get('/v1/projects/1/forms/simpleEntity/draft/dataset-diff')
+            .expect(403))))));
+
   it('should return all properties of dataset', testService(async (service) => {
     // Upload a form and then create a new draft version
     await service.login('alice', (asAlice) =>

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -115,6 +115,16 @@ describe('api: /projects/:id/forms (entity-handling)', () => {
 
 describe('api: /projects/:id/forms/draft/dataset', () => {
 
+  it('should reject dataset-diff if the user cannot modify the form', testService((service) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => service.login('chelsea', (asChelsea) =>
+          asChelsea.get('/v1/projects/1/forms/simpleEntity/draft/dataset-diff')
+            .expect(403))))));
+
   it('should return all properties of dataset', testService(async (service) => {
     // Upload a form and then create a new draft version
     await service.login('alice', (asAlice) =>

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1336,7 +1336,7 @@ describe('api: /projects', () => {
 });
 
 
-describe('api: /projects?forms=true', () => {
+describe('api: /projects', () => {
   describe('GET', () => {
     it('should return projects with verbs and nested extended forms', testService((service) =>
       service.login('alice', (asAlice) => asAlice.get('/v1/projects?forms=true')
@@ -1345,7 +1345,7 @@ describe('api: /projects?forms=true', () => {
           body.length.should.equal(1);
           body[0].should.be.a.Project();
           const { formList, verbs } = body[0];
-          verbs.length.should.equal(40);
+          verbs.length.should.equal(44);
           formList.length.should.equal(2);
           const form = formList[0];
           form.should.be.a.ExtendedForm();
@@ -1409,7 +1409,7 @@ describe('api: /projects?forms=true', () => {
             body.length.should.equal(2);
             // First project
             body[0].formList.length.should.equal(2);
-            body[0].verbs.length.should.equal(25);
+            body[0].verbs.length.should.equal(29);
             // Second project
             body[1].formList.length.should.equal(1);
             body[1].verbs.length.should.be.lessThan(5); // 4 for data collector
@@ -1465,6 +1465,10 @@ describe('api: /projects?forms=true', () => {
                   'submission.list',   // from role(s): viewer
                   // eslint-disable-next-line no-multi-spaces
                   'submission.read',   // from role(s): viewer
+                  // eslint-disable-next-line no-multi-spaces
+                  'dataset.list',     // from role(s): viewer
+                  // eslint-disable-next-line no-multi-spaces
+                  'dataset.read'      // from role(s): viewer
                 ]);
               }))))));
   });
@@ -1505,7 +1509,11 @@ describe('api: /projects?forms=true', () => {
               'submission.read',  // from role(s): viewer
               // eslint-disable-next-line no-multi-spaces
               'submission.list',  // from role(s): viewer
-              'submission.create' // from role(s): app-user
+              'submission.create', // from role(s): app-user
+              // eslint-disable-next-line no-multi-spaces
+              'dataset.list',  // from role(s): viewer
+              // eslint-disable-next-line no-multi-spaces
+              'dataset.read'   // from role(s): viewer
             ]);
           }))))));
 });

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -355,7 +355,7 @@ describe('api: /projects', () => {
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
             body.verbs.length.should.be.greaterThan(39);
-            body.verbs.should.containDeep([ 'user.password.invalidate' ]);
+            body.verbs.should.containDeep([ 'user.password.invalidate', 'project.delete' ]);
           }))));
 
     it('should return verb information with extended metadata (bob)', testService((service) =>
@@ -365,7 +365,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
-            body.verbs.length.should.be.lessThan(30);
+            body.verbs.length.should.be.lessThan(28);
             body.verbs.should.containDeep([ 'assignment.create', 'project.delete', 'dataset.list' ]);
             body.verbs.should.not.containDeep([ 'project.create' ]);
           }))));
@@ -383,11 +383,11 @@ describe('api: /projects', () => {
               .then(({ body }) => {
                 body.verbs.should.eqlInAnyOrder([
                   // eslint-disable-next-line no-multi-spaces
-                  'project.read',      // from role(s): formfill, viewer
+                  'project.read',      // from role(s): formfill
                   // eslint-disable-next-line no-multi-spaces
-                  'form.list',         // from role(s): formfill, viewer
+                  'form.list',         // from role(s): formfill
                   // eslint-disable-next-line no-multi-spaces
-                  'form.read',         // from role(s): formfill, viewer
+                  'form.read',         // from role(s): formfill
                   'submission.create', // from role(s): formfill
                 ]);
               }))))));

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -420,7 +420,7 @@ describe('api: /projects', () => {
                   // eslint-disable-next-line no-multi-spaces
                   'dataset.list',      // from role(s): viewer
                   // eslint-disable-next-line no-multi-spaces
-                  'dataset.read',      // from role(s): viewer
+                  'entity.list',      // from role(s): viewer
                 ]);
               }))))));
   });
@@ -1468,7 +1468,7 @@ describe('api: /projects', () => {
                   // eslint-disable-next-line no-multi-spaces
                   'dataset.list',     // from role(s): viewer
                   // eslint-disable-next-line no-multi-spaces
-                  'dataset.read'      // from role(s): viewer
+                  'entity.list'      // from role(s): viewer
                 ]);
               }))))));
   });
@@ -1513,7 +1513,7 @@ describe('api: /projects', () => {
               // eslint-disable-next-line no-multi-spaces
               'dataset.list',  // from role(s): viewer
               // eslint-disable-next-line no-multi-spaces
-              'dataset.read'   // from role(s): viewer
+              'entity.list'   // from role(s): viewer
             ]);
           }))))));
 });

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -295,6 +295,7 @@ describe('api: /projects', () => {
           .then(({ body }) => {
             body.should.be.an.ExtendedProject();
             body.forms.should.equal(2);
+            body.datasets.should.equal(0);
             should.not.exist(body.lastSubmission);
           })
           .then(() => Promise.all([
@@ -307,12 +308,17 @@ describe('api: /projects', () => {
               .set('Content-Type', 'application/xml')
               .expect(200)
           ]))
+          .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200))
           .then(() => asAlice.get('/v1/projects/1')
             .set('X-Extended-Metadata', 'true')
             .expect(200)
             .then(({ body }) => {
               body.should.be.an.ExtendedProject();
-              body.forms.should.equal(2);
+              body.forms.should.equal(3);
+              body.datasets.should.equal(1);
               body.lastSubmission.should.be.a.recentIsoDate();
             })))));
 

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -355,7 +355,7 @@ describe('api: /projects', () => {
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
             body.verbs.length.should.be.greaterThan(39);
-            body.verbs.should.containDeep([ 'user.password.invalidate', 'dataset.create' ]);
+            body.verbs.should.containDeep([ 'user.password.invalidate' ]);
           }))));
 
     it('should return verb information with extended metadata (bob)', testService((service) =>
@@ -367,7 +367,7 @@ describe('api: /projects', () => {
             body.verbs.should.be.an.Array();
             body.verbs.length.should.be.lessThan(30);
             body.verbs.should.containDeep([ 'assignment.create', 'project.delete', 'dataset.list' ]);
-            body.verbs.should.not.containDeep([ 'project.create', 'dataset.create' ]);
+            body.verbs.should.not.containDeep([ 'project.create' ]);
           }))));
 
     it('should return verb information with extended metadata (data collector only)', testService((service) =>
@@ -1345,7 +1345,7 @@ describe('api: /projects', () => {
           body.length.should.equal(1);
           body[0].should.be.a.Project();
           const { formList, verbs } = body[0];
-          verbs.length.should.equal(44);
+          verbs.length.should.equal(42);
           formList.length.should.equal(2);
           const form = formList[0];
           form.should.be.a.ExtendedForm();
@@ -1409,7 +1409,7 @@ describe('api: /projects', () => {
             body.length.should.equal(2);
             // First project
             body[0].formList.length.should.equal(2);
-            body[0].verbs.length.should.equal(29);
+            body[0].verbs.length.should.equal(27);
             // Second project
             body[1].formList.length.should.equal(1);
             body[1].verbs.length.should.be.lessThan(5); // 4 for data collector


### PR DESCRIPTION
Changes to backend to support Frontend PR: https://github.com/getodk/central-frontend/pull/636 (first version of Datasets tab)

* Adds dataset count to Project extended metadata (so Frontend can show datasets tab and page only if some exist)
* Adds `dataset.list` and `dataset.read` verbs to the permissions for the following roles: admin, manager, and viewer.
* Adds some other verbs like `dataset.create` and `dataset.update` to admin and manager only (not viewer)

Still todo in this PR or a separate one:
- [x] Use these permissions in endpoints about datasets.
- [x] Write tests checking the permission guards work.

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Needed by frontend.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

- [ ] Documentation needs to be updated to include this extra dataset count in the Project extended metadata description.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes