### PR TITLE
Don't return meta/entity fields for form def not associated with dataset

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -172,7 +172,7 @@ const getByName = (datasetName, projectId) => ({ all }) =>
 const getAllByProjectId = (projectId) => ({ all }) => all(_getAllByProjectId(projectId)).then(map(construct(Dataset)));
 
 // Returns list of Fields augmented by dataset property name OR entity creation information
-// including create, label, and id.
+// including label.
 const getFieldsByFormDefId = (formDefId) => ({ all }) => all(sql`
 SELECT
   form_fields.*, ds_properties."name" as "propertyName"

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -178,6 +178,8 @@ SELECT
   form_fields.*, ds_properties."name" as "propertyName"
 FROM
   form_fields
+JOIN dataset_form_defs ON
+  dataset_form_defs."formDefId" = form_fields."formDefId"
 LEFT OUTER JOIN ds_property_fields ON
   ds_property_fields."formDefId" = form_fields."formDefId"
     AND ds_property_fields."path" = form_fields."path"


### PR DESCRIPTION
Closes #686.

I think this is pretty tricky to test in a way that's not brittle. I believe this issue only comes up if you upload a form def with a `meta/entity` field in an earlier version of Central, then upgrade to a version that supports datasets/entities. That's not something that we're really set up to test. The query that I'm modifying is only used in one place, and I think we can be confident that this join is helpful (or at least not harmful!). This area might get more complicated once a single form can contribute to multiple datasets, but we're not there yet.