### PR TITLE
new: dataset-diff endpoint for published forms

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -223,6 +223,7 @@ const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
     SELECT DISTINCT p."datasetId", p.name, ps."isNew" "isNew", ps."inForm" FROM properties p 
     JOIN propertyStatus ps ON ps.name = p.name AND ps."datasetId" = p."datasetId" 
   ) p ON ds.id = p."datasetId"
+  ${forDraft ? sql`` : sql`WHERE NOT p."isNew"`}
   ORDER BY p.name
 `)
   .then(reduceBy((acc, { propertyName, isPropertyNew, inForm }) => (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -185,15 +185,15 @@ ORDER BY form_fields."order"
 `)
   .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName }))); // TODO augment this field so it also has the property name
 
-const getDatasetDiff = (projectId, formDefId) => ({ all }) => all(sql`
+const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
   WITH form AS (
-    SELECT * FROM forms WHERE "projectId" = ${projectId} and "xmlFormId" = ${formDefId}
+    SELECT * FROM forms WHERE "projectId" = ${projectId} and "xmlFormId" = ${xmlFormId}
   ),
   ds AS (
     SELECT id, name, sum(formStatus) <= 0 "isNew" FROM (
       SELECT d.id, d.name, all_dd."formDefId", CASE WHEN all_fd."publishedAt" IS NULL THEN 0 ELSE 1 END formStatus 
       FROM form f 
-      JOIN dataset_form_defs dd ON dd."formDefId" = f."draftDefId"  
+      JOIN dataset_form_defs dd ON dd."formDefId" = f.${forDraft ? sql.identifier(['draftDefId']) : sql.identifier(['currentDefId'])} 
       JOIN datasets d ON d.id = dd."datasetId" 
       JOIN dataset_form_defs all_dd ON all_dd."datasetId" = d.id 
       JOIN form_defs all_fd ON all_fd.id = all_dd."formDefId"
@@ -201,28 +201,32 @@ const getDatasetDiff = (projectId, formDefId) => ({ all }) => all(sql`
     GROUP BY id, name
   ),
   properties AS (
-    SELECT dp.*, dpf.*, CASE WHEN pfd."publishedAt" IS NULL THEN 0 ELSE 1 END pfStatus FROM ds_properties dp 
+    SELECT 
+      dp.*, 
+      dpf.*, 
+      CASE WHEN pfd."publishedAt" IS NULL THEN 0 ELSE 1 END pfStatus,
+      CASE WHEN form.id IS NULL THEN 0 ELSE 1 END inFormStatus
+    FROM ds_properties dp 
     JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id 
     JOIN form_defs pfd ON pfd.id = dpf."formDefId" 
     JOIN ds ON ds.id = dp."datasetId"
+    LEFT JOIN form on form.${forDraft ? sql.identifier(['draftDefId']) : sql.identifier(['currentDefId'])} = pfd.id
   ),
   propertyStatus AS (
-    SELECT "datasetId", name, sum(pfStatus) <= 0 "isNew"
+    SELECT "datasetId", name, sum(pfStatus) = 0 "isNew", sum(inFormStatus) > 0 "inForm"
     FROM properties
     GROUP BY "datasetId", name
   )
-  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew" FROM form
+  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew", p."inForm" FROM form
   CROSS JOIN ds
   LEFT JOIN (
-    SELECT p.*, ps."isNew" "isNew" FROM properties p 
+    SELECT DISTINCT p."datasetId", p.name, ps."isNew" "isNew", ps."inForm" FROM properties p 
     JOIN propertyStatus ps ON ps.name = p.name AND ps."datasetId" = p."datasetId" 
-  ) p ON ds.id = p."datasetId" AND form."draftDefId" = p."formDefId"
-  WHERE p.name IS NOT NULL OR ds."isNew"
+  ) p ON ds.id = p."datasetId"
   ORDER BY p.name
 `)
-// AND ps.status = 'Draft'
-  .then(reduceBy((acc, { propertyName, isPropertyNew }) => (propertyName ? acc.concat({ name: propertyName, isNew: isPropertyNew }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
-  .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: k.split(',')[1] === 'true', properties: r[k] })));
+  .then(reduceBy((acc, { propertyName, isPropertyNew, inForm }) => (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
+  .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: forDraft ? k.split(',')[1] === 'true' : undefined, properties: r[k] })));
 
 const getByProjectAndName = (projectId, name) => ({ maybeOne }) => maybeOne(sql`
 SELECT * FROM datasets WHERE "projectId" = ${projectId} AND name = ${name}`)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -164,7 +164,25 @@ module.exports = (service, endpoint) => {
           auth.canOrReject('dataset.list', project)
         ]))
       .then(([form, ]) => ensureDef(form))
-      .then(() => Datasets.getDatasetDiff(params.projectId, params.id))));
+      .then(() => Datasets.getDatasetDiff(params.projectId, params.id, true))));
+
+  service.get('/projects/:projectId/forms/:id/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
+    Promise.all([
+      Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.PublishedVersion),
+      Projects.getById(params.projectId)
+    ])
+      .then(([form, project]) =>
+        Promise.all([
+          getOrNotFound(form),
+          getOrNotFound(project),
+        ]))
+      .then(([form, project]) =>
+        Promise.all([
+          auth.canOrReject('form.update', form),
+          auth.canOrReject('dataset.list', project)
+        ]))
+      .then(([form, ]) => ensureDef(form))
+      .then(() => Datasets.getDatasetDiff(params.projectId, params.id, false))));
 
   service.delete('/projects/:projectId/forms/:id/draft', endpoint(({ Audits, Forms, Submissions }, { params, auth }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id)

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -190,7 +190,6 @@ describe('api: /projects/:id/forms/draft/dataset-diff', () => {
             .expect(403))))));
 
   it('should return all properties of dataset', testService(async (service) => {
-    // Upload a form and then create a new draft version
     await service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms')
         .send(testData.forms.simpleEntity)
@@ -204,8 +203,8 @@ describe('api: /projects/:id/forms/draft/dataset-diff', () => {
                 name: 'people',
                 isNew: true,
                 properties: [
-                  { name: 'age', isNew: true },
-                  { name: 'first_name', isNew: true }
+                  { name: 'age', isNew: true, inForm: true },
+                  { name: 'first_name', isNew: true, inForm: true }
                 ]
               }
             ]);
@@ -230,14 +229,8 @@ describe('api: /projects/:id/forms/draft/dataset-diff', () => {
                   name: 'people',
                   isNew: false,
                   properties: [
-                    {
-                      name: 'age',
-                      isNew: false
-                    },
-                    {
-                      name: 'first_name',
-                      isNew: false
-                    }
+                    { name: 'age', isNew: false, inForm: true },
+                    { name: 'first_name', isNew: false, inForm: true }
                   ]
                 }
               ]);
@@ -263,8 +256,9 @@ describe('api: /projects/:id/forms/draft/dataset-diff', () => {
                 name: 'people',
                 isNew: false,
                 properties: [
-                  { name: 'age', isNew: false },
-                  { name: 'lastName', isNew: true }
+                  { name: 'age', isNew: false, inForm: true },
+                  { name: 'first_name', isNew: false, inForm: false },
+                  { name: 'lastName', isNew: true, inForm: true }
                 ]
               }]);
             }))));
@@ -325,8 +319,56 @@ describe('api: /projects/:id/forms/draft/dataset-diff', () => {
                   name: 'people',
                   isNew: true,
                   properties: [
-                    { name: 'age', isNew: true },
-                    { name: 'first_name', isNew: true }
+                    { name: 'age', isNew: true, inForm: true },
+                    { name: 'first_name', isNew: true, inForm: true }
                   ]
                 }])))))));
+});
+
+describe('api: /projects/:id/forms/dataset-diff', () => {
+  it('should return all properties of dataset', testService(async (service) => {
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/dataset-diff')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.eql([
+              {
+                name: 'people',
+                properties: [
+                  { name: 'age', inForm: true },
+                  { name: 'first_name', inForm: true }
+                ]
+              }
+            ]);
+          })));
+  }));
+
+  it('should return all properties with appropriate value of inForm', testService(async (service) => {
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity
+            .replace(/simpleEntity/, 'simpleEntity2')
+            .replace(/saveto="first_name"/, 'saveto="last_name"'))
+          .expect(200)
+          .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity2/dataset-diff')
+            .expect(200)
+            .then(({ body }) => {
+              body.should.be.eql([{
+                name: 'people',
+                properties: [
+                  { name: 'age', inForm: true },
+                  { name: 'first_name', inForm: false },
+                  { name: 'last_name', inForm: true }
+                ]
+              }]);
+            }))));
+  }));
 });

--- a/test/integration/api/forms/datasets.js
+++ b/test/integration/api/forms/datasets.js
@@ -371,4 +371,28 @@ describe('api: /projects/:id/forms/dataset-diff', () => {
               }]);
             }))));
   }));
+
+  it('should not return unpublished properties', testService(async (service) => {
+    await service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity
+            .replace(/simpleEntity/, 'simpleEntity2')
+            .replace(/saveto="first_name"/, 'saveto="last_name"'))
+          .expect(200)
+          .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/dataset-diff')
+            .expect(200)
+            .then(({ body }) => {
+              body.should.be.eql([{
+                name: 'people',
+                properties: [
+                  { name: 'age', inForm: true },
+                  { name: 'first_name', inForm: true }
+                ]
+              }]);
+            }))));
+  }));
 });


### PR DESCRIPTION
#Changes:
- Response now returns all the properties of the dataset, regardless of which form defined it
- Added `inForm` fields in the response, it distinguishes if the a property is defined by the current form. Had to make this change to cater the need of the frontend design
- Added `dataset-diff` endpoint for published forms, it doesn't return `isNew` flag