### PR TITLE
Set Sentry tags

### DIFF
--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { inspect } = require('util');
-const { isBlank } = require('../util/util');
+const { isBlank, isPresent } = require('../util/util');
 
 
 // Endpoints where query strings are sensitive and should be removed
@@ -132,6 +132,12 @@ const init = (config) => {
 
   const username = require('os').hostname();
   Sentry.setUser({ username });
+
+  if (isPresent(process.env.SENTRY_TAGS)) {
+    const tags = JSON.parse(process.env.SENTRY_TAGS);
+    for (const [key, value] of Object.entries(tags))
+      Sentry.setTag(key, value);
+  }
 
   return Sentry;
 };


### PR DESCRIPTION
This PR sets [Sentry tags](https://docs.sentry.io/platforms/node/enriching-events/tags/) that are specified in an environment variable named `SENTRY_TAGS`. The approach is generic — any sort of tags could be set — but it was developed as part of getodk/central#317 in order to pass Central version information to Sentry. Together with getodk/central#317, this PR closes #547.

#### What has been done to verify that this works as intended?

Nothing yet. Once this PR has been merged, I'll verify it on the QA server.

#### Why is this the best possible solution? Were any other approaches considered?

We discussed this broad strategy in getodk/central#317.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change only touches Sentry. When I verify this change, that'll also verify that Sentry is still working.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No change needed.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments