### PR TITLE
Add label and dataset name to entity.create audit log

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -21,7 +21,7 @@ const { construct } = require('../../util/util');
 // so we will look up the dataset id by name (unique within a project)
 // and project id (from submission def -> submission -> form def -> form)
 const _getDataset = (dsName, subDefId) => sql`
-SELECT datasets."id", sd."id" as "subDefId", datasets."acteeId"
+SELECT datasets."id", sd."id" as "subDefId", datasets."acteeId", datasets."name"
 FROM submission_defs AS sd
   JOIN form_defs AS fd ON sd."formDefId" = fd."id"
   JOIN forms AS f ON fd."formId" = f."id"
@@ -48,8 +48,8 @@ ins as (insert into entities (id, "datasetId", "uuid", "label", "createdAt", "cr
   select def."entityId", ds."id", ${partial.uuid}, ${partial.label}, def."createdAt", ${subDef.submitterId} from def
   join ds on ds."subDefId" = def."submissionDefId"
   returning entities.*)
-select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId" from ins, def, ds;`)
-    .then(({ entityDefId, dsActeeId, ...entityData }) => // TODO/HACK: reassembly inspired by Submissions.createNew
+select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as "dsName" from ins, def, ds;`)
+    .then(({ entityDefId, dsActeeId, dsName, ...entityData }) => // TODO/HACK: reassembly inspired by Submissions.createNew
       new Entity(entityData, {
         def: new Entity.Def({
           id: entityDefId,
@@ -58,7 +58,7 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId" from ins, def
           createdAt: entityData.createdAt,
           data: partial.def.data
         }),
-        dataset: { acteeId: dsActeeId }
+        dataset: { acteeId: dsActeeId, name: dsName }
       }));
 };
 

--- a/lib/worker/entity.js
+++ b/lib/worker/entity.js
@@ -12,7 +12,7 @@ const createEntityFromSubmission = ({ Audits, Entities }, event) => {
     return Entities.processSubmissionDef(event.details.submissionDefId)
       .then((entity) => {
         Audits.log({ id: event.actorId }, 'entity.create', { acteeId: entity.aux.dataset.acteeId },
-          { entityUuid: entity.uuid,
+          { entity: { uuid: entity.uuid, label: entity.label, dataset: entity.aux.dataset.name },
             submissionId: event.details.submissionId,
             submissionDefId: event.details.submissionDefId });
       })

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -331,9 +331,10 @@ describe('worker: entity', () => {
       const createEvent = await container.Audits.getLatestByAction('entity.create').then((o) => o.get());
       createEvent.actorId.should.equal(6); // Bob
       createEvent.details.submissionId.should.equal(approveEvent.details.submissionId);
-
-      const entity = await container.Entities.getByUuid(createEvent.details.entityUuid).then((o) => o.get());
-      entity.label.should.equal('Alice (88)');
+      // should contain information about entity
+      createEvent.details.entity.label.should.equal('Alice (88)');
+      createEvent.details.entity.dataset.should.equal('people');
+      createEvent.details.entity.uuid.should.equal('12345678-1234-4123-8234-123456789abc');
     }));
 
     it.skip('should log entity error in audit log', testService(async (service, container) => {


### PR DESCRIPTION
Frontend needs to have the entity **label** and **dataset name** in the details of the `entity.create` audit log in order to display this info on the submission activity feed.

#### What has been done to verify that this works as intended?

Tests and seeing it in action.

#### Why is this the best possible solution? Were any other approaches considered?

It's pretty straightforward. It does mean duplicating the data of the entity label, but saves us from changing how the audit log pulls in extra info. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Lets the right information come through the API to show on Frontend.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No, we don't describe the details of the different types of audit events in the API docs.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
