### PR TITLE
ci-benchmark: add final timeout for stream queries

### DIFF
--- a/benchmarker/scripts/ci-benchmark
+++ b/benchmarker/scripts/ci-benchmark
@@ -50,7 +50,7 @@ else
 fi
 
 log 'Checking open DB query count...'
-(cd .. && node lib/bin/check-open-db-queries.js)
+timeout 120 bash -c "cd ..; while ! node lib/bin/check-open-db-queries.js; do sleep 1; done"
 
 # TODO upload results to getodk.cloud for graphing.  Include:
 #


### PR DESCRIPTION
Streams should time out after 2 minutes of inactivity, so we should wait for that before deciding if there are unterminated/hanging connections left open after requests have been served.
