### PR TITLE
Long tail of entity/dataset small code changes

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -99,7 +99,7 @@ const formatRow = (entity, props) => {
   return out;
 };
 
-const streamEntityCsvs = (inStream, properties) => {
+const streamEntityCsv = (inStream, properties) => {
   const header = [ 'name', 'label' ];
   const props = [];
 
@@ -110,25 +110,25 @@ const streamEntityCsvs = (inStream, properties) => {
     props.push(prop);
   }
 
-  let rootHeaderSent = false;
-  const rootStream = new Transform({
+  let headerSent = false;
+  const entityStream = new Transform({
     objectMode: true,
     transform(entity, _, done) {
       try {
-        if (rootHeaderSent === false) {
+        if (headerSent === false) {
           this.push(header);
-          rootHeaderSent = true;
+          headerSent = true;
         }
         this.push(formatRow(entity, props));
         done();
       } catch (ex) { done(ex); }
     }, flush(done) {
-      if (rootHeaderSent === false) this.push(header);
+      if (headerSent === false) this.push(header);
       done();
     }
   });
 
-  return PartialPipe.of(inStream, rootStream, csv());
+  return PartialPipe.of(inStream, entityStream, csv());
 };
 
 const selectFields = (entity, properties, selectedProperties) => {
@@ -239,7 +239,7 @@ const streamEntityOdata = (inStream, properties, domain, originalUrl, query, tab
 
 module.exports = {
   parseSubmissionXml, validateEntity,
-  streamEntityCsvs, streamEntityOdata,
+  streamEntityCsv, streamEntityOdata,
   odataToColumnMap,
   extractSelectedProperties, selectFields
 };

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -136,7 +136,7 @@ const getAllByFormDefIdForOpenRosa = (formDefId) => ({ all }) => all(sql`
 select ${_unjoinMd5.fields} from form_attachments
   left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
   left outer join (
-    select d.id, max(e."updatedAt") "dsUpdatedAt" from datasets d left outer join entities e on d.id = e."datasetId" group by d.id
+    select d.id, max(coalesce(e."updatedAt", e."createdAt")) "dsUpdatedAt" from datasets d left outer join entities e on d.id = e."datasetId" group by d.id
   ) as ds on form_attachments."datasetId"=ds.id
   where "formDefId"=${formDefId}`)
   .then(map(_unjoinMd5));

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -180,7 +180,7 @@ where submissions."instanceId"=${instanceId}
   and submissions."deletedAt" is null
   and draft=${draft}
   and submission_defs.current=true`)
-  .then(map((row) => new Submission.Partial(row, { def: new Submission.Def({ id: row.defId }) })));
+  .then(map((row) => new Submission(row, { def: new Submission.Def({ id: row.defId }) })));
 
 const getCurrentDefByIds = (projectId, xmlFormId, instanceId, draft) => ({ maybeOne }) => maybeOne(sql`
 select submission_defs.* from submission_defs

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -9,7 +9,7 @@
 
 const sanitize = require('sanitize-filename');
 const { getOrNotFound } = require('../util/promise');
-const { streamEntityCsvs } = require('../data/entity');
+const { streamEntityCsv } = require('../data/entity');
 const { contentDisposition } = require('../util/http');
 
 module.exports = (service, endpoint) => {
@@ -38,6 +38,6 @@ module.exports = (service, endpoint) => {
             const extension = 'csv';
             response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
             response.append('Content-Type', 'text/csv');
-            return streamEntityCsvs(entities, dataset.properties);
+            return streamEntityCsv(entities, dataset.properties);
           })))));
 };

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -19,7 +19,7 @@ const { getOrNotFound, reject, resolve, rejectIf } = require('../util/promise');
 const { success } = require('../util/http');
 const { formList, formManifest } = require('../formats/openrosa');
 const { noargs, isPresent, isBlank } = require('../util/util');
-const { streamEntityCsvs } = require('../data/entity');
+const { streamEntityCsv } = require('../data/entity');
 
 // excel-related util funcs/data used below:
 const isExcel = (contentType) => (contentType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') || (contentType === 'application/vnd.ms-excel');
@@ -288,7 +288,7 @@ module.exports = (service, endpoint) => {
                   .then((entities) => {
                     response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
                     response.append('Content-Type', 'text/csv');
-                    return streamEntityCsvs(entities, dataset.properties);
+                    return streamEntityCsv(entities, dataset.properties);
                   }))))))));
   };
 


### PR DESCRIPTION
Closes #678: long tail of entity-related changes that don't fit in their own issues/PRs. 

Links to the specific comments:
1. [coalesce(e."updatedAt", e."createdAt") ](https://github.com/getodk/central-backend/pull/576#discussion_r1013194274)
2. [renaming `streamEntityCsvs` and variables in that function](https://github.com/getodk/central-backend/pull/576/files/b70ec975c5fffb70b01b74b91073aefa926eaee1#r1012891214)
3. [SubmissionPartial to just Submission](https://github.com/getodk/central-backend/pull/576/files/b70ec975c5fffb70b01b74b91073aefa926eaee1#r1012111496) 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

I went through every comment in PR #576 where this issue came from and either
- marked it as resolved a while ago through some other code change
- fixed it here if it was a quick fix
- made sure it had its own issue

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Very small changes here.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No. Things that do require changes to the docs have their own issues.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that there are no external sources