### PR TITLE
Make attachment exists flag or of blobExists and datasetExists

### DIFF
--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -106,7 +106,7 @@ Form.Attachment = class extends Frame.define(
   'updatedAt',    readable
 ) {
   forApi() {
-    const data = { name: this.name, type: this.type, blobExists: this.blobId != null, datasetExists: this.datasetId != null };
+    const data = { name: this.name, type: this.type, exists: (this.blobId != null || this.datasetId != null),  blobExists: this.blobId != null, datasetExists: this.datasetId != null };
     if (this.updatedAt != null) data.updatedAt = this.updatedAt;
     return data;
   }

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -110,6 +110,7 @@ describe('datasets and entities', () => {
               .then(({ body }) => omit(['updatedAt'], body).should.be.eql({
                 name: 'goodone.csv',
                 type: 'file',
+                exists: true,
                 blobExists: false,
                 datasetExists: true
               })))

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -416,8 +416,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
               .expect(200)
               .then(({ body }) => {
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', blobExists: false, datasetExists: false },
-                  { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
+                  { name: 'goodone.csv', type: 'file', exists: false, blobExists: false, datasetExists: false },
+                  { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                 ]);
               })))));
 
@@ -450,8 +450,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
-                  { name: 'greattwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
+                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false },
+                  { name: 'greattwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                 ]);
               })))));
 
@@ -482,8 +482,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
-                  { name: 'greattwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
+                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false },
+                  { name: 'greattwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                 ]);
               })))));
 
@@ -946,8 +946,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
-                  { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
+                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false },
+                  { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                 ]);
               })))));
 

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -786,8 +786,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                 .expect(200)
                 .then(({ body }) => {
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', blobExists: false, datasetExists: false },
-                    { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
+                    { name: 'goodone.csv', type: 'file', exists: false, blobExists: false, datasetExists: false },
+                    { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                   ]);
                 })))));
 
@@ -812,8 +812,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                   delete body[0].updatedAt;
 
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
-                    { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
+                    { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false },
+                    { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                   ]);
                 })))));
 
@@ -835,7 +835,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                 .expect(200)
                 .then(({ body }) => {
                   body[0].name.should.equal('goodone.csv'); // sanity
-                  body[0].blobExists.should.equal(true);
+                  body[0].exists.should.equal(true);
                   body[0].updatedAt.should.be.a.recentIsoDate();
                 })))));
 
@@ -861,7 +861,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                   .set('X-Extended-Metadata', 'true')
                   .expect(200)
                   .then((secondListing) => {
-                    secondListing.body[0].blobExists.should.equal(false);
+                    secondListing.body[0].exists.should.equal(false);
                     secondListing.body[0].updatedAt.should.be.a.recentIsoDate();
 
                     const firstUpdatedAt = DateTime.fromISO(firstListing.body[0].updatedAt);

--- a/test/integration/api/forms/versions.js
+++ b/test/integration/api/forms/versions.js
@@ -354,8 +354,8 @@ describe('api: /projects/:id/forms (versions)', () => {
                   delete body[0].updatedAt;
 
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', blobExists: true, datasetExists: false },
-                    { name: 'goodtwo.mp3', type: 'audio', blobExists: false, datasetExists: false }
+                    { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false },
+                    { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                   ]);
                 })))));
 


### PR DESCRIPTION
Addresses some comment that came up in code review ([here](https://github.com/getodk/central-backend/pull/576#discussion_r996173898) and [here](https://github.com/getodk/central-backend/pull/576#discussion_r1008407467)) about how the attachment API endpoint changes with the addition of attachments from datasets. 

Instead of removing `exists` in the attachment response, `exists` will be true if there is an attachment either from a file or a dataset (e.g. it will be the boolean OR of `blobExists` and `datasetExists`). Thus this change will no longer be a breaking change. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Made the change, checked the tests, fixed the tests.

#### Why is this the best possible solution? Were any other approaches considered?

There are 3 flags returned now about attachment state, but they are clear/descriptive and they are additive so they will not impact people using earlier versions of the API. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Reduces risk.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Docs will be updated in separate PR. 

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes