### PR TITLE
fix #459: use for-loop instead of Promise.all in migration

### DIFF
--- a/lib/model/migrations/20221208-01-reduce-tz-precision.js
+++ b/lib/model/migrations/20221208-01-reduce-tz-precision.js
@@ -7,13 +7,15 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
+const { groupBy } = require('ramda');
+
 // Issue:        #cb459 - `gt` filter for submissionDate is not working as expected because of tz precision
 // Root cause:   Default timestamptz precision in postgres is microseconds and node/js has just milliseconds
 // Solution:     Let's change precision to milliseconds in database, since there is no value in having higher precision
 //               in the database when application can't use/handle it + typical usage of ODK Central doesn't demand higher
 //               precision.
 
-const getTimestampColumns = (db) => db.raw(`
+const getTablesWithTimestampColumns = (db) => db.raw(`
   SELECT
     table_name, column_name, is_nullable
   FROM
@@ -21,26 +23,29 @@ const getTimestampColumns = (db) => db.raw(`
   WHERE
     table_schema = 'public'
     AND udt_name = 'timestamptz'`)
-  .then(data => data.rows);
+  .then(data => groupBy(r => r.table_name, data.rows));
 
-const changePrecision = (db, columnMeta, precision) => db.schema.alterTable(columnMeta.table_name, (table) => {
-  if (columnMeta.is_nullable === 'YES') {
-    table.dateTime(columnMeta.column_name, { useTz: true, precision }).alter();
-  } else {
-    table.dateTime(columnMeta.column_name, { useTz: true, precision }).notNullable().alter();
-  }
-});
+const changePrecision = (db, tablename, columns, precision) => db.raw(`
+  ALTER TABLE ${tablename} 
+  ${columns.map(c => `ALTER COLUMN "${c.column_name}" TYPE timestamptz(${precision})`).join(', ')}
+`);
 
 const up = async (db) => {
-  const columns = await getTimestampColumns(db);
+  console.log('Migrating timestamps, this may take a while if you have a lot of submissions.'); // eslint-disable-line no-console
 
-  await Promise.all(columns.map(c => changePrecision(db, c, 3)));
+  const tables = await getTablesWithTimestampColumns(db);
+
+  for (const tablename of Object.keys(tables)) {
+    await changePrecision(db, tablename, tables[tablename], 3); // eslint-disable-line no-await-in-loop
+  }
 };
 
 const down = async (db) => {
-  const columns = await getTimestampColumns(db);
+  const tables = await getTablesWithTimestampColumns(db);
 
-  await Promise.all(columns.map(c => changePrecision(db, c, 6)));
+  for (const tablename of Object.keys(tables)) {
+    await changePrecision(db, tablename, tables[tablename], 6); // eslint-disable-line no-await-in-loop
+  }
 };
 
 module.exports = { up, down };

--- a/lib/model/migrations/20221208-01-reduce-tz-precision.js
+++ b/lib/model/migrations/20221208-01-reduce-tz-precision.js
@@ -7,8 +7,6 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { groupBy } = require('ramda');
-
 // Issue:        #cb459 - `gt` filter for submissionDate is not working as expected because of tz precision
 // Root cause:   Default timestamptz precision in postgres is microseconds and node/js has just milliseconds
 // Solution:     Let's change precision to milliseconds in database, since there is no value in having higher precision
@@ -17,17 +15,16 @@ const { groupBy } = require('ramda');
 
 const getTablesWithTimestampColumns = (db) => db.raw(`
   SELECT
-    table_name, column_name, is_nullable
+    table_name, JSON_AGG(column_name) AS columns
   FROM
     information_schema.columns
-  WHERE
-    table_schema = 'public'
-    AND udt_name = 'timestamptz'`)
-  .then(data => groupBy(r => r.table_name, data.rows));
+  WHERE table_schema = 'public'
+    AND udt_name = 'timestamptz'
+  GROUP BY table_name`);
 
 const changePrecision = (db, tablename, columns, precision) => db.raw(`
   ALTER TABLE ${tablename} 
-  ${columns.map(c => `ALTER COLUMN "${c.column_name}" TYPE timestamptz(${precision})`).join(', ')}
+  ${columns.map(c => `ALTER COLUMN "${c}" TYPE timestamptz(${precision})`).join(', ')}
 `);
 
 const up = async (db) => {
@@ -35,16 +32,16 @@ const up = async (db) => {
 
   const tables = await getTablesWithTimestampColumns(db);
 
-  for (const tablename of Object.keys(tables)) {
-    await changePrecision(db, tablename, tables[tablename], 3); // eslint-disable-line no-await-in-loop
+  for (const table of tables.rows) {
+    await changePrecision(db, table.table_name, table.columns, 3); // eslint-disable-line no-await-in-loop
   }
 };
 
 const down = async (db) => {
   const tables = await getTablesWithTimestampColumns(db);
 
-  for (const tablename of Object.keys(tables)) {
-    await changePrecision(db, tablename, tables[tablename], 6); // eslint-disable-line no-await-in-loop
+  for (const table of tables.rows) {
+    await changePrecision(db, table.table_name, table.columns, 6); // eslint-disable-line no-await-in-loop
   }
 };
 


### PR DESCRIPTION
Issue: `20221208-01-reduce-tz-precision.js` is timing out if there is too much data in DB.
Change: Replaced `Promise.all` with for-loop in migration file