### PR TITLE
Allows task frequencies for purging and analytics to be set in config

### DIFF
--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -590,8 +590,11 @@ const previewMetrics = () => (({ Analytics }) => Promise.all([
   return metrics;
 }));
 
-// Get most recent 'analytics' audit from the past 30 days
-const AUDIT_SCHEDULE = 30;
+// Get most recent 'analytics' audit from the past N days
+const AUDIT_SCHEDULE = config.has('default.taskSchedule.analytics')
+  ? config.get('default.taskSchedule.analytics')
+  : 30; // Default is 30 days
+
 const getLatestAudit = () => ({ maybeOne }) => maybeOne(sql`select * from audits
   where action='analytics' and "loggedAt" >= current_date - cast(${AUDIT_SCHEDULE} as int)
   order by "loggedAt" desc limit 1`);

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -7,6 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
+const config = require('config');
 const { sql } = require('slonik');
 const { map, compose } = require('ramda');
 const { Frame, into } = require('../frame');
@@ -269,7 +270,10 @@ restore.audit = (form) => (log) => log('form.restore', form);
 //    (useful to purge forms immediately for testing or other time sensitive scenarios)
 // 3. by a specific form id if deletedAt is also set (again for testing or potential future scenarios)
 
-const DAY_RANGE = 30;
+const DAY_RANGE = config.has('default.taskSchedule.purge')
+  ? config.get('default.taskSchedule.purge')
+  : 30; // Default is 30 days
+
 const _trashedFilter = (force, id, projectId) => {
   const idFilter = (id
     ? sql`and forms.id = ${id}`


### PR DESCRIPTION
To enable, add to `default` in config:
```
"taskSchedule": {
  "purge": 1,
  "analytics": 1
}
```

Otherwise default remains set to 30 days.

Closes #713

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I tried setting the numbers through the config and printing them out? Not sure how to write a test or if it's necessary. We don't test other server config settings. 

#### Why is this the best possible solution? Were any other approaches considered?

It's pretty simple.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Not really for users, more for QA to use. Since the default time ranges aren't even being added to the config, most people won't even notice this.

Should there be some sanitization of these values? 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

no.