### PR TITLE
Fix: update dataset form attachment on publish

### DIFF
--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -87,6 +87,7 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
           formId: form.id,
           formDefId: savedDef.id,
           blobId: extant.map((e) => e.blobId).orElse(undefined),
+          datasetId: extant.map((e) => e.datasetId).orElse(undefined),
           updatedAt: extant.map((e) => e.updatedAt).orElse(undefined)
         }, expected));
       });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -111,7 +111,7 @@ describe('projects/:id/forms/:formId/draft/attachment/:name PATCH', () => {
             blobExists: false,
             datasetExists: true
           })))
-        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish')
+        .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish?version=newversion')
           .expect(200))
         .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/attachments')
           .expect(200)


### PR DESCRIPTION
Fixes a bug I noticed while trying to make use of entities.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments