### PR TITLE
Fix: Reprocessing doubly-approved entity submission

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -92,24 +92,23 @@ const canInsertEntity = (datasetName, submissionDefId, entityUuid) => ({ one }) 
 const processSubmissionDef = (submissionDefId) => ({ Datasets, Entities, Submissions }) =>
   new Promise((resolve, reject) => {
     Entities.getDefBySubmissionDefId(submissionDefId)
-      .then((def) =>
-        (def.isDefined()
-          ? reject(Problem.user.entityViolation({ reason: 'This submission was already used to create an entity.' }))
-          : Submissions.getDefById(submissionDefId).then((s) => s.get())))
-      .then((submissionDef) => Datasets.getFieldsByFormDefId(submissionDef.formDefId)
-        .then((fields) =>
-          ((fields.length === 0)
-            ? resolve()
-            : Entity.fromSubmissionXml(submissionDef.xml, fields)
-              .then((partial) =>
-                Entities.canInsertEntity(partial.aux.dataset, submissionDefId, partial.uuid)
-                  .then((okToInsert) =>
-                    (okToInsert
-                      ? Entities.createNew(partial, submissionDef)
-                        .then((entity) => resolve(entity))
-                        .catch((err) => reject(Problem.user.entityViolation({ reason: 'Entity could not be created', err: err.problemDetails })))
-                      : reject(Problem.user.entityViolation({ reason: 'It is not possible to create an entity from this data.' })))))
-              .catch((problem) => reject(problem)))));
+      .then((def) => (def.isDefined()
+        ? reject(Problem.user.entityViolation({ reason: 'This submission was already used to create an entity.' }))
+        : Submissions.getDefById(submissionDefId).then((s) => s.get())
+          .then((submissionDef) => Datasets.getFieldsByFormDefId(submissionDef.formDefId)
+            .then((fields) =>
+              ((fields.length === 0)
+                ? resolve()
+                : Entity.fromSubmissionXml(submissionDef.xml, fields)
+                  .then((partial) =>
+                    Entities.canInsertEntity(partial.aux.dataset, submissionDefId, partial.uuid)
+                      .then((okToInsert) =>
+                        (okToInsert
+                          ? Entities.createNew(partial, submissionDef)
+                            .then((entity) => resolve(entity))
+                            .catch((err) => reject(Problem.user.entityViolation({ reason: 'Entity could not be created', err: err.problemDetails })))
+                          : reject(Problem.user.entityViolation({ reason: 'It is not possible to create an entity from this data.' })))))
+                  .catch((problem) => reject(problem)))))));
   });
 
 


### PR DESCRIPTION
There was a bug with reapproving an entity-creating submission where when the entity worker would just crash the backend server.

Now it cleanly fails to make a new entity without crashing.

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

Small fix of promise chain bug.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's good -- Less crashing!

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
