### PR TITLE
Check for existing entity across submission defs for same submission

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -114,10 +114,6 @@ const processSubmissionEvent = (event) => (container) =>
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES
 
-const getDefBySubmissionDefId = (submissionDefId) => ({ maybeOne }) =>
-  maybeOne(sql`select * from entity_defs where "submissionDefId" = ${submissionDefId} limit 1`)
-    .then(map(construct(Entity.Def)));
-
 // This will check for an entity related to any def of the same submission
 // as the one specified. Used when trying to reapprove an edited submission.
 const getDefBySubmissionId = (submissionId) => ({ maybeOne }) =>
@@ -150,4 +146,4 @@ order by entities.id`)
 
 
 module.exports = { createNew, _processSubmissionDef, processSubmissionEvent, streamForExport,
-  getDefBySubmissionDefId, getDefBySubmissionId, getByUuid };
+  getDefBySubmissionId, getByUuid };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -63,8 +63,8 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as
 
 
 // Entrypoint to where submissions (a specific version) become entities
-const _processSubmissionDef = (submissionDefId) => async ({ Datasets, Entities, Submissions }) => {
-  const existingEntity = await Entities.getDefBySubmission(submissionDefId);
+const _processSubmissionDef = (submissionDefId, submissionId) => async ({ Datasets, Entities, Submissions }) => {
+  const existingEntity = await Entities.getDefBySubmissionId(submissionId);
   // If the submission has already been used to make an entity, don't try again
   // and don't log it as an error.
   if (existingEntity.isDefined())
@@ -86,7 +86,7 @@ const _processSubmissionDef = (submissionDefId) => async ({ Datasets, Entities, 
 
 const processSubmissionEvent = (event) => (container) =>
   container.db.transaction((trxn) =>
-    container.with({ db: trxn }).Entities._processSubmissionDef(event.details.submissionDefId))
+    container.with({ db: trxn }).Entities._processSubmissionDef(event.details.submissionDefId, event.details.submissionId))
     .then((entity) => {
       if (entity != null) {
         return container.Audits.log({ id: event.actorId }, 'entity.create', { acteeId: entity.aux.dataset.acteeId },
@@ -120,12 +120,11 @@ const getDefBySubmissionDefId = (submissionDefId) => ({ maybeOne }) =>
 
 // This will check for an entity related to any def of the same submission
 // as the one specified. Used when trying to reapprove an edited submission.
-const getDefBySubmission = (submissionDefId) => ({ maybeOne }) =>
+const getDefBySubmissionId = (submissionId) => ({ maybeOne }) =>
   maybeOne(sql`select ed.* from submissions as s
   join submission_defs as sd on s."id" = sd."submissionId"
-  join submission_defs as sd2 on s."id" = sd2."submissionId"
-  join entity_defs as ed on ed."submissionDefId" = sd2."id"
-  where sd.id = ${submissionDefId} limit 1`)
+  join entity_defs as ed on ed."submissionDefId" = sd."id"
+  where s.id = ${submissionId} limit 1`)
     .then(map(construct(Entity.Def)));
 
 const getByUuid = (uuid) => ({ maybeOne }) =>
@@ -151,4 +150,4 @@ order by entities.id`)
 
 
 module.exports = { createNew, _processSubmissionDef, processSubmissionEvent, streamForExport,
-  getDefBySubmissionDefId, getDefBySubmission, getByUuid };
+  getDefBySubmissionDefId, getDefBySubmissionId, getByUuid };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -64,7 +64,7 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as
 
 // Entrypoint to where submissions (a specific version) become entities
 const _processSubmissionDef = (submissionDefId) => async ({ Datasets, Entities, Submissions }) => {
-  const existingEntity = await Entities.getDefBySubmissionDefId(submissionDefId);
+  const existingEntity = await Entities.getDefBySubmission(submissionDefId);
   // If the submission has already been used to make an entity, don't try again
   // and don't log it as an error.
   if (existingEntity.isDefined())
@@ -118,6 +118,16 @@ const getDefBySubmissionDefId = (submissionDefId) => ({ maybeOne }) =>
   maybeOne(sql`select * from entity_defs where "submissionDefId" = ${submissionDefId} limit 1`)
     .then(map(construct(Entity.Def)));
 
+// This will check for an entity related to any def of the same submission
+// as the one specified. Used when trying to reapprove an edited submission.
+const getDefBySubmission = (submissionDefId) => ({ maybeOne }) =>
+  maybeOne(sql`select ed.* from submissions as s
+  join submission_defs as sd on s."id" = sd."submissionId"
+  join submission_defs as sd2 on s."id" = sd2."submissionId"
+  join entity_defs as ed on ed."submissionDefId" = sd2."id"
+  where sd.id = ${submissionDefId} limit 1`)
+    .then(map(construct(Entity.Def)));
+
 const getByUuid = (uuid) => ({ maybeOne }) =>
   maybeOne(sql`select * from entities where "uuid" = ${uuid} limit 1`)
     .then(map(construct(Entity)));
@@ -140,4 +150,5 @@ order by entities.id`)
     .then(stream.map(_exportUnjoiner));
 
 
-module.exports = { createNew, _processSubmissionDef, processSubmissionEvent, streamForExport, getDefBySubmissionDefId, getByUuid };
+module.exports = { createNew, _processSubmissionDef, processSubmissionEvent, streamForExport,
+  getDefBySubmissionDefId, getDefBySubmission, getByUuid };

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -822,7 +822,7 @@ describe('datasets and entities', () => {
               .expect(200))
             .then(() => container.Submissions.getCurrentDefByIds(1, 'simpleEntity', 'one', false)
               .then(getOrNotFound)
-              .then((subDef) => createEntityFromSubmission(container, { details: { submissionDefId: subDef.id, reviewState: 'approved' } })))
+              .then((subDef) => createEntityFromSubmission(container, { details: { submissionDefId: subDef.id, submissionId: subDef.submissionId, reviewState: 'approved' } })))
             .then(() => asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
               .send({ dataset: true })
               .expect(200))

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -132,7 +132,7 @@ describe('worker: entity', () => {
       // second event should look like it was processed.
       // also double-checking that there was a second event and another entity really was not made.
       const secondApproveEvent = await container.Audits.getLatestByAction('submission.update').then((o) => o.get());
-      should.exist(firstApproveEvent.processed);
+      should.exist(secondApproveEvent.processed);
       firstApproveEvent.id.should.not.equal(secondApproveEvent.id);
 
       // there should be no log of an entity-creation error
@@ -141,40 +141,40 @@ describe('worker: entity', () => {
     }));
 
     it('should not make an entity when reprocessing an edited submission', testService(async (service, container) => {
-      await service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.simpleEntity)
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .set('Content-Type', 'application/xml')
+        .expect(200)
+        .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one)
           .set('Content-Type', 'application/xml')
-          .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
-            .send(testData.instances.simpleEntity.one)
-            .set('Content-Type', 'application/xml')
-            .expect(200))
-          .then(() => asAlice.patch('/v1/projects/1/forms/simpleEntity/submissions/one')
-            .send({ reviewState: 'approved' })
-            .expect(200)));
+          .expect(200))
+        .then(() => asAlice.patch('/v1/projects/1/forms/simpleEntity/submissions/one')
+          .send({ reviewState: 'approved' })
+          .expect(200));
 
       await exhaust(container);
 
       const firstApproveEvent = await container.Audits.getLatestByAction('submission.update').then((o) => o.get());
       should.exist(firstApproveEvent.processed);
 
-      await service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/submission')
-          .set('X-OpenRosa-Version', '1.0')
-          .attach('xml_submission_file', Buffer.from(testData.instances.simpleEntity.one
-            .replace('<instanceID>one', '<deprecatedID>one</deprecatedID><instanceID>one2')),
-          { filename: 'data.xml' })
-          .expect(201)
-          .then(() => asAlice.patch('/v1/projects/1/forms/simpleEntity/submissions/one')
-            .send({ reviewState: 'approved' })
-            .expect(200)));
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .attach('xml_submission_file', Buffer.from(testData.instances.simpleEntity.one
+          .replace('<instanceID>one', '<deprecatedID>one</deprecatedID><instanceID>one2')),
+        { filename: 'data.xml' })
+        .expect(201)
+        .then(() => asAlice.patch('/v1/projects/1/forms/simpleEntity/submissions/one')
+          .send({ reviewState: 'approved' })
+          .expect(200));
 
       await exhaust(container);
 
       const secondApproveEvent = await container.Audits.getLatestByAction('submission.update').then((o) => o.get());
       firstApproveEvent.id.should.not.equal(secondApproveEvent.id);
-      should.exist(firstApproveEvent.processed);
+      should.exist(secondApproveEvent.processed);
 
       // there should be no log of an entity-creation error
       const errorEvent = await container.Audits.getLatestByAction('entity.create.error');


### PR DESCRIPTION
Closes #729. This is to make the server not log an error when reapproving an edited submission that was already made into an entity.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Wrote a test to mimic scenario where this came up. It failed and then with the code change, it passes.

#### Why is this the best possible solution? Were any other approaches considered?

It's ok for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Not very risky.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No.
#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes