### PR TITLE
Check for meta group on form upload

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -170,9 +170,6 @@ const createVersion = (partial, form, publish = false, duplicating = false) => a
     if (match)
       schemaId = prevFields[0].schemaId;
     else {
-      // Check that meta field (group containing instanceId and name) exists
-      await Forms.checkMeta(fields);
-
       // Only need to check new fields against old fields if the structure does not match
       const allFields = await Forms.getMergedFields(form.id);
       await Forms.checkFieldDowncast(allFields, fields);
@@ -623,8 +620,10 @@ order by actors."displayName" asc`)
 ////////////////////////////////////////////////////////////////////////////////
 // CHECKING CONSTRAINTS, STRUCTURAL CHANGES, ETC.
 
+// This will check if a form contains a meta group (for capturing instanceID).
+// It is only to be used for newly uploaded forms.
 const checkMeta = (fields) => () =>
-  (fields.some((f) => f.name === 'meta')
+  (fields.some((f) => (f.name === 'meta' && f.type === 'structure'))
     ? resolve()
     : reject(Problem.user.missingMeta()));
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -75,6 +75,9 @@ const createNew = (partial, project, publish = false) => async ({ run, Datasets,
     (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml)) // Don't parse dataset schema if Form has encryption key
   ]);
 
+  // Check that meta field (group containing instanceId and name) exists
+  await Forms.checkMeta(fields);
+
   // Check for xmlFormId collisions with previously deleted forms
   await Forms.checkDeletedForms(partial.xmlFormId, project.id);
   await Forms.rejectIfWarnings();
@@ -167,6 +170,9 @@ const createVersion = (partial, form, publish = false, duplicating = false) => a
     if (match)
       schemaId = prevFields[0].schemaId;
     else {
+      // Check that meta field (group containing instanceId and name) exists
+      await Forms.checkMeta(fields);
+
       // Only need to check new fields against old fields if the structure does not match
       const allFields = await Forms.getMergedFields(form.id);
       await Forms.checkFieldDowncast(allFields, fields);
@@ -617,6 +623,11 @@ order by actors."displayName" asc`)
 ////////////////////////////////////////////////////////////////////////////////
 // CHECKING CONSTRAINTS, STRUCTURAL CHANGES, ETC.
 
+const checkMeta = (fields) => () =>
+  (fields.some((f) => f.name === 'meta')
+    ? resolve()
+    : reject(Problem.user.missingMeta()));
+
 const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => (context.query.ignoreWarnings ? resolve() : maybeOne(sql`SELECT 1 FROM forms WHERE "xmlFormId" = ${xmlFormId} AND "projectId" = ${projectId} AND "deletedAt" IS NOT NULL LIMIT 1`)
   .then(deletedForm => {
     if (deletedForm.isDefined()) {
@@ -681,7 +692,7 @@ module.exports = {
   getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
-  rejectIfWarnings, checkDeletedForms, checkStructuralChange, checkFieldDowncast,
+  rejectIfWarnings, checkMeta, checkDeletedForms, checkStructuralChange, checkFieldDowncast,
   _newSchema,
   lockDefs, getAllSubmitters
 };

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -108,6 +108,9 @@ const problems = {
     // problem parsing the entity form
     datasetLinkNotAllowed: problem(400.26, () => 'Dataset can only be linked to attachments with "Data File" type.'),
 
+    // meta group in form definition is missing
+    missingMeta: problem(400.27, () => 'The form does not contain a \'meta\' group.'),
+
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),
 

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -173,11 +173,15 @@ module.exports = {
     <model>
       <instance>
         <data id="withAttachments">
+          <meta>
+            <instanceID/>
+          </meta>
           <name/>
           <age/>
           <hometown/>
         </data>
       </instance>
+      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
       <instance id="mydata" src="badnoroot.xls"/>
       <instance id="seconddata" src="jr://files/badsubpath.csv"/>
       <instance id="thirddata" src="jr://file/goodone.csv"/>
@@ -202,10 +206,14 @@ module.exports = {
     <model>
       <instance>
         <data id="itemsets">
+          <meta>
+            <instanceID/>
+          </meta>
           <name/>
         </data>
       </instance>
       <instance id="itemsets" src="jr://file/itemsets.csv"/>
+      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
       <bind nodeset="/data/name" type="string"/>
     </model>
   </h:head>
@@ -316,10 +324,14 @@ module.exports = {
     <model>
       <instance>
         <data id="selectMultiple">
+          <meta>
+            <instanceID/>
+          </meta>
           <q1/>
           <g1><q2/></g1>
         </data>
       </instance>
+      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
       <bind nodeset="/data/q1" type="string"/>
       <bind nodeset="/data/g1/q2" type="string"/>
     </model>

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -407,7 +407,10 @@ describe('api: /projects/:id/forms (drafts)', () => {
               .expect(200)))));
 
 
-      it('should reject new draft with missing meta group', testService(async (service) => {
+      it('should allow new draft with missing meta group', testService(async (service) => {
+        // This case is not expected, but it mimics a different scenario where there are
+        // already meta-less forms in a user's central repo and they need to be able to update them
+        // without breaking their workflows.
         const asAlice = await service.login('alice');
 
         const simpleMissingMeta = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
@@ -429,7 +432,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         await asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
           .send(simpleMissingMeta)
           .set('Content-Type', 'application/xml')
-          .expect(400);
+          .expect(200);
       }));
 
       it('should identify attachments', testService((service) =>

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -406,6 +406,32 @@ describe('api: /projects/:id/forms (drafts)', () => {
               .set('Content-Type', 'application/xml')
               .expect(200)))));
 
+
+      it('should reject new draft with missing meta group', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        const simpleMissingMeta = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+          <h:head>
+            <h:title>Simple</h:title>
+            <model>
+              <instance>
+                <data id="simple">
+                  <name/>
+                  <age/>
+                </data>
+              </instance>
+              <bind nodeset="/data/name" type="string"/>
+              <bind nodeset="/data/age" type="int"/>
+            </model>
+          </h:head>
+        </h:html>`;
+
+        await asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')
+          .send(simpleMissingMeta)
+          .set('Content-Type', 'application/xml')
+          .expect(400);
+      }));
+
       it('should identify attachments', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms/simple/draft?ignoreWarnings=true')

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -438,8 +438,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         });
     }));
 
-    it('should reject with missing meta group', testService(async (service) => {
-      const asAlice = await service.login('alice', identity);
+    it('should reject form with missing meta group', testService(async (service) => {
+      const asAlice = await service.login('alice');
 
       const missingMeta = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
       <h:head>
@@ -447,6 +447,33 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         <model>
           <instance>
             <data id="missingMeta">
+              <name/>
+              <age/>
+            </data>
+          </instance>
+          <bind nodeset="/data/name" type="string"/>
+          <bind nodeset="/data/age" type="int"/>
+        </model>
+      </h:head>
+
+    </h:html>`;
+
+      await asAlice.post('/v1/projects/1/forms')
+        .send(missingMeta)
+        .set('Content-Type', 'application/xml')
+        .expect(400);
+    }));
+
+    it('should reject form with meta field that is not a group', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      const missingMeta = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+      <h:head>
+        <h:title>Non Group Meta</h:title>
+        <model>
+          <instance>
+            <data id="missingMeta">
+              <meta/>
               <name/>
               <age/>
             </data>

--- a/test/integration/api/forms/list.js
+++ b/test/integration/api/forms/list.js
@@ -328,7 +328,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
       <formID>withAttachments</formID>
       <name>withAttachments</name>
       <version></version>
-      <hash>md5:7eb21b5b123b0badcf2b8f50bcf1cbd0</hash>
+      <hash>md5:dda89055c8fec222458f702aead30a83</hash>
       <downloadUrl>${domain}/v1/projects/1/forms/withAttachments.xml</downloadUrl>
       <manifestUrl>${domain}/v1/projects/1/forms/withAttachments/manifest</manifestUrl>
     </xform>

--- a/test/integration/api/forms/test.js
+++ b/test/integration/api/forms/test.js
@@ -120,7 +120,7 @@ describe('api: /projects/:id/forms (testing drafts)', () => {
       <formID>withAttachments</formID>
       <name>withAttachments</name>
       <version></version>
-      <hash>md5:7eb21b5b123b0badcf2b8f50bcf1cbd0</hash>
+      <hash>md5:dda89055c8fec222458f702aead30a83</hash>
       <downloadUrl>${domain}/v1/test/${token}/projects/1/forms/withAttachments/draft.xml</downloadUrl>
       <manifestUrl>${domain}/v1/test/${token}/projects/1/forms/withAttachments/draft/manifest</manifestUrl>
     </xform>

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1575,11 +1575,11 @@ describe('api: /forms/:id/submissions', () => {
             .then((result) => {
               result.filenames.should.containDeep([ 'selectMultiple.csv' ]);
               const lines = result['selectMultiple.csv'].split('\n');
-              lines[0].should.equal('SubmissionDate,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+              lines[0].should.equal('SubmissionDate,meta-instanceID,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
               lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',b,0,1,m x,1,1,0,0,two,5,Alice,0,0,,,,0,');
+                .should.equal(',two,b,0,1,m x,1,1,0,0,two,5,Alice,0,0,,,,0,');
               lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',a b,1,1,x y z,0,1,1,1,one,5,Alice,0,0,,,,0,');
+                .should.equal(',one,a b,1,1,x y z,0,1,1,1,one,5,Alice,0,0,,,,0,');
             })))));
 
     it('should omit multiples it does not know about', testService((service) =>
@@ -1597,11 +1597,11 @@ describe('api: /forms/:id/submissions', () => {
             .then((result) => {
               result.filenames.should.containDeep([ 'selectMultiple.csv' ]);
               const lines = result['selectMultiple.csv'].split('\n');
-              lines[0].should.equal('SubmissionDate,q1,g1-q2,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+              lines[0].should.equal('SubmissionDate,meta-instanceID,q1,g1-q2,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
               lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',b,m x,two,5,Alice,0,0,,,,0,');
+                .should.equal(',two,b,m x,two,5,Alice,0,0,,,,0,');
               lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',a b,x y z,one,5,Alice,0,0,,,,0,');
+                .should.equal(',one,a b,x y z,one,5,Alice,0,0,,,,0,');
             })))));
 
     it('should split select multiples and filter given both options', testService((service, container) =>
@@ -1741,11 +1741,11 @@ describe('api: /forms/:id/submissions', () => {
             .then((result) => {
               result.filenames.should.containDeep([ 'selectMultiple.csv' ]);
               const lines = result['selectMultiple.csv'].split('\n');
-              lines[0].should.equal('SubmissionDate,q1,q1/a,q1/b,q2,q2/m,q2/x,q2/y,q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+              lines[0].should.equal('SubmissionDate,instanceID,q1,q1/a,q1/b,q2,q2/m,q2/x,q2/y,q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
               lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',b,0,1,m x,1,1,0,0,two,5,Alice,0,0,,,,0,');
+                .should.equal(',two,b,0,1,m x,1,1,0,0,two,5,Alice,0,0,,,,0,');
               lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',a b,1,1,x y z,0,1,1,1,one,5,Alice,0,0,,,,0,');
+                .should.equal(',one,a b,1,1,x y z,0,1,1,1,one,5,Alice,0,0,,,,0,');
             })))));
 
     it('should properly count present attachments', testService((service) =>
@@ -2186,11 +2186,11 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             // eslint-disable-next-line no-multi-spaces
             .then(({ text }) =>  {
               const lines = text.split('\n');
-              lines[0].should.equal('SubmissionDate,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+              lines[0].should.equal('SubmissionDate,meta-instanceID,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
               lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',b,0,1,m x,1,1,0,0,two,5,Alice,0,0,,,,0,');
+                .should.equal(',two,b,0,1,m x,1,1,0,0,two,5,Alice,0,0,,,,0,');
               lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',a b,1,1,x y z,0,1,1,1,one,5,Alice,0,0,,,,0,');
+                .should.equal(',one,a b,1,1,x y z,0,1,1,1,one,5,Alice,0,0,,,,0,');
             })))));
 
     it('should omit group paths if ?groupPaths=false is given', testService((service) =>
@@ -2279,11 +2279,13 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                     <model>
                       <instance>
                         <data id="selectMultiple" version='3'>
+                          <meta><instanceID/></meta>
                           <q1/>
                           <g1><q2/></g1>
                           <q3/>
                         </data>
                       </instance>
+                      <bind nodeset="/data/meta/instanceID" type="string"/>
                       <bind nodeset="/data/q1" type="string"/>
                       <bind nodeset="/data/g1/q2" type="string"/>
                       <bind nodeset="/data/q3" type="string"/>
@@ -2323,13 +2325,13 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
               .expect(200)
               .then(({ text }) => {
                 const lines = text.split('\n');
-                lines[0].should.equal('SubmissionDate,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,q3,q3/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+                lines[0].should.equal('SubmissionDate,meta-instanceID,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,q3,q3/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
                 lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                  .should.equal(',a b,1,1,m,1,0,0,0,z,1,three,5,Alice,0,0,,,,0,3');
+                  .should.equal(',three,a b,1,1,m,1,0,0,0,z,1,three,5,Alice,0,0,,,,0,3');
                 lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                  .should.equal(',b,0,1,m x,1,1,0,0,,0,two,5,Alice,0,0,,,,0,');
+                  .should.equal(',two,b,0,1,m x,1,1,0,0,,0,two,5,Alice,0,0,,,,0,');
                 lines[3].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                  .should.equal(',a b,1,1,x y z,0,1,1,1,,0,one,5,Alice,0,0,,,,0,');
+                  .should.equal(',one,a b,1,1,x y z,0,1,1,1,,0,one,5,Alice,0,0,,,,0,');
               })))));
     });
   });
@@ -2471,11 +2473,11 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             .then((result) => {
               result.filenames.should.containDeep([ 'selectMultiple.csv' ]);
               const lines = result['selectMultiple.csv'].split('\n');
-              lines[0].should.equal('SubmissionDate,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+              lines[0].should.equal('SubmissionDate,meta-instanceID,q1,q1/a,q1/b,g1-q2,g1-q2/m,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
               lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',b,0,1,m x,1,1,0,0,two,,,0,0,,,,0,');
+                .should.equal(',two,b,0,1,m x,1,1,0,0,two,,,0,0,,,,0,');
               lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-                .should.equal(',a b,1,1,x y z,0,1,1,1,one,,,0,0,,,,0,');
+                .should.equal(',one,a b,1,1,x y z,0,1,1,1,one,,,0,0,,,,0,');
             })))));
   });
 

--- a/test/integration/other/select-many.js
+++ b/test/integration/other/select-many.js
@@ -94,10 +94,12 @@ describe('select many value processing', () => {
           <model>
             <instance>
               <data id="selectMultiple">
+                <meta><instanceID/></meta>
                 <q1/>
                 <g1><q2/></g1>
               </data>
             </instance>
+            <bind nodeset="/data/meta/instanceID" type="string"/>
             <bind nodeset="/data/q1" type="string"/>
             <bind nodeset="/data/g1/q2" type="string"/>
           </model>
@@ -143,11 +145,11 @@ describe('select many value processing', () => {
       .expect(200)
       .then(({ text }) => {
         const lines = text.split('\n');
-        lines[0].should.equal('SubmissionDate,q1,q1/a,q1/b,g1-q2,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
+        lines[0].should.equal('SubmissionDate,meta-instanceID,q1,q1/a,q1/b,g1-q2,g1-q2/x,g1-q2/y,g1-q2/z,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion');
         lines[1].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-          .should.equal(',a b,1,1,x y z,1,1,1,one,5,Alice,0,0,,,,0,2');
+          .should.equal(',one,a b,1,1,x y z,1,1,1,one,5,Alice,0,0,,,,0,2');
         lines[2].slice('yyyy-mm-ddThh:mm:ss._msZ'.length)
-          .should.equal(',b,0,1,x,1,0,0,two,5,Alice,0,0,,,,0,');
+          .should.equal(',two,b,0,1,x,1,0,0,two,5,Alice,0,0,,,,0,');
       });
   }));
 });

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -21,7 +21,7 @@ const instance = (id, data, formVersion = 'version') => ({
   instanceId: id,
   createdAt: new Date('2018-01-01T00:00:00Z'),
   def: {},
-  xml: `<data id="data">${data}</data>`,
+  xml: `<data id="data"><meta><instanceID>${id}</instanceID></meta>${data}</data>`,
   aux: { attachment: { present: 0, expected: 0 }, encryption: {}, edit: { count: 0 }, exports: { formVersion } }
 });
 
@@ -417,9 +417,9 @@ describe('.csv.zip briefcase output @slow', () => {
 
         result.filenames.should.eql([ 'selectMultiple.csv' ]);
         result['selectMultiple.csv'].should.equal(
-          `SubmissionDate,q1,q1/x,q1/y,q1/z,g1-q2,g1-q2/m,g1-q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
-2018-01-01T00:00:00.000Z,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0,version
-2018-01-01T00:00:00.000Z,b,0,0,0,m x,1,0,two,,,0,0,,,,0,version
+          `SubmissionDate,meta-instanceID,q1,q1/x,q1/y,q1/z,g1-q2,g1-q2/m,g1-q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,one,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,two,b,0,0,0,m x,1,0,two,,,0,0,,,,0,version
 `); // eslint-disable-line function-paren-newline
         done();
       });
@@ -457,9 +457,9 @@ describe('.csv.zip briefcase output @slow', () => {
       </h:html>`;
 
     const inStream = streamTest.fromObjects([
-      instance('one', '<orx:meta><orx:instanceID>one</orx:instanceID></orx:meta><name>Alice</name><home><type>Apartment</type><address><street>101 Pike St</street><city>Seattle, WA</city></address></home>'),
-      instance('two', '<orx:meta><orx:instanceID>two</orx:instanceID></orx:meta><name>Bob</name><home><address><street>20 Broadway</street><city>Portland, OR</city></address><type>Condo</type></home>'),
-      instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><home><type>House</type><address><city>San Francisco, CA</city><street>99 Mission Ave</street></address></home>'),
+      instance('one', '<name>Alice</name><home><type>Apartment</type><address><street>101 Pike St</street><city>Seattle, WA</city></address></home>'),
+      instance('two', '<name>Bob</name><home><address><street>20 Broadway</street><city>Portland, OR</city></address><type>Condo</type></home>'),
+      instance('three', '<name>Chelsea</name><home><type>House</type><address><city>San Francisco, CA</city><street>99 Mission Ave</street></address></home>'),
     ]);
 
     callAndParse(inStream, formXml, 'structuredform', (err, result) => {
@@ -508,9 +508,9 @@ describe('.csv.zip briefcase output @slow', () => {
       </h:html>`;
 
     const inStream = streamTest.fromObjects([
-      instance('one', '<orx:meta><orx:instanceID>one</orx:instanceID></orx:meta><name>Alice</name><home><type>Apartment</type><address><street>101 Pike St</street><city>Seattle, WA</city></address></home>'),
-      instance('two', '<orx:meta><orx:instanceID>two</orx:instanceID></orx:meta><name>Bob</name><home><address><street>20 Broadway</street><city>Portland, OR</city></address><type>Condo</type></home>'),
-      instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><home><type>House</type><address><city>San Francisco, CA</city><street>99 Mission Ave</street></address></home>'),
+      instance('one', '<name>Alice</name><home><type>Apartment</type><address><street>101 Pike St</street><city>Seattle, WA</city></address></home>'),
+      instance('two', '<name>Bob</name><home><address><street>20 Broadway</street><city>Portland, OR</city></address><type>Condo</type></home>'),
+      instance('three', '<name>Chelsea</name><home><type>House</type><address><city>San Francisco, CA</city><street>99 Mission Ave</street></address></home>'),
     ]);
 
     fieldsFor(formXml).then((fields) => {
@@ -543,9 +543,9 @@ describe('.csv.zip briefcase output @slow', () => {
 
         result.filenames.should.eql([ 'selectMultiple.csv' ]);
         result['selectMultiple.csv'].should.equal(
-          `SubmissionDate,q1,q1/x,q1/y,q1/z,q2,q2/m,q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
-2018-01-01T00:00:00.000Z,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0,version
-2018-01-01T00:00:00.000Z,b,0,0,0,m x,1,0,two,,,0,0,,,,0,version
+          `SubmissionDate,instanceID,q1,q1/x,q1/y,q1/z,q2,q2/m,q2/n,KEY,SubmitterID,SubmitterName,AttachmentsPresent,AttachmentsExpected,Status,ReviewState,DeviceID,Edits,FormVersion
+2018-01-01T00:00:00.000Z,one,a b,0,0,0,x y z,0,0,one,,,0,0,,,,0,version
+2018-01-01T00:00:00.000Z,two,b,0,0,0,m x,1,0,two,,,0,0,,,,0,version
 `); // eslint-disable-line function-paren-newline
         done();
       });
@@ -602,9 +602,9 @@ describe('.csv.zip briefcase output @slow', () => {
       </h:html>`;
 
     const inStream = streamTest.fromObjects([
-      instance('one', '<orx:meta><orx:instanceID>one</orx:instanceID></orx:meta><name>Alice</name><age>30</age>'),
-      instance('two', '<orx:meta><orx:instanceID>two</orx:instanceID></orx:meta><name>Bob</name><age>34</age><children><child><name>Billy</name><age>4</age></child></children><children><child><name>Blaine</name><age>6</age></child></children>'),
-      instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><age>38</age><children><child><name>Candace</name><age>2</age></child></children>'),
+      instance('one', '<name>Alice</name><age>30</age>'),
+      instance('two', '<name>Bob</name><age>34</age><children><child><name>Billy</name><age>4</age></child></children><children><child><name>Blaine</name><age>6</age></child></children>'),
+      instance('three', '<name>Chelsea</name><age>38</age><children><child><name>Candace</name><age>2</age></child></children>'),
     ]);
 
     callAndParse(inStream, formXml, 'singlerepeat', (err, result) => {
@@ -745,9 +745,9 @@ Candace,2,three,three/children/child[1]
       </h:html>`;
 
     const inStream = streamTest.fromObjects([
-      instance('one', '<orx:meta><orx:instanceID>one</orx:instanceID></orx:meta><name>Alice</name><age>30</age>'),
-      instance('two', '<orx:meta><orx:instanceID>two</orx:instanceID></orx:meta><name>Bob</name><age>34</age><children><child><name>Billy</name><age>4</age><toy><name>R2-D2</name></toy></child><child><name>Blaine</name><age>6</age><toy><name>BB-8</name></toy><toy><name>Porg plushie</name></toy></child><child><name>Baker</name><age>7</age></child></children>'),
-      instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><age>38</age><children><child><name>Candace</name><toy><name>Millennium Falcon</name></toy><toy><name>X-Wing</name></toy><toy><name>Pod racer</name></toy><age>2</age></child></children>'),
+      instance('one', '<name>Alice</name><age>30</age>'),
+      instance('two', '<name>Bob</name><age>34</age><children><child><name>Billy</name><age>4</age><toy><name>R2-D2</name></toy></child><child><name>Blaine</name><age>6</age><toy><name>BB-8</name></toy><toy><name>Porg plushie</name></toy></child><child><name>Baker</name><age>7</age></child></children>'),
+      instance('three', '<name>Chelsea</name><age>38</age><children><child><name>Candace</name><toy><name>Millennium Falcon</name></toy><toy><name>X-Wing</name></toy><toy><name>Pod racer</name></toy><age>2</age></child></children>'),
     ]);
 
     callAndParse(inStream, formXml, 'multirepeat', (err, result) => {
@@ -1119,9 +1119,9 @@ some text 3.1.4,uuid:0a1b861f-a5fd-4f49-846a-78dcf06cfc1b/g1[3]/g2[1],uuid:0a1b8
       </h:html>`;
 
     const inStream = streamTest.fromObjects([
-      instance('one', '<orx:meta><orx:instanceID>one</orx:instanceID></orx:meta><name>Alice</name>'),
-      instance('two', '<orx:meta><orx:instanceID>two</orx:instanceID></orx:meta><name>Bob</name><jobs><entry><name>Bobs Hardware</name></entry><entry><name>Local Coffee</name></entry></jobs><friends><entry><name>Nasrin</name></entry></friends>'),
-      instance('three', '<orx:meta><orx:instanceID>three</orx:instanceID></orx:meta><name>Chelsea</name><jobs><entry><name>Instantaneous Food</name></entry></jobs><friends><entry><name>Ferrence</name></entry><entry><name>Mick</name></entry></friends>'),
+      instance('one', '<name>Alice</name>'),
+      instance('two', '<name>Bob</name><jobs><entry><name>Bobs Hardware</name></entry><entry><name>Local Coffee</name></entry></jobs><friends><entry><name>Nasrin</name></entry></friends>'),
+      instance('three', '<name>Chelsea</name><jobs><entry><name>Instantaneous Food</name></entry></jobs><friends><entry><name>Ferrence</name></entry><entry><name>Mick</name></entry></friends>'),
     ]);
 
     callAndParse(inStream, formXml, 'ambiguous', (err, result) => {


### PR DESCRIPTION
This PR addresses a situation (maybe this should become an issue but it's also not that big of a deal) where the submission view page on Frontend failed to load when showing a submission for a form without a `<meta/>` tag (generally containing the instance ID). We expect forms in the present day to all include meta information, but in case they don't, this change will now reject the uploading of forms that are missing the meta group.


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Another option is leaving the code as is and not checking. I think the biggest risk is for us as developers - it's more code to maintain. And many of the old tests didn't have meta information so I had to go through and update them. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

*Edited to add*: For forms that are already in the system, this might cause problems when trying to make a new draft of a meta-less form. 

It should prevent the uploading of a form without `<meta><instanceID/></meta>`, which was a condition that would break a small part of frontend (the submission viewing page).

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I don't think so; I think this is part of the xform spec already. 

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments