### PR TITLE
Disable timeout when calling initialize()

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -94,16 +94,21 @@ const initialize = async () => {
   return withDefaults({ db, bcrypt, context }).transacting(populate);
 };
 
-before(initialize);
+// eslint-disable-next-line func-names, space-before-function-paren
+before(function() {
+  this.timeout(0);
+  return initialize();
+});
 
 let mustReinitAfter;
 beforeEach(() => {
   // eslint-disable-next-line keyword-spacing
   if(mustReinitAfter) throw new Error(`Failed to reinitalize after previous test: '${mustReinitAfter}'.  You may need to increase your mocha timeout.`);
 });
-afterEach(async () => {
-  // eslint-disable-next-line keyword-spacing
-  if(mustReinitAfter) {
+// eslint-disable-next-line func-names, space-before-function-paren
+afterEach(async function() {
+  this.timeout(0);
+  if (mustReinitAfter) {
     await initialize();
     mustReinitAfter = false;
   }


### PR DESCRIPTION
CircleCI has [failed](https://app.circleci.com/pipelines/github/getodk/central-backend/1307/workflows/4bb5130e-cb29-4534-8169-b1e57b0bfced/jobs/2130) (timed out) on `master`, and the error message points to a `before` hook in test/integration/setup.js that calls `initialize()`. I suspect that the `afterEach` hook that calls `initialize()` has the same issue: CircleCI timed out [here](https://app.circleci.com/pipelines/github/getodk/central-backend/1304/workflows/e7526ea9-e86f-440d-ab72-dbb09b5a1e2a/jobs/2123) for the test "should pass the container and event details to the job", but there's no `afterEach` hook in that file. The `afterEach` hook that calls `initialize()` is the only one in test/integration/setup.js.

In terms of why we're seeing these timeouts now, maybe #583 made things slightly slower? I think that PR was a necessary change, but since `initialize()` now connects to and destroys the database, maybe it's a little slower in some cases?

I tagged @sadiqkhoja for review since I think some of his recent builds have been affected by this, but I think anyone could take a look.