### PR TITLE
Have service.login() call expect(200)

### DIFF
--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -96,8 +96,9 @@ describe('api: /users', () => {
         asAlice.post('/v1/users')
           .send({ email: 'david@getodk.org', password: '' })
           .expect(200) // treats a blank password as no password provided
-          .then(() => service.login({ email: 'david@getodk.org', password: '' }, (failed) =>
-            failed.get('/v1/users/current').expect(401))))));
+          .then(() => service.post('/v1/sessions')
+            .send({ email: 'david@getodk.org', password: '' })
+            .expect(400)))));
 
     it('should not accept a password that is too short', testService((service) =>
       service.login('alice', (asAlice) =>

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -131,7 +131,9 @@ const augment = (service) => {
       const credentials = (typeof user === 'string')
         ? { email: `${user}@getodk.org`, password: user }
         : user;
-      const { body } = await service.post('/v1/sessions').send(credentials);
+      const { body } = await service.post('/v1/sessions')
+        .send(credentials)
+        .expect(200);
       return body.token;
     }));
     const proxies = tokens.map((token) => new Proxy(service, authProxy(token)));


### PR DESCRIPTION
This PR updates `service.login()` to call `expect(200)` after it sends a request to create a session. I somehow managed to misspell alice in a test 😅 and adding this `expect()` call helped me figure out what was going wrong. Making this change means that the error message will be more informative. I also think that setting the expectation that the session request is successful makes it easier to reason about what `service.login()` does. `service.login()` retrieves the `token` property from the response body, so if the response isn't a 200, I think things get confusing.

However, there was one test that actually expected that the session request sent by `service.login()` would fail. I rewrote that part of the test, and I think doing so actually made the test clearer as well.