### PR TITLE
fix: dataset-diff should return dataset even if there's no properties

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -108,11 +108,10 @@ const _getByNameSql = ((fields, datasetName, projectId) => sql`
     FROM
         datasets
     LEFT OUTER JOIN ds_properties ON
-        datasets.id = ds_properties."datasetId"
+        datasets.id = ds_properties."datasetId" AND ds_properties."publishedAt" IS NOT NULL
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
       AND datasets."publishedAt" IS NOT NULL
-      AND ds_properties."publishedAt" IS NOT NULL
  `);
 
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -216,7 +216,7 @@ const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
   FROM ds
   LEFT JOIN properties p on ds.id = p."datasetId"
   LEFT JOIN form f ON f."formDefId" = p."formDefId"
-  ${forDraft ? sql`` : sql`WHERE NOT p."isNew"`}
+  ${forDraft ? sql`` : sql`WHERE p.id IS NULL OR NOT p."isNew"`}
   GROUP BY ds.name, ds."isNew", p.name, p."isNew"
   ORDER BY p.name
 `)

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -833,6 +833,21 @@ describe('datasets and entities', () => {
 
       }));
 
+      it('should let the user download even if there are no properties', testService(async (service) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/entities:saveto[^/]+/g, ''))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities.csv')
+          .expect(200)
+          .then(({ text }) => {
+            text.should.equal('name,label\n');
+          });
+      }));
+
     });
   });
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -813,6 +813,26 @@ describe('datasets and entities', () => {
                   }]);
                 }))));
       }));
+
+      it('should return dataset name only if there is no properties', testService(async (service) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/entities:saveto[^/]+/g, ''))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/forms/simpleEntity/dataset-diff')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.eql([{
+              name: 'people',
+              properties: []
+            }]);
+          });
+
+      }));
+
     });
   });
 


### PR DESCRIPTION
Added condition in dataset-diff SQL query to return dataset even if there is no published properties. 
Fixes issue # 8 in QA's "ODK Central" doc

#### What has been done to verify that this works as intended?
- Integration tests

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- Dataset summary on Form Draft Status page and Publish modal should be tested as well

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
NA

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments