### PR TITLE
fixes #669: cleaning up code for entity worker

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -39,7 +39,7 @@ const validateEntity = (entity) => {
 
   const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
   const matches = uuidPattern.exec(id);
-  if (matches == null) throw Problem.user.entityViolation({ reason: `ID [${id}] not a valid UUID.` });
+  if (matches == null) throw Problem.user.entityViolation({ reason: `ID [${id}] is not a valid UUID.` });
   const uuid = matches[2];
 
   const newEntity = { ...entity };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -10,7 +10,6 @@
 const { sql } = require('slonik');
 const { Entity } = require('../frames');
 const { unjoiner } = require('../../util/db');
-const Problem = require('../../util/problem');
 const { map } = require('ramda');
 const { construct } = require('../../util/util');
 
@@ -65,28 +64,21 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as
 
 // Entrypoint to where submissions (a specific version) become entities
 const _processSubmissionDef = (submissionDefId) => async ({ Datasets, Entities, Submissions }) => {
-  try {
-    const existingEntity = await Entities.getDefBySubmissionDefId(submissionDefId);
-    // If the submission has already been used to make an entity, don't try again
-    // and don't log it as an error.
-    if (existingEntity.isDefined())
-      return null;
-    const submissionDef = await Submissions.getDefById(submissionDefId).then((s) => s.get());
-    const fields = await Datasets.getFieldsByFormDefId(submissionDef.formDefId);
-    // No fields found for this formDefId means there is nothing entity-related to parse out
-    // of this submission. Even entity system properties like ID and dataset name would be here
-    // if the form def is about datasets and entities.
-    if (fields.length === 0)
-      return null;
-    const partial = await Entity.fromSubmissionXml(submissionDef.xml, fields);
-    const entity = await Entities.createNew(partial, submissionDef);
-    return entity;
-  } catch (problem) {
-    if (problem.problemCode === 409.14)
-      throw problem;
-    else
-      throw Problem.user.entityViolation({ reason: 'Something went wrong validating or inserting' });
-  }
+  const existingEntity = await Entities.getDefBySubmissionDefId(submissionDefId);
+  // If the submission has already been used to make an entity, don't try again
+  // and don't log it as an error.
+  if (existingEntity.isDefined())
+    return null;
+  const submissionDef = await Submissions.getDefById(submissionDefId).then((s) => s.get());
+  const fields = await Datasets.getFieldsByFormDefId(submissionDef.formDefId);
+  // No fields found for this formDefId means there is nothing entity-related to parse out
+  // of this submission. Even entity system properties like ID and dataset name would be here
+  // if the form def is about datasets and entities.
+  if (fields.length === 0)
+    return null;
+  const partial = await Entity.fromSubmissionXml(submissionDef.xml, fields);
+  const entity = await Entities.createNew(partial, submissionDef);
+  return entity;
 };
 
 const processSubmissionEvent = (event) => (container) =>
@@ -100,11 +92,21 @@ const processSubmissionEvent = (event) => (container) =>
             submissionDefId: event.details.submissionDefId });
       }
     })
-    .catch((problem) =>
+    .catch((err) =>
+      // err could be any kind of problem, from an entity violation error, to a
+      // database constraint error, to some other kind of error within the processing code.
+      // We always surface the error message but only log the error if it is one of our
+      // known Problems, just in case there are weird error details we don't want to
+      // expose. In experimenting with breaking the code, it seems that non-Problem errors
+      // convert to empty objects through the JSON.stringify transformation within audit logging
+      // so this probably isn't even an issue.
+      // The JSON.stringify appears to strip out error.stack so that doesn't make it to the
+      // log details even for our Problems.
       container.Audits.log({ id: event.actorId }, 'entity.create.error', null,
         { submissionId: event.details.submissionId,
           submissionDefId: event.details.submissionDefId,
-          problem }));
+          errorMessage: err.message,
+          problem: (err.isProblem === true) ? err : null }));
 
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -62,55 +62,49 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as
       }));
 };
 
-// HACK: This is a function to check if the entity *can* successfully be inserted
-// because without it... in the case of processing an entity within a worker,
-// the database hits its constraints and then breaks the rest of the transaction.
-// Then it won't do things like update the processing time on the relevant audit log event,
-// and I can't log any more errors :(
-const canInsertEntity = (datasetName, submissionDefId, entityUuid) => ({ one }) =>
-  one(sql`
-  WITH dataset AS (
-    SELECT datasets."id", sd."id" as "subDefId" FROM
-    submission_defs AS sd
-      JOIN form_defs AS fd ON sd."formDefId" = fd."id"
-      JOIN forms AS f ON fd."formId" = f."id"
-      JOIN datasets ON datasets."projectId" = f."projectId"
-    left outer join entities on datasets."id" = entities."datasetId"
-    WHERE datasets."name" = ${datasetName} AND sd."id" = ${submissionDefId}
-    LIMIT 1),
-  entity AS (
-    SELECT entities."datasetId", entities."uuid", entities."id" from entities
-    WHERE entities."uuid" = ${entityUuid}
-  )
-  select dataset."id" as "datasetId", entity."id" as "entityId" from dataset
-  FULL OUTER JOIN entity
-    ON dataset."id" = entity."datasetId"`)
-    .then(({ datasetId, entityId }) =>
-      (datasetId !== null && entityId == null));
 
 // Entrypoint to where submissions (a specific version) become entities
-const processSubmissionDef = (submissionDefId) => ({ Datasets, Entities, Submissions }) =>
-  new Promise((resolve, reject) => {
-    Entities.getDefBySubmissionDefId(submissionDefId)
-      .then((def) => (def.isDefined()
-        ? reject(Problem.user.entityViolation({ reason: 'This submission was already used to create an entity.' }))
-        : Submissions.getDefById(submissionDefId).then((s) => s.get())
-          .then((submissionDef) => Datasets.getFieldsByFormDefId(submissionDef.formDefId)
-            .then((fields) =>
-              ((fields.length === 0)
-                ? resolve()
-                : Entity.fromSubmissionXml(submissionDef.xml, fields)
-                  .then((partial) =>
-                    Entities.canInsertEntity(partial.aux.dataset, submissionDefId, partial.uuid)
-                      .then((okToInsert) =>
-                        (okToInsert
-                          ? Entities.createNew(partial, submissionDef)
-                            .then((entity) => resolve(entity))
-                            .catch((err) => reject(Problem.user.entityViolation({ reason: 'Entity could not be created', err: err.problemDetails })))
-                          : reject(Problem.user.entityViolation({ reason: 'It is not possible to create an entity from this data.' })))))
-                  .catch((problem) => reject(problem)))))));
-  });
+const _processSubmissionDef = (submissionDefId) => async ({ Datasets, Entities, Submissions }) => {
+  try {
+    const existingEntity = await Entities.getDefBySubmissionDefId(submissionDefId);
+    // If the submission has already been used to make an entity, don't try again
+    // and don't log it as an error.
+    if (existingEntity.isDefined())
+      return null;
+    const submissionDef = await Submissions.getDefById(submissionDefId).then((s) => s.get());
+    const fields = await Datasets.getFieldsByFormDefId(submissionDef.formDefId);
+    // No fields found for this formDefId means there is nothing entity-related to parse out
+    // of this submission. Even entity system properties like ID and dataset name would be here
+    // if the form def is about datasets and entities.
+    if (fields.length === 0)
+      return null;
+    const partial = await Entity.fromSubmissionXml(submissionDef.xml, fields);
+    const entity = await Entities.createNew(partial, submissionDef);
+    return entity;
+  } catch (problem) {
+    if (problem.problemCode === 409.14)
+      throw problem;
+    else
+      throw Problem.user.entityViolation({ reason: 'Something went wrong validating or inserting' });
+  }
+};
 
+const processSubmissionEvent = (event) => (container) =>
+  container.db.transaction((trxn) =>
+    container.with({ db: trxn }).Entities._processSubmissionDef(event.details.submissionDefId))
+    .then((entity) => {
+      if (entity != null) {
+        return container.Audits.log({ id: event.actorId }, 'entity.create', { acteeId: entity.aux.dataset.acteeId },
+          { entity: { uuid: entity.uuid, label: entity.label, dataset: entity.aux.dataset.name },
+            submissionId: event.details.submissionId,
+            submissionDefId: event.details.submissionDefId });
+      }
+    })
+    .catch((problem) =>
+      container.Audits.log({ id: event.actorId }, 'entity.create.error', null,
+        { submissionId: event.details.submissionId,
+          submissionDefId: event.details.submissionDefId,
+          problem }));
 
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES
@@ -141,4 +135,4 @@ order by entities.id`)
     .then(stream.map(_exportUnjoiner));
 
 
-module.exports = { createNew, processSubmissionDef, streamForExport, getDefBySubmissionDefId, getByUuid, canInsertEntity };
+module.exports = { createNew, _processSubmissionDef, processSubmissionEvent, streamForExport, getDefBySubmissionDefId, getByUuid };

--- a/lib/worker/entity.js
+++ b/lib/worker/entity.js
@@ -7,23 +7,9 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const createEntityFromSubmission = ({ Audits, Entities }, event) => {
-  if (event.details.reviewState === 'approved' && event.details.submissionDefId) {
-    return Entities.processSubmissionDef(event.details.submissionDefId)
-      .then((entity) => {
-        Audits.log({ id: event.actorId }, 'entity.create', { acteeId: entity.aux.dataset.acteeId },
-          { entity: { uuid: entity.uuid, label: entity.label, dataset: entity.aux.dataset.name },
-            submissionId: event.details.submissionId,
-            submissionDefId: event.details.submissionDefId });
-      })
-      .catch((problem) => {
-        Audits.log({ id: event.actorId }, 'entity.create.error', null,
-          { submissionId: event.details.submissionId,
-            submissionDefId: event.details.submissionDefId,
-            problem });
-      });
-  }
+const createEntityFromSubmission = ({ Entities }, event) => {
+  if (event.details.reviewState === 'approved')
+    return Entities.processSubmissionEvent(event);
 };
 
 module.exports = { createEntityFromSubmission };
-


### PR DESCRIPTION
Closes #669 by cleaning up the entity creation code used by the worker that processes submission update events. 

- went back to relying on postgres to flag entity creation errors due to constraint violations (use a nested transaction to do this and properly catch the errors and then be able to continue logging)
- made the processing code use async/await to be easier to follow
- moved the audit logging code for entity creation and error events into the processing code, not the worker
- refactored the tests to be clearer and handle different kinds of failure/non-failure cases:
    * submission should not be processed
    * submission successfully makes entity
    * submission fails to make entity because of validation error
    * submission fails to make entity because of constraint violation error (duplicate uuid or something)

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

It's a lot better than it was! This change gets rid of a big weird hacky code block that was trying to carefully catch specific kind of errors.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

n/a

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

no

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes