### PR TITLE
cascade delete dataset_form_defs and ds_property_fields

### DIFF
--- a/lib/model/migrations/20220803-01-create-entities-schema.js
+++ b/lib/model/migrations/20220803-01-create-entities-schema.js
@@ -38,7 +38,7 @@ const up = async (db) => {
     dsPropertyFields.text('path');
 
     dsPropertyFields.foreign('dsPropertyId').references('ds_properties.id');
-    dsPropertyFields.foreign(['formDefId', 'path']).references(['formDefId', 'path']).inTable('form_fields');
+    dsPropertyFields.foreign(['formDefId', 'path']).references(['formDefId', 'path']).inTable('form_fields').onDelete('cascade');
     dsPropertyFields.unique(['dsPropertyId', 'formDefId', 'path']);
   });
 
@@ -76,7 +76,7 @@ const up = async (db) => {
     t.integer('formDefId').notNull();
 
     t.foreign('datasetId').references('datasets.id');
-    t.foreign('formDefId').references('form_defs.id');
+    t.foreign('formDefId').references('form_defs.id').onDelete('cascade');
     t.unique(['datasetId', 'formDefId']);
   });
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -738,6 +738,27 @@ describe('datasets and entities', () => {
             result.properties[0].fields.length.should.equal(2);
           });
       }));
+
+      it('should be able to upload multiple drafts', testService(async (service) => {
+        // Upload a form and then create a new draft version
+        await service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms?publish=true')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
+              .expect(200)
+              .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
+                .send(testData.forms.simpleEntity)
+                .set('Content-Type', 'application/xml')
+                .expect(200))
+              .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
+                .set('X-Extended-Metadata', 'true')
+                .expect(200)
+                .then(({ body }) => {
+                  body.entityRelated.should.equal(true);
+                }))));
+      }));
     });
 
     describe('dataset audit logging at /projects/:id/forms POST', () => {


### PR DESCRIPTION
# Changes:
- Added cascade on delete for `dataset_form_defs` and `ds_property_fields` because unused drafts are deleted whenever a new draft is uploaded. Since there's a relationship between above table with `form_defs`, deletion fails.