### PR TITLE
Update analytics for v2023.1

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -34,7 +34,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/submission",
         "formId": "odk-analytics",
-        "version": "2022.11.29.01"
+        "version": "2023.01.22.01"
       }
     }
   },

--- a/docs/api.md
+++ b/docs/api.md
@@ -3924,7 +3924,6 @@ An Administrator can use this endpoint to preview the metrics being sent. The pr
                   "recent":1,
                   "total":1
                 },
-                "backups_configured":1,
                 "database_size":12345,
                 ...
               },

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -29,7 +29,6 @@ const metricsTemplate = {
     "num_unique_managers": {},
     "num_unique_viewers": {},
     "num_unique_collectors": {},
-    "backups_configured": {},
     "database_size": {},
     "uses_external_db": 0
   },

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -104,9 +104,6 @@ where r."system" = 'formfill'`);
 const databaseSize = () => ({ one }) => one(sql`
 select pg_database_size(current_database()) as database_size`);
 
-const backupsEnabled = () => ({ one }) => one(sql`
-select count(*) as backups_configured from config where key = 'backups.main'`);
-
 // PER PROJECT
 // Users
 const countUsersPerRole = () => ({ all }) => all(sql`
@@ -555,7 +552,6 @@ const projectMetrics = () => (({ Analytics }) => Promise.all([
 
 const previewMetrics = () => (({ Analytics }) => Promise.all([
   Analytics.databaseSize(),
-  Analytics.backupsEnabled(),
   Analytics.encryptedProjects(),
   Analytics.biggestForm(),
   Analytics.countAdmins(),
@@ -565,13 +561,11 @@ const previewMetrics = () => (({ Analytics }) => Promise.all([
   Analytics.countUniqueViewers(),
   Analytics.countUniqueDataCollectors(),
   Analytics.projectMetrics()
-]).then(([db, backups, encrypt, bigForm, admins, audits,
+]).then(([db, encrypt, bigForm, admins, audits,
   archived, managers, viewers, collectors, projMetrics]) => {
   const metrics = clone(metricsTemplate);
   // system
   for (const [key, value] of Object.entries(db))
-    metrics.system[key] = value;
-  for (const [key, value] of Object.entries(backups))
     metrics.system[key] = value;
   for (const [key, value] of Object.entries(archived))
     metrics.system[key] = value;
@@ -603,7 +597,6 @@ const getLatestAudit = () => ({ maybeOne }) => maybeOne(sql`select * from audits
 module.exports = {
   archivedProjects,
   auditLogs,
-  backupsEnabled,
   biggestForm,
   databaseSize,
   databaseExternal,

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -857,10 +857,6 @@ describe('analytics task queries', () => {
     this.timeout(4000);
 
     it('should combine system level queries', testService(async (service, container) => {
-      // backups
-      // eslint-disable-next-line object-curly-spacing
-      await container.Configs.set('backups.main', { detail: 'dummy' });
-
       // encrypting a project
       await service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/key')

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -197,15 +197,6 @@ describe('analytics task queries', () => {
       res.database_size.should.be.above(0); // Probably around 13 MB?
     }));
 
-    it('should determine whether backups are enabled', testContainer(async ({ Analytics, Configs }) => {
-      let res = await Analytics.backupsEnabled();
-      res.backups_configured.should.equal(0);
-      // eslint-disable-next-line object-curly-spacing
-      await Configs.set('backups.main', { detail: 'dummy' });
-      res = await Analytics.backupsEnabled();
-      res.backups_configured.should.equal(1);
-    }));
-
     it('should check database configurations', testContainer(async ({ Analytics }) => {
       // only localhost (dev) and postgres (docker) should count as not external
       Analytics.databaseExternal('localhost').should.equal(0);


### PR DESCRIPTION
See getodk/central#350. The only change to the metrics is removing the `backups_configured` metric. I'm removing that metric because we're removing Google Drive backups (getodk/central#323), which means that backups will never be configured. (Direct backups will continue to work, but those aren't configured.)

#### What has been done to verify that this works as intended?

Tests. During regression testing, the QA team will verify that analytics are shown in Frontend and sent to data.getodk.cloud. I don't think that the team usually verifies specific changes to metrics, but they probably could do so here. If that sounds like it'd be useful, I could mark getodk/central#350 as "needs testing".

#### Why is this the best possible solution? Were any other approaches considered?

I think this is the first metric that we're removing, so I'm not totally sure what the best approach is. I think it makes sense to remove the `backups_configured` field entirely, since we will no longer collect data for it. I don't expect that the field will continue to be useful going forward. Another approach would be to keep the field, but send an empty string for it. However, I think it's cleaner to remove the field, and as we continue to add and remove metrics, I think we want the ability to decrease the size of the form and reduce noise. We will continue to be able to retrieve past submissions' values for this field if we need to. If we end up deciding we want the field back for any reason, we can reverse its removal in a new form version.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We should verify that analytics as a whole continue working. Users shouldn't be relying on the existence of a particular metric in analytics, so I don't think there's much risk of regression in removing this metric.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

The specific metrics we send for analytics aren't part of the stable API and aren't documented. There was an example response that included `backups_configured`, so I removed that there.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments