### PR TITLE
Revert "Allow submission edits on closed forms (#530)"

### DIFF
--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -107,7 +107,6 @@ module.exports = (service, endpoint) => {
                     return SubmissionAttachments.upsert(extant, files);
                   }
                   // NEW SUBMISSION REQUEST: create a new submission and attachments.
-                  if (!draft && !form.acceptsSubmissions()) throw Problem.user.notAcceptingSubmissions();
                   return Promise.all([
                     Submissions.createNew(partial, form, query.deviceID, headers['user-agent']),
                     Forms.getBinaryFields(form.def.id)
@@ -122,6 +121,7 @@ module.exports = (service, endpoint) => {
     Forms.getByProjectAndXmlFormId(projectId, xmlFormId, false, version)
       .then(getOrNotFound)
       .then(ensureDef)
+      .then(rejectIf(((form) => !form.acceptsSubmissions()), noargs(Problem.user.notAcceptingSubmissions)))
       .then((form) => auth.canOrReject('submission.create', form)));
 
   // draft-testing submission path:

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -542,7 +542,8 @@ describe('api: /submission', () => {
                 body.value[0].name.should.equal('Alyssa');
               })))));
 
-      it('should accept submission update for a closing form', testService((service) =>
+      // TODO should be re-instated as part of https://github.com/getodk/central-backend/issues/469
+      it.skip('should accept submission update for a closing form', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/submission')
             .set('X-OpenRosa-Version', '1.0')
@@ -560,7 +561,8 @@ describe('api: /submission', () => {
                 body.value[0].name.should.equal('Alyssa');
               })))));
 
-      it('should accept submission update for a closed form', testService((service) =>
+      // TODO should be re-instated as part of https://github.com/getodk/central-backend/issues/469
+      it.skip('should accept submission update for a closed form', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/submission')
             .set('X-OpenRosa-Version', '1.0')
@@ -709,7 +711,8 @@ describe('api: /submission', () => {
                 .expect(404)
             ]))))));
 
-    it('should save a submission for the draft of a closing form', testService((service) =>
+    // TODO should be re-instated as part of https://github.com/getodk/central-backend/issues/469
+    it.skip('should save a submission for the draft of a closing form', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.patch('/v1/projects/1/forms/simple')
           .send({ state: 'closing' })
@@ -737,7 +740,8 @@ describe('api: /submission', () => {
                 .expect(404)
             ]))))));
 
-    it('should save a submission for the draft of a closed form', testService((service) =>
+    // TODO should be re-instated as part of https://github.com/getodk/central-backend/issues/469
+    it.skip('should save a submission for the draft of a closed form', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.patch('/v1/projects/1/forms/simple')
           .send({ state: 'closed' })


### PR DESCRIPTION
This reverts commit 8377a0f1f62607098148af77a939f2cce3710994.

This commit may be re-introduced alongside similar changes to the OpenRosa API.