### PR TITLE
fixes 681: added constrainst to check datasetId is null for non-data attachments

### DIFF
--- a/lib/model/migrations/20221117-01-check-datasetId-is-null-for-non-file-type.js
+++ b/lib/model/migrations/20221117-01-check-datasetId-is-null-for-non-file-type.js
@@ -1,0 +1,19 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`ALTER TABLE form_attachments
+    ADD CONSTRAINT "check_datasetId_is_null_for_non_file"
+    CHECK (("type" = 'file') OR ("datasetId" IS NULL));`);
+};
+const down = async (db) => {
+  await db.raw('ALTER TABLE form_attachments DROP CONSTRAINT "check_datasetId_is_null_for_non_file"');
+};
+
+module.exports = { up, down };

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -62,7 +62,7 @@ const createNew = (xml, form, itemsets) => ({ Blobs, Datasets, run }) =>
         .then(datasets => {
           const dsHashtable = datasets.reduce((acc, ds) => Object.assign(acc, { [`${ds.name}.csv`]: ds }), {});
           const ids = { formId: form.id, formDefId: form.def.id };
-          return run(insertMany(expected.map((att) => new Form.Attachment(Object.assign({}, att, ids, { datasetId: dsHashtable[att.name]?.id })))));
+          return run(insertMany(expected.map((att) => new Form.Attachment(Object.assign({}, att, ids, { datasetId: att.type === 'file' ? dsHashtable[att.name]?.id : null })))));
         }));
 
 const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blobs, FormAttachments, Datasets, run }) =>
@@ -89,7 +89,7 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
 
           const attachments = expecteds.map((expected) => {
             const extant = Option.of(lookup[expected.name]).filter((e) => e.type === expected.type);
-            const matchingDsId = Option.of(dsHashtable[expected.name]).map(d => d.id);
+            const matchingDsId = expected.type === 'file' ? Option.of(dsHashtable[expected.name]).map(d => d.id) : Option.none();
             return new Form.Attachment(mergeRight({
               formId: form.id,
               formDefId: savedDef.id,

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -192,7 +192,9 @@ module.exports = (service, endpoint) => {
         Datasets.getByProjectAndName(params.projectId, params.name.replace(/\.csv$/, '')).then(getOrNotFound),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
       ])
-        .then(([dataset, attachment]) => FormAttachments.update(form, attachment, null, body.dataset ? dataset.id : null)))));
+        .then(([dataset, attachment]) => (attachment.type !== 'file' && body.dataset ?
+          Problem.user.datasetLinkNotAllowed() :
+          FormAttachments.update(form, attachment, null, body.dataset ? dataset.id : null))))));
 
 
   service.delete('/projects/:projectId/forms/:id/draft', endpoint(({ Audits, Forms, Submissions }, { params, auth }) =>

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -105,6 +105,9 @@ const problems = {
     // problem parsing the entity form
     invalidEntityForm: problem(400.25, ({ reason }) => `The entity definition within the form is invalid. ${reason}`),
 
+    // problem parsing the entity form
+    datasetLinkNotAllowed: problem(400.26, () => 'Dataset can only be linked to attachments with "Data File" type.'),
+
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),
 


### PR DESCRIPTION
Closes #681 

#### What has been done to verify that this works as intended?
Adds a database constraint on `form_attachments` table to check datasetId is null for non-file/non-data type attachments

#### Why is this the best possible solution? Were any other approaches considered?
I could have added condition to existing constraint but to keep things segregated I have added a new constraint

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
NA

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
NA

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments