### PR TITLE
Improve code at several places for dataset/entities feature

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -58,7 +58,7 @@ const validateEntity = (entity) => {
 // 2. the "meta/entity" structural field should be included to get necessary
 //    entity node attributes like dataset name.
 const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) => {
-  const entity = { system: {}, data: {} };
+  const entity = { system: Object.create(null), data: Object.create(null) };
   const stream = submissionXmlToFieldStream(entityFields, xml, true);
   stream.on('error', reject);
   stream.on('data', ({ field, text }) => {

--- a/lib/model/frames/dataset.js
+++ b/lib/model/frames/dataset.js
@@ -9,27 +9,32 @@
 
 /* eslint-disable no-multi-spaces */
 
-const { Frame, table, readable, writable, embedded } = require('../frame');
+const { Frame, table, readable, embedded } = require('../frame');
 
+// Only Dataset frame is returned directly in any API response, and we don't
+// have any API that receives Dataset frame in the request body, hence it has
+// only `readable` attribute on few fields. Rest of the frames here are used
+// internally, hence they don't have writables/readables
 const Dataset = Frame.define(
   table('datasets'),
-  'id',        readable,                       'name', readable, writable,
+  'id',                                        'name', readable,
   'createdAt', readable,                       'acteeId',
-  'projectId', readable, writable,             'revisionNumber', readable,
+  'projectId', readable,                       'revisionNumber',
+  'publishedAt',
   embedded('properties')
 );
 
 Dataset.Property = Frame.define(
   table('ds_properties', 'properties'),
-  'id',     readable,                        'name', readable, writable,
-  'datasetId',        readable, writable
+  'id',                                        'name',
+  'datasetId',                                 'publishedAt'
 
 );
 
 Dataset.PropertyField = Frame.define(
   table('ds_property_fields', 'propertyField'),
-  'dsPropertyId',     readable,                        'formDefId', readable, writable,
-  'path',             readable, writable
+  'dsPropertyId',                              'formDefId',
+  'path'
 );
 
 module.exports = { Dataset };

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -9,14 +9,15 @@
 
 /* eslint-disable no-multi-spaces */
 
-const { Frame, table, readable } = require('../frame');
+const { Frame, table } = require('../frame');
 const { parseSubmissionXml } = require('../../data/entity');
 
+// These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
   table('entities'),
-  'id',         readable,           'uuid',      readable,
-  'datasetId',  readable,           'label',     readable,
-  'createdAt',  readable,           'createdBy', readable
+  'id',                  'uuid',
+  'datasetId',           'label',
+  'createdAt',           'createdBy'
 ) {
   get def() { return this.aux.def; }
 
@@ -39,8 +40,8 @@ Entity.Partial = class extends Entity {};
 
 Entity.Def = Frame.define(
   table('entity_defs', 'def'),
-  'id',               readable,   'entityId',
-  'createdAt',        readable,   'current',      readable,
+  'id',                  'entityId',
+  'createdAt',           'current',
   'submissionDefId',
   'data'
 );

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -25,9 +25,8 @@ const pickFrameFields = (frame, obj) => compose(
 )(obj);
 
 const makeHierarchy = reduce((result, item) => {
-  const dataset = new Dataset(pickFrameFields(Dataset, item)).forApi();
-  const property = new Dataset.Property(pickFrameFields(Dataset.Property, item)).forApi();
-  const propertyField = new Dataset.PropertyField(pickFrameFields(Dataset.PropertyField, item)).forApi();
+  const dataset = new Dataset(pickFrameFields(Dataset, item));
+  const property = new Dataset.Property(pickFrameFields(Dataset.Property, item));
 
   return {
     ...result,
@@ -35,13 +34,7 @@ const makeHierarchy = reduce((result, item) => {
       ...dataset,
       properties: !property.id ? { ...(result[dataset.id]?.properties || {}) } : {
         ...(result[dataset.id]?.properties || {}),
-        [property.id]: {
-          ...property,
-          fields: [
-            ...(result[dataset.id]?.properties[property.id]?.fields || []),
-            propertyField
-          ]
-        }
+        [property.id]: property
       }
     }
   };
@@ -80,23 +73,23 @@ ${_insertDatasetDef(dataset, acteeId, true, publish)}
 fields("propertyName", "formDefId", path) AS (VALUES      
   ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.formDefId, p.path], sql`,`)} )`), sql`,`)}
 ),
-dsProperties AS (
+insert_properties AS (
     INSERT INTO ds_properties (id, name, "datasetId", "publishedAt")
     SELECT nextval(pg_get_serial_sequence('ds_properties', 'id')), fields."propertyName", ds.id, ${(publish === true) ? sql`clock_timestamp()` : null} FROM fields, ds
     ON CONFLICT  ON CONSTRAINT ds_properties_name_datasetid_unique
     DO NOTHING 
     RETURNING ds_properties.id, ds_properties.name, ds_properties."datasetId"
 ),
-dsPropertiesAll AS (
-    (SELECT dsProperties.id "dsPropertyId", dsProperties.name "propertyName", fields."formDefId", fields.path FROM fields
-    JOIN dsProperties ON fields."propertyName" = dsProperties.name)
+all_properties AS (
+    (SELECT insert_properties.id "dsPropertyId", insert_properties.name "propertyName", fields."formDefId", fields.path FROM fields
+    JOIN insert_properties ON fields."propertyName" = insert_properties.name)
     UNION 
     (SELECT ds_properties.id "dsPropertyId", ds_properties.name "propertyName", fields."formDefId", fields.path FROM fields
     JOIN ds_properties ON fields."propertyName" = ds_properties.name
     JOIN ds ON ds.id = ds_properties."datasetId")
 )
 INSERT INTO ds_property_fields
-SELECT "dsPropertyId", "formDefId"::integer, path FROM dsPropertiesAll
+SELECT "dsPropertyId", "formDefId"::integer, path FROM all_properties
 `);
 
 const _getByIdSql = ((fields, datasetId) => sql`
@@ -106,8 +99,6 @@ const _getByIdSql = ((fields, datasetId) => sql`
            datasets
        LEFT OUTER JOIN ds_properties ON
            datasets.id = ds_properties."datasetId"
-       LEFT OUTER JOIN ds_property_fields ON
-           ds_properties.id = ds_property_fields."dsPropertyId"
        WHERE datasets.id = ${datasetId}
     `);
 
@@ -118,8 +109,6 @@ const _getByNameSql = ((fields, datasetName, projectId) => sql`
         datasets
     LEFT OUTER JOIN ds_properties ON
         datasets.id = ds_properties."datasetId"
-    LEFT OUTER JOIN ds_property_fields ON
-        ds_properties.id = ds_property_fields."dsPropertyId"
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
       AND datasets."publishedAt" IS NOT NULL
@@ -164,14 +153,14 @@ createOrMerge.audit.withResult = true;
 
 // Returns dataset along with it properties and field mappings
 const getById = (datasetId) => ({ all }) =>
-  all(_getByIdSql(unjoiner(Dataset, Dataset.Property, Dataset.PropertyField).fields, datasetId))
+  all(_getByIdSql(unjoiner(Dataset, Dataset.Property).fields, datasetId))
     .then(makeHierarchy)
     .then(asArray)
     .then(nth(0));
 
 // Returns only published dataset with its published properties
 const getByName = (datasetName, projectId) => ({ all }) =>
-  all(_getByNameSql(unjoiner(Dataset, Dataset.Property, Dataset.PropertyField).fields, datasetName, projectId))
+  all(_getByNameSql(unjoiner(Dataset, Dataset.Property).fields, datasetName, projectId))
     .then(makeHierarchy)
     .then(asArray)
     .then(nth(0))
@@ -199,14 +188,14 @@ WHERE form_fields."formDefId" = ${formDefId}
   AND (ds_properties."id" IS NOT NULL OR form_fields."path" LIKE '/meta/entity%')
 ORDER BY form_fields."order"
 `)
-  .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName }))); // TODO augment this field so it also has the property name
+  .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName })));
 
 const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
   WITH form AS (
     SELECT f.id, f."xmlFormId", fd.id "formDefId" 
     FROM forms f
-    JOIN form_defs fd on fd.id = f.${forDraft ? sql.identifier(['draftDefId']) : sql.identifier(['currentDefId'])}
-    WHERE "projectId" = ${projectId} and "xmlFormId" = ${xmlFormId}
+    JOIN form_defs fd ON fd.id = f.${forDraft ? sql.identifier(['draftDefId']) : sql.identifier(['currentDefId'])}
+    WHERE "projectId" = ${projectId} AND "xmlFormId" = ${xmlFormId} AND f."deletedAt" IS NULL
   ),
   ds AS (
     SELECT d.id, d.name, dd."formDefId", d."publishedAt" IS NULL "isNew"

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -36,8 +36,8 @@ describe('datasets and entities', () => {
               asAlice.get('/v1/projects/1/datasets')
                 .expect(200)
                 .then(({ body }) => {
-                  body.map(({ id, createdAt, ...d }) => d).should.eql([
-                    { name: 'people', projectId: 1, revisionNumber: 0 }
+                  body.map(({ createdAt, ...d }) => d).should.eql([
+                    { name: 'people', projectId: 1 }
                   ]);
                 })))));
 
@@ -57,7 +57,7 @@ describe('datasets and entities', () => {
                   .expect(200)
                   .then(({ body }) => {
                     body.map(({ id, createdAt, ...d }) => d).should.eql([
-                      { name: 'student', projectId: 1, revisionNumber: 0 }
+                      { name: 'student', projectId: 1 }
                     ]);
                   }))))));
     });
@@ -869,7 +869,6 @@ describe('datasets and entities', () => {
         await Datasets.getById(datasetId)
           .then(result => {
             result.properties.length.should.be.eql(2);
-            result.properties[0].fields.length.should.equal(2);
           });
       }));
 

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1286,43 +1286,6 @@ describe('api: /projects', () => {
                 .then((o) => { o.isDefined().should.equal(false); })
             ])))))));
   });
-
-  describe('/:id/datasets GET', () => {
-    it('should return the datasets of Default project', testService((service) =>
-      service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.simpleEntity)
-          .set('Content-Type', 'application/xml')
-          .expect(200)
-          .then(() =>
-            asAlice.get('/v1/projects/1/datasets')
-              .expect(200)
-              .then(({ body }) => {
-                body.map(({ id, createdAt, ...d }) => d).should.eql([
-                  { name: 'people', projectId: 1, revisionNumber: 0 }
-                ]);
-              })))));
-
-    it('should not return draft datasets', testService((service) =>
-      service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms')
-          .send(testData.forms.simpleEntity)
-          .set('Content-Type', 'application/xml')
-          .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
-            .send(testData.forms.simpleEntity
-              .replace(/simpleEntity/, 'simpleEntity2')
-              .replace(/people/, 'student'))
-            .expect(200)
-            .then(() =>
-              asAlice.get('/v1/projects/1/datasets')
-                .expect(200)
-                .then(({ body }) => {
-                  body.map(({ id, createdAt, ...d }) => d).should.eql([
-                    { name: 'student', projectId: 1, revisionNumber: 0 }
-                  ]);
-                }))))));
-  });
 });
 
 // Nested extended forms

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -32,12 +32,12 @@ describe('extracting entities from submissions', () => {
         .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
         .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one))
         .then((result) => {
-          result.data.should.eql({ first_name: 'Alice', age: '88' });
-          result.system.should.eql({
+          should(result.data).eql(Object.assign(Object.create(null), { first_name: 'Alice', age: '88' }));
+          should(result.system).eql(Object.assign(Object.create(null), {
             uuid: '12345678-1234-4123-8234-123456789abc',
             label: 'Alice (88)',
             dataset: 'people'
-          });
+          }));
           result.system.uuid.should.be.a.uuid();
         }));
 
@@ -46,12 +46,12 @@ describe('extracting entities from submissions', () => {
         .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
         .then((fields) => parseSubmissionXml(fields, testData.instances.simpleEntity.one.replace('12345678-1234-4123-8234-123456789abc', '12345678-1234-4123-8234-ABCD56789abc')))
         .then((result) => {
-          result.data.should.eql({ first_name: 'Alice', age: '88' });
-          result.system.should.eql({
+          should(result.data).eql(Object.assign(Object.create(null), { first_name: 'Alice', age: '88' }));
+          should(result.system).eql(Object.assign(Object.create(null), {
             uuid: '12345678-1234-4123-8234-abcd56789abc',
             label: 'Alice (88)',
             dataset: 'people'
-          });
+          }));
           result.system.uuid.should.be.a.uuid();
         }));
 


### PR DESCRIPTION
Fixes several items of #678
and partial fix for #674

## Changes
- removed unnecessary readables writables
- removed duplicate tests
- renamed CTE expressions
- removed  from makeHierarchy
- changed {} with Object.create
- added deletedAt is null to getDatasetDiff sql
- projects/:id/datasets doesn't return revisionNumber

#### What has been done to verify that this works as intended?
All tests are passing

#### Why is this the best possible solution? Were any other approaches considered?
NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
NA

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
`projects/:id/datasets` doesn't return `revisionNumber` anymore

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments