### PR TITLE
fix duplicate linked forms in dataset metadata endpoint

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -142,7 +142,7 @@ const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
  `);
 
 const _getLinkedForms = (datasetName, projectId) => sql`
-  SELECT f."xmlFormId", coalesce(fd.name, f."xmlFormId") "name" FROM form_attachments fa
+  SELECT DISTINCT f."xmlFormId", coalesce(fd.name, f."xmlFormId") "name" FROM form_attachments fa
   JOIN forms f ON f.id = fa."formId"
   JOIN form_defs fd ON f."currentDefId" = fd.id
   JOIN datasets ds ON ds.id = fa."datasetId"


### PR DESCRIPTION
Fixes duplicate linked forms in dataset metadata endpoint

#### What has been done to verify that this works as intended?
Added a test

#### Why is this the best possible solution? Were any other approaches considered?
NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
NA

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
Will be done separately

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments