### PR TITLE
Create audit log entry when password is invalidated

### DIFF
--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -43,6 +43,9 @@ const invalidatePassword = (user) => ({ Sessions, run }) => Promise.all([
   run(sql`update users set password=null where "actorId"=${user.actor.id}`),
   Sessions.terminateByActorId(user.actorId)
 ]);
+invalidatePassword.audit = (user) => (log) => log('user.update', user.actor, {
+  data: { password: null }
+});
 
 const provisionPasswordResetToken = (user) => ({ Actors, Assignments, Sessions }) => {
   const expiresAt = new Date();

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -141,7 +141,9 @@ const augment = (service) => {
       return body.token;
     }));
     const proxies = tokens.map((token) => new Proxy(service, authProxy(token)));
-    return test != null ? test(...proxies) : proxies;
+    return test != null
+      ? test(...proxies)
+      : (Array.isArray(userOrUsers) ? proxies : proxies[0]);
   };
   return service;
 };


### PR DESCRIPTION
Closes #736.

#### What has been done to verify that this works as intended?

New integration test.

#### Why is this the best possible solution? Were any other approaches considered?

The biggest question to me was which action to use. I used `user.update` since changing a password also logs that action. This is how we describe `user.update` in the API docs:

> * `user.update` when User information is updated, like email or password.

I think that fits its new use in this PR.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is a targeted change, so regression risks should be low.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I think the current description of `user.update` in the API docs already fits its use in this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments