### PR TITLE
fixes #679: added not null constraints on several columns

### DIFF
--- a/lib/model/migrations/20221118-01-make-entities-columns-not-null.js
+++ b/lib/model/migrations/20221118-01-make-entities-columns-not-null.js
@@ -1,0 +1,52 @@
+// Copyright 2022 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.schema.table('datasets', (datasets) => {
+    datasets.dateTime('createdAt').notNull().alter();
+  });
+
+  await db.schema.table('ds_property_fields', (dsPropertyFields) => {
+    dsPropertyFields.dropUnique(['dsPropertyId', 'formDefId', 'path']);
+    dsPropertyFields.unique(['dsPropertyId', 'formDefId']);
+  });
+
+  await db.schema.table('entities', (entities) => {
+    entities.dateTime('createdAt').notNull().alter();
+  });
+
+  await db.schema.table('entity_defs', (eDef) => {
+    eDef.dateTime('createdAt').notNull().alter();
+    eDef.jsonb('data').notNull().alter();
+    eDef.unique(['entityId', 'submissionDefId']);
+  });
+
+};
+const down = async (db) => {
+  await db.schema.table('datasets', (datasets) => {
+    datasets.dateTime('createdAt').alter();
+  });
+
+  await db.schema.table('ds_property_fields', (dsPropertyFields) => {
+    dsPropertyFields.dropUnique(['dsPropertyId', 'formDefId']);
+    dsPropertyFields.unique(['dsPropertyId', 'formDefId', 'path']);
+  });
+
+  await db.schema.table('entities', (entities) => {
+    entities.dateTime('createdAt').alter();
+  });
+
+  await db.schema.table('entity_defs', (eDef) => {
+    eDef.dateTime('createdAt').alter();
+    eDef.jsonb('data').alter();
+    eDef.dropUnique(['entityId', 'submissionDefId']);
+  });
+};
+
+module.exports = { up, down };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -96,7 +96,7 @@ dsPropertiesAll AS (
 )
 INSERT INTO ds_property_fields
 SELECT "dsPropertyId", "formDefId"::integer, path FROM dsPropertiesAll
-ON CONFLICT ON CONSTRAINT ds_property_fields_dspropertyid_formdefid_path_unique 
+ON CONFLICT ON CONSTRAINT ds_property_fields_dspropertyid_formdefid_unique 
 DO NOTHING
 `);
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -14,6 +14,7 @@ const { Dataset, Form } = require('../frames');
 const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either, reduceBy, groupBy } = require('ramda');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
+const Problem = require('../../util/problem');
 
 // It removes prefix from all the key of an object
 const removePrefix = curry((prefix, obj) => compose(reduce((acc, key) => assoc(key.replace(prefix, ''), obj[key], acc), {}), keys)(obj));
@@ -96,8 +97,6 @@ dsPropertiesAll AS (
 )
 INSERT INTO ds_property_fields
 SELECT "dsPropertyId", "formDefId"::integer, path FROM dsPropertiesAll
-ON CONFLICT ON CONSTRAINT ds_property_fields_dspropertyid_formdefid_unique 
-DO NOTHING
 `);
 
 const _getByIdSql = ((fields, datasetId) => sql`
@@ -142,7 +141,13 @@ const createOrMerge = (dataset, fields, publish = false) => ({ all, Actees, Data
         ? datasetOption.get().acteeId
         : Actees.provision('dataset', project).then((actee) => (actee.id))))
     .then((acteeId) =>
-      all(_createOrMerge(dataset, fields, acteeId, publish)))
+      all(_createOrMerge(dataset, fields, acteeId, publish))
+        .catch(error => {
+          if (error.constraint === 'ds_property_fields_dspropertyid_formdefid_unique') {
+            throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single Dataset Property.' });
+          }
+          throw error;
+        }))
     .then(() => Datasets.getByProjectAndName(dataset.projectId, dataset.name))
     .then((ds) => ((publish === true)
       ? Datasets.getPublishedProperties(ds.get().id).then(properties => ({ ...ds.get(), properties }))

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -897,12 +897,12 @@ describe('datasets and entities', () => {
       it('should not let multiple fields to be mapped to a single property', testService(async (service) => {
         await service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms')
-            .send(testData.forms.simpleEntity.replace(/first_name/g, 'name'))
+            .send(testData.forms.simpleEntity.replace(/first_name/g, 'age'))
             .set('Content-Type', 'application/xml')
             .expect(400)
             .then(({ body }) => {
               body.code.should.be.eql(400.25);
-              body.message.should.be.eql('The entity definition within the form is invalid. Invalid Dataset property.');
+              body.message.should.be.eql('The entity definition within the form is invalid. Multiple Form Fields cannot be saved to a single Dataset Property.');
             }));
       }));
     });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -893,6 +893,18 @@ describe('datasets and entities', () => {
                   body.entityRelated.should.equal(true);
                 }))));
       }));
+
+      it('should not let multiple fields to be mapped to a single property', testService(async (service) => {
+        await service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.simpleEntity.replace(/first_name/g, 'name'))
+            .set('Content-Type', 'application/xml')
+            .expect(400)
+            .then(({ body }) => {
+              body.code.should.be.eql(400.25);
+              body.message.should.be.eql('The entity definition within the form is invalid. Invalid Dataset property.');
+            }));
+      }));
     });
 
     describe('dataset audit logging at /projects/:id/forms POST', () => {


### PR DESCRIPTION
Closes #679

#### Changes:
- added not null constraints on several columns
- Updated unique constraint on ds_property_fields table, added a test to ensure that we don't allow multiple fields to be mapped to a single dataset property

#### What has been done to verify that this works as intended?
All tests are passing

#### Why is this the best possible solution? Were any other approaches considered?
NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
NA

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
NA

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments