### PR TITLE
Return specific Problem when form version in submission not found

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -10,13 +10,13 @@
 const config = require('config');
 const { sql } = require('slonik');
 const { map, compose } = require('ramda');
-const { Frame, into } = require('../frame');
+const { Frame, into, ensureDef } = require('../frame');
 const { Actor, Blob, Form, Dataset } = require('../frames');
 const { getFormFields, merge, compare } = require('../../data/schema');
 const { getDataset } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
-const { resolve, reject } = require('../../util/promise');
+const { resolve, reject, getOrNotFound } = require('../../util/promise');
 const { splitStream } = require('../../util/stream');
 const { construct, noop } = require('../../util/util');
 const Option = require('../../util/option');
@@ -686,6 +686,24 @@ const checkFieldDowncast = (allFields, fields) => () => {
   return resolve();
 };
 
+// This is replacing ensureDef(form) in some places (accepting submissions)
+// If the form has a form def, all is well. If the def is missing, we can find
+// the form but not the def matching the specific constraints, suggesting that
+// the provided form version probably doesn't match.
+// This is only for checking versions in submissions to published forms. Draft
+// form/submissions don't require the a version to match.
+const checkWrongFormVersion = (form, version) => ({ Forms }) => {
+  if (form.def.id != null)
+    return form;
+  // Check again for form and form def, this time just looking at the published version.
+  // If they exist, reject with a message about getting the form version wrong.
+  // If they don't exist, reject for the standard reasons.
+  return Forms.getByProjectAndXmlFormId(form.projectId, form.xmlFormId, Form.PublishedVersion)
+    .then(getOrNotFound)
+    .then(ensureDef)
+    .then(() => reject(Problem.user.formVersionNotFound({ formVersion: version })));
+};
+
 const _newSchema = () => ({ one }) =>
   one(sql`insert into form_schemas (id) values (default) returning *`)
     .then((s) => s.id);
@@ -699,6 +717,7 @@ module.exports = {
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,
   getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
+  checkWrongFormVersion,
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
   rejectIfWarnings, checkMeta, checkDeletedForms, checkStructuralChange, checkFieldDowncast,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -10,13 +10,13 @@
 const config = require('config');
 const { sql } = require('slonik');
 const { map, compose } = require('ramda');
-const { Frame, into, ensureDef } = require('../frame');
+const { Frame, into } = require('../frame');
 const { Actor, Blob, Form, Dataset } = require('../frames');
 const { getFormFields, merge, compare } = require('../../data/schema');
 const { getDataset } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
-const { resolve, reject, getOrNotFound } = require('../../util/promise');
+const { resolve, reject } = require('../../util/promise');
 const { splitStream } = require('../../util/stream');
 const { construct, noop } = require('../../util/util');
 const Option = require('../../util/option');
@@ -686,24 +686,6 @@ const checkFieldDowncast = (allFields, fields) => () => {
   return resolve();
 };
 
-// This is replacing ensureDef(form) in some places (accepting submissions)
-// If the form has a form def, all is well. If the def is missing, we can find
-// the form but not the def matching the specific constraints, suggesting that
-// the provided form version probably doesn't match.
-// This is only for checking versions in submissions to published forms. Draft
-// form/submissions don't require the a version to match.
-const checkWrongFormVersion = (form, version) => ({ Forms }) => {
-  if (form.def.id != null)
-    return form;
-  // Check again for form and form def, this time just looking at the published version.
-  // If they exist, reject with a message about getting the form version wrong.
-  // If they don't exist, reject for the standard reasons.
-  return Forms.getByProjectAndXmlFormId(form.projectId, form.xmlFormId, Form.PublishedVersion)
-    .then(getOrNotFound)
-    .then(ensureDef)
-    .then(() => reject(Problem.user.formVersionNotFound({ formVersion: version })));
-};
-
 const _newSchema = () => ({ one }) =>
   one(sql`insert into form_schemas (id) values (default) returning *`)
     .then((s) => s.id);
@@ -717,7 +699,6 @@ module.exports = {
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,
   getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
-  checkWrongFormVersion,
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
   rejectIfWarnings, checkMeta, checkDeletedForms, checkStructuralChange, checkFieldDowncast,

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -120,7 +120,7 @@ module.exports = (service, endpoint) => {
   openRosaSubmission('/projects/:projectId/submission', false, (auth, { projectId }, xmlFormId, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, xmlFormId, false, version)
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then((form) => Forms.checkWrongFormVersion(form, version))
       .then(rejectIf(((form) => !form.acceptsSubmissions()), noargs(Problem.user.notAcceptingSubmissions)))
       .then((form) => auth.canOrReject('submission.create', form)));
 
@@ -206,7 +206,7 @@ module.exports = (service, endpoint) => {
   restSubmission('/projects/:projectId/forms/:formId', false, ({ projectId, formId }, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, formId, false, version) // TODO: okay so this is exactly the same as the func above..
       .then(getOrNotFound)
-      .then(ensureDef)
+      .then((form) => Forms.checkWrongFormVersion(form, version))
       .then(rejectIf(
         (form) => !form.acceptsSubmissions(),
         () => Problem.user.notAcceptingSubmissions()

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -120,7 +120,9 @@ module.exports = (service, endpoint) => {
   openRosaSubmission('/projects/:projectId/submission', false, (auth, { projectId }, xmlFormId, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, xmlFormId, false, version)
       .then(getOrNotFound)
-      .then((form) => Forms.checkWrongFormVersion(form, version))
+      // This replaces ensureDef(form). If the form was found with the project ID and form ID
+      // constraints but the def was not found, that suggest the problem was with the version.
+      .then(rejectIf(((form) => (form.def.id == null)), () => Problem.user.formVersionNotFound({ formVersion: version })))
       .then(rejectIf(((form) => !form.acceptsSubmissions()), noargs(Problem.user.notAcceptingSubmissions)))
       .then((form) => auth.canOrReject('submission.create', form)));
 
@@ -206,7 +208,9 @@ module.exports = (service, endpoint) => {
   restSubmission('/projects/:projectId/forms/:formId', false, ({ projectId, formId }, Forms, version) =>
     Forms.getByProjectAndXmlFormId(projectId, formId, false, version) // TODO: okay so this is exactly the same as the func above..
       .then(getOrNotFound)
-      .then((form) => Forms.checkWrongFormVersion(form, version))
+      // This replaces ensureDef(form). If the form was found with the project ID and form ID
+      // constraints but the def was not found, that suggest the problem was with the version.
+      .then(rejectIf(((form) => (form.def.id == null)), () => Problem.user.formVersionNotFound({ formVersion: version })))
       .then(rejectIf(
         (form) => !form.acceptsSubmissions(),
         () => Problem.user.notAcceptingSubmissions()

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -136,6 +136,9 @@ const problems = {
     // deprecated id does not exist.
     deprecatedIdNotFound: problem(404.5, ({ deprecatedId }) => `You tried to update an existing submission, but we can't find that submission to update (${deprecatedId})`),
 
+    // form version in submission does not exist
+    formVersionNotFound: problem(404.6, ({ formVersion }) => `The form version specified in this submission (${formVersion}) does not exist.`),
+
     // { allowed: [ acceptable formats ], got }
     unacceptableFormat: problem(406.1, ({ allowed }) => `Requested format not acceptable; this resource allows: ${allowed.join()}.`),
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -137,7 +137,7 @@ const problems = {
     deprecatedIdNotFound: problem(404.5, ({ deprecatedId }) => `You tried to update an existing submission, but we can't find that submission to update (${deprecatedId})`),
 
     // form version in submission does not exist
-    formVersionNotFound: problem(404.6, ({ formVersion }) => `The form version specified in this submission (${formVersion}) does not exist.`),
+    formVersionNotFound: problem(404.6, ({ formVersion }) => `The form version specified in this submission '${formVersion}' does not exist.`),
 
     // { allowed: [ acceptable formats ], got }
     unacceptableFormat: problem(406.1, ({ allowed }) => `Requested format not acceptable; this resource allows: ${allowed.join()}.`),


### PR DESCRIPTION
Closes #629, where if the submission XML is missing the version string or has a version that doesn't match any known version for that form, the response returns a generic 404 error message. Now it returns a more informative 404 error message. 

The 404 resource not found is an artifact of how when we have a specific version to look for, our form query has these specific constrains and it's easy to reject if we don't find what we are looking for.

The approach of this PR changes that flow a bit: if we don't find the right form and form def/version that the submission is targeting, we look again _without_ the specific version constraint. If we find something when we look that way, then it's a problem with the form version. It feels like extra work, but it'll lead to clearer error messages.

It seems like we only check for the form version when dealing with a published form. For draft forms, the version in the submission doesn't actually have to match (maybe it should? it would be more code..) It may not be that necessary because all the submissions for that draft will be purged when the draft is purged (via publishing or deleting).  

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Open to discussing other options... this is very focused on the version. I think if the user gets the project ID or xmlFormId wrong, the original rejection is appropriate.


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Clearer error messages, which will especially help API users and ourselves when writing tests!

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I don't think we document the nuances of such errors.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
