### PR TITLE
Enhance: See more context on Datasets list

### DIFF
--- a/lib/model/frames/dataset.js
+++ b/lib/model/frames/dataset.js
@@ -23,6 +23,18 @@ const Dataset = Frame.define(
   embedded('properties')
 );
 
+Dataset.Extended = class extends Frame.define(
+  'entities',      readable,               'lastEntity', readable
+) {
+  // default these properties to 0, since sql gives null if they're 0.
+  forApi() {
+    return {
+      entities: this.entities || 0,
+      lastEntity: this.lastEntity
+    };
+  }
+};
+
 Dataset.Property = Frame.define(
   table('ds_properties', 'properties'),
   'id',                                        'name',

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { unjoiner } = require('../../util/db');
+const { unjoiner, extender, QueryOptions, equals } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
 const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either, reduceBy, groupBy } = require('ramda');
 const { construct } = require('../../util/util');
@@ -46,9 +46,15 @@ const isNilOrEmpty = either(isNil, isEmpty);
 
 ////////////////////////////////////////////////////////////////////////////////
 // SQL Queries
-const _getAllByProjectId = (projectId) => sql`
-  SELECT DISTINCT d.* FROM datasets d  
-  WHERE d."publishedAt" IS NOT NULL AND d."projectId" = ${projectId}
+const _getAllByProjectId = (fields, extend, options) => sql`
+  SELECT ${fields} FROM datasets
+  ${extend|| sql`
+  LEFT JOIN (
+    SELECT "datasetId", count(1) "entities", max("createdAt") "lastEntity" 
+    FROM entities e 
+    GROUP BY "datasetId" 
+  ) stats on stats."datasetId" = datasets.id`}
+  WHERE "publishedAt" IS NOT NULL AND ${equals(options.condition)}
 `;
 
 const _insertDatasetDef = (dataset, acteeId, withDsDefsCTE, publish) => sql`
@@ -180,7 +186,10 @@ const getByName = (datasetName, projectId) => ({ all }) =>
 
 // Returns list of dataset for a given projectId
 // Properties and field mappings are not returned
-const getAllByProjectId = (projectId) => ({ all }) => all(_getAllByProjectId(projectId)).then(map(construct(Dataset)));
+
+
+const getAllByProjectId = (projectId, queryOptions = QueryOptions.none) => ({ all }) => extender(Dataset)(Dataset.Extended)(_getAllByProjectId)(all, queryOptions.withCondition({ projectId }));
+
 
 // Returns list of Fields augmented by dataset property name OR entity creation information
 // including label.

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -17,7 +17,7 @@ module.exports = (service, endpoint) => {
     Projects.getById(params.id, queryOptions)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('dataset.list', project))
-      .then(() => Datasets.getAllByProjectId(params.id))));
+      .then(() => Datasets.getAllByProjectId(params.id, queryOptions))));
 
   service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
     Projects.getById(params.projectId)


### PR DESCRIPTION
Added `extended` option for datasets API that returns entities count and timestamp of latest entity