### PR TITLE
Add request duration in Sentry logs

### DIFF
--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -92,9 +92,7 @@ const sanitizeEventRequest = (event) => {
       event.request.url = filterTokenFromUrl(event.request.url);
     }
 
-    event.extra = {
-      duration: `${Math.round((Date.now() - event.request.headers['x-request-received-at']) / 1000)} sec`
-    };
+    event.extra.duration = Date.now() - event.extra.startTimestamp;
   }
 
   /* eslint-enable no-param-reassign */

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { inspect } = require('util');
-const { isBlank, isPresent } = require('../util/util');
+const { isBlank, isPresent, noop } = require('../util/util');
 
 
 // Endpoints where query strings are sensitive and should be removed
@@ -92,7 +92,6 @@ const sanitizeEventRequest = (event) => {
       event.request.url = filterTokenFromUrl(event.request.url);
     }
 
-    event.extra.duration = Date.now() - event.extra.startTimestamp;
   }
 
   /* eslint-enable no-param-reassign */
@@ -112,7 +111,8 @@ const init = (config) => {
         process.stderr.write('attempted to log Sentry exception in development:\n');
         process.stderr.write(inspect(err));
         process.stderr.write('\n');
-      }
+      },
+      configureScope: noop
     };
   }
 
@@ -123,6 +123,10 @@ const init = (config) => {
     environment: process.env.SENTRY_ENVIRONMENT || 'production',
     beforeSend(event, hint) {
       const sanitizedEvent = sanitizeEventRequest(event);
+
+      if (sanitizedEvent.extra && sanitizedEvent.extra.startTimestamp) { // just an extra safety check. this should be always true
+        sanitizedEvent.extra.duration = Date.now() - sanitizedEvent.extra.startTimestamp;
+      }
 
       // only file the event if it is a bare exception or it is a true 500.x Problem.
       const error = hint.originalException;

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -91,6 +91,10 @@ const sanitizeEventRequest = (event) => {
       // filter out access tokens embedded in URLs
       event.request.url = filterTokenFromUrl(event.request.url);
     }
+
+    event.extra = {
+      duration: `${Math.round((Date.now() - event.request.headers['x-request-received-at']) / 1000)} sec`
+    };
   }
 
   /* eslint-enable no-param-reassign */

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -18,6 +18,11 @@ module.exports = (container) => {
   ////////////////////////////////////////////////////////////////////////////////
   // PRERESOURCE MIDDLEWARE
 
+  service.use((req, res, next) => {
+    req.headers['x-request-received-at'] = Date.now();
+    next();
+  });
+
   // apply the Sentry request hook.
   service.use(container.Sentry.Handlers.requestHandler());
 

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -10,7 +10,6 @@
 // This file glues together all the middleware and the HTTP REST resources we have
 // defined elsewhere into an actual Express service. The only thing it needs in
 // order to do this is a valid dependency injection context container.
-const Sentry = require('@sentry/node');
 
 module.exports = (container) => {
   const service = require('express')();
@@ -22,7 +21,7 @@ module.exports = (container) => {
   service.use(container.Sentry.Handlers.requestHandler());
 
   service.use((req, res, next) => {
-    Sentry.configureScope(scope => {
+    container.Sentry.configureScope(scope => {
       scope.setExtra('startTimestamp', Date.now());
     });
     next();

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -10,7 +10,7 @@
 // This file glues together all the middleware and the HTTP REST resources we have
 // defined elsewhere into an actual Express service. The only thing it needs in
 // order to do this is a valid dependency injection context container.
-
+const Sentry = require('@sentry/node');
 
 module.exports = (container) => {
   const service = require('express')();
@@ -18,13 +18,15 @@ module.exports = (container) => {
   ////////////////////////////////////////////////////////////////////////////////
   // PRERESOURCE MIDDLEWARE
 
-  service.use((req, res, next) => {
-    req.headers['x-request-received-at'] = Date.now();
-    next();
-  });
-
   // apply the Sentry request hook.
   service.use(container.Sentry.Handlers.requestHandler());
+
+  service.use((req, res, next) => {
+    Sentry.configureScope(scope => {
+      scope.setExtra('startTimestamp', Date.now());
+    });
+    next();
+  });
 
   // automatically parse JSON if it is marked as such. otherwise, just pull the
   // plain-text body contents.

--- a/test/unit/external/sanitize-sentry.js
+++ b/test/unit/external/sanitize-sentry.js
@@ -549,19 +549,9 @@ const filteredTokenUrls = [
 describe('external: sanitize-sentry', () => {
   it('removes sensitive data from request objects ', () => {
 
-    // Mock Date.now()
-    const actualDateNow = global.Date.now;
-    global.Date.now = () => 1640995210000;
-
-    const startTimestamp = 1640995200000;
-    const extra = { startTimestamp };
-
     for (const [input, expectedOutput] of cases) {
-      sanitizeEventRequest({ request: input, extra }).should.eql({ request: expectedOutput, extra: { startTimestamp, duration: 10000 } });
+      sanitizeEventRequest({ request: input }).should.eql({ request: expectedOutput });
     }
-
-    // Restore actual function
-    global.Date.now = actualDateNow;
   });
 
   it('identifies sensitive URLs ', () => {

--- a/test/unit/external/sanitize-sentry.js
+++ b/test/unit/external/sanitize-sentry.js
@@ -17,8 +17,7 @@ const cases = [
         accept: 'application/json, */*;q=0.5',
         connection: 'keep-alive',
         'content-type': 'application/json',
-        'content-length': '48',
-        'x-request-received-at': 1640995200000
+        'content-length': '48'
       },
       method: 'POST',
       query_string: null,
@@ -34,8 +33,7 @@ const cases = [
         accept: 'application/json, */*;q=0.5',
         connection: 'keep-alive',
         'content-type': 'application/json',
-        'content-length': '48',
-        'x-request-received-at': 1640995200000
+        'content-length': '48'
       },
       method: 'POST',
       query_string: null,
@@ -53,8 +51,7 @@ const cases = [
         'accept-encoding': 'gzip, deflate',
         accept: '*/*',
         connection: 'keep-alive',
-        authorization: 'Bearer sdff.....sdQ',
-        'x-request-received-at': 1640995200000
+        authorization: 'Bearer sdff.....sdQ'
       },
       method: 'GET',
       query_string: null,
@@ -69,8 +66,7 @@ const cases = [
         'accept-encoding': 'gzip, deflate',
         accept: '*/*',
         connection: 'keep-alive',
-        authorization: null,
-        'x-request-received-at': 1640995200000
+        authorization: null
       },
       method: 'GET',
       query_string: null,
@@ -103,8 +99,7 @@ const cases = [
         referer: 'http://localhost:8989/',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken=j0j3....QU5; __enketo_meta_deviceid=s%3Alocalhost%3AzgCh....AE; __csrf=kG2...1d; session=Ajp....vjSnR',
-        'x-request-received-at': 1640995200000
+        cookie: 'csrftoken=j0j3....QU5; __enketo_meta_deviceid=s%3Alocalhost%3AzgCh....AE; __csrf=kG2...1d; session=Ajp....vjSnR'
       },
       method: 'GET',
       query_string: '%24filter=__system%2FsubmitterId+eq+26+and+__system%2FreviewState+eq+null',
@@ -129,8 +124,7 @@ const cases = [
         referer: null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session',
-        'x-request-received-at': 1640995200000
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
       },
       method: 'GET',
       query_string: null,
@@ -150,8 +144,7 @@ const cases = [
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
         'content-type': 'multipart/form-data; boundary=58a8898824454fadb1e9d19fac47882c',
-        'content-length': '311',
-        'x-request-received-at': 1640995200000
+        'content-length': '311'
       },
       method: 'POST',
       query_string: null,
@@ -168,8 +161,7 @@ const cases = [
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
         'content-type': 'multipart/form-data; boundary=58a8898824454fadb1e9d19fac47882c',
-        'content-length': '311',
-        'x-request-received-at': 1640995200000
+        'content-length': '311'
       },
       method: 'POST',
       query_string: null,
@@ -188,8 +180,7 @@ const cases = [
         accept: '*/*',
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
-        'content-type': 'text/xml',
-        'x-request-received-at': 1640995200000
+        'content-type': 'text/xml'
       },
       method: 'GET',
       query_string: null,
@@ -205,8 +196,7 @@ const cases = [
         accept: '*/*',
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
-        'content-type': 'text/xml',
-        'x-request-received-at': 1640995200000
+        'content-type': 'text/xml'
       },
       method: 'GET',
       query_string: null,
@@ -238,8 +228,7 @@ const cases = [
         referer: 'http://localhost:8989/',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken=j0j32..6LEzgQU5; __enketo_meta_deviceid=s%3Alo...ucHhAE; __csrf=tdgs7t0..12lwQ; session=RPP..dUz',
-        'x-request-received-at': 1640995200000
+        cookie: 'csrftoken=j0j32..6LEzgQU5; __enketo_meta_deviceid=s%3Alo...ucHhAE; __csrf=tdgs7t0..12lwQ; session=RPP..dUz'
       },
       method: 'GET',
       query_string: '%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null',
@@ -265,8 +254,7 @@ const cases = [
         referer: null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session',
-        'x-request-received-at': 1640995200000
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
       },
       method: 'GET',
       query_string: '%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null',
@@ -305,8 +293,7 @@ const cases = [
         referer: 'http://localhost:8989/-/XoecwziQ',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken=j0j3..QU5; __enketo_meta_deviceid=s%3Aloc..AE; __csrf=tdg..lwQ; session=RP..SdUz',
-        'x-request-received-at': 1640995200000
+        cookie: 'csrftoken=j0j3..QU5; __enketo_meta_deviceid=s%3Aloc..AE; __csrf=tdg..lwQ; session=RP..SdUz'
       },
       method: 'POST',
       query_string: null,
@@ -340,8 +327,7 @@ const cases = [
         referer:  null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session',
-        'x-request-received-at': 1640995200000
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
       },
       method: 'POST',
       query_string: null,
@@ -363,8 +349,7 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid=s%3Aloc..p4; _csrf=W_..Ua',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 18:47:25 GMT',
-        'x-request-received-at': 1640995200000
+        date: 'Mon, 14 Jun 2021 18:47:25 GMT'
       },
       method: 'HEAD',
       query_string: 'formID=simple-name-age&st=Cpl...62M0d',
@@ -380,8 +365,7 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid, _csrf',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 18:47:25 GMT',
-        'x-request-received-at': 1640995200000
+        date: 'Mon, 14 Jun 2021 18:47:25 GMT'
       },
       method: 'HEAD',
       query_string: null,
@@ -418,8 +402,7 @@ const cases = [
         referer: 'http://localhost:8989/-/single/Xo..iQ?st=Cp...d',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZzEustWflva1byvA.R..p4; _csrf=W_..a',
-        'x-request-received-at': 1640995200000
+        cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZzEustWflva1byvA.R..p4; _csrf=W_..a'
       },
       method: 'POST',
       query_string: 'st=Cpl...M0d',
@@ -450,8 +433,7 @@ const cases = [
         referer: null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: '__enketo_meta_deviceid, _csrf',
-        'x-request-received-at': 1640995200000
+        cookie: '__enketo_meta_deviceid, _csrf'
       },
       method: 'POST',
       query_string: null,
@@ -473,8 +455,7 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZz..Fp4; _csrf=W..Ua',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 19:08:30 GMT',
-        'x-request-received-at': 1640995200000
+        date: 'Mon, 14 Jun 2021 19:08:30 GMT'
       },
       method: 'HEAD',
       query_string: 'formID=simple-name-age&st=CplI..0d',
@@ -490,8 +471,7 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid, _csrf',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 19:08:30 GMT',
-        'x-request-received-at': 1640995200000
+        date: 'Mon, 14 Jun 2021 19:08:30 GMT'
       },
       method: 'HEAD',
       query_string: null,
@@ -512,8 +492,7 @@ const cases = [
         'content-type': 'application/json',
         'x-action-notes': 'some test note',
         authorization: 'Bearer Ojz....1I',
-        'content-length': '36',
-        'x-request-received-at': 1640995200000
+        'content-length': '36'
       },
       method: 'POST',
       query_string: null,
@@ -531,8 +510,7 @@ const cases = [
         'content-type': 'application/json',
         'x-action-notes': null,
         authorization: null,
-        'content-length': '36',
-        'x-request-received-at': 1640995200000
+        'content-length': '36'
       },
       method: 'POST',
       query_string: null,
@@ -575,8 +553,11 @@ describe('external: sanitize-sentry', () => {
     const actualDateNow = global.Date.now;
     global.Date.now = () => 1640995210000;
 
+    const startTimestamp = 1640995200000;
+    const extra = { startTimestamp };
+
     for (const [input, expectedOutput] of cases) {
-      sanitizeEventRequest({ request: input }).should.eql({ request: expectedOutput, extra: { duration: '10 sec' } });
+      sanitizeEventRequest({ request: input, extra }).should.eql({ request: expectedOutput, extra: { startTimestamp, duration: 10000 } });
     }
 
     // Restore actual function

--- a/test/unit/external/sanitize-sentry.js
+++ b/test/unit/external/sanitize-sentry.js
@@ -17,7 +17,8 @@ const cases = [
         accept: 'application/json, */*;q=0.5',
         connection: 'keep-alive',
         'content-type': 'application/json',
-        'content-length': '48'
+        'content-length': '48',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -33,7 +34,8 @@ const cases = [
         accept: 'application/json, */*;q=0.5',
         connection: 'keep-alive',
         'content-type': 'application/json',
-        'content-length': '48'
+        'content-length': '48',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -51,7 +53,8 @@ const cases = [
         'accept-encoding': 'gzip, deflate',
         accept: '*/*',
         connection: 'keep-alive',
-        authorization: 'Bearer sdff.....sdQ'
+        authorization: 'Bearer sdff.....sdQ',
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: null,
@@ -66,7 +69,8 @@ const cases = [
         'accept-encoding': 'gzip, deflate',
         accept: '*/*',
         connection: 'keep-alive',
-        authorization: null
+        authorization: null,
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: null,
@@ -99,7 +103,8 @@ const cases = [
         referer: 'http://localhost:8989/',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken=j0j3....QU5; __enketo_meta_deviceid=s%3Alocalhost%3AzgCh....AE; __csrf=kG2...1d; session=Ajp....vjSnR'
+        cookie: 'csrftoken=j0j3....QU5; __enketo_meta_deviceid=s%3Alocalhost%3AzgCh....AE; __csrf=kG2...1d; session=Ajp....vjSnR',
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: '%24filter=__system%2FsubmitterId+eq+26+and+__system%2FreviewState+eq+null',
@@ -124,7 +129,8 @@ const cases = [
         referer: null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session',
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: null,
@@ -144,7 +150,8 @@ const cases = [
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
         'content-type': 'multipart/form-data; boundary=58a8898824454fadb1e9d19fac47882c',
-        'content-length': '311'
+        'content-length': '311',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -161,7 +168,8 @@ const cases = [
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
         'content-type': 'multipart/form-data; boundary=58a8898824454fadb1e9d19fac47882c',
-        'content-length': '311'
+        'content-length': '311',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -180,7 +188,8 @@ const cases = [
         accept: '*/*',
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
-        'content-type': 'text/xml'
+        'content-type': 'text/xml',
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: null,
@@ -196,7 +205,8 @@ const cases = [
         accept: '*/*',
         connection: 'keep-alive',
         'x-openrosa-version': '1.0',
-        'content-type': 'text/xml'
+        'content-type': 'text/xml',
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: null,
@@ -228,7 +238,8 @@ const cases = [
         referer: 'http://localhost:8989/',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken=j0j32..6LEzgQU5; __enketo_meta_deviceid=s%3Alo...ucHhAE; __csrf=tdgs7t0..12lwQ; session=RPP..dUz'
+        cookie: 'csrftoken=j0j32..6LEzgQU5; __enketo_meta_deviceid=s%3Alo...ucHhAE; __csrf=tdgs7t0..12lwQ; session=RPP..dUz',
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: '%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null',
@@ -254,7 +265,8 @@ const cases = [
         referer: null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session',
+        'x-request-received-at': 1640995200000
       },
       method: 'GET',
       query_string: '%24top=250&%24skip=0&%24count=true&%24wkt=true&%24filter=__system%2FsubmitterId+eq+48+and+__system%2FreviewState+eq+null',
@@ -293,7 +305,8 @@ const cases = [
         referer: 'http://localhost:8989/-/XoecwziQ',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken=j0j3..QU5; __enketo_meta_deviceid=s%3Aloc..AE; __csrf=tdg..lwQ; session=RP..SdUz'
+        cookie: 'csrftoken=j0j3..QU5; __enketo_meta_deviceid=s%3Aloc..AE; __csrf=tdg..lwQ; session=RP..SdUz',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -327,7 +340,8 @@ const cases = [
         referer:  null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session'
+        cookie: 'csrftoken, __enketo_meta_deviceid, __csrf, session',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -349,7 +363,8 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid=s%3Aloc..p4; _csrf=W_..Ua',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 18:47:25 GMT'
+        date: 'Mon, 14 Jun 2021 18:47:25 GMT',
+        'x-request-received-at': 1640995200000
       },
       method: 'HEAD',
       query_string: 'formID=simple-name-age&st=Cpl...62M0d',
@@ -365,7 +380,8 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid, _csrf',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 18:47:25 GMT'
+        date: 'Mon, 14 Jun 2021 18:47:25 GMT',
+        'x-request-received-at': 1640995200000
       },
       method: 'HEAD',
       query_string: null,
@@ -402,7 +418,8 @@ const cases = [
         referer: 'http://localhost:8989/-/single/Xo..iQ?st=Cp...d',
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZzEustWflva1byvA.R..p4; _csrf=W_..a'
+        cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZzEustWflva1byvA.R..p4; _csrf=W_..a',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: 'st=Cpl...M0d',
@@ -433,7 +450,8 @@ const cases = [
         referer: null,
         'accept-encoding': 'gzip, deflate, br',
         'accept-language': 'en-US,en;q=0.9',
-        cookie: '__enketo_meta_deviceid, _csrf'
+        cookie: '__enketo_meta_deviceid, _csrf',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -455,7 +473,8 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid=s%3Alocalhost%3AZz..Fp4; _csrf=W..Ua',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 19:08:30 GMT'
+        date: 'Mon, 14 Jun 2021 19:08:30 GMT',
+        'x-request-received-at': 1640995200000
       },
       method: 'HEAD',
       query_string: 'formID=simple-name-age&st=CplI..0d',
@@ -471,7 +490,8 @@ const cases = [
         'content-length': '0',
         cookie: '__enketo_meta_deviceid, _csrf',
         'x-openrosa-version': '1.0',
-        date: 'Mon, 14 Jun 2021 19:08:30 GMT'
+        date: 'Mon, 14 Jun 2021 19:08:30 GMT',
+        'x-request-received-at': 1640995200000
       },
       method: 'HEAD',
       query_string: null,
@@ -492,7 +512,8 @@ const cases = [
         'content-type': 'application/json',
         'x-action-notes': 'some test note',
         authorization: 'Bearer Ojz....1I',
-        'content-length': '36'
+        'content-length': '36',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -510,7 +531,8 @@ const cases = [
         'content-type': 'application/json',
         'x-action-notes': null,
         authorization: null,
-        'content-length': '36'
+        'content-length': '36',
+        'x-request-received-at': 1640995200000
       },
       method: 'POST',
       query_string: null,
@@ -548,9 +570,17 @@ const filteredTokenUrls = [
 
 describe('external: sanitize-sentry', () => {
   it('removes sensitive data from request objects ', () => {
+
+    // Mock Date.now()
+    const actualDateNow = global.Date.now;
+    global.Date.now = () => 1640995210000;
+
     for (const [input, expectedOutput] of cases) {
-      sanitizeEventRequest({ request: input }).should.eql({ request: expectedOutput });
+      sanitizeEventRequest({ request: input }).should.eql({ request: expectedOutput, extra: { duration: '10 sec' } });
     }
+
+    // Restore actual function
+    global.Date.now = actualDateNow;
   });
 
   it('identifies sensitive URLs ', () => {


### PR DESCRIPTION
# Change:
- Added request duration in the event object of Sentry

#### What has been done to verify that this works as intended?
- Tested manually 

#### Why is this the best possible solution? Were any other approaches considered?
- I have added `x-request-received-at` in the request header, I could have created a different property in the request object but that would have forced me to modify RequestHandler of Sentry. Implemented solution is the simplest one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- NA

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
- NA

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments