### PR TITLE
fixes #671: only published dataset and its published properties should be accessible

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -13,6 +13,7 @@ const { unjoiner } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
 const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either, reduceBy, groupBy } = require('ramda');
 const { construct } = require('../../util/util');
+const Option = require('../../util/option');
 
 // It removes prefix from all the key of an object
 const removePrefix = curry((prefix, obj) => compose(reduce((acc, key) => assoc(key.replace(prefix, ''), obj[key], acc), {}), keys)(obj));
@@ -122,6 +123,8 @@ const _getByNameSql = ((fields, datasetName, projectId) => sql`
         ds_properties.id = ds_property_fields."dsPropertyId"
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
+      AND datasets."publishedAt" IS NOT NULL
+      AND ds_properties."publishedAt" IS NOT NULL
  `);
 
 
@@ -161,11 +164,13 @@ const getById = (datasetId) => ({ all }) =>
     .then(asArray)
     .then(nth(0));
 
+// Returns only published dataset with its published properties
 const getByName = (datasetName, projectId) => ({ all }) =>
   all(_getByNameSql(unjoiner(Dataset, Dataset.Property, Dataset.PropertyField).fields, datasetName, projectId))
     .then(makeHierarchy)
     .then(asArray)
-    .then(nth(0));
+    .then(nth(0))
+    .then(Option.of);
 
 // Returns list of dataset for a given projectId
 // Properties and field mappings are not returned
@@ -222,8 +227,8 @@ const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
   .then(reduceBy((acc, { propertyName, isPropertyNew, inForm }) => (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
   .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: forDraft ? k.split(',')[1] === 'true' : undefined, properties: r[k] })));
 
-const getByProjectAndName = (projectId, name) => ({ maybeOne }) => maybeOne(sql`
-SELECT * FROM datasets WHERE "projectId" = ${projectId} AND name = ${name}`)
+const getByProjectAndName = (projectId, name, excludeUnpublished = false) => ({ maybeOne }) => maybeOne(sql`
+SELECT * FROM datasets WHERE "projectId" = ${projectId} AND name = ${name} ${excludeUnpublished ? sql`AND "publishedAt" IS NOT NULL` : sql``}`)
   .then(map(construct(Dataset)));
 
 const getPublishedProperties = (id) => ({ all }) => all(sql`

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -19,7 +19,7 @@ module.exports = (service, endpoint) => {
       .then((project) => auth.canOrReject('dataset.list', project))
       .then(() => Datasets.getAllByProjectId(params.id))));
 
-  service.get('/projects/:projectId/datasets/:name.csv', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
+  service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('entity.list', project))

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -19,12 +19,12 @@ module.exports = (service, endpoint) => {
       .then((project) => auth.canOrReject('dataset.list', project))
       .then(() => Datasets.getAllByProjectId(params.id))));
 
-  service.get('/projects/:projectId/datasets/:name/download', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
+  service.get('/projects/:projectId/datasets/:name.csv', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('entity.list', project))
       .then(() => Datasets.getByName(params.name, params.projectId)
-        //.then(getOrNotFound) // TODO: change dataset query to return option so this can be used
+        .then(getOrNotFound)
         .then((dataset) => Entities.streamForExport(dataset.id)
           .then((entities) => {
             const filename = sanitize(dataset.name);

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -189,7 +189,7 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then((form) => Promise.all([
-        Datasets.getByProjectAndName(params.projectId, params.name.replace(/\.csv$/, '')).then(getOrNotFound),
+        Datasets.getByProjectAndName(params.projectId, params.name.replace(/\.csv$/, ''), true).then(getOrNotFound),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
       ])
         .then(([dataset, attachment]) => (attachment.type !== 'file' && body.dataset ?

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -70,7 +70,7 @@ describe('datasets and entities', () => {
             .set('Content-Type', 'application/xml')
             .expect(200)
             .then(() => service.login('chelsea', (asChelsea) =>
-              asChelsea.get('/v1/projects/1/datasets/people.csv')
+              asChelsea.get('/v1/projects/1/datasets/people/entities.csv')
                 .expect(403))))));
 
       it('should let the user download the dataset (even if 0 entity rows)', testService((service) =>
@@ -79,7 +79,7 @@ describe('datasets and entities', () => {
             .send(testData.forms.simpleEntity)
             .set('Content-Type', 'application/xml')
             .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/datasets/people.csv')
+            .then(() => asAlice.get('/v1/projects/1/datasets/people/entities.csv')
               .expect(200)
               .then(({ text }) => {
                 text.should.equal('name,label,first_name,age\n');
@@ -100,7 +100,7 @@ describe('datasets and entities', () => {
           .set('Content-Type', 'application/xml')
           .expect(200);
 
-        await asAlice.get('/v1/projects/1/datasets/people.csv')
+        await asAlice.get('/v1/projects/1/datasets/people/entities.csv')
           .expect(200)
           .then(({ text }) => {
             text.should.equal('name,label,first_name,age\n');
@@ -114,7 +114,7 @@ describe('datasets and entities', () => {
             .send(testData.forms.simpleEntity)
             .set('Content-Type', 'application/xml')
             .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/datasets/nonexistent.csv')
+            .then(() => asAlice.get('/v1/projects/1/datasets/nonexistent/entities.csv')
               .expect(404)))));
 
       it('should reject if dataset is not published', testService((service) =>
@@ -123,7 +123,7 @@ describe('datasets and entities', () => {
             .send(testData.forms.simpleEntity)
             .set('Content-Type', 'application/xml')
             .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/datasets/people.csv')
+            .then(() => asAlice.get('/v1/projects/1/datasets/people/entities.csv')
               .expect(404)))));
     });
   });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -62,7 +62,7 @@ describe('datasets and entities', () => {
                   }))))));
     });
 
-    describe('projects/:id/datasets/:dataset/download GET', () => {
+    describe('projects/:id/datasets/:dataset.csv GET', () => {
       it('should reject if the user cannot access dataset', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms?publish=true')
@@ -70,7 +70,7 @@ describe('datasets and entities', () => {
             .set('Content-Type', 'application/xml')
             .expect(200)
             .then(() => service.login('chelsea', (asChelsea) =>
-              asChelsea.get('/v1/projects/1/datasets/people/download')
+              asChelsea.get('/v1/projects/1/datasets/people.csv')
                 .expect(403))))));
 
       it('should let the user download the dataset (even if 0 entity rows)', testService((service) =>
@@ -79,20 +79,51 @@ describe('datasets and entities', () => {
             .send(testData.forms.simpleEntity)
             .set('Content-Type', 'application/xml')
             .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/datasets/people/download')
+            .then(() => asAlice.get('/v1/projects/1/datasets/people.csv')
               .expect(200)
               .then(({ text }) => {
                 text.should.equal('name,label,first_name,age\n');
               })))));
 
-      // TODO: right now this returns 500 internal server error
-      it.skip('should reject if dataset does not exist', testService((service) =>
+      it('should return only published properties', testService(async (service) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity
+            .replace(/simpleEntity/g, 'simpleEntity2')
+            .replace(/first_name/, 'full_name'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/people.csv')
+          .expect(200)
+          .then(({ text }) => {
+            text.should.equal('name,label,first_name,age\n');
+          });
+
+      }));
+
+      it('should reject if dataset does not exist', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms?publish=true')
             .send(testData.forms.simpleEntity)
             .set('Content-Type', 'application/xml')
             .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/datasets/nonexistent/download')
+            .then(() => asAlice.get('/v1/projects/1/datasets/nonexistent.csv')
+              .expect(404)))));
+
+      it('should reject if dataset is not published', testService((service) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1/datasets/people.csv')
               .expect(404)))));
     });
   });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -281,6 +281,26 @@ describe('datasets and entities', () => {
               .then(({ body }) => {
                 body.message.should.be.equal('Dataset can only be linked to attachments with "Data File" type.');
               })))));
+
+      it('should return error if dataset is not published', testService(async (service) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.withAttachments)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity.replace(/people/g, 'goodone'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .send({ dataset: true })
+          .expect(404);
+
+      }));
+
     });
 
     describe('projects/:id/forms/:formId/draft/attachment/:name DELETE', () => {

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -320,7 +320,7 @@ describe('worker: entity', () => {
             .send({ reviewState: 'approved' })
             .expect(200))
           .then(() => exhaust(container))
-          .then(() => asAlice.get('/v1/projects/1/datasets/people/download')
+          .then(() => asAlice.get('/v1/projects/1/datasets/people.csv')
             .then(({ text }) => {
               // eslint-disable-next-line no-console
               //console.log(text);

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -320,7 +320,7 @@ describe('worker: entity', () => {
             .send({ reviewState: 'approved' })
             .expect(200))
           .then(() => exhaust(container))
-          .then(() => asAlice.get('/v1/projects/1/datasets/people.csv')
+          .then(() => asAlice.get('/v1/projects/1/datasets/people/entities.csv')
             .then(({ text }) => {
               // eslint-disable-next-line no-console
               //console.log(text);


### PR DESCRIPTION
Closes #671

#### What has been done to verify that this works as intended?
Added integration tests

#### Why is this the best possible solution? Were any other approaches considered?
none

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
APIs should now return only published datasets with its published properties. 
On the frontend we have to update download dataset link and test that linking dataset to attachment is working - especially it links only published datasets

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
We should mention that dataset related APIs only returns published datasets, explicitly mention what do we mean by "published datasets" and "published property"

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments