### PR TITLE
Enhance: don't parse dataset schema of an encrypted form

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -62,7 +62,7 @@ const createNew = (partial, project, publish = false) => ({ run, Datasets, FormA
   Promise.all([
     partial.aux.key.map(Keys.ensure).orElse(resolve(null)),
     getFormFields(partial.xml),
-    getDataset(partial.xml)
+    partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml) // Don't parse dataset schema if Form has encryption key
   ])
     .then(([ keyId, fields, dataset ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
       .then((savedForm) => {
@@ -123,7 +123,7 @@ const createVersion = (partial, form, publish = false) => ({ run, one, Datasets,
       .then(ignoringResult((savedDef) => ((publish === true)
         ? Forms._update(form, { currentDefId: savedDef.id })
         : Forms._update(form, { draftDefId: savedDef.id })))),
-    getDataset(partial.xml),
+    partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml), // Don't parse dataset schema if Form has encryption key
     // process the form schema locally while everything happens
     getFormFields(partial.xml)
   ])

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -135,8 +135,8 @@ module.exports = (service, endpoint) => {
   // Entity/Dataset-specific endpoint that is used to show how publishing
   // a form will change any datasets mentioned in the form.
   // Even though there are dataset-related permissions, we will use a combination of dataset access and
-  // form modification verbs for authentication. Though form.update and dataset.list will likely be part
-  // of the same role, we want to use the combined authentication strength. One scenario where they are
+  // form modification verbs for authorization. Though form.update and dataset.list will likely be part
+  // of the same role, we want to use the combined authorization strength. One scenario where they are
   // different is if a user has been assigned a higher auth role on a specific form but not a project,
   // which can be done through the API: projects/.../forms/.../assignments
   //
@@ -163,8 +163,10 @@ module.exports = (service, endpoint) => {
           auth.canOrReject('form.update', form),
           auth.canOrReject('dataset.list', project)
         ]))
-      .then(([form, ]) => ensureDef(form))
-      .then(() => Datasets.getDatasetDiff(params.projectId, params.id, true))));
+      .then(([form]) => ensureDef(form))
+      .then((form) => (form.aux.def.keyId
+        ? [] // return empty array if encryption is enabled
+        : Datasets.getDatasetDiff(params.projectId, params.id, true)))));
 
   service.get('/projects/:projectId/forms/:id/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
     Promise.all([
@@ -181,8 +183,10 @@ module.exports = (service, endpoint) => {
           auth.canOrReject('form.update', form),
           auth.canOrReject('dataset.list', project)
         ]))
-      .then(([form, ]) => ensureDef(form))
-      .then(() => Datasets.getDatasetDiff(params.projectId, params.id, false))));
+      .then(([form]) => ensureDef(form))
+      .then((form) => (form.aux.def.keyId
+        ? [] // return empty array if encryption is enabled
+        : Datasets.getDatasetDiff(params.projectId, params.id, false)))));
 
   service.patch('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Datasets, FormAttachments, Forms }, { auth, params, body }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -741,6 +741,42 @@ describe('datasets and entities', () => {
             }]);
           });
       }));
+
+      it('should return empty array if managed encryption is enabled', testService(async (service) => {
+        // Upload a form and then create a new draft version
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/key')
+          .send({ passphrase: 'supersecret' })
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/forms/simpleEntity/draft/dataset-diff')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.eql([]);
+          });
+      }));
+
+      it('should return empty array if form is encrypted', testService(async (service) => {
+        // Upload a form and then create a new draft version
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity.replace('</model>', '<submission base64RsaPublicKey="abc"/></model>'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/forms/simpleEntity/draft/dataset-diff')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.eql([]);
+          });
+      }));
     });
 
     describe('/projects/:id/forms/:formId/dataset-diff GET', () => {


### PR DESCRIPTION
## Changes:
* don't parse dataset schema of an encrypted form
* If we have keyId on a Form then we can skip dataset parsing logic
* For Form with keyId, we can return empty array for dataset-diff endpoints

Closes #698

#### What has been done to verify that this works as intended?
- Integration tests and manual testing

#### Why is this the best possible solution? Were any other approaches considered?
- For now, I have short-circuited dataset parsing logic on form upload. Later we can parse complete form and return warnings, for that we have to validate form xml.
 
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- Initially I was thinking that frontend needs to be changed as well for this but it turns out nothing is required there. I have manually tested and all looks fine.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
NA

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments