### PR TITLE
fixes #676: Updating parsing to match entity spec

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -48,10 +48,10 @@ const getDataset = (xml) => {
     metaNode(findOne(root(), node('entity'))(tree())),
     metaNode(findOne(root(), and(node('entity'), hasAttr('dataset')))(attr('dataset')))
   ]).then(([ version, entityTag, datasetName ]) => {
-    if (version.isEmpty() || version.get() !== '2022.1.0')
-      return Option.none();
     if (entityTag.isEmpty() && datasetName.isEmpty())
       return Option.none();
+    if (version.isEmpty() || version.get() !== '2022.1.0')
+      throw Problem.user.invalidEntityForm({ reason: 'Version is not supported.' });
     // check that dataset name is valid
     if (datasetName.isEmpty())
       throw Problem.user.invalidEntityForm({ reason: 'Dataset name is empty.' });

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -50,7 +50,7 @@ const getDataset = (xml) => {
   ]).then(([ version, entityTag, datasetName ]) => {
     if (entityTag.isEmpty() && datasetName.isEmpty())
       return Option.none();
-    if (version.isEmpty() || version.get() !== '2022.1.0')
+    if (version.isEmpty() || !version.get().startsWith('2022.1.'))
       throw Problem.user.invalidEntityForm({ reason: 'Version is not supported.' });
     // check that dataset name is valid
     if (datasetName.isEmpty())

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -50,11 +50,13 @@ const getDataset = (xml) => {
   ]).then(([ version, entityTag, datasetName ]) => {
     if (entityTag.isEmpty() && datasetName.isEmpty())
       return Option.none();
-    if (version.isEmpty() || !version.get().startsWith('2022.1.'))
-      throw Problem.user.invalidEntityForm({ reason: 'Version is not supported.' });
+    if (version.isEmpty())
+      throw Problem.user.invalidEntityForm({ reason: 'Entities specification version is missing.' });
+    else if (!version.get().startsWith('2022.1.'))
+      throw Problem.user.invalidEntityForm({ reason: `Entities specification version [${version.get()}] is not supported.` });
     // check that dataset name is valid
     if (datasetName.isEmpty())
-      throw Problem.user.invalidEntityForm({ reason: 'Dataset name is empty.' });
+      throw Problem.user.invalidEntityForm({ reason: 'Dataset name is missing.' });
     if (!validateDatasetName(datasetName.get()))
       throw Problem.user.invalidEntityForm({ reason: 'Invalid dataset name.' });
     return Option.of(datasetName.get().toLowerCase());

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -59,7 +59,7 @@ const getDataset = (xml) => {
       throw Problem.user.invalidEntityForm({ reason: 'Dataset name is missing.' });
     if (!validateDatasetName(datasetName.get()))
       throw Problem.user.invalidEntityForm({ reason: 'Invalid dataset name.' });
-    return Option.of(datasetName.get().toLowerCase());
+    return Option.of(datasetName.get().trim());
   });
 };
 

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -44,10 +44,12 @@ const validateDatasetName = (name) => {
 const getDataset = (xml) => {
   const metaNode = findOne(root('html'), node('head'), node('model'), node('instance'), node(), node('meta'));
   return traverseXml(xml, [
+    findOne(root('html'), node('head'), node('model'))(attr('entities-version')),
     metaNode(findOne(root(), node('entity'))(tree())),
     metaNode(findOne(root(), and(node('entity'), hasAttr('dataset')))(attr('dataset')))
-  ]).then(([ entityTag, datasetName ]) => {
-    // check if <entity> tag exists at all
+  ]).then(([ version, entityTag, datasetName ]) => {
+    if (version.isEmpty() || version.get() !== '2022.1.0')
+      return Option.none();
     if (entityTag.isEmpty() && datasetName.isEmpty())
       return Option.none();
     // check that dataset name is valid

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -43,7 +43,7 @@ const validateEntity = (entity) => {
   const uuid = matches[2];
 
   // If create is not an allowed value of true, don't return entity data
-  if (entity.system.create !== '1' || entity.system.create === 'true')
+  if (!(entity.system.create === '1' || entity.system.create === 'true'))
     return null;
 
   const newEntity = { ...entity };

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -42,9 +42,14 @@ const validateEntity = (entity) => {
   if (matches == null) throw Problem.user.entityViolation({ reason: `ID [${id}] is not a valid UUID.` });
   const uuid = matches[2];
 
+  // If create is not an allowed value of true, don't return entity data
+  if (entity.system.create !== '1' || entity.system.create === 'true')
+    return null;
+
   const newEntity = { ...entity };
   newEntity.system.uuid = uuid;
   delete newEntity.system.id;
+  delete newEntity.system.create;
   return newEntity;
 };
 
@@ -58,7 +63,9 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
   stream.on('error', reject);
   stream.on('data', ({ field, text }) => {
     if (field.name === 'entity') {
-      entity.system.dataset = (field.attrs.dataset ? field.attrs.dataset : field.attrs['entities:dataset']);
+      entity.system.dataset = field.attrs.dataset;
+      entity.system.id = field.attrs.id;
+      entity.system.create = field.attrs.create;
     } else if (field.path.indexOf('/meta/entity') === 0)
       entity.system[field.name] = text;
     else if (field.propertyName != null)

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -40,7 +40,7 @@ const validateEntity = (entity) => {
   const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
   const matches = uuidPattern.exec(id);
   if (matches == null) throw Problem.user.entityViolation({ reason: `ID [${id}] is not a valid UUID.` });
-  const uuid = matches[2];
+  const uuid = matches[2].toLowerCase();
 
   // If create is not an allowed value of true, don't return entity data
   if (!(entity.system.create === '1' || entity.system.create === 'true'))

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -23,6 +23,8 @@ class Entity extends Frame.define(
   static fromSubmissionXml(xml, fields) {
     return parseSubmissionXml(fields, xml)
       .then((entityData) => {
+        if (!entityData)
+          return null; // entity create was false
         const { uuid, label, dataset } = entityData.system;
         const { data } = entityData;
         return new Entity.Partial({ uuid, label }, {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -77,6 +77,9 @@ const _processSubmissionDef = (submissionDefId) => async ({ Datasets, Entities, 
   if (fields.length === 0)
     return null;
   const partial = await Entity.fromSubmissionXml(submissionDef.xml, fields);
+  // If no data was returned, e.g. if create flag was not set, then don't continue
+  if (!partial)
+    return null;
   const entity = await Entities.createNew(partial, submissionDef);
   return entity;
 };

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -336,17 +336,16 @@ module.exports = {
     simpleEntity: `<?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
   <h:head>
-    <model>
+    <model entities:entities-version="2022.1.0">
       <instance>
         <data id="simpleEntity" orx:version="1.0">
           <name/>
           <age/>
           <hometown/>
           <meta>
-            <entities:entity dataset="people" create="">
-              <entities:id/>
-              <entities:label/>
-            </entities:entity>
+            <entity dataset="people" id="" create="">
+              <label/>
+            </entity>
           </meta>
         </data>
       </instance>
@@ -438,10 +437,8 @@ module.exports = {
       one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="1.0">
       <meta>
         <instanceID>one</instanceID>
-        <entities:entity dataset="people">
-          <entities:id>uuid:12345678-1234-4123-8234-123456789abc</entities:id>
+        <entities:entity dataset="people" id="uuid:12345678-1234-4123-8234-123456789abc" create="1">
           <entities:label>Alice (88)</entities:label>
-          <entities:create/>
         </entities:entity>
       </meta>
       <name>Alice</name>

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -721,8 +721,8 @@ describe('datasets and entities', () => {
               <instance>
                 <data id="noDatasetName">
                   <meta>
-                  <entities:entity>
-                  </entities:entity>
+                  <entity>
+                  </entity>
                   </meta>
                 </data>
               </instance>
@@ -780,10 +780,9 @@ describe('datasets and entities', () => {
                 <name/>
                 <age/>
                 <meta>
-                  <entities:entity entities:dataset="something">
-                    <entities:create/>
-                    <entities:label/>
-                  </entities:entity>
+                  <entity dataset="something" id="" create="1">
+                    <label/>
+                  </entity>
                 </meta>
               </data>
             </instance>

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -721,7 +721,7 @@ describe('datasets and entities', () => {
             .expect(400)
             .then(({ body }) => {
               body.code.should.equal(400.25);
-              body.details.reason.should.equal('Version is not supported.');
+              body.details.reason.should.equal('Entities specification version [bad-version] is not supported.');
             }))));
 
       it('should return a Problem if the entity xml is invalid (e.g. missing dataset name)', testService((service) =>
@@ -732,7 +732,7 @@ describe('datasets and entities', () => {
             .expect(400)
             .then(({ body }) => {
               body.code.should.equal(400.25);
-              body.details.reason.should.equal('Dataset name is empty.');
+              body.details.reason.should.equal('Dataset name is missing.');
             }))));
 
       it('should return a Problem if the savetos reference invalid properties', testService((service) =>

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -16,10 +16,15 @@ describe('parsing dataset from entity block', () => {
     getDataset(testData.forms.simple).then((res) =>
       res.should.equal(Option.none())));
 
-  it('should extract entity properties from form field bindings', () =>
+  it('should complain if version is wrong', () =>
     getDataset(testData.forms.simpleEntity
       .replace('entities-version="2022.1.0"', 'entities-version="bad-version"'))
-      .then((res) => res.should.equal(Option.none())));
+      .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+
+  it('should complain if version is missing', () =>
+    getDataset(testData.forms.simpleEntity
+      .replace('entities-version="2022.1.0"', ''))
+      .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
 
   describe('extracting dataset name', () => {
     it('should retrieve the name of a dataset defined in entity block', () => {

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -16,15 +16,27 @@ describe('parsing dataset from entity block', () => {
     getDataset(testData.forms.simple).then((res) =>
       res.should.equal(Option.none())));
 
-  it('should complain if version is wrong', () =>
-    getDataset(testData.forms.simpleEntity
-      .replace('entities-version="2022.1.0"', 'entities-version="bad-version"'))
-      .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+  describe('versioning', () => {
+    it('should check for any version that starts with 2022.1.', () =>
+      getDataset(testData.forms.simpleEntity
+        .replace('2022.1.0', '2022.1.123')).then((res) =>
+        res.get().should.eql('people')));
 
-  it('should complain if version is missing', () =>
-    getDataset(testData.forms.simpleEntity
-      .replace('entities-version="2022.1.0"', ''))
-      .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+    it('should reject probable future version', () =>
+      getDataset(testData.forms.simpleEntity
+        .replace('2022.1.0', '2023.1.0'))
+        .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+
+    it('should complain if version is wrong', () =>
+      getDataset(testData.forms.simpleEntity
+        .replace('entities-version="2022.1.0"', 'entities-version="bad-version"'))
+        .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+
+    it('should complain if version is missing', () =>
+      getDataset(testData.forms.simpleEntity
+        .replace('entities-version="2022.1.0"', ''))
+        .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+  });
 
   describe('extracting dataset name', () => {
     it('should retrieve the name of a dataset defined in entity block', () => {

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -25,17 +25,20 @@ describe('parsing dataset from entity block', () => {
     it('should reject probable future version', () =>
       getDataset(testData.forms.simpleEntity
         .replace('2022.1.0', '2023.1.0'))
-        .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+        .should.be.rejectedWith(Problem, { problemCode: 400.25,
+          message: 'The entity definition within the form is invalid. Entities specification version [2023.1.0] is not supported.' }));
 
     it('should complain if version is wrong', () =>
       getDataset(testData.forms.simpleEntity
         .replace('entities-version="2022.1.0"', 'entities-version="bad-version"'))
-        .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+        .should.be.rejectedWith(Problem, { problemCode: 400.25,
+          message: 'The entity definition within the form is invalid. Entities specification version [bad-version] is not supported.' }));
 
     it('should complain if version is missing', () =>
       getDataset(testData.forms.simpleEntity
         .replace('entities-version="2022.1.0"', ''))
-        .should.be.rejectedWith(Problem, { problemCode: 400.25 }));
+        .should.be.rejectedWith(Problem, { problemCode: 400.25,
+          message: 'The entity definition within the form is invalid. Entities specification version is missing.' }));
   });
 
   describe('extracting dataset name', () => {

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -66,7 +66,7 @@ describe('parsing dataset from entity block', () => {
         res.get().should.eql('foo'));
     });
 
-    it('should retrieve the name of a dataset with superfluous prefix on dataset attribute ', () => {
+    it('should retrieve the name of a dataset with namespace prefix on dataset attribute ', () => {
       const xml = `
       <?xml version="1.0"?>
       <h:html xmlns:entities="http://www.opendatakit.org/xforms">
@@ -77,9 +77,9 @@ describe('parsing dataset from entity block', () => {
                 <name/>
                 <age/>
                 <meta>
-                  <entities:entity entities:dataset="foo">
-                    <entities:label/>
-                  </entities:entity>
+                  <entity entities:dataset="foo">
+                    <label/>
+                  </entity>
                 </meta>
               </data>
             </instance>
@@ -213,6 +213,16 @@ describe('parsing dataset from entity block', () => {
 });
 
 describe('dataset name validation', () => {
+  it('should have name be case sensitive', () =>
+    getDataset(testData.forms.simpleEntity
+      .replace('people', 'PeopleWithACapitalP')).then((res) =>
+      res.get().should.eql('PeopleWithACapitalP')));
+
+  it('should strip whitespace from name', () =>
+    getDataset(testData.forms.simpleEntity
+      .replace('people', '   people ')).then((res) =>
+      res.get().should.eql('people')));
+
   it('should reject names with .', () => {
     validateDatasetName('this.that').should.equal(false);
   });

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -16,13 +16,18 @@ describe('parsing dataset from entity block', () => {
     getDataset(testData.forms.simple).then((res) =>
       res.should.equal(Option.none())));
 
+  it('should extract entity properties from form field bindings', () =>
+    getDataset(testData.forms.simpleEntity
+      .replace('entities-version="2022.1.0"', 'entities-version="bad-version"'))
+      .then((res) => res.should.equal(Option.none())));
+
   describe('extracting dataset name', () => {
     it('should retrieve the name of a dataset defined in entity block', () => {
       const xml = `
       <?xml version="1.0"?>
       <h:html xmlns:entities="http://www.opendatakit.org/xforms">
         <h:head>
-          <model>
+          <model entities:entities-version="2022.1.0">
             <instance>
               <data id="FooForm">
                 <name/>
@@ -46,7 +51,7 @@ describe('parsing dataset from entity block', () => {
       <?xml version="1.0"?>
       <h:html xmlns:entities="http://www.opendatakit.org/xforms">
         <h:head>
-          <model>
+          <model entities:entities-version="2022.1.0">
             <instance>
               <data id="FooForm">
                 <name/>
@@ -71,7 +76,7 @@ describe('parsing dataset from entity block', () => {
       <h:html xmlns:entities="http://www.opendatakit.org/xforms">
           <h:head>
               <h:title>Foo Registration 2</h:title>
-              <model odk:xforms-version="1.0.0">
+              <model entities:entities-version="2022.1.0">
                   <instance>
                       <data id="bar_registration" version="1234">
                           <bbb/>
@@ -79,9 +84,9 @@ describe('parsing dataset from entity block', () => {
                           <meta>
                               <instanceID/>
                               <instanceName/>
-                              <entities:entity dataset="bar">
-                                <entities:label/>
-                              </entities:entity>
+                              <entity dataset="bar">
+                                <label/>
+                              </entity>
                           </meta>
                       </data>
                   </instance>
@@ -98,15 +103,15 @@ describe('parsing dataset from entity block', () => {
       <?xml version="1.0"?>
       <h:html xmlns:entities="http://www.opendatakit.org/xforms">
         <h:head>
-          <model>
+          <model entities:entities-version="2022.1.0">
             <instance>
               <data id="NoName">
                 <name/>
                 <age/>
                 <meta>
-                  <entities:entity>
-                    <entities:label/>
-                  </entities:entity>
+                  <entity>
+                    <label/>
+                  <entity>
                 </meta>
               </data>
             </instance>
@@ -122,15 +127,15 @@ describe('parsing dataset from entity block', () => {
       <?xml version="1.0"?>
       <h:html xmlns:entities="http://www.opendatakit.org/xforms">
         <h:head>
-          <model>
+          <model entities:entities-version="2022.1.0">
             <instance>
               <data id="badName">
                 <name/>
                 <age/>
                 <meta>
-                  <entities:entity dataset="bad.name">
-                    <entities:label/>
-                  </entities:entity>
+                  <entity dataset="bad.name">
+                    <label/>
+                  </entity>
                 </meta>
               </data>
             </instance>

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -41,13 +41,47 @@ describe('extracting entities from submissions', () => {
           result.system.uuid.should.be.a.uuid();
         }));
 
-    it('should return null if entity create is not true', () =>
-      fieldsFor(testData.forms.simpleEntity)
-        .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
-        .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="false"')))
-        .then((result) => {
-          should.not.exist(result);
-        }));
+    describe('create', () => {
+      it('should create entity if create is "1"', () =>
+        fieldsFor(testData.forms.simpleEntity)
+          .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+          .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one))
+          .then((result) => {
+            should.exist(result);
+          }));
+
+      it('should create entity if create is "true"', () =>
+        fieldsFor(testData.forms.simpleEntity)
+          .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+          .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="true"')))
+          .then((result) => {
+            should.exist(result);
+          }));
+
+      it('should return null if entity if create is false', () =>
+        fieldsFor(testData.forms.simpleEntity)
+          .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+          .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="false"')))
+          .then((result) => {
+            should.not.exist(result);
+          }));
+
+      it('should return null if entity if create is "0"', () =>
+        fieldsFor(testData.forms.simpleEntity)
+          .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+          .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="0"')))
+          .then((result) => {
+            should.not.exist(result);
+          }));
+
+      it('should return null if entity if create is something else weird', () =>
+        fieldsFor(testData.forms.simpleEntity)
+          .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+          .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="bad-create"')))
+          .then((result) => {
+            should.not.exist(result);
+          }));
+    });
 
     describe('entity validation errors', () => {
       it('should reject entity with missing dataset', () =>

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -1,4 +1,4 @@
-require('should');
+const should = require('should');
 const appRoot = require('app-root-path');
 const assert = require('assert');
 // eslint-disable-next-line import/no-dynamic-require
@@ -39,6 +39,14 @@ describe('extracting entities from submissions', () => {
             dataset: 'people'
           });
           result.system.uuid.should.be.a.uuid();
+        }));
+
+    it('should return null if entity create is not true', () =>
+      fieldsFor(testData.forms.simpleEntity)
+        .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+        .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="false"')))
+        .then((result) => {
+          should.not.exist(result);
         }));
 
     describe('entity validation errors', () => {

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -58,7 +58,7 @@ describe('extracting entities from submissions', () => {
             should.exist(result);
           }));
 
-      it('should return null if entity if create is false', () =>
+      it('should return null if create is false', () =>
         fieldsFor(testData.forms.simpleEntity)
           .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
           .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="false"')))
@@ -66,7 +66,7 @@ describe('extracting entities from submissions', () => {
             should.not.exist(result);
           }));
 
-      it('should return null if entity if create is "0"', () =>
+      it('should return null if create is "0"', () =>
         fieldsFor(testData.forms.simpleEntity)
           .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
           .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="0"')))
@@ -74,7 +74,7 @@ describe('extracting entities from submissions', () => {
             should.not.exist(result);
           }));
 
-      it('should return null if entity if create is something else weird', () =>
+      it('should return null if create is something else weird', () =>
         fieldsFor(testData.forms.simpleEntity)
           .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
           .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('create="1"', 'create="bad-create"')))

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -41,6 +41,20 @@ describe('extracting entities from submissions', () => {
           result.system.uuid.should.be.a.uuid();
         }));
 
+    it('should lowercase UUIDs for better comparison', () =>
+      fieldsFor(testData.forms.simpleEntity)
+        .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+        .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('12345678-1234-4123-8234-123456789abc', '12345678-1234-4123-8234-ABCD56789abc')))
+        .then((result) => {
+          result.data.should.eql({ first_name: 'Alice', age: '88' });
+          result.system.should.eql({
+            uuid: '12345678-1234-4123-8234-abcd56789abc',
+            label: 'Alice (88)',
+            dataset: 'people'
+          });
+          result.system.uuid.should.be.a.uuid();
+        }));
+
     describe('create', () => {
       it('should create entity if create is "1"', () =>
         fieldsFor(testData.forms.simpleEntity)


### PR DESCRIPTION
Closes #676

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests and trying it out end-to-end in central. Here's a full entity registration form in xml:

```xml
<?xml version="1.0"?>
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:entities="http://www.opendatakit.org/xforms/entities" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <h:head>
    <h:title>Trees registration with gps</h:title>
    <model odk:xforms-version="1.0.0" entities:entities-version="2022.1.0">
      <instance>
        <data id="trees_registration_gps" version="2022.11.18.01">
          <location/>
          <species/>
          <meta>
            <instanceID/>
            <entity dataset="trees" id="" create="">
              <label/>
            </entity>
          </meta>
        </data>
      </instance>
      <bind nodeset="/data/location" type="geopoint" entities:saveto="geometry" />
      <bind nodeset="/data/species" type="string" entities:saveto="species" />

      <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>

      <bind nodeset="/data/meta/entity/@id" type="string"/>
      <setvalue event="odk-instance-first-load" ref="/data/meta/entity/@id" value="uuid()"/>
      <bind nodeset="/data/meta/entity/@create" type="string" calculate="true()"/>
      <bind nodeset="/data/meta/entity/label" calculate="/data/species"  type="string"/>
    </model>
  </h:head>
  <h:body>
    <input ref="/data/species">
      <label>Species of Tree</label>
    </input>
    <input appearance="placement-map" ref="/data/location">
        <label>Location Position</label>
        <hint>Choose where on a map this is</hint>
    </input>
  </h:body>
</h:html>
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Matching the current spec is good!

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Spec documentation is being updated separately and is what is driving this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes