### PR TITLE
Audit logging of dataset and entity creation

### DIFF
--- a/lib/model/frames/dataset.js
+++ b/lib/model/frames/dataset.js
@@ -14,7 +14,8 @@ const { Frame, table, readable, writable, embedded } = require('../frame');
 const Dataset = Frame.define(
   table('datasets'),
   'id',        readable,                       'name', readable, writable,
-  'projectId',        readable, writable,             'revisionNumber', readable,
+  'createdAt', readable,                       'acteeId',
+  'projectId', readable, writable,             'revisionNumber', readable,
   embedded('properties')
 );
 

--- a/lib/model/migrations/20220803-01-create-entities-schema.js
+++ b/lib/model/migrations/20220803-01-create-entities-schema.js
@@ -11,6 +11,8 @@ const up = async (db) => {
   await db.schema.createTable('datasets', (datasets) => {
     datasets.increments('id').primary();
     datasets.text('name').notNull();
+    datasets.string('acteeId', 36).notNull();
+    datasets.dateTime('createdAt');
     datasets.integer('projectId').notNull();
     datasets.integer('revisionNumber').notNull().defaultTo(0);
 

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -33,7 +33,7 @@ values (${actorId}, ${action}, ${acteeId}, ${(details == null) ? null : JSON.str
 // TODO: some sort of central table for all these things, not here.
 const actionCondition = (action) => {
   if (action === 'nonverbose')
-    return sql`action not in ('entity.create', 'submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup', 'analytics')`;
+    return sql`action not in ('entity.create', 'entity.create.error', 'submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup', 'analytics')`;
   else if (action === 'user')
     return sql`action in ('user.create', 'user.update', 'user.delete', 'user.assignment.create', 'user.assignment.delete', 'user.session.create')`;
   else if (action === 'field_key')
@@ -49,7 +49,7 @@ const actionCondition = (action) => {
   else if (action === 'dataset')
     return sql`action in ('dataset.create', 'dataset.update')`;
   else if (action === 'entity')
-    return sql`action in ('entity.create')`;
+    return sql`action in ('entity.create', 'entity.create.error')`;
 
   return sql`action=${action}`;
 };

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -9,7 +9,7 @@
 
 const { sql } = require('slonik');
 const { map } = require('ramda');
-const { Actee, Actor, Audit, Form, Project } = require('../frames');
+const { Actee, Actor, Audit, Dataset, Form, Project } = require('../frames');
 const { extender, equals, page, QueryOptions } = require('../../util/db');
 const Option = require('../../util/option');
 const { construct } = require('../../util/util');
@@ -33,7 +33,7 @@ values (${actorId}, ${action}, ${acteeId}, ${(details == null) ? null : JSON.str
 // TODO: some sort of central table for all these things, not here.
 const actionCondition = (action) => {
   if (action === 'nonverbose')
-    return sql`action not in ('submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup', 'analytics')`;
+    return sql`action not in ('entity.create', 'submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup', 'analytics')`;
   else if (action === 'user')
     return sql`action in ('user.create', 'user.update', 'user.delete', 'user.assignment.create', 'user.assignment.delete', 'user.session.create')`;
   else if (action === 'field_key')
@@ -46,6 +46,10 @@ const actionCondition = (action) => {
     return sql`action in ('form.create', 'form.update', 'form.delete', 'form.restore', 'form.purge', 'form.attachment.update', 'form.submission.export', 'form.update.draft.set', 'form.update.draft.delete', 'form.update.publish')`;
   else if (action === 'submission')
     return sql`action in ('submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update')`;
+  else if (action === 'dataset')
+    return sql`action in ('dataset.create', 'dataset.update')`;
+  else if (action === 'entity')
+    return sql`action in ('entity.create')`;
 
   return sql`action=${action}`;
 };
@@ -66,7 +70,7 @@ const auditFilterer = (options) => {
   return (result.length === 0) ? sql`true` : sql.join(result, sql` and `);
 };
 
-const _get = extender(Audit)(Option.of(Actor), Option.of(Actor.alias('actee_actor', 'acteeActor')), Option.of(Form), Option.of(Form.Def), Option.of(Project), Option.of(Actee))((fields, extend, options) => sql`
+const _get = extender(Audit)(Option.of(Actor), Option.of(Actor.alias('actee_actor', 'acteeActor')), Option.of(Form), Option.of(Form.Def), Option.of(Project), Option.of(Dataset), Option.of(Actee))((fields, extend, options) => sql`
 select ${fields} from audits
   ${extend|| sql`
     left outer join actors on actors.id=audits."actorId"
@@ -74,6 +78,7 @@ select ${fields} from audits
     left outer join actors as actee_actor on actee_actor."acteeId"=audits."acteeId"
     left outer join forms on forms."acteeId"=audits."acteeId"
     left outer join form_defs on form_defs.id=forms."currentDefId"
+    left outer join datasets on datasets."acteeId"=audits."acteeId"
     left outer join actees on actees.id=audits."acteeId"`}
   where ${equals(options.condition)} and ${auditFilterer(options)}
   order by "loggedAt" desc, audits.id desc
@@ -87,7 +92,7 @@ const get = (options = QueryOptions.none) => ({ all }) =>
     // TODO: better if we don't have to loop over all this data twice.
     return rows.map((row) => {
       const form = row.aux.form.map((f) => f.withAux('def', row.aux.def));
-      const actees = [ row.aux.acteeActor, form, row.aux.project, row.aux.actee ];
+      const actees = [ row.aux.acteeActor, form, row.aux.project, row.aux.dataset, row.aux.actee ];
       return new Audit(row, { actor: row.aux.actor, actee: Option.firstDefined(actees) });
     });
   });

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -128,6 +128,8 @@ const _getByNameSql = ((fields, datasetName, projectId) => sql`
 
 // Creates or merges dataset, properties and field mapping.
 // Expects dataset:Frame auxed with `formDefId` and array of field:Frame auxed with `propertyName`
+// Note from Kathleen: I apologize at how hacky it is to get the provisioned actee ID into this
+// and get the created dataset out again...
 const createOrMerge = (dataset, fields) => ({ all, Actees, Datasets, Projects }) =>
   Promise.all([
     Projects.getById(dataset.projectId).then((o) => o.get()),
@@ -138,7 +140,15 @@ const createOrMerge = (dataset, fields) => ({ all, Actees, Datasets, Projects })
         ? datasetOption.get().acteeId
         : Actees.provision('dataset', project).then((actee) => (actee.id))))
     .then((acteeId) =>
-      all(_createOrMerge(dataset, fields, acteeId)));
+      all(_createOrMerge(dataset, fields, acteeId)))
+    .then(() => Datasets.getByProjectAndName(dataset.projectId, dataset.name))
+    .then((ds) => ds.get());
+
+createOrMerge.audit = (dataset, _, fields) => (log) =>
+  ((dataset.revisionNumber === 0)
+    ? log('dataset.create', dataset, { fields: fields.map((f) => [f.path, f.propertyName]) })
+    : log('dataset.update', dataset, { fields: fields.map((f) => [f.path, f.propertyName]) }));
+createOrMerge.audit.withResult = true;
 
 // Returns dataset along with it properties and field mappings
 const getById = (datasetId) => ({ all }) =>

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -59,10 +59,10 @@ const _getAllByProjectId = (projectId) => sql`
   WHERE fd."publishedAt" IS NOT NULL AND d."projectId" = ${projectId}
 `;
 
-const _insertDatasetDef = (dataset, withDsDefsCTE) => sql`
+const _insertDatasetDef = (dataset, acteeId, withDsDefsCTE) => sql`
   WITH ds AS (
-    INSERT INTO datasets VALUES 
-    (nextval(pg_get_serial_sequence('datasets', 'id')), ${dataset.name}, ${dataset.projectId}, 0) 
+    INSERT INTO datasets (id, name, "projectId", "revisionNumber", "createdAt", "acteeId")
+    VALUES (nextval(pg_get_serial_sequence('datasets', 'id')), ${dataset.name}, ${dataset.projectId}, 0, clock_timestamp(), ${acteeId})
     ON CONFLICT ON CONSTRAINT datasets_name_projectid_unique 
     DO UPDATE SET "revisionNumber" = datasets."revisionNumber" + 1
     RETURNING *
@@ -75,8 +75,8 @@ const _insertDatasetDef = (dataset, withDsDefsCTE) => sql`
   ${raw(withDsDefsCTE ? '),' : '')}
 `;
 
-const _createOrMerge = (dataset, fields) => (isNilOrEmpty(fields) ? _insertDatasetDef(dataset, false) : sql`
-${_insertDatasetDef(dataset, true)}
+const _createOrMerge = (dataset, fields, acteeId) => (isNilOrEmpty(fields) ? _insertDatasetDef(dataset, acteeId, false) : sql`
+${_insertDatasetDef(dataset, acteeId, true)}
 fields("propertyName", "formDefId", path) AS (VALUES      
   ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.formDefId, p.path], sql`,`)} )`), sql`,`)}
 ),
@@ -128,8 +128,17 @@ const _getByNameSql = ((fields, datasetName, projectId) => sql`
 
 // Creates or merges dataset, properties and field mapping.
 // Expects dataset:Frame auxed with `formDefId` and array of field:Frame auxed with `propertyName`
-const createOrMerge = (dataset, fields) => ({ all }) =>
-  all(_createOrMerge(dataset, fields));
+const createOrMerge = (dataset, fields) => ({ all, Actees, Datasets, Projects }) =>
+  Promise.all([
+    Projects.getById(dataset.projectId).then((o) => o.get()),
+    Datasets.getByProjectAndName(dataset.projectId, dataset.name)
+  ])
+    .then(([project, datasetOption]) =>
+      (datasetOption.isDefined()
+        ? datasetOption.get().acteeId
+        : Actees.provision('dataset', project).then((actee) => (actee.id))))
+    .then((acteeId) =>
+      all(_createOrMerge(dataset, fields, acteeId)));
 
 // Returns dataset along with it properties and field mappings
 const getById = (datasetId) => ({ all }) =>

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -33,7 +33,12 @@ const _defInsert = (id, partial, subDefId, json) => sql`insert into entity_defs 
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 
-// creates both the entity and its initial entity def in one go.
+// Creates both the entity and its initial entity def in one go.
+// Note: the logging of this action will happen elsewhere, not with the usual
+// createNew.audit mechanism because this is called by a worker rather than a
+// standard authenticated API request. The worker has better access to the event
+// actor/initiator and actee/target so it will do the logging itself (including
+// error logging).
 const createNew = (partial, subDef) => ({ one }) => {
   const json = JSON.stringify(partial.def.data);
   return one(sql`
@@ -55,8 +60,6 @@ select ins.*, def.id as "entityDefId" from ins, def;`)
         })
       }));
 };
-
-// TODO: add and tests entity creation audit logging and error handling (failed validation, etc.)
 
 // HACK: This is a function to check if the entity *can* successfully be inserted
 // because without it... in the case of processing an entity within a worker,

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -21,8 +21,8 @@ const { construct } = require('../../util/util');
 // so we will look up the dataset id by name (unique within a project)
 // and project id (from submission def -> submission -> form def -> form)
 const _getDataset = (dsName, subDefId) => sql`
-SELECT datasets."id", sd."id" as "subDefId" FROM
-submission_defs AS sd
+SELECT datasets."id", sd."id" as "subDefId", datasets."acteeId"
+FROM submission_defs AS sd
   JOIN form_defs AS fd ON sd."formDefId" = fd."id"
   JOIN forms AS f ON fd."formId" = f."id"
   JOIN datasets ON datasets."projectId" = f."projectId"
@@ -48,8 +48,8 @@ ins as (insert into entities (id, "datasetId", "uuid", "label", "createdAt", "cr
   select def."entityId", ds."id", ${partial.uuid}, ${partial.label}, def."createdAt", ${subDef.submitterId} from def
   join ds on ds."subDefId" = def."submissionDefId"
   returning entities.*)
-select ins.*, def.id as "entityDefId" from ins, def;`)
-    .then(({ entityDefId, ...entityData }) => // TODO/HACK: reassembly inspired by Submissions.createNew
+select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId" from ins, def, ds;`)
+    .then(({ entityDefId, dsActeeId, ...entityData }) => // TODO/HACK: reassembly inspired by Submissions.createNew
       new Entity(entityData, {
         def: new Entity.Def({
           id: entityDefId,
@@ -57,7 +57,8 @@ select ins.*, def.id as "entityDefId" from ins, def;`)
           submissionDefId: subDef.id,
           createdAt: entityData.createdAt,
           data: partial.def.data
-        })
+        }),
+        dataset: { acteeId: dsActeeId }
       }));
 };
 

--- a/lib/worker/entity.js
+++ b/lib/worker/entity.js
@@ -11,9 +11,7 @@ const createEntityFromSubmission = ({ Audits, Entities }, event) => {
   if (event.details.reviewState === 'approved' && event.details.submissionDefId) {
     return Entities.processSubmissionDef(event.details.submissionDefId)
       .then((entity) => {
-        // TODO: figure out target for this audit. Could be the form of the
-        // original event or it could be the entity's dataset.
-        Audits.log({ id: event.actorId }, 'entity.create', null,
+        Audits.log({ id: event.actorId }, 'entity.create', { acteeId: entity.aux.dataset.acteeId },
           { entityUuid: entity.uuid,
             submissionId: event.details.submissionId,
             submissionDefId: event.details.submissionDefId });

--- a/lib/worker/entity.js
+++ b/lib/worker/entity.js
@@ -7,15 +7,22 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const createEntityFromSubmission = ({ Entities }, event) => {
+const createEntityFromSubmission = ({ Audits, Entities }, event) => {
   if (event.details.reviewState === 'approved' && event.details.submissionDefId) {
     return Entities.processSubmissionDef(event.details.submissionDefId)
+      .then((entity) => {
+        // TODO: figure out target for this audit. Could be the form of the
+        // original event or it could be the entity's dataset.
+        Audits.log({ id: event.actorId }, 'entity.create', null,
+          { entityUuid: entity.uuid,
+            submissionId: event.details.submissionId,
+            submissionDefId: event.details.submissionDefId });
+      })
       .catch((problem) => {
-        // TODO: log error
-        // e.g. Audits.log({ id: event.actorId }, 'submission.process.entity', { acteeId: event.acteeId }, { problem })
-
-        // eslint-disable-next-line no-console
-        console.log('Problem successfully caught by entity worker:', problem);
+        Audits.log({ id: event.actorId }, 'entity.create.error', null,
+          { submissionId: event.details.submissionId,
+            submissionDefId: event.details.submissionDefId,
+            problem });
       });
   }
 };

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -574,6 +574,21 @@ describe('/audits', () => {
               deletedActee.deletedAt.should.be.a.recentIsoDate();
             }))));
     });
+
+    describe('audit logs of dataset and entity events', () => {
+      it('should get the actee information of a dataset', testService(async (service) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms?publish=true')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.get('/v1/audits?action=dataset').set('X-Extended-Metadata', true)
+              .expect(200))
+            .then(({ body }) => {
+              const datasetActee = body[0].actee;
+              datasetActee.name.should.equal('people');
+            }))));
+    });
   });
 });
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -32,7 +32,7 @@ describe('projects/:id/datasets', () => {
             asAlice.get('/v1/projects/1/datasets')
               .expect(200)
               .then(({ body }) => {
-                body.map(({ id, ...d }) => d).should.eql([
+                body.map(({ id, createdAt, ...d }) => d).should.eql([
                   { name: 'people', projectId: 1, revisionNumber: 0 }
                 ]);
               })))));
@@ -52,7 +52,7 @@ describe('projects/:id/datasets', () => {
               asAlice.get('/v1/projects/1/datasets')
                 .expect(200)
                 .then(({ body }) => {
-                  body.map(({ id, ...d }) => d).should.eql([
+                  body.map(({ id, createdAt, ...d }) => d).should.eql([
                     { name: 'student', projectId: 1, revisionNumber: 0 }
                   ]);
                 }))))));

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1298,7 +1298,7 @@ describe('api: /projects', () => {
             asAlice.get('/v1/projects/1/datasets')
               .expect(200)
               .then(({ body }) => {
-                body.map(({ id, ...d }) => d).should.eql([
+                body.map(({ id, createdAt, ...d }) => d).should.eql([
                   { name: 'people', projectId: 1, revisionNumber: 0 }
                 ]);
               })))));
@@ -1318,7 +1318,7 @@ describe('api: /projects', () => {
               asAlice.get('/v1/projects/1/datasets')
                 .expect(200)
                 .then(({ body }) => {
-                  body.map(({ id, ...d }) => d).should.eql([
+                  body.map(({ id, createdAt, ...d }) => d).should.eql([
                     { name: 'student', projectId: 1, revisionNumber: 0 }
                   ]);
                 }))))));

--- a/test/integration/other/entities.js
+++ b/test/integration/other/entities.js
@@ -74,6 +74,87 @@ describe('entities, etc.', () => {
     count.should.equal(1);
   }));
 
+  it('should log entity creation in audit log', testService(async (service, container) => {
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200)));
+
+    await service.login('bob', (asBob) =>
+      asBob.patch('/v1/projects/1/forms/simpleEntity/submissions/one')
+        .send({ reviewState: 'approved' })
+        .expect(200));
+
+    await exhaust(container);
+
+    const approveEvent = await container.Audits.getLatestByAction('submission.update').then((o) => o.get());
+
+    const event = await container.Audits.getLatestByAction('entity.create').then((o) => o.get());
+    event.actorId.should.equal(6); // Bob
+    event.details.submissionId.should.equal(approveEvent.details.submissionId);
+
+    const entity = await container.Entities.getByUuid(event.details.entityUuid).then((o) => o.get());
+    entity.label.should.equal('Alice (88)');
+  }));
+
+  it.skip('should log entity error in audit log', testService(async (service, container) => {
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one.replace('people', 'invalid.dataset'))
+          .set('Content-Type', 'application/xml')
+          .expect(200)));
+
+    await service.login('bob', (asBob) =>
+      asBob.patch('/v1/projects/1/forms/simpleEntity/submissions/one')
+        .send({ reviewState: 'approved' })
+        .expect(200));
+
+    await exhaust(container);
+
+    const approveEvent = await container.Audits.getLatestByAction('submission.update').then((o) => o.get());
+
+    const event = await container.Audits.getLatestByAction('entity.create.error').then((o) => o.get());
+    event.actorId.should.equal(6); // Bob
+    event.details.submissionId.should.equal(approveEvent.details.submissionId);
+    // TODO: nonexistent dataset currently throwing the wrong kind of error
+    should.exist(event.details.problem);
+  }));
+
+  it('should log entity error in audit log', testService(async (service, container) => {
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one.replace('uuid', 'nomoreuuid'))
+          .set('Content-Type', 'application/xml')
+          .expect(200)));
+
+    await service.login('bob', (asBob) =>
+      asBob.patch('/v1/projects/1/forms/simpleEntity/submissions/one')
+        .send({ reviewState: 'approved' })
+        .expect(200));
+
+    await exhaust(container);
+
+    const approveEvent = await container.Audits.getLatestByAction('submission.update').then((o) => o.get());
+
+    const event = await container.Audits.getLatestByAction('entity.create.error').then((o) => o.get());
+    event.actorId.should.equal(6); // Bob
+    event.details.submissionId.should.equal(approveEvent.details.submissionId);
+    event.details.problem.problemCode.should.equal(409.14);
+  }));
+
   it('should write out some csv stuff from worker', testService((service, container) =>
     service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms?publish=true')

--- a/test/integration/other/entities.js
+++ b/test/integration/other/entities.js
@@ -94,11 +94,11 @@ describe('entities, etc.', () => {
 
     const approveEvent = await container.Audits.getLatestByAction('submission.update').then((o) => o.get());
 
-    const event = await container.Audits.getLatestByAction('entity.create').then((o) => o.get());
-    event.actorId.should.equal(6); // Bob
-    event.details.submissionId.should.equal(approveEvent.details.submissionId);
+    const createEvent = await container.Audits.getLatestByAction('entity.create').then((o) => o.get());
+    createEvent.actorId.should.equal(6); // Bob
+    createEvent.details.submissionId.should.equal(approveEvent.details.submissionId);
 
-    const entity = await container.Entities.getByUuid(event.details.entityUuid).then((o) => o.get());
+    const entity = await container.Entities.getByUuid(createEvent.details.entityUuid).then((o) => o.get());
     entity.label.should.equal('Alice (88)');
   }));
 


### PR DESCRIPTION
Logs `dataset.create`, `dataset.update`, `entity.create` and `entity.create.error` events.

Some changes to make this happen:
* adding an `acteeId` on Datasets
* adding the above events to the listed types of audit log events under new categories of Dataset and Entity events


#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This will add new audit log events but shouldn't have any regression risks.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Need to document new types of events.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
