### PR TITLE
Feature/workflow warnings

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -146,7 +146,7 @@ const queryOptionsHandler = (_, context) => {
   // add an inert reference to all passed params:
   options.argData = query;
 
-  return context.with({ queryOptions: new QueryOptions(options) });
+  return context.with({ queryOptions: new QueryOptions(options), transitoryData: new Map() });
 };
 
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -530,13 +530,13 @@ inner join
 order by actors."displayName" asc`)
   .then(map(construct(Actor)));
 
-const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL LIMIT 1`)
+const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => (context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL LIMIT 1`)
   .then(deletedForm => {
     if (deletedForm.isDefined()) {
-      if (!context.transitoryData.has('xmlFormWarnings')) context.transitoryData.set('xmlFormWarnings', []);
-      context.transitoryData.get('xmlFormWarnings').push({ type: 'deletedFormExists' });
+      if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
+      context.transitoryData.get('workflowWarnings').push({ type: 'deletedFormExists' });
     }
-  });
+  }));
 
 const checkStructuralChange = (form, fields) => ({ Forms, context }) => (!form.currentDefId || context.query.ignoreWarnings ? resolve() : Forms.getFields(form.currentDefId)
   .then(existingFields => {
@@ -544,23 +544,23 @@ const checkStructuralChange = (form, fields) => ({ Forms, context }) => (!form.c
     const removedFields = existingFields.filter(f => !newFieldSet.has(f.path));
 
     if (removedFields.length > 0) {
-      if (!context.transitoryData.has('xmlFormWarnings')) context.transitoryData.set('xmlFormWarnings', []);
-      context.transitoryData.get('xmlFormWarnings').push({ type: 'structureChanged', details: removedFields.map(f => f.name) });
+      if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
+      context.transitoryData.get('workflowWarnings').push({ type: 'structureChanged', details: removedFields.map(f => f.name) });
     }
   }));
 
-const rejectIfWarnings = () => ({ context }) => {  
+const rejectIfWarnings = () => ({ context }) => {
   const warnings = {};
 
   if (context.transitoryData.has('xlsFormWarnings')) {
     warnings.xlsFormWarnings = context.transitoryData.get('xlsFormWarnings');
   }
 
-  if (context.transitoryData.has('xmlFormWarnings')) {
-    warnings.xmlFormWarnings = context.transitoryData.get('xmlFormWarnings');
+  if (context.transitoryData.has('workflowWarnings')) {
+    warnings.workflowWarnings = context.transitoryData.get('workflowWarnings');
   }
 
-  if (warnings.xlsFormWarnings || warnings.xmlFormWarnings) {
+  if (warnings.xlsFormWarnings || warnings.workflowWarnings) {
     return reject(Problem.user.formWarnings({ warnings }));
   } else {
     return resolve();

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -530,11 +530,11 @@ inner join
 order by actors."displayName" asc`)
   .then(map(construct(Actor)));
 
-const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL`)
+const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL LIMIT 1`)
   .then(deletedForm => {
     if (deletedForm.isDefined()) {
       if (!context.transitoryData.has('xmlFormWarnings')) context.transitoryData.set('xmlFormWarnings', []);
-      context.transitoryData.get('xmlFormWarnings').push({ warning: 'deletedFormExists' });
+      context.transitoryData.get('xmlFormWarnings').push({ type: 'deletedFormExists' });
     }
   });
 
@@ -545,7 +545,7 @@ const checkStructuralChange = (form, fields) => ({ Forms, context }) => (!form.c
 
     if (removedFields.length > 0) {
       if (!context.transitoryData.has('xmlFormWarnings')) context.transitoryData.set('xmlFormWarnings', []);
-      context.transitoryData.get('xmlFormWarnings').push({ warning: 'structureChanged', details: removedFields.map(f => f.name) });
+      context.transitoryData.get('xmlFormWarnings').push({ type: 'structureChanged', details: removedFields.map(f => f.name) });
     }
   }));
 
@@ -561,7 +561,7 @@ const rejectIfWarnings = () => ({ context }) => {
   }
 
   if (warnings.xlsFormWarnings || warnings.xmlFormWarnings) {
-    return reject(Problem.user.formWarnings(warnings));
+    return reject(Problem.user.formWarnings({ warnings }));
   } else {
     return resolve();
   }

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -28,16 +28,17 @@ const Problem = require('../../util/problem');
 // given binary stream, sends that stream to the configured xlsform transformation
 // service and if successful returns the same result fromXml would, but with an
 // additional xlsBlobId column pointing at the xls file blob id.
-const fromXls = (stream, contentType, formIdFallback, ignoreWarnings) => ({ Blobs, xlsform }) =>
+const fromXls = (stream, contentType, formIdFallback, ignoreWarnings) => ({ Blobs, xlsform, context }) =>
   splitStream(stream,
     ((s) => xlsform(s, formIdFallback)),
     ((s) => Blob.fromStream(s, contentType)))
-    .then(([ { xml, itemsets, warnings }, blob ]) =>
-      (((warnings.length > 0) && !ignoreWarnings)
-        ? reject(Problem.user.xlsformWarnings({ warnings }))
-        : Promise.all([ Form.fromXml(xml), Blobs.ensure(blob) ])
-          .then(([ partial, xlsBlobId ]) => partial.withAux('xls', { xlsBlobId, itemsets }))));
-
+    .then(([ { xml, itemsets, warnings }, blob ]) => {
+      if ((warnings.length > 0 && !ignoreWarnings)) {
+        context.transitoryData.set('xlsFormWarnings', warnings);
+      }
+      return Promise.all([ Form.fromXml(xml), Blobs.ensure(blob) ])
+        .then(([ partial, xlsBlobId ]) => partial.withAux('xls', { xlsBlobId, itemsets }));
+    });
 
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING NEW FORMS+VERSIONS
@@ -64,27 +65,29 @@ const createNew = (partial, project, publish = false) => ({ run, Datasets, FormA
     getFormFields(partial.xml),
     partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml) // Don't parse dataset schema if Form has encryption key
   ])
-    .then(([ keyId, fields, dataset ]) => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
-      .then((savedForm) => {
-        const ids = { formId: savedForm.id, formDefId: savedForm.def.id };
-        return Promise.all([
-          FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets),
-          run(insertMany(fields.map((field) => new Form.Field(Object.assign(field, ids)))))
-        ])
-          .then(() => {
-            if (dataset.isDefined()) {
-              const dsPropertyFields = fields.filter((field) => (field.propertyName));
-              if (dsPropertyFields.filter((field) => field.propertyName === 'name' || field.propertyName === 'label').length > 0)
-                throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
-              return Datasets.createOrMerge(
-                new Dataset({ name: dataset.get(), projectId: project.id }, { formDefId: savedForm.def.id }),
-                dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName })),
-                publish
-              );
-            }
-          })
-          .then(always(savedForm));
-      }));
+    .then(([ keyId, fields, dataset ]) => Forms.checkDeletedForms(partial.xmlFormId, project.id)
+      .then(Forms.rejectIfWarnings)
+      .then(() => Forms._createNew(partial, partial.def.with({ keyId }), project, publish)
+        .then((savedForm) => {
+          const ids = { formId: savedForm.id, formDefId: savedForm.def.id };
+          return Promise.all([
+            FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets),
+            run(insertMany(fields.map((field) => new Form.Field(Object.assign(field, ids)))))
+          ])
+            .then(() => {
+              if (dataset.isDefined()) {
+                const dsPropertyFields = fields.filter((field) => (field.propertyName));
+                if (dsPropertyFields.filter((field) => field.propertyName === 'name' || field.propertyName === 'label').length > 0)
+                  throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
+                return Datasets.createOrMerge(
+                  new Dataset({ name: dataset.get(), projectId: project.id }, { formDefId: savedForm.def.id }),
+                  dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName })),
+                  publish
+                );
+              }
+            })
+            .then(always(savedForm));
+        })));
 
 // (if we are asked to publish right away, log that too:)
 createNew.audit = (form, partial, _, publish) => (log) =>
@@ -111,45 +114,47 @@ const createVersion = (partial, form, publish = false) => ({ run, one, Datasets,
   if (form.xmlFormId !== partial.xmlFormId)
     return reject(Problem.user.unexpectedValue({ field: 'xmlFormId', value: partial.xmlFormId, reason: 'does not match the form you are updating' }));
 
-  return Promise.all([
-    // ensure the encryption key exists, then make sure our new def is in the
-    // database, and mark it as either draft or current.
-    partial.aux.key.map(Keys.ensure).orElse(resolve(null))
-      .then((keyId) => partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId }))
-      .then((def) => ((publish === true)
-        ? def.with({ publishedAt: new Date(), xml: partial.xml })
-        : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
-      .then(compose(one, insert))
-      .then(ignoringResult((savedDef) => ((publish === true)
-        ? Forms._update(form, { currentDefId: savedDef.id })
-        : Forms._update(form, { draftDefId: savedDef.id })))),
-    partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml), // Don't parse dataset schema if Form has encryption key
-    // process the form schema locally while everything happens
-    getFormFields(partial.xml)
-  ])
-    .then(([ savedDef, dataset, fields ]) => {
-      // deal with fields for a moment; we just need to attach a bunch of ids
-      // to them for storage.
-      const ids = { formId: form.id, formDefId: savedDef.id };
-      const fieldsForInsert = new Array(fields.length);
-      for (let i = 0; i < fields.length; i += 1)
-        fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
-
-      return Promise.all([
-        run(insertMany(fieldsForInsert)),
-        FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
+  return getFormFields(partial.xml)
+    .then((fields) => Forms.checkStructuralChange(form, fields)
+      .then(Forms.rejectIfWarnings)
+      .then(() => Promise.all([
+      // ensure the encryption key exists, then make sure our new def is in the
+      // database, and mark it as either draft or current.
+        partial.aux.key.map(Keys.ensure).orElse(resolve(null))
+          .then((keyId) => partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId }))
+          .then((def) => ((publish === true)
+            ? def.with({ publishedAt: new Date(), xml: partial.xml })
+            : def.with({ draftToken: _getDraftToken(form), xml: partial.xml })))
+          .then(compose(one, insert))
+          .then(ignoringResult((savedDef) => ((publish === true)
+            ? Forms._update(form, { currentDefId: savedDef.id })
+            : Forms._update(form, { draftDefId: savedDef.id })))),
+        partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml), // Don't parse dataset schema if Form has encryption key
       ])
-        .then(() => {
-          if (dataset.isDefined())
-            return Datasets.createOrMerge(
-              new Dataset({ name: dataset.get(), projectId: form.projectId }, { formDefId: savedDef.id }),
-              fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName })),
-              publish
-            );
-        })
-        .then(always(savedDef));
-    });
+        .then(([ savedDef, dataset ]) => {
+          // deal with fields for a moment; we just need to attach a bunch of ids
+          // to them for storage.
+          const ids = { formId: form.id, formDefId: savedDef.id };
+          const fieldsForInsert = new Array(fields.length);
+          for (let i = 0; i < fields.length; i += 1)
+            fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
+
+          return Promise.all([
+            run(insertMany(fieldsForInsert)),
+            FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
+          ])
+            .then(() => {
+              if (dataset.isDefined())
+                return Datasets.createOrMerge(
+                  new Dataset({ name: dataset.get(), projectId: form.projectId }, { formDefId: savedDef.id }),
+                  fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName })),
+                  publish
+                );
+            })
+            .then(always(savedDef));
+        })));
 };
+
 createVersion.audit = (newDef, partial, form, _, publish) => (log) => ((publish === true)
   ? log('form.update.publish', form, { oldDefId: form.currentDefId, newDefId: newDef.id })
   : log('form.update.draft.set', form, { oldDraftDefId: form.draftDefId, newDraftDefId: newDef.id }));
@@ -525,6 +530,42 @@ inner join
 order by actors."displayName" asc`)
   .then(map(construct(Actor)));
 
+const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL`)
+  .then(deletedForm => {
+    if (deletedForm.isDefined()) {
+      if (!context.transitoryData.has('xmlFormWarnings')) context.transitoryData.set('xmlFormWarnings', []);
+      context.transitoryData.get('xmlFormWarnings').push({ warning: 'deletedFormExists' });
+    }
+  });
+
+const checkStructuralChange = (form, fields) => ({ Forms, context }) => (!form.currentDefId || context.query.ignoreWarnings ? resolve() : Forms.getFields(form.currentDefId)
+  .then(existingFields => {
+    const newFieldSet = new Set(fields.map(f => f.path));
+    const removedFields = existingFields.filter(f => !newFieldSet.has(f.path));
+
+    if (removedFields.length > 0) {
+      if (!context.transitoryData.has('xmlFormWarnings')) context.transitoryData.set('xmlFormWarnings', []);
+      context.transitoryData.get('xmlFormWarnings').push({ warning: 'structureChanged', details: removedFields.map(f => f.name) });
+    }
+  }));
+
+const rejectIfWarnings = () => ({ context }) => {  
+  const warnings = {};
+
+  if (context.transitoryData.has('xlsFormWarnings')) {
+    warnings.xlsFormWarnings = context.transitoryData.get('xlsFormWarnings');
+  }
+
+  if (context.transitoryData.has('xmlFormWarnings')) {
+    warnings.xmlFormWarnings = context.transitoryData.get('xmlFormWarnings');
+  }
+
+  if (warnings.xlsFormWarnings || warnings.xmlFormWarnings) {
+    return reject(Problem.user.formWarnings(warnings));
+  } else {
+    return resolve();
+  }
+};
 
 module.exports = {
   fromXls, _createNew, createNew, createVersion,
@@ -537,6 +578,6 @@ module.exports = {
   getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
-  lockDefs, getAllSubmitters
+  lockDefs, getAllSubmitters, checkDeletedForms, checkStructuralChange, rejectIfWarnings
 };
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -534,7 +534,7 @@ const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => (
   .then(deletedForm => {
     if (deletedForm.isDefined()) {
       if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
-      context.transitoryData.get('workflowWarnings').push({ type: 'deletedFormExists' });
+      context.transitoryData.get('workflowWarnings').push({ type: 'deletedFormExists', details: { xmlFormId } });
     }
   }));
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -84,7 +84,7 @@ const problems = {
 
     xlsformNotValid: problem(400.15, () => 'The given XLSForm file was not valid. Please see the error details for more information.'),
 
-    xlsformWarnings: problem(400.16, () => 'The XLSForm is valid, but with warnings. Please check the warnings and if they are acceptable resubmit with ?ignoreWarnings=true'),
+    formWarnings: problem(400.16, () => 'The Form is valid, but with warnings. Please check the warnings and if they are acceptable resubmit with ?ignoreWarnings=true'),
 
     fieldTypeConflict: problem(400.17, ({ path, type }) => `The form you have uploaded attempts to change the type of the field at ${path}. In a previous version, it had the type ${type}. Please either return that field to its previous type, or rename the field so it lives at a new path.`),
 

--- a/test/integration/api/forms/delete-restore.js
+++ b/test/integration/api/forms/delete-restore.js
@@ -123,6 +123,7 @@ describe('api: /projects/:id/forms (delete, restore)', () => {
     it('should restore a specific form by numeric id when multiple trashed forms share the same xmlFormId', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200)
           .then(() => asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
             .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="two"'))
             .set('Content-Type', 'application/xml')

--- a/test/integration/api/forms/delete-restore.js
+++ b/test/integration/api/forms/delete-restore.js
@@ -123,14 +123,13 @@ describe('api: /projects/:id/forms (delete, restore)', () => {
     it('should restore a specific form by numeric id when multiple trashed forms share the same xmlFormId', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.delete('/v1/projects/1/forms/simple')
-          .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms/')
+          .then(() => asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
             .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="two"'))
             .set('Content-Type', 'application/xml')
             .expect(200))
           .then(() => asAlice.delete('/v1/projects/1/forms/simple')
             .expect(200))
-          .then(() => asAlice.post('/v1/projects/1/forms/1/restore')
+          .then(() => asAlice.post('/v1/projects/1/forms/1/restore')            
             .expect(200)))));
 
     it('should fail restoring a form that is not deleted', testService((service) =>
@@ -142,7 +141,7 @@ describe('api: /projects/:id/forms (delete, restore)', () => {
       service.login('alice', (asAlice) =>
         asAlice.delete('/v1/projects/1/forms/simple')
           .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms/')
+          .then(() => asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
             .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="two"'))
             .set('Content-Type', 'application/xml')
             .expect(200))

--- a/test/integration/api/forms/delete-restore.js
+++ b/test/integration/api/forms/delete-restore.js
@@ -129,7 +129,7 @@ describe('api: /projects/:id/forms (delete, restore)', () => {
             .expect(200))
           .then(() => asAlice.delete('/v1/projects/1/forms/simple')
             .expect(200))
-          .then(() => asAlice.post('/v1/projects/1/forms/1/restore')            
+          .then(() => asAlice.post('/v1/projects/1/forms/1/restore')
             .expect(200)))));
 
     it('should fail restoring a form that is not deleted', testService((service) =>

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -254,7 +254,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
             .send(testData.forms.simple.replace(/simple/g, 'itemsets'))
             .set('Content-Type', 'application/xml')
             .expect(200)
-            .then(() => asAlice.post('/v1/projects/1/forms/itemsets/draft')
+            .then(() => asAlice.post('/v1/projects/1/forms/itemsets/draft?ignoreWarnings=true')
               .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
               .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
               .set('X-XlsForm-FormId-Fallback', 'itemsets'))
@@ -307,7 +307,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
 
       it('should complain about field conflicts (older)', testService((service) =>
         service.login('alice', (asAlice) =>
-          asAlice.post('/v1/projects/1/forms/simple/draft')
+          asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
             .send(testData.forms.simple
               .replace('id="simple"', 'id="simple" version="2"')
               .replace(/age/g, 'number'))
@@ -315,7 +315,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
             .expect(200)
             .then(() => asAlice.post('/v1/projects/1/forms/simple/draft/publish')
               .expect(200))
-            .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+            .then(() => asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
               .send(testData.forms.simple.replace('type="int"', 'type="date"'))
               .set('Content-Type', 'application/xml')
               .expect(400)
@@ -397,18 +397,18 @@ describe('api: /projects/:id/forms (drafts)', () => {
 
       it('should not complain about discarded draft field conflicts', testService((service) =>
         service.login('alice', (asAlice) =>
-          asAlice.post('/v1/projects/1/forms/simple/draft')
+          asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
             .send(testData.forms.simple.replace(/age/g, 'number'))
             .set('Content-Type', 'application/xml')
             .expect(200)
-            .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+            .then(() => asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
               .send(testData.forms.simple.replace(/age/g, 'number').replace('type="int"', 'type="string"'))
               .set('Content-Type', 'application/xml')
               .expect(200)))));
 
       it('should identify attachments', testService((service) =>
         service.login('alice', (asAlice) =>
-          asAlice.post('/v1/projects/1/forms/simple/draft')
+          asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
             .send(testData.forms.withAttachments.replace('id="withAttachments"', 'id="simple"'))
             .set('Content-Type', 'application/xml')
             .expect(200)

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -365,7 +365,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         .expect(400)
         .then(({ body }) => {
           body.code.should.be.eql(400.16);
-          body.details.warnings.workflowWarnings[0].type.should.be.eql('deletedFormExists');
+          body.details.warnings.workflowWarnings[0].should.be.eql({ type: 'deletedFormExists', details: { xmlFormId: 'simple' } });
         });
     }));
 
@@ -389,7 +389,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         .then(({ body }) => {
           body.code.should.be.eql(400.16);
           body.details.warnings.xlsFormWarnings.should.be.eql(['warning 1', 'warning 2']);
-          body.details.warnings.workflowWarnings[0].type.should.be.eql('deletedFormExists');
+          body.details.warnings.workflowWarnings[0].should.be.eql({ type: 'deletedFormExists', details: { xmlFormId: 'simple2' } });
         });
     }));
 

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -7,6 +7,7 @@ const superagent = require('superagent');
 const { DateTime } = require('luxon');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
+const { identity } = require('ramda');
 // eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
@@ -69,7 +70,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
       service.login('alice', (asAlice) =>
         asAlice.delete('/v1/projects/1/forms/simple')
           .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
+          .then(() => asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
             .send(testData.forms.simple)
             .set('Content-Type', 'application/xml')
             .expect(409)
@@ -154,7 +155,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
           .expect(400)
           .then(({ body }) => {
             body.code.should.equal(400.16);
-            body.details.should.eql({ warnings: [ 'warning 1', 'warning 2' ] });
+            body.details.xlsFormWarnings.should.eql([ 'warning 1', 'warning 2' ]);
           }));
     }));
 
@@ -351,6 +352,98 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
               body[0].action.should.equal('form.update.publish');
               body[1].action.should.equal('form.create');
             })))));
+
+    it('should reject with deleted form exists warning', testService(async (service) => {
+      const asAlice = await service.login('alice', identity);
+
+      await asAlice.delete('/v1/projects/1/forms/simple')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simple)
+        .set('Content-Type', 'application/xml')
+        .expect(400)
+        .then(({ body }) => {
+          body.code.should.be.eql(400.16);
+          body.details.xmlFormWarnings[0].warning.should.be.eql('deletedFormExists');
+        });
+    }));
+
+    it('should reject with xls and deleted form exists warnings', testService(async (service) => {
+      const asAlice = await service.login('alice', identity);
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simple2)
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.delete('/v1/projects/1/forms/simple2')
+        .expect(200);
+
+      global.xlsformTest = 'warning'; // set up the mock service to warn.
+
+      await asAlice.post('/v1/projects/1/forms')
+        .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
+        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        .expect(400)
+        .then(({ body }) => {
+          body.code.should.be.eql(400.16);
+          body.details.xlsFormWarnings.should.be.eql(['warning 1', 'warning 2']);
+          body.details.xmlFormWarnings[0].warning.should.be.eql('deletedFormExists');
+        });
+    }));
+
+    it('should reject with structure changed warning', testService(async (service) => {
+      const asAlice = await service.login('alice', identity);
+
+      await asAlice.post('/v1/projects/1/forms/simple/draft')
+        .send(testData.forms.simple.replace(/age/g, 'address'))
+        .set('Content-Type', 'application/xml')
+        .then(({ body }) => {
+          body.code.should.be.eql(400.16);
+          body.details.xmlFormWarnings[0].should.be.eql({ warning: 'structureChanged', details: [ 'age' ] });
+        });
+    }));
+
+    it('should reject with xls and structure changed warnings', testService(async (service) => {
+      const asAlice = await service.login('alice', identity);
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simple2.replace(/age/g, 'address'))
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      global.xlsformTest = 'warning'; // set up the mock service to warn.
+
+      await asAlice.post('/v1/projects/1/forms/simple2/draft')
+        .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
+        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        .expect(400)
+        .then(({ body }) => {
+          body.code.should.be.eql(400.16);
+          body.details.xlsFormWarnings.should.be.eql(['warning 1', 'warning 2']);
+          body.details.xmlFormWarnings[0].should.be.eql({ warning: 'structureChanged', details: [ 'address' ] });
+        });
+    }));
+
+    it('should create the form for xml files with warnings given ignoreWarnings', testService(async (service) => {
+      const asAlice = await service.login('alice', identity);
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simple2)
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.delete('/v1/projects/1/forms/simple2')
+        .expect(200);
+
+      global.xlsformTest = 'warning'; // set up the mock service to warn.
+
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
+        .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
+        .set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        .expect(200);
+    }));
   });
 
 

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -155,7 +155,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
           .expect(400)
           .then(({ body }) => {
             body.code.should.equal(400.16);
-            body.details.xlsFormWarnings.should.eql([ 'warning 1', 'warning 2' ]);
+            body.details.warnings.xlsFormWarnings.should.eql([ 'warning 1', 'warning 2' ]);
           }));
     }));
 
@@ -365,7 +365,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         .expect(400)
         .then(({ body }) => {
           body.code.should.be.eql(400.16);
-          body.details.xmlFormWarnings[0].warning.should.be.eql('deletedFormExists');
+          body.details.warnings.workflowWarnings[0].type.should.be.eql('deletedFormExists');
         });
     }));
 
@@ -388,8 +388,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         .expect(400)
         .then(({ body }) => {
           body.code.should.be.eql(400.16);
-          body.details.xlsFormWarnings.should.be.eql(['warning 1', 'warning 2']);
-          body.details.xmlFormWarnings[0].warning.should.be.eql('deletedFormExists');
+          body.details.warnings.xlsFormWarnings.should.be.eql(['warning 1', 'warning 2']);
+          body.details.warnings.workflowWarnings[0].type.should.be.eql('deletedFormExists');
         });
     }));
 
@@ -401,7 +401,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         .set('Content-Type', 'application/xml')
         .then(({ body }) => {
           body.code.should.be.eql(400.16);
-          body.details.xmlFormWarnings[0].should.be.eql({ warning: 'structureChanged', details: [ 'age' ] });
+          body.details.warnings.workflowWarnings[0].should.be.eql({ type: 'structureChanged', details: [ 'age' ] });
         });
     }));
 
@@ -421,8 +421,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         .expect(400)
         .then(({ body }) => {
           body.code.should.be.eql(400.16);
-          body.details.xlsFormWarnings.should.be.eql(['warning 1', 'warning 2']);
-          body.details.xmlFormWarnings[0].should.be.eql({ warning: 'structureChanged', details: [ 'address' ] });
+          body.details.warnings.xlsFormWarnings.should.be.eql(['warning 1', 'warning 2']);
+          body.details.warnings.workflowWarnings[0].should.be.eql({ type: 'structureChanged', details: [ 'address' ] });
         });
     }));
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1635,7 +1635,7 @@ describe('api: /forms/:id/submissions', () => {
           .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions')
             .set('Content-Type', 'application/xml')
             .send(testData.instances.simple.two))
-          .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+          .then(() => asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
             .set('Content-Type', 'application/xml')
             .send(`
               <?xml version="1.0"?>

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -475,11 +475,11 @@ describe('analytics task queries', () => {
 
       // one deleted unpublished form reused (in the same project)
       await service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms')
+        asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
           .send(testData.forms.simple2)
           .set('Content-Type', 'application/xml')
           .then(() => asAlice.delete('/v1/projects/1/forms/simple2'))
-          .then(() => asAlice.post('/v1/projects/1/forms')
+          .then(() => asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
             .send(testData.forms.simple2)
             .set('Content-Type', 'application/xml')));
 
@@ -490,11 +490,11 @@ describe('analytics task queries', () => {
           .send(testData.forms.simple)
           .set('Content-Type', 'application/xml')
           .then(() => asAlice.delete(`/v1/projects/${proj2}/forms/simple`))
-          .then(() => asAlice.post(`/v1/projects/${proj2}/forms?publish=true`)
+          .then(() => asAlice.post(`/v1/projects/${proj2}/forms?publish=true&ignoreWarnings=true`)
             .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="two"'))
             .set('Content-Type', 'application/xml'))
           .then(() => asAlice.delete(`/v1/projects/${proj2}/forms/simple`))
-          .then(() => asAlice.post(`/v1/projects/${proj2}/forms?publish=true`)
+          .then(() => asAlice.post(`/v1/projects/${proj2}/forms?publish=true&ignoreWarnings=true`)
             .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="three"'))
             .set('Content-Type', 'application/xml')));
 
@@ -945,11 +945,11 @@ describe('analytics task queries', () => {
 
       // deleted and reused form id
       await service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms')
+        asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
           .send(testData.forms.simple2)
           .set('Content-Type', 'application/xml')
           .then(() => asAlice.delete('/v1/projects/1/forms/simple2'))
-          .then(() => asAlice.post('/v1/projects/1/forms')
+          .then(() => asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
             .send(testData.forms.simple2)
             .set('Content-Type', 'application/xml')));
 

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -58,7 +58,7 @@ const { ODKAnalytics } = require(appRoot + '/test/util/odk-analytics-mock');
 const odkAnalytics = new ODKAnalytics();
 
 // set up mock context
-const context = { query: {}, transitoryData: new Map(), headers: []};
+const context = { query: {}, transitoryData: new Map(), headers: [] };
 
 // application things.
 // eslint-disable-next-line import/no-dynamic-require

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -57,6 +57,9 @@ const enketo = require(appRoot + '/test/util/enketo');
 const { ODKAnalytics } = require(appRoot + '/test/util/odk-analytics-mock');
 const odkAnalytics = new ODKAnalytics();
 
+// set up mock context
+const context = { query: {}, transitoryData: new Map(), headers: []};
+
 // application things.
 // eslint-disable-next-line import/no-dynamic-require
 const { withDefaults } = require(appRoot + '/lib/model/container');
@@ -88,7 +91,7 @@ const initialize = async () => {
     await migrator.destroy();
   }
 
-  return withDefaults({ db, bcrypt }).transacting(populate);
+  return withDefaults({ db, bcrypt, context }).transacting(populate);
 };
 
 before(initialize);
@@ -141,7 +144,8 @@ const augment = (service) => {
 ////////////////////////////////////////////////////////////////////////////////
 // FINAL TEST WRAPPERS
 
-const baseContainer = withDefaults({ db, mail, env, xlsform, google, bcrypt, enketo, Sentry, odkAnalytics });
+
+const baseContainer = withDefaults({ db, mail, env, xlsform, google, bcrypt, enketo, Sentry, odkAnalytics, context });
 
 // called to get a service context per request. we do some work to hijack the
 // transaction system so that each test runs in a single transaction that then


### PR DESCRIPTION
Closes #439 & #616

#### What has been done to verify that this works as intended?
- Added integration test
- Manual testing

#### Why is this the best possible solution? Were any other approaches considered?
- Added `transitoryData` in the http context, so that I don't have to pass warnings array from one function to another through out the application. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- Form uploads should be tested thoroughly

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
- The `details` object for the 400 error on the form upload has been changed. But we don't document that in the API document. Since this is a breaking change (if anyone is parsing body of 400 response), we can mentioned this in the release announcement

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments