### PR TITLE
new: /datasets/:name API

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -115,18 +115,35 @@ const _getByIdSql = ((fields, datasetId) => sql`
        WHERE datasets.id = ${datasetId}
     `);
 
-const _getByNameSql = ((fields, datasetName, projectId) => sql`
+const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     SELECT
         ${fields}
     FROM
         datasets
     LEFT OUTER JOIN ds_properties ON
         datasets.id = ds_properties."datasetId" AND ds_properties."publishedAt" IS NOT NULL
+    ${includeForms ? sql`
+    LEFT OUTER JOIN ds_property_fields ON
+        ds_properties.id = ds_property_fields."dsPropertyId"
+    LEFT OUTER JOIN forms ON
+        ds_property_fields."formDefId" = forms."currentDefId"
+    LEFT JOIN form_defs ON 
+        forms."currentDefId" = form_defs.id
+    ` : sql``}
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
       AND datasets."publishedAt" IS NOT NULL
  `);
 
+const _getLinkedForms = (datasetName, projectId) => sql`
+  SELECT f."xmlFormId", coalesce(fd.name, f."xmlFormId") "name" FROM form_attachments fa
+  JOIN forms f ON f.id = fa."formId"
+  JOIN form_defs fd ON f."currentDefId" = fd.id
+  JOIN datasets ds ON ds.id = fa."datasetId"
+  WHERE ds.name = ${datasetName} 
+    AND ds."projectId" = ${projectId}
+    AND ds."publishedAt" IS NOT NULL 
+`;
 
 // Creates or merges dataset, properties and field mapping.
 // Expects dataset:Frame auxed with `formDefId` and array of field:Frame auxed with `propertyName`
@@ -176,6 +193,53 @@ const getByName = (datasetName, projectId) => ({ all }) =>
     .then(makeHierarchy)
     .then(asArray)
     .then(nth(0))
+    .then(Option.of);
+
+// Returns dataset properties, creation forms and followup forms
+const getDatasetMetadata = (datasetName, projectId) => ({ all }) =>
+  Promise.all([
+    all(_getByNameSql(unjoiner(Dataset, Dataset.Property, Form, Form.Def).fields, datasetName, projectId, true)),
+    all(_getLinkedForms(datasetName, projectId))
+  ])
+    .then(([dsPropForms, linkedForms]) => { //dsPropForms is an array of rows that contains datasets, ds_properties, forms and form_defs columns
+
+      if (!dsPropForms || dsPropForms.length === 0) return null;
+
+      const propertiesMap = new Map();
+
+      const result = {
+        ...new Dataset(pickFrameFields(Dataset, dsPropForms[0])).forApi(),
+        linkedForms
+      };
+
+      // Lets populate dataset properties
+      for (const row of dsPropForms) {
+        const propertyName = row['ds_properties!name'];
+
+        // put property in the map if not there yet
+        if (!propertiesMap.has(propertyName)) {
+          propertiesMap.set(propertyName, {
+            ...new Dataset.Property(pickFrameFields(Dataset.Property, row)),
+            forms: []
+          });
+        }
+
+        const property = propertiesMap.get(propertyName);
+
+        // populate forms
+        if (row['forms!xmlFormId']) {
+          property.forms.push({
+            xmlFormId: row['forms!xmlFormId'],
+            name: row['form_defs!name'] || row['forms!xmlFormId']
+          });
+        }
+      }
+
+      // map to array conversion
+      result.properties = Array.from(propertiesMap.values());
+
+      return result;
+    })
     .then(Option.of);
 
 // Returns list of dataset for a given projectId
@@ -294,5 +358,6 @@ module.exports = {
   createOrMerge, publishIfExists,
   getById, getAllByProjectId, getByName,
   getFieldsByFormDefId, getPublishedProperties,
-  getDatasetDiff, getByProjectAndName
+  getDatasetDiff, getByProjectAndName,
+  getDatasetMetadata
 };

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -19,6 +19,13 @@ module.exports = (service, endpoint) => {
       .then((project) => auth.canOrReject('dataset.list', project))
       .then(() => Datasets.getAllByProjectId(params.id))));
 
+  service.get('/projects/:projectId/datasets/:name', endpoint(({ Datasets, Projects }, { params, auth }) =>
+    Projects.getById(params.projectId)
+      .then(getOrNotFound)
+      .then((project) => auth.canOrReject('dataset.list', project))
+      .then(() => Datasets.getDatasetMetadata(params.name, params.projectId)
+        .then(getOrNotFound))));
+
   service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)


### PR DESCRIPTION
Added new API `datasets/:name` that returns metadata of a dataset i.e. properties, forms that created properties and linked forms that consume the dataset.