### PR TITLE
Intermediate form schema table to collapse dupe schemas

### DIFF
--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -427,20 +427,16 @@ const merge = (as, bs) => {
 // if they match. Path, order, type must all match across
 // fields from both form versions.
 const compare = (prevFields, fields) => {
-  let match = prevFields.length <= fields.length;
+  if (prevFields.length !== fields.length)
+    return false;
   for (let i = 0; i < fields.length; i += 1) {
-    if (!prevFields[i]) {
-      match = false;
-      break;
-    }
     if (!(prevFields[i].path === fields[i].path &&
       prevFields[i].order === fields[i].order &&
       prevFields[i].type === fields[i].type)) {
-      match = false;
-      break;
+      return false;
     }
   }
-  return match;
+  return true;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -423,6 +423,25 @@ const merge = (as, bs) => {
   return result;
 };
 
+// Compare the schemas, field by field, to determine
+// if they match. Path, order, type must all match across
+// fields from both form versions.
+const compare = (prevFields, fields) => {
+  let match = prevFields.length <= fields.length;
+  for (let i = 0; i < fields.length; i += 1) {
+    if (!prevFields[i]) {
+      match = false;
+      break;
+    }
+    if (!(prevFields[i].path === fields[i].path &&
+      prevFields[i].order === fields[i].order &&
+      prevFields[i].type === fields[i].type)) {
+      match = false;
+      break;
+    }
+  }
+  return match;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // RAW XML MANIPULATION
@@ -562,7 +581,7 @@ module.exports = {
   getFormFields,
   SchemaStack,
   sanitizeFieldsForOdata,
-  expectedFormAttachments, merge,
+  expectedFormAttachments, merge, compare,
   injectPublicKey, addVersionSuffix, setVersion
 };
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -175,13 +175,13 @@ Form.Def = Frame.define(
   'sha256',      readable,              'draftToken',   readable,
   'enketoId',    readable,              'createdAt',
   'publishedAt', readable,              'xlsBlobId',
-  'name',        readable
+  'name',        readable,              'schemaId'
 );
 Form.Xml = Frame.define(into('xml'), 'xml');
 
 Form.Field = class extends Frame.define(
   table('form_fields'),
-  'formId',                             'formDefId',
+  'formId',                             'schemaId',
   'path',       readable,               'name',         readable,
   'type',       readable,               'binary',       readable,
   'order',                              'selectMultiple', readable

--- a/lib/model/migrations/20230109-01-add-form-schema.js
+++ b/lib/model/migrations/20230109-01-add-form-schema.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // Copyright 2023 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
 // https://github.com/getodk/central-backend/blob/master/NOTICE.
@@ -59,7 +60,11 @@ const up = async (db) => {
   /* eslint-disable no-await-in-loop */
   const allForms = await db.select('id')
     .from('forms');
+
+  let formCount = 1;
   for (const form of allForms) {
+    console.log(`Processing form ${formCount} out of ${allForms.length}`);
+    formCount += 1;
     const allDefs = await db.select('id', 'name', 'version', 'xml')
       .from('form_defs')
       .where({ formId: form.id })
@@ -69,7 +74,11 @@ const up = async (db) => {
     let prevFields = [];
     let prevSchemaId = null;
 
+    let defCount = 1;
     for (const formDef of allDefs) {
+      console.log(`Processing form version ${defCount} out of ${allDefs.length}`);
+      defCount += 1;
+
       const currFields = await getFormFields(formDef.xml);
 
       const match = compare(prevFields, currFields);

--- a/lib/model/migrations/20230109-01-add-form-schema.js
+++ b/lib/model/migrations/20230109-01-add-form-schema.js
@@ -45,13 +45,13 @@ const up = async (db) => {
 
   await db.schema.table('form_fields', (ff) => {
     ff.integer('schemaId');
-    ff.foreign('schemaId').references('form_schemas.id');
+    ff.foreign('schemaId').references('form_schemas.id').onDelete('cascade');
     // remove formDef later after backfilling
   });
 
   await db.schema.table('ds_property_fields', (fd) => {
     fd.integer('schemaId');
-    fd.foreign('schemaId').references('form_schemas.id');
+    fd.foreign('schemaId').references('form_schemas.id').onDelete('cascade');
     // keep formdefid for now, so don't remove after backfilling (see note below)
   });
 

--- a/lib/model/migrations/20230109-01-add-form-schema.js
+++ b/lib/model/migrations/20230109-01-add-form-schema.js
@@ -1,0 +1,142 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { getFormFields, compare } = require('../../data/schema');
+
+/* Steps of this migration
+  1. remove check field collision trigger
+  2. disable check_managed_key trigger
+  3. alter schema:
+    a. add schema table
+    b. add schema column on form fields
+    c. add schema column on form defs
+    d. add schema column on dataset property fields
+  4. backfill
+  5. remove form def column from form fields and update FKs, uniqueness constraints, indicies in response
+  6. re-enable check_managed_key trigger
+*/
+
+const up = async (db) => {
+  // This trigger was responsible for checking for field downcasts that
+  // would break oData streams (e.g. a freeform string becoming an int).
+  // The functionality of it has been recreated in javascript, although
+  // it goes against our design principle of checking constraints in the
+  // database as much as possible. Maybe we'll put it back in the database
+  // someday?
+  await db.raw('DROP TRIGGER check_field_collisions ON form_fields');
+
+  // Disable this trigger for the migration and renable it at the end
+  await db.raw('ALTER TABLE form_defs DISABLE TRIGGER check_managed_key');
+
+  await db.schema.createTable('form_schemas', (fs) => {
+    fs.increments('id');
+  });
+
+  await db.schema.table('form_defs', (fd) => {
+    fd.integer('schemaId');
+    fd.foreign('schemaId').references('form_schemas.id');
+  });
+
+  await db.schema.table('form_fields', (ff) => {
+    ff.integer('schemaId');
+    ff.foreign('schemaId').references('form_schemas.id');
+    // remove formDef later after backfilling
+  });
+
+  await db.schema.table('ds_property_fields', (fd) => {
+    fd.integer('schemaId');
+    fd.foreign('schemaId').references('form_schemas.id');
+    // keep formdefid for now, so don't remove after backfilling (see note below)
+  });
+
+  // backfill
+  /* eslint-disable no-await-in-loop */
+  const allForms = await db.select('id')
+    .from('forms');
+  for (const form of allForms) {
+    const allDefs = await db.select('id', 'name', 'version', 'xml')
+      .from('form_defs')
+      .where({ formId: form.id })
+      .orderBy('id', 'asc');
+
+    // Fields from the previous def version
+    let prevFields = [];
+    let prevSchemaId = null;
+
+    for (const formDef of allDefs) {
+      const currFields = await getFormFields(formDef.xml);
+
+      const match = compare(prevFields, currFields);
+
+      if (match && prevSchemaId) {
+        await db.update({ schemaId: prevSchemaId })
+          .into('form_defs')
+          .where({ id: formDef.id });
+        await db.delete().from('form_fields')
+          .where({ formDefId: formDef.id, schemaId: null });
+        await db.delete().from('ds_property_fields')
+          .where({ formDefId: formDef.id, schemaId: null });
+      } else {
+        const [ schema ] = await db.insert({})
+          .into('form_schemas').returning('*');
+        await db.update({ schemaId: schema.id })
+          .into('form_defs')
+          .where({ id: formDef.id });
+        await db.update({ schemaId: schema.id })
+          .into('form_fields')
+          .where({ formDefId: formDef.id });
+        await db.update({ schemaId: schema.id })
+          .into('ds_property_fields')
+          .where({ formDefId: formDef.id });
+        prevSchemaId = schema.id;
+      }
+
+      prevFields = currFields;
+    }
+    /* eslint-enable no-await-in-loop */
+  }
+
+  // We've considered dropping 'formDefId' from ds_property_fields for the same
+  // reason we're dropping it from form_fields, however this would involve a larger
+  // restructuring of the code to insert/update a dataset and its property fields.
+  await db.schema.table('ds_property_fields', (t) => {
+    t.dropForeign(['formDefId', 'path']); // This used to be a foreign key on form_fields
+  });
+
+  await db.schema.table('form_fields', (t) => {
+    t.dropIndex(['formDefId', 'binary']);
+    t.dropIndex(['formDefId', 'order']);
+    t.dropPrimary();
+    t.dropForeign(['formDefId']);
+    t.dropColumn('formDefId');
+    t.primary(['schemaId', 'path']);
+    t.index(['schemaId', 'binary']);
+    t.index(['schemaId', 'order']);
+  });
+
+  await db.schema.table('ds_property_fields', (t) => {
+    t.foreign(['schemaId', 'path']).references(['schemaId', 'path']).inTable('form_fields').onDelete('cascade');
+    t.unique(['dsPropertyId', 'schemaId', 'path', 'formDefId']);
+  });
+
+  await db.raw('ALTER TABLE form_defs ENABLE TRIGGER check_managed_key');
+};
+
+const down = async (db) => {
+  await db.schema.table('form_fields', (t) => {
+    t.dropColumn('schemaId');
+  });
+  await db.schema.table('form_defs', (t) => {
+    t.dropColumn('schemaId');
+  });
+  await db.schema.dropTable('form_fields');
+};
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20230109-01-add-form-schema.js
+++ b/lib/model/migrations/20230109-01-add-form-schema.js
@@ -56,14 +56,30 @@ const up = async (db) => {
     // keep formdefid for now, so don't remove after backfilling (see note below)
   });
 
+  // Drop some indexes and foreign key constraints that we won't need later
+
+  // We've considered dropping 'formDefId' from ds_property_fields for the same
+  // reason we're dropping it from form_fields, however this would involve a larger
+  // restructuring of the code to insert/update a dataset and its property fields.
+  await db.schema.table('ds_property_fields', (t) => {
+    t.dropForeign(['formDefId', 'path']); // This used to be a foreign key on form_fields
+  });
+
+  await db.schema.table('form_fields', (t) => {
+    t.dropIndex(['formDefId', 'binary']);
+    t.dropIndex(['formDefId', 'order']);
+    t.dropPrimary();
+    t.dropForeign(['formDefId']);
+  });
+
   // backfill
   /* eslint-disable no-await-in-loop */
-  const allForms = await db.select('id')
+  const allForms = await db.select('id', 'xmlFormId')
     .from('forms');
 
   let formCount = 1;
   for (const form of allForms) {
-    console.log(`Processing form ${formCount} out of ${allForms.length}`);
+    console.log(`Processing Form ${formCount}/${allForms.length}: [${form.xmlFormId}]`);
     formCount += 1;
     const allDefs = await db.select('id', 'name', 'version', 'xml')
       .from('form_defs')
@@ -76,7 +92,7 @@ const up = async (db) => {
 
     let defCount = 1;
     for (const formDef of allDefs) {
-      console.log(`Processing form version ${defCount} out of ${allDefs.length}`);
+      console.log(`\tProcessing Version ${defCount}/${allDefs.length}: [${formDef.version}]`);
       defCount += 1;
 
       const currFields = await getFormFields(formDef.xml);
@@ -111,18 +127,8 @@ const up = async (db) => {
     /* eslint-enable no-await-in-loop */
   }
 
-  // We've considered dropping 'formDefId' from ds_property_fields for the same
-  // reason we're dropping it from form_fields, however this would involve a larger
-  // restructuring of the code to insert/update a dataset and its property fields.
-  await db.schema.table('ds_property_fields', (t) => {
-    t.dropForeign(['formDefId', 'path']); // This used to be a foreign key on form_fields
-  });
 
   await db.schema.table('form_fields', (t) => {
-    t.dropIndex(['formDefId', 'binary']);
-    t.dropIndex(['formDefId', 'order']);
-    t.dropPrimary();
-    t.dropForeign(['formDefId']);
     t.dropColumn('formDefId');
     t.primary(['schemaId', 'path']);
     t.index(['schemaId', 'binary']);
@@ -131,21 +137,13 @@ const up = async (db) => {
 
   await db.schema.table('ds_property_fields', (t) => {
     t.foreign(['schemaId', 'path']).references(['schemaId', 'path']).inTable('form_fields').onDelete('cascade');
-    t.unique(['dsPropertyId', 'schemaId', 'path', 'formDefId']);
+    t.unique(['dsPropertyId', 'path', 'formDefId']);
   });
 
   await db.raw('ALTER TABLE form_defs ENABLE TRIGGER check_managed_key');
 };
 
-const down = async (db) => {
-  await db.schema.table('form_fields', (t) => {
-    t.dropColumn('schemaId');
-  });
-  await db.schema.table('form_defs', (t) => {
-    t.dropColumn('schemaId');
-  });
-  await db.schema.dropTable('form_fields');
-};
+const down = () => {}; // no. would cause problems.
 
 module.exports = { up, down };
 

--- a/lib/model/migrations/20230109-01-add-form-schema.js
+++ b/lib/model/migrations/20230109-01-add-form-schema.js
@@ -23,6 +23,12 @@ const { getFormFields, compare } = require('../../data/schema');
 */
 
 const up = async (db) => {
+  // eslint-disable-next-line no-console
+  console.log(`*** This migration [20230109-01-add-form-schema.js] may take a long time ***
+The purpose of this migration is to clean up redundant data related to how form schemas are
+stored. Please be aware that it may take a while to complete if there are many different
+versions of forms and/or many large forms with many fields in the database.`);
+
   // This trigger was responsible for checking for field downcasts that
   // would break oData streams (e.g. a freeform string becoming an int).
   // The functionality of it has been recreated in javascript, although
@@ -56,12 +62,11 @@ const up = async (db) => {
   });
 
   // Drop some indexes and foreign key constraints that we won't need later
-
-  // We've considered dropping 'formDefId' from ds_property_fields for the same
-  // reason we're dropping it from form_fields, however this would involve a larger
-  // restructuring of the code to insert/update a dataset and its property fields.
   await db.schema.table('ds_property_fields', (t) => {
     t.dropForeign(['formDefId', 'path']); // This used to be a foreign key on form_fields
+    // Note: We considered dropping 'formDefId' from ds_property_fields for the same
+    // reason we're dropping it from form_fields, however this would involve a larger
+    // restructuring of the code to insert/update a dataset and its property fields.
   });
 
   await db.schema.table('form_fields', (t) => {

--- a/lib/model/migrations/20230109-01-add-form-schema.js
+++ b/lib/model/migrations/20230109-01-add-form-schema.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // Copyright 2023 ODK Central Developers
 // See the NOTICE file at the top-level directory of this distribution and at
 // https://github.com/getodk/central-backend/blob/master/NOTICE.
@@ -79,6 +78,7 @@ const up = async (db) => {
 
   let formCount = 1;
   for (const form of allForms) {
+    // eslint-disable-next-line no-console
     console.log(`Processing Form ${formCount}/${allForms.length}: [${form.xmlFormId}]`);
     formCount += 1;
     const allDefs = await db.select('id', 'name', 'version', 'xml')
@@ -92,6 +92,7 @@ const up = async (db) => {
 
     let defCount = 1;
     for (const formDef of allDefs) {
+      // eslint-disable-next-line no-console
       console.log(`\tProcessing Version ${defCount}/${allDefs.length}: [${formDef.version}]`);
       defCount += 1;
 
@@ -103,10 +104,11 @@ const up = async (db) => {
         await db.update({ schemaId: prevSchemaId })
           .into('form_defs')
           .where({ id: formDef.id });
-        await db.delete().from('form_fields')
+        await db.delete().from('form_fields') // delete spurious copies of form fields
           .where({ formDefId: formDef.id, schemaId: null });
-        await db.delete().from('ds_property_fields')
-          .where({ formDefId: formDef.id, schemaId: null });
+        await db.update({ schemaId: prevSchemaId }) // keep ds_property_fields but update schemaId
+          .into('ds_property_fields')
+          .where({ formDefId: formDef.id });
       } else {
         const [ schema ] = await db.insert({})
           .into('form_schemas').returning('*');

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -75,9 +75,11 @@ left join (
 // meta/instanceID is included in this count
 const biggestForm = () => ({ oneFirst }) => oneFirst(sql`
 select max(count) from (
-  select ff."formDefId", count(path) from form_fields as ff
+  select fd."id", count(path) from form_fields as ff
+  join form_schemas as fs on fs."id" = ff."schemaId"
+  join form_defs as fd on fs."id" = fd."schemaId"
   where ff."type" not in ('structure', 'repeat')
-  group by ff."formDefId"
+  group by fd."id"
 ) as "formFieldCounts"`);
 
 const archivedProjects = () => ({ one }) => one(sql`

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -79,8 +79,8 @@ const _insertDatasetDef = (dataset, acteeId, withDsDefsCTE, publish) => sql`
 `;
 
 const _insertProperties = (fields, publish) => sql`
-,fields("propertyName", "formDefId", path) AS (VALUES      
-  ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.formDefId, p.path], sql`,`)} )`), sql`,`)}
+,fields("propertyName", "formDefId", "schemaId", path) AS (VALUES      
+  ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.aux.formDefId, p.schemaId, p.path], sql`,`)} )`), sql`,`)}
 ),
 insert_properties AS (
     INSERT INTO ds_properties (id, name, "datasetId", "publishedAt")
@@ -90,20 +90,18 @@ insert_properties AS (
     RETURNING ds_properties.id, ds_properties.name, ds_properties."datasetId"
 ),
 all_properties AS (
-    (SELECT insert_properties.id "dsPropertyId", insert_properties.name "propertyName", fields."formDefId", fields.path FROM fields
+    (SELECT insert_properties.id "dsPropertyId", insert_properties.name "propertyName", fields."formDefId", fields."schemaId", fields.path FROM fields
     JOIN insert_properties ON fields."propertyName" = insert_properties.name)
     UNION 
-    (SELECT ds_properties.id "dsPropertyId", ds_properties.name "propertyName", fields."formDefId", fields.path FROM fields
+    (SELECT ds_properties.id "dsPropertyId", ds_properties.name "propertyName", fields."formDefId", fields."schemaId", fields.path FROM fields
     JOIN ds_properties ON fields."propertyName" = ds_properties.name
     JOIN ds ON ds.id = ds_properties."datasetId")
 ),
 insert_property_fields AS (
-  INSERT INTO ds_property_fields
-  SELECT "dsPropertyId", "formDefId"::integer, path FROM all_properties
+  INSERT INTO ds_property_fields ("dsPropertyId", "formDefId", "schemaId", "path")
+  SELECT "dsPropertyId", "formDefId"::integer, "schemaId"::integer, path FROM all_properties
 )
 `;
-
-//(isNilOrEmpty(fields) ? _insertDatasetDef(dataset, acteeId, false, publish) :
 
 const _createOrMerge = (dataset, fields, acteeId, publish) => sql`
 ${_insertDatasetDef(dataset, acteeId, true, publish)}
@@ -152,9 +150,8 @@ const _getLinkedForms = (datasetName, projectId) => sql`
 `;
 
 // Creates or merges dataset, properties and field mapping.
-// Expects dataset:Frame auxed with `formDefId` and array of field:Frame auxed with `propertyName`
-// Note from Kathleen: I apologize at how hacky it is to get the provisioned actee ID into this
-// and get the created dataset out again...
+// Expects dataset:Frame auxed with `formDefId`, `schemaId`,
+// and array of field:Frame auxed with `propertyName`
 const createOrMerge = (dataset, fields, publish = false) => ({ one, Actees, Datasets, Projects }) =>
   Promise.all([
     Projects.getById(dataset.projectId).then((o) => o.get()),
@@ -262,14 +259,16 @@ SELECT
   form_fields.*, ds_properties."name" as "propertyName"
 FROM
   form_fields
+JOIN form_schemas fs ON fs.id = form_fields."schemaId"
+JOIN form_defs ON fs.id = form_defs."schemaId"
 JOIN dataset_form_defs ON
-  dataset_form_defs."formDefId" = form_fields."formDefId"
+  dataset_form_defs."formDefId" = form_defs."id"
 LEFT OUTER JOIN ds_property_fields ON
-  ds_property_fields."formDefId" = form_fields."formDefId"
+  ds_property_fields."schemaId" = form_fields."schemaId"
     AND ds_property_fields."path" = form_fields."path"
 LEFT OUTER JOIN ds_properties ON
   ds_properties."id" = ds_property_fields."dsPropertyId"
-WHERE form_fields."formDefId" = ${formDefId}
+WHERE form_defs."id" = ${formDefId}
   AND (ds_properties."id" IS NOT NULL OR form_fields."path" LIKE '/meta/entity%')
 ORDER BY form_fields."order"
 `)
@@ -277,7 +276,7 @@ ORDER BY form_fields."order"
 
 const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
   WITH form AS (
-    SELECT f.id, f."xmlFormId", fd.id "formDefId" 
+    SELECT f.id, f."xmlFormId", fd.id "formDefId", fd."schemaId"
     FROM forms f
     JOIN form_defs fd ON fd.id = f.${forDraft ? sql.identifier(['draftDefId']) : sql.identifier(['currentDefId'])}
     WHERE "projectId" = ${projectId} AND "xmlFormId" = ${xmlFormId} AND f."deletedAt" IS NULL
@@ -319,9 +318,11 @@ const publishIfExists = (formDefId, publishedAt) => ({ all }) => all(sql`
 WITH properties_update as (
   UPDATE ds_properties dp SET "publishedAt" = ${publishedAt}
   FROM ds_property_fields dpf
-  WHERE dpf."formDefId" = ${formDefId}
+  JOIN form_schemas fs ON fs."id" = dpf."schemaId"
+  JOIN form_defs fd ON fs."id" = fd."schemaId"
+  WHERE fd."id" = ${formDefId}
   AND dpf."dsPropertyId" = dp.id
-  RETURNING *
+  RETURNING dp.*
 ), datasets_update as (
   UPDATE datasets ds SET "publishedAt" = ${publishedAt}
   FROM dataset_form_defs dfd

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -569,25 +569,22 @@ order by "schemaId" asc, "order" asc`)
   });
 
 ////////////////////////////////////////////////////////////////////////////////
+// MISC
+
+const lockDefs = () => ({ run }) => run(sql`lock form_defs in share mode`);
+
+const getAllSubmitters = (formId) => ({ all }) => all(sql`
+select actors.* from actors
+inner join
+  (select "submitterId" from submissions
+    where "deletedAt" is null and "formId"=${formId}
+    group by "submitterId")
+  as submitters on submitters."submitterId"=actors.id
+order by actors."displayName" asc`)
+  .then(map(construct(Actor)));
+
+////////////////////////////////////////////////////////////////////////////////
 // CHECKING CONSTRAINTS, STRUCTURAL CHANGES, ETC.
-
-const rejectIfWarnings = () => ({ context }) => {
-  const warnings = {};
-
-  if (context.transitoryData.has('xlsFormWarnings')) {
-    warnings.xlsFormWarnings = context.transitoryData.get('xlsFormWarnings');
-  }
-
-  if (context.transitoryData.has('workflowWarnings')) {
-    warnings.workflowWarnings = context.transitoryData.get('workflowWarnings');
-  }
-
-  if (warnings.xlsFormWarnings || warnings.workflowWarnings) {
-    return reject(Problem.user.formWarnings({ warnings }));
-  } else {
-    return resolve();
-  }
-};
 
 const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => (context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL LIMIT 1`)
   .then(deletedForm => {
@@ -610,6 +607,24 @@ const checkStructuralChange = (existingFields, fields) => ({ context }) => {
   return resolve();
 };
 
+const rejectIfWarnings = () => ({ context }) => {
+  const warnings = {};
+
+  if (context.transitoryData.has('xlsFormWarnings')) {
+    warnings.xlsFormWarnings = context.transitoryData.get('xlsFormWarnings');
+  }
+
+  if (context.transitoryData.has('workflowWarnings')) {
+    warnings.workflowWarnings = context.transitoryData.get('workflowWarnings');
+  }
+
+  if (warnings.xlsFormWarnings || warnings.workflowWarnings) {
+    return reject(Problem.user.formWarnings({ warnings }));
+  } else {
+    return resolve();
+  }
+};
+
 const checkFieldDowncast = (allFields, fields) => () => {
   const lookup = {};
   for (const f of allFields) lookup[f.path] = f;
@@ -627,21 +642,6 @@ const compareFormSchemas = (prevFields, fields) => async ({ one }) => {
   const newSchemaId = await one(sql`insert into form_schemas (id) values (default) returning *`);
   return { schemaId: newSchemaId.id, match: false };
 };
-
-////////////////////////////////////////////////////////////////////////////////
-// MISC
-
-const lockDefs = () => ({ run }) => run(sql`lock form_defs in share mode`);
-
-const getAllSubmitters = (formId) => ({ all }) => all(sql`
-select actors.* from actors
-inner join
-  (select "submitterId" from submissions
-    where "deletedAt" is null and "formId"=${formId}
-    group by "submitterId")
-  as submitters on submitters."submitterId"=actors.id
-order by actors."displayName" asc`)
-  .then(map(construct(Actor)));
 
 module.exports = {
   fromXls, _createNew, createNew, createVersion,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -547,7 +547,7 @@ const getMergedFields = (formId) => ({ all }) => all(sql`
 select form_fields.* from form_fields
 join form_schemas on form_fields."schemaId" = form_schemas."id"
 inner join
-  (select "schemaId" from form_defs where "publishedAt" is not null)
+  (select distinct "schemaId" from form_defs where "publishedAt" is not null)
   as defs on defs."schemaId"=form_schemas."id"
 where form_fields."formId"=${formId}
 order by "schemaId" asc, "order" asc`)

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -341,7 +341,13 @@ using forms
 where form_defs."formId" = forms.id
 and form_defs."publishedAt" is null
 and form_defs.id is distinct from forms."draftDefId"
-${_draftFilter(form, project)}`);
+${_draftFilter(form, project)}`)
+    .then(() => run(sql`
+delete from form_schemas
+  using form_schemas as fs
+  left join form_defs as fd on fd."schemaId" = fs."id"
+where (form_schemas.id = fs.id
+  and fd."schemaId" is null)`));
 
 ////////////////////////////////////////////////////////////////////////////////
 // ENCRYPTION

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -350,18 +350,19 @@ const _draftFilter = (form, project) =>
 // NOTE: copypasta alert! The following SQL also appears in 20220209-01-purge-unneeded-drafts.js
 const clearUnneededDrafts = (form = null, project = null) => ({ run }) =>
   run(sql`
-delete from form_defs
-using forms
-where form_defs."formId" = forms.id
-and form_defs."publishedAt" is null
-and form_defs.id is distinct from forms."draftDefId"
+DELETE FROM form_defs
+  USING forms
+WHERE form_defs."formId" = forms.id
+  AND form_defs."publishedAt" IS NULL
+  AND form_defs.id IS DISTINCT FROM forms."draftDefId"
 ${_draftFilter(form, project)}`)
     .then(() => run(sql`
-delete from form_schemas
-  using form_schemas as fs
-  left join form_defs as fd on fd."schemaId" = fs."id"
-where (form_schemas.id = fs.id
-  and fd."schemaId" is null)`));
+DELETE FROM form_schemas
+  USING form_schemas AS fs
+LEFT JOIN form_defs AS fd
+  ON fd."schemaId" = fs."id"
+WHERE (form_schemas.id = fs.id
+  AND fd."schemaId" IS NULL)`));
 
 ////////////////////////////////////////////////////////////////////////////////
 // ENCRYPTION
@@ -527,26 +528,26 @@ const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
 // SCHEMA
 
 const getFields = (formDefId) => ({ all }) =>
-  all(sql`select form_fields.* from form_fields
-  join form_schemas on form_schemas."id" = form_fields."schemaId"
-  join form_defs on form_schemas."id" = form_defs."schemaId"
-  where form_defs."id"=${formDefId} order by form_fields."order" asc`)
+  all(sql`SELECT form_fields.* FROM form_fields
+  JOIN form_schemas ON form_schemas."id" = form_fields."schemaId"
+  JOIN form_defs ON form_schemas."id" = form_defs."schemaId"
+  WHERE form_defs."id"=${formDefId} ORDER BY form_fields."order" ASC`)
     .then(map(construct(Form.Field)));
 
 const getBinaryFields = (formDefId) => ({ all }) =>
-  all(sql`select form_fields.* from form_fields
-  join form_schemas on form_schemas."id" = form_fields."schemaId"
-  join form_defs on form_schemas."id" = form_defs."schemaId"
-  where form_defs."id"=${formDefId} and form_fields."binary"=true
-  order by form_fields."order" asc`)
+  all(sql`SELECT form_fields.* FROM form_fields
+  JOIN form_schemas ON form_schemas."id" = form_fields."schemaId"
+  JOIN form_defs ON form_schemas."id" = form_defs."schemaId"
+  WHERE form_defs."id"=${formDefId} AND form_fields."binary"=true
+  ORDER BY form_fields."order" ASC`)
     .then(map(construct(Form.Field)));
 
 const getStructuralFields = (formDefId) => ({ all }) =>
   all(sql`select form_fields.* from form_fields
-  join form_schemas on form_schemas."id" = form_fields."schemaId"
-  join form_defs on form_schemas."id" = form_defs."schemaId"
-  where form_defs."id"=${formDefId} and (form_fields.type='repeat' or form_fields.type='structure')
-  order by form_fields."order" asc`)
+  join form_schemas ON form_schemas."id" = form_fields."schemaId"
+  join form_defs ON form_schemas."id" = form_defs."schemaId"
+  WHERE form_defs."id"=${formDefId} AND (form_fields.type='repeat' OR form_fields.type='structure')
+  ORDER BY form_fields."order" ASC`)
     .then(map(construct(Form.Field)));
 
 // TODO: this could be split up into eg getFieldsForAllVersions and a lot of the

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -142,17 +142,31 @@ const createVersion = (partial, form, publish = false) => async ({ run, one, Dat
     (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml))
   ]);
 
-  // Fetch fields of previous version to compare new schema against
-  const prevFields = await Forms.getFields(form.currentDefId);
-  const { schemaId, match } = await Forms.compareFormSchemas(prevFields, fields);
+  // Compute the intermediate schema ID
+  let schemaId;
+  let match;
 
-  if (!match) {
-    // Only need to check new fields against old fields if the structure
-    // does not match.
-    const allFields = await Forms.getMergedFields(form.id);
-    await Forms.checkFieldDowncast(allFields, fields);
-    await Forms.checkStructuralChange(prevFields, fields)
-      .then(Forms.rejectIfWarnings);
+  // If there is no current published def, only a draft, we definitely need a new schema
+  // and we don't need to compare against old schemas/check for structural changes
+  if (!form.currentDefId) {
+    schemaId = await Forms._newSchema();
+    match = false;
+  } else {
+    // Fetch fields of previous version to compare new schema against
+    const prevFields = await Forms.getFields(form.currentDefId);
+    match = compare(prevFields, fields);
+
+    if (match)
+      schemaId = prevFields[0].schemaId;
+    else {
+      // Only need to check new fields against old fields if the structure does not match
+      const allFields = await Forms.getMergedFields(form.id);
+      await Forms.checkFieldDowncast(allFields, fields);
+      await Forms.checkStructuralChange(prevFields, fields)
+        .then(Forms.rejectIfWarnings);
+      // If we haven't been rejected or warned yet, make a new schema id
+      schemaId = await Forms._newSchema();
+    }
   }
 
   // Make sure our new def is in the database, and mark it as either draft or current.
@@ -635,13 +649,9 @@ const checkFieldDowncast = (allFields, fields) => () => {
   return resolve();
 };
 
-const compareFormSchemas = (prevFields, fields) => async ({ one }) => {
-  const match = compare(prevFields, fields);
-  if (match)
-    return { schemaId: prevFields[0].schemaId, match: true };
-  const newSchemaId = await one(sql`insert into form_schemas (id) values (default) returning *`);
-  return { schemaId: newSchemaId.id, match: false };
-};
+const _newSchema = () => ({ one }) =>
+  one(sql`insert into form_schemas (id) values (default) returning *`)
+    .then((s) => s.id);
 
 module.exports = {
   fromXls, _createNew, createNew, createVersion,
@@ -655,7 +665,7 @@ module.exports = {
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
   rejectIfWarnings, checkDeletedForms, checkStructuralChange, checkFieldDowncast,
-  compareFormSchemas,
+  _newSchema,
   lockDefs, getAllSubmitters
 };
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -11,13 +11,13 @@ const { sql } = require('slonik');
 const { map, compose } = require('ramda');
 const { Frame, into } = require('../frame');
 const { Actor, Blob, Form, Dataset } = require('../frames');
-const { getFormFields, merge } = require('../../data/schema');
+const { getFormFields, merge, compare } = require('../../data/schema');
 const { getDataset } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject } = require('../../util/promise');
 const { splitStream } = require('../../util/stream');
-const { construct } = require('../../util/util');
+const { construct, noop } = require('../../util/util');
 const Option = require('../../util/option');
 const Problem = require('../../util/problem');
 
@@ -46,9 +46,14 @@ const fromXls = (stream, contentType, formIdFallback, ignoreWarnings) => ({ Blob
 const _createNew = (form, def, project, publish) => ({ oneFirst, Actees, Forms }) =>
   Actees.provision('form', project)
     .then((actee) => oneFirst(sql`
-with def as
-  (insert into form_defs ("formId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt")
-  values (nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null})
+with sch as
+  (insert into form_schemas (id)
+    values (default)
+    returning *),
+def as
+  (insert into form_defs ("formId", "schemaId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt")
+  select nextval(pg_get_serial_sequence('forms', 'id')), sch.id, ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null}
+    from sch
   returning *),
 form as
   (insert into forms (id, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "createdAt")
@@ -77,7 +82,7 @@ const createNew = (partial, project, publish = false) => async ({ run, Datasets,
   const savedForm = await Forms._createNew(partial, partial.def.with({ keyId }), project, publish);
 
   // Prepare the form fields
-  const ids = { formId: savedForm.id, formDefId: savedForm.def.id };
+  const ids = { formId: savedForm.id, schemaId: savedForm.def.schemaId };
 
   // Insert fields and setup form attachment slots
   await Promise.all([
@@ -92,7 +97,7 @@ const createNew = (partial, project, publish = false) => async ({ run, Datasets,
       throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
     await Datasets.createOrMerge(
       new Dataset({ name: dataset.get(), projectId: project.id }, { formDefId: savedForm.def.id }),
-      dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName })),
+      dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId: savedForm.def.schemaId, formDefId: savedForm.def.id })),
       publish
     );
   }
@@ -137,9 +142,18 @@ const createVersion = (partial, form, publish = false) => async ({ run, one, Dat
     (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml))
   ]);
 
-  // Check new structure of form compared to old, possibly warn about deleted fields
-  await Forms.checkStructuralChange(form, fields);
-  await Forms.rejectIfWarnings();
+  // Fetch fields of previous version to compare new schema against
+  const prevFields = await Forms.getFields(form.currentDefId);
+  const { schemaId, match } = await Forms.compareFormSchemas(prevFields, fields);
+
+  if (!match) {
+    // Only need to check new fields against old fields if the structure
+    // does not match.
+    const allFields = await Forms.getMergedFields(form.id);
+    await Forms.checkFieldDowncast(allFields, fields);
+    await Forms.checkStructuralChange(prevFields, fields)
+      .then(Forms.rejectIfWarnings);
+  }
 
   // Make sure our new def is in the database, and mark it as either draft or current.
   let def = partial.def.with({ formId: form.id, keyId, xlsBlobId: partial.xls.xlsBlobId });
@@ -153,15 +167,17 @@ const createVersion = (partial, form, publish = false) => async ({ run, one, Dat
     ? Forms._update(form, { currentDefId: savedDef.id })
     : Forms._update(form, { draftDefId: savedDef.id }));
 
+  await Forms._updateDef(new Form.Def(savedDef), { schemaId });
+
   // Prepare the form fields
-  const ids = { formId: form.id, formDefId: savedDef.id };
+  const ids = { formId: form.id, schemaId };
   const fieldsForInsert = new Array(fields.length);
   for (let i = 0; i < fields.length; i += 1)
     fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
 
   // Insert fields and setup form attachments
   await Promise.all([
-    run(insertMany(fieldsForInsert)),
+    (!match) ? run(insertMany(fieldsForInsert)) : noop,
     FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
   ]);
 
@@ -169,7 +185,7 @@ const createVersion = (partial, form, publish = false) => async ({ run, one, Dat
   if (dataset.isDefined())
     await Datasets.createOrMerge(
       new Dataset({ name: dataset.get(), projectId: form.projectId }, { formDefId: savedDef.id }),
-      fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ formDefId: savedDef.id, ...field }, { propertyName: field.propertyName })),
+      fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ schemaId, ...field }, { propertyName: field.propertyName, formDefId: savedDef.id })),
       publish
     );
 
@@ -193,7 +209,7 @@ const publish = (form) => ({ Forms, Datasets }) => {
   const publishedAt = (new Date()).toISOString();
   return Promise.all([
     Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null }),
-    Forms._updateDef(form, { draftToken: null, enketoId: null, publishedAt }),
+    Forms._updateDef(form.def, { draftToken: null, enketoId: null, publishedAt }),
     Datasets.publishIfExists(form.def.id, publishedAt)
   ])
     .catch(Problem.translate(
@@ -217,7 +233,7 @@ const _update = (form, data) => ({ one }) => one(updater(form, data));
 const update = (form, data) => ({ Forms }) => Forms._update(form, data);
 update.audit = (form, data) => (log) => log('form.update', form, { data });
 
-const _updateDef = (form, data) => ({ one }) => one(updater(form.def, data));
+const _updateDef = (formDef, data) => ({ one }) => one(updater(formDef, data));
 
 const del = (form) => ({ run }) =>
   run(markDeleted(form));
@@ -491,15 +507,26 @@ const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
 // SCHEMA
 
 const getFields = (formDefId) => ({ all }) =>
-  all(sql`select * from form_fields where "formDefId"=${formDefId} order by "order" asc`)
+  all(sql`select form_fields.* from form_fields
+  join form_schemas on form_schemas."id" = form_fields."schemaId"
+  join form_defs on form_schemas."id" = form_defs."schemaId"
+  where form_defs."id"=${formDefId} order by form_fields."order" asc`)
     .then(map(construct(Form.Field)));
 
 const getBinaryFields = (formDefId) => ({ all }) =>
-  all(sql`select * from form_fields where "formDefId"=${formDefId} and "binary"=true order by "order" asc`)
+  all(sql`select form_fields.* from form_fields
+  join form_schemas on form_schemas."id" = form_fields."schemaId"
+  join form_defs on form_schemas."id" = form_defs."schemaId"
+  where form_defs."id"=${formDefId} and form_fields."binary"=true
+  order by form_fields."order" asc`)
     .then(map(construct(Form.Field)));
 
 const getStructuralFields = (formDefId) => ({ all }) =>
-  all(sql`select * from form_fields where "formDefId"=${formDefId} and (type='repeat' or type='structure') order by "order" asc`)
+  all(sql`select form_fields.* from form_fields
+  join form_schemas on form_schemas."id" = form_fields."schemaId"
+  join form_defs on form_schemas."id" = form_defs."schemaId"
+  where form_defs."id"=${formDefId} and (form_fields.type='repeat' or form_fields.type='structure')
+  order by form_fields."order" asc`)
     .then(map(construct(Form.Field)));
 
 // TODO: this could be split up into eg getFieldsForAllVersions and a lot of the
@@ -512,18 +539,19 @@ const getStructuralFields = (formDefId) => ({ all }) =>
 // N.B. will only return published form fields! do not use this to try to get draft fields.
 const getMergedFields = (formId) => ({ all }) => all(sql`
 select form_fields.* from form_fields
+join form_schemas on form_fields."schemaId" = form_schemas."id"
 inner join
-  (select id from form_defs where "publishedAt" is not null)
-  as defs on defs.id=form_fields."formDefId"
-where "formId"=${formId}
-order by "formDefId" asc, "order" asc`)
+  (select "schemaId" from form_defs where "publishedAt" is not null)
+  as defs on defs."schemaId"=form_schemas."id"
+where form_fields."formId"=${formId}
+order by "schemaId" asc, "order" asc`)
   .then(map(construct(Form.Field)))
   .then((fields) => {
     // first, partition the fields into different versions.
     const versions = [];
     let mark = 0;
     for (let idx = 1; idx < fields.length; idx += 1) {
-      if (fields[idx].formDefId !== fields[idx - 1].formDefId) {
+      if (fields[idx].schemaId !== fields[idx - 1].schemaId) {
         versions.push(fields.slice(mark, idx));
         mark = idx;
       }
@@ -534,41 +562,8 @@ order by "formDefId" asc, "order" asc`)
     return versions.reduce(merge);
   });
 
-
-
 ////////////////////////////////////////////////////////////////////////////////
-// MISC
-
-const lockDefs = () => ({ run }) => run(sql`lock form_defs in share mode`);
-
-const getAllSubmitters = (formId) => ({ all }) => all(sql`
-select actors.* from actors
-inner join
-  (select "submitterId" from submissions
-    where "deletedAt" is null and "formId"=${formId}
-    group by "submitterId")
-  as submitters on submitters."submitterId"=actors.id
-order by actors."displayName" asc`)
-  .then(map(construct(Actor)));
-
-const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => (context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL LIMIT 1`)
-  .then(deletedForm => {
-    if (deletedForm.isDefined()) {
-      if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
-      context.transitoryData.get('workflowWarnings').push({ type: 'deletedFormExists', details: { xmlFormId } });
-    }
-  }));
-
-const checkStructuralChange = (form, fields) => ({ Forms, context }) => (!form.currentDefId || context.query.ignoreWarnings ? resolve() : Forms.getFields(form.currentDefId)
-  .then(existingFields => {
-    const newFieldSet = new Set(fields.map(f => f.path));
-    const removedFields = existingFields.filter(f => !newFieldSet.has(f.path));
-
-    if (removedFields.length > 0) {
-      if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
-      context.transitoryData.get('workflowWarnings').push({ type: 'structureChanged', details: removedFields.map(f => f.name) });
-    }
-  }));
+// CHECKING CONSTRAINTS, STRUCTURAL CHANGES, ETC.
 
 const rejectIfWarnings = () => ({ context }) => {
   const warnings = {};
@@ -588,6 +583,60 @@ const rejectIfWarnings = () => ({ context }) => {
   }
 };
 
+const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => (context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL LIMIT 1`)
+  .then(deletedForm => {
+    if (deletedForm.isDefined()) {
+      if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
+      context.transitoryData.get('workflowWarnings').push({ type: 'deletedFormExists', details: { xmlFormId } });
+    }
+  }));
+
+const checkStructuralChange = (existingFields, fields) => ({ context }) => {
+  if (context.query.ignoreWarnings) return resolve();
+
+  const newFieldSet = new Set(fields.map(f => f.path));
+  const removedFields = existingFields.filter(f => !newFieldSet.has(f.path));
+
+  if (removedFields.length > 0) {
+    if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
+    context.transitoryData.get('workflowWarnings').push({ type: 'structureChanged', details: removedFields.map(f => f.name) });
+  }
+  return resolve();
+};
+
+const checkFieldDowncast = (allFields, fields) => () => {
+  const lookup = {};
+  for (const f of allFields) lookup[f.path] = f;
+  for (const f of fields.filter(ff => (ff.type !== 'string'))) {
+    if (lookup[f.path] && f.type !== lookup[f.path].type)
+      return reject(Problem.user.fieldTypeConflict({ path: f.path, type: lookup[f.path].type }));
+  }
+  return resolve();
+};
+
+const compareFormSchemas = (prevFields, fields) => async ({ one }) => {
+  const match = compare(prevFields, fields);
+  if (match)
+    return { schemaId: prevFields[0].schemaId, match: true };
+  const newSchemaId = await one(sql`insert into form_schemas (id) values (default) returning *`);
+  return { schemaId: newSchemaId.id, match: false };
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// MISC
+
+const lockDefs = () => ({ run }) => run(sql`lock form_defs in share mode`);
+
+const getAllSubmitters = (formId) => ({ all }) => all(sql`
+select actors.* from actors
+inner join
+  (select "submitterId" from submissions
+    where "deletedAt" is null and "formId"=${formId}
+    group by "submitterId")
+  as submitters on submitters."submitterId"=actors.id
+order by actors."displayName" asc`)
+  .then(map(construct(Actor)));
+
 module.exports = {
   fromXls, _createNew, createNew, createVersion,
   publish, clearDraft,
@@ -599,6 +648,8 @@ module.exports = {
   getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
-  lockDefs, getAllSubmitters, checkDeletedForms, checkStructuralChange, rejectIfWarnings
+  rejectIfWarnings, checkDeletedForms, checkStructuralChange, checkFieldDowncast,
+  compareFormSchemas,
+  lockDefs, getAllSubmitters
 };
 

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -21,7 +21,7 @@ const pushDraftToEnketo = ({ Forms, enketo, env }, event) =>
 
       const path = `${env.domain}/v1/test/${form.def.draftToken}/projects/${form.projectId}/forms/${encodeURIComponent(form.xmlFormId)}/draft`;
       return enketo.create(path, form.xmlFormId)
-        .then((enketoId) => Forms._updateDef(form, new Form.Def({ enketoId })));
+        .then((enketoId) => Forms._updateDef(form.def, new Form.Def({ enketoId })));
     }).orNull());
 
 const pushFormToEnketo = ({ Actors, Assignments, Forms, Sessions, enketo, env }, event) =>

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1363,6 +1363,40 @@ describe('datasets and entities', () => {
       }));
 
     });
+
+    describe('dataset property interaction with intermediate form schemas and purging uneeded drafts', () => {
+      it('should clean up form fields and dataset properties of unneeded drafts', testService(async (service, container) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.simpleEntity)
+          .expect(200);
+
+        // ignoring warning about removing a field
+        await asAlice.post('/v1/projects/1/forms/simpleEntity/draft?ignoreWarnings=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.simpleEntity.replace('orx:version="1.0"', 'orx:version="draft1"').replace(/first_name/g, 'nickname'))
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.simpleEntity.replace('orx:version="1.0"', 'orx:version="draft"'))
+          .expect(200);
+
+        // there are expected to be
+        // 2 defs of this form (published and new draft)
+        // 6 form fields of original form (and new form): 3 entity related fields and 3 question fields
+        // ideally only 4 ds property fields, but 2 from deleted def are still there
+        await Promise.all([
+          container.oneFirst(sql`select count(*) from form_defs as fd join forms as f on fd."formId" = f.id where f."xmlFormId"='simpleEntity'`),
+          container.oneFirst(sql`select count(*) from form_fields as fs join forms as f on fs."formId" = f.id where f."xmlFormId"='simpleEntity'`),
+          container.oneFirst(sql`select count(*) from ds_property_fields`),
+        ])
+          .then((counts) => counts.should.eql([ 2, 6, 6 ]));
+
+      }));
+    });
   });
 
   describe('dataset and entities should have isolated lifecycle', () => {

--- a/test/integration/api/forms/versions.js
+++ b/test/integration/api/forms/versions.js
@@ -1,6 +1,8 @@
 const { readFileSync } = require('fs');
 const appRoot = require('app-root-path');
 const should = require('should');
+const { identity } = require('ramda');
+const { sql } = require('slonik');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const superagent = require('superagent');
 const { testService } = require('../../setup');
@@ -384,5 +386,119 @@ describe('api: /projects/:id/forms (versions)', () => {
                 })))));
       });
     });
+  });
+
+  // These tests relate to adding new drafts with the same or different field
+  // structure will reuse or change an intermedia form schema representation.
+  describe('intermediate form schema', () => {
+    it('should not make additional form schemas for a form with unchanged fields', testService(async (service, container) => {
+      const asAlice = await service.login('alice', identity);
+
+      // Submit to first version of form
+      await asAlice.post('/v1/projects/1/forms/simple/submissions')
+        .set('Content-Type', 'application/xml')
+        .send(testData.instances.simple.one);
+
+      // Upload new version with same schema
+      await asAlice.post('/v1/projects/1/forms/simple/draft')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="2"'))
+        .expect(200);
+      await asAlice.post('/v1/projects/1/forms/simple/draft/publish');
+
+      // Submit to second version of form
+      await asAlice.post('/v1/projects/1/forms/simple/submissions')
+        .set('Content-Type', 'application/xml')
+        .send(testData.instances.simple.two.replace('id="simple"', 'id="simple" version="2"'))
+        .expect(200);
+
+      const fieldsBySchema = await container.all(sql`
+      select count(*), "schemaId" from form_fields
+      where "formId"=1
+      group by "schemaId"`);
+      fieldsBySchema.length.should.equal(1); // There should be only one schema
+      fieldsBySchema[0].count.should.equal(4); // There should be four fields for that schema
+
+      const defsBySchema = await container.all(sql`
+      select count(*), "schemaId" from form_defs
+      where "formId"=1
+      group by "schemaId"`);
+      defsBySchema.length.should.equal(1);
+      defsBySchema[0].count.should.equal(2);
+
+      // Check that two subs are there and export properly
+      const lines = await asAlice.get('/v1/projects/1/forms/simple/submissions.csv')
+        .expect(200)
+        .then(({ text }) => text.split('\n'));
+      lines[0].should.equal('SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+      lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+        .should.equal(',two,Bob,34,two,5,Alice,0,0,,,,0,2');
+      lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+        .should.equal(',one,Alice,30,one,5,Alice,0,0,,,,0,');
+    }));
+
+    it('should make additional form schema when fields change', testService(async (service, container) => {
+      const asAlice = await service.login('alice', identity);
+
+      // Submit to first version of form
+      await asAlice.post('/v1/projects/1/forms/simple/submissions')
+        .set('Content-Type', 'application/xml')
+        .send(testData.instances.simple.one);
+
+      // Upload new version with different schema (1 field removed)
+      await asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.simple
+          .replace('id="simple"', 'id="simple" version="2"')
+          .replace('<age/>', ''))
+        .expect(200);
+      await asAlice.post('/v1/projects/1/forms/simple/draft/publish');
+
+      // Submit to second version of form
+      await asAlice.post('/v1/projects/1/forms/simple/submissions')
+        .set('Content-Type', 'application/xml')
+        .send(testData.instances.simple.two
+          .replace('id="simple"', 'id="simple" version="2"')
+          .replace('<age>34</age>', ''))
+        .expect(200);
+
+      const fieldsBySchema = await container.all(sql`
+      select count(*), "schemaId" from form_fields
+      where "formId"=1
+      group by "schemaId"
+      order by "schemaId" asc`);
+      fieldsBySchema.length.should.equal(2); // There should be two schemas
+      fieldsBySchema[0].count.should.equal(4); // There should be four fields for that schema
+      fieldsBySchema[1].count.should.equal(3);
+
+      const defsBySchema = await container.all(sql`
+      select count(*), "schemaId" from form_defs
+      where "formId"=1
+      group by "schemaId"
+      order by "schemaId" asc`);
+      defsBySchema.length.should.equal(2);
+      defsBySchema[0].count.should.equal(1);
+      defsBySchema[0].count.should.equal(1);
+
+      // Check that two subs are there and export properly
+      let lines = await asAlice.get('/v1/projects/1/forms/simple/submissions.csv')
+        .expect(200)
+        .then(({ text }) => text.split('\n'));
+      lines[0].should.equal('SubmissionDate,meta-instanceID,name,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+      lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+        .should.equal(',two,Bob,two,5,Alice,0,0,,,,0,2');
+      lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+        .should.equal(',one,Alice,one,5,Alice,0,0,,,,0,');
+
+      // Check that two subs are there and export properly
+      lines = await asAlice.get('/v1/projects/1/forms/simple/submissions.csv?deletedFields=true')
+        .expect(200)
+        .then(({ text }) => text.split('\n'));
+      lines[0].should.equal('SubmissionDate,meta-instanceID,name,age,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+      lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+        .should.equal(',two,Bob,,two,5,Alice,0,0,,,,0,2');
+      lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
+        .should.equal(',one,Alice,30,one,5,Alice,0,0,,,,0,');
+    }));
   });
 });

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -151,6 +151,26 @@ describe('query module form purge', () => {
           ]))
           .then((counts) => counts.should.eql([ 0, 0, 0, 0 ]))))));
 
+  it('should purge the form fields of a form', testService((service, container) =>
+    service.login('alice', (asAlice) =>
+      asAlice.post('/v1/projects/1/forms/simple/draft')
+        .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="2"'))
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft/publish')
+          .expect(200))
+        .then(() => asAlice.post('/v1/projects/1/forms/simple/draft')
+          .send(testData.forms.simple.replace('id="simple"', 'id="simple" version="3"'))
+          .set('Content-Type', 'application/xml')
+          .expect(200))
+        .then(() => asAlice.delete('/v1/projects/1/forms/simple')
+          .expect(200))
+        .then(() => container.Forms.purge(true)) // force all deleted forms to be purged
+        .then(() => Promise.all([
+          container.oneFirst(sql`select count(*) from form_fields where "formId" = 1`)
+        ]))
+        .then((counts) => counts.should.eql([ 0 ])))));
+
   it('should purge the select multiple values of a purged form', testService((service, container) =>
     service.login('alice', (asAlice) =>
       asAlice.post('/v1/projects/1/forms?publish=true')

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -1145,7 +1145,7 @@ describe('form schema', () => {
 
     it('should say two forms with the different schemas do not match', () => Promise.all([
       fieldsFor(testData.forms.simple),
-      fieldsFor(testData.forms.withrepeat) // same form structure but different xmlFormId
+      fieldsFor(testData.forms.withrepeat)
     ]).then(([ a, b ]) => {
       compare(a, b).should.be.false();
     }));

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -1,7 +1,7 @@
 const appRoot = require('app-root-path');
 const should = require('should');
 // eslint-disable-next-line import/no-dynamic-require
-const { getFormFields, sanitizeFieldsForOdata, SchemaStack, merge, expectedFormAttachments, injectPublicKey, addVersionSuffix, setVersion } = require(appRoot + '/lib/data/schema');
+const { getFormFields, sanitizeFieldsForOdata, SchemaStack, merge, compare, expectedFormAttachments, injectPublicKey, addVersionSuffix, setVersion } = require(appRoot + '/lib/data/schema');
 // eslint-disable-next-line import/no-dynamic-require
 const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
 // eslint-disable-next-line import/no-dynamic-require
@@ -1132,6 +1132,30 @@ describe('form schema', () => {
         new MockField({ name: 'c', order: 6, path: '/group/c', type: 'string' }),
         new MockField({ name: 'name', order: 7, path: '/name', type: 'string' })
       ]);
+    }));
+  });
+
+  describe('compare', () => {
+    it('should say two forms with the same schemas do match', () => Promise.all([
+      fieldsFor(testData.forms.simple),
+      fieldsFor(testData.forms.simple2) // same form structure but different xmlFormId
+    ]).then(([ a, b ]) => {
+      compare(a, b).should.be.true();
+    }));
+
+    it('should say two forms with the different schemas do not match', () => Promise.all([
+      fieldsFor(testData.forms.simple),
+      fieldsFor(testData.forms.withrepeat) // same form structure but different xmlFormId
+    ]).then(([ a, b ]) => {
+      compare(a, b).should.be.false();
+    }));
+
+    it('should say two forms with the different schemas of same size do not match', () => Promise.all([
+      fieldsFor(testData.forms.simple),
+      fieldsFor(testData.forms.simple.replace(/age/g, 'address'))
+    ]).then(([ a, b ]) => {
+      compare(a, b).should.be.false();
+      compare(b, a).should.be.false(); // try both directions
     }));
   });
 


### PR DESCRIPTION
Introduces an intermediate form schema table for collapsing form fields from different versions of the same form that share the same schema. Closes issue #662.

This PR is meant to be all under the hood, but it touches a lot of things under the hood. The main structure of these changes are as follows:

1. Migration to collapse duplicate form schemas. This involves adding a `form_schemas` table that just stores an int, and replacing `formDefId` columns on `form_fields` and `form_defs` with a link to this schema ID `schemaId` that can be shared across defs. There is also a block of code that goes through all existing form defs and compares their fields to assign appropriate schema IDs. 
2. A change of all queries that include `form_fields` to join with `form_defs` through the schema ID instead of the def ID. Also changes to queries for dataset property fields, which are coupled with regular form fields.
3. Changes to the logic of `forms.createNew` and `forms.createVersion` to make sure this new schema ID gets checked, created and used. The structure of the code for these two functions has been made into async/await.
4. Moving the trigger (that was the cause of the 504 in the linked issue) out of SQL and into the code. This point is still up for discussion... the trigger is meant to check for disallowed field type downcasts.

#### What has been done to verify that this works as intended?

Tests, but I'm also going to do an external round of testing. 

#### Why is this the best possible solution? Were any other approaches considered?

A lot of discussion went into possible solutions for the root cause issue #662, from getting people to start using entities, to allowing them to update their attachments on published forms, to this chosen solution of collapsing redundant form field schemas by introducing an intermediate schema representation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It should make form def uploads faster for users, especially in the case where they are rapidly uploading new versions with the exact same schema in order to automatically update a CSV attachment.

There regression risks (that we're trying hard to avoid) are:
- data loss from migration
- a bug in how the new form schema table is joined in various queries that breaks functionality (but this is what our integration tests are for)
- some other part of the process gets unintentionally slower

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes