### PR TITLE
fixes 707: use sql.unnest instead of sql.join for bulk insert

### DIFF
--- a/lib/model/frame.js
+++ b/lib/model/frame.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { raw } = require('slonik-sql-tag-raw');
-const { pick, without } = require('ramda');
+const { pick, without, remove, indexOf } = require('ramda');
 const uuid = require('uuid/v4');
 const { pickAll, noargs } = require('../util/util');
 const Option = require('../util/option');
@@ -26,6 +26,10 @@ const table = (name, to) => (def) => {
   def.from = name;
   def.to = to || name.substring(0, name.length - 1); // take off the s
 };
+const fieldTypes = (types) => (def) => {
+  def.fieldTypes = types;
+};
+
 const from = (fro) => (def) => { def.from = fro; };
 const into = (to) => (def) => { def.to = to; };
 
@@ -66,6 +70,8 @@ class Frame {
       const Frame = class extends this { static get def() { return def; } };
       Frame.fieldlist = raw(def.fields.map((s) => `"${s}"`).join(','));
       Frame.insertfields = without([ 'id' ], def.fields);
+      const indexOfId = indexOf('id', def.fields);
+      Frame.insertFieldTypes = indexOfId > -1 ? remove(indexOf('id', def.fields), 1, def.fieldTypes ?? []) : def.fieldTypes;
       Frame.insertlist = raw(Frame.insertfields.map((s) => `"${s}"`).join(','));
       Frame.hasCreatedAt = def.fields.includes('createdAt');
       Frame.hasUpdatedAt = def.fields.includes('updatedAt');
@@ -156,5 +162,5 @@ Frame.def = { fields: [], readable: [], hasCreatedAt: false, hasUpdatedAt: false
 // util func to ensure the frame we fetched successfully joined to the intended def.
 const ensureDef = rejectIf(((f) => f.def.id == null), noargs(Problem.user.notFound));
 
-module.exports = { Frame, table, from, into, aux, species, embedded, readable, writable, ensureDef };
+module.exports = { Frame, table, fieldTypes, from, into, aux, species, embedded, readable, writable, ensureDef };
 

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { Frame, table, readable, writable, aux, species, embedded } = require('./frame');
+const { Frame, table, readable, writable, aux, species, embedded, fieldTypes } = require('./frame');
 const { isBlank } = require('../util/util');
 const Option = require('../util/option');
 
@@ -45,6 +45,7 @@ class Audit extends Frame.define(
   'details',    readable,               'loggedAt',     readable,
   'notes',      readable,
   'claimed', 'processed', 'lastFailure', 'failures',
+  fieldTypes(['int4', 'int4', 'text', 'varchar', 'jsonb', 'timestamptz', 'text', 'timestamptz', 'timestamptz', 'timestamptz', 'int4']),
   embedded('actor'), embedded('actee')
 ) {
   // TODO: sort of duplicative of Audits.log
@@ -71,7 +72,12 @@ class Audit extends Frame.define(
 const { Blob } = require('./frames/blob');
 
 const { headers } = require('../data/client-audits');
-const ClientAudit = Frame.define(table('client_audits'), 'blobId', 'remainder', ...headers);
+const ClientAudit = Frame.define(
+  table('client_audits'),
+  'blobId',       'remainder',
+  ...headers,
+  fieldTypes(['int4', 'jsonb', ...headers.map(() => 'text')])
+);
 
 const Comment = Frame.define(
   table('comments'),
@@ -103,7 +109,8 @@ Form.Attachment = class extends Frame.define(
   'formId',                             'formDefId',
   'blobId',                             'datasetId',
   'name',         readable,             'type',       readable,
-  'updatedAt',    readable
+  'updatedAt',    readable,
+  fieldTypes(['int4', 'int4', 'int4', 'int4', 'text', 'text', 'timestamptz'])
 ) {
   forApi() {
     const data = { name: this.name, type: this.type, exists: (this.blobId != null || this.datasetId != null),  blobExists: this.blobId != null, datasetExists: this.datasetId != null };
@@ -171,7 +178,8 @@ class Session extends Frame.define(
 const { Submission } = require('./frames/submission');
 Submission.Attachment = class extends Frame.define(
   table('submission_attachments'),
-  'submissionDefId', 'blobId', 'name', 'index', 'isClientAudit'
+  'submissionDefId', 'blobId', 'name', 'index', 'isClientAudit',
+  fieldTypes(['int4', 'int4', 'text', 'int4', 'bool'])
 ) {
   forApi() {
     return { name: this.name, exists: (this.blobId != null) };

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -25,7 +25,7 @@
 // As with Users/Actors, this information is merged together upon return via the
 // API. This is partly for legacy reasons: Forms and FormsDef did not used to
 
-const { Frame, table, readable, writable, into, embedded } = require('../frame');
+const { Frame, table, readable, writable, into, embedded, fieldTypes } = require('../frame');
 const { injectPublicKey, addVersionSuffix } = require('../../data/schema');
 const { Key } = require('./key');
 const { md5sum, shasum, sha256sum, digestWith, generateVersionSuffix } = require('../../util/crypto');
@@ -184,7 +184,8 @@ Form.Field = class extends Frame.define(
   'formId',                             'schemaId',
   'path',       readable,               'name',         readable,
   'type',       readable,               'binary',       readable,
-  'order',                              'selectMultiple', readable
+  'order',                              'selectMultiple', readable,
+  fieldTypes(['int4', 'int4', 'text', 'text', 'varchar', 'bool', 'int4', 'bool' ])
 ) {
   isStructural() { return (this.type === 'repeat') || (this.type === 'structure'); }
 };
@@ -192,7 +193,8 @@ Form.Field = class extends Frame.define(
 Form.FieldValue = Frame.define(
   table('form_field_values'),
   'formId',                             'submissionDefId',
-  'path',                               'value'
+  'path',                               'value',
+  fieldTypes(['int4', 'int4', 'text', 'text'])
 );
 
 

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { inspect } = require('util');
-const { mergeRight, pick, always } = require('ramda');
+const { mergeRight, pick, always, without, remove, indexOf } = require('ramda');
 const { sql } = require('slonik');
 const { raw } = require('slonik-sql-tag-raw');
 const { reject } = require('./promise');
@@ -151,15 +151,35 @@ values (${sql.join(keys.map(_assign(obj)), sql`,`)})
 returning *`;
 };
 
+// Arguments:
+// objs: An array of Frames to be inserted in the database table.
+//       Frame should defined fieldTypes for this function to work
+//       because Slonik's sql.unnest function has a mandatory columnType argument
 const insertMany = (objs) => {
   if (objs.length === 0) return sql`select true`;
   const Type = objs[0].constructor;
+  if (!Type.def.fieldTypes) throw Problem.internal.fieldTypesNotDefined(Type.from);
+
+  let columns; let rows; let columnTypes; let
+    selectExp;
+
+  // we need to set clock_timestamp if there's createdAt column
+  // Slonik doesn't support setting sql identitfier for sql.unnest yet
+  if (Type.hasCreatedAt) {
+    columns = sql`"createdAt", ${raw(without(['createdAt'], Type.insertfields).map((s) => `"${s}"`).join(','))}`;
+    rows = objs.map(obj => without(['createdAt'], Type.insertfields).map(_assign(obj)));
+    columnTypes = remove(indexOf(['createdAt'], Type.insertfields), 1, Type.insertFieldTypes);
+    selectExp = sql`clock_timestamp(), *`;
+  } else {
+    columns = Type.insertlist;
+    rows = objs.map(obj => Type.insertfields.map(_assign(obj)));
+    columnTypes = Type.insertFieldTypes;
+    selectExp = sql`*`;
+  }
+
   return sql`
-insert into ${raw(Type.table)} (${Type.insertlist})
-values ${sql.join(
-    objs.map((obj) => sql`(${sql.join(Type.insertfields.map(_assign(obj)), sql`,`)})`),
-    sql`,`
-  )}`;
+  INSERT INTO ${raw(Type.table)} (${columns})
+  SELECT ${selectExp} FROM ${sql.unnest(rows, columnTypes)} AS t`;
 };
 
 // generic update utility

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -223,7 +223,9 @@ const problems = {
     enketoUnexpectedResponse: problem(500.4, () => 'The Enketo service returned an unexpected response.'),
 
     // returned if ODK Analytics returns an unexpected response.
-    analyticsUnexpectedResponse: problem(500.5, () => 'The Analytics service returned an unexpected response.')
+    analyticsUnexpectedResponse: problem(500.5, () => 'The Analytics service returned an unexpected response.'),
+
+    fieldTypesNotDefined: problem(500.6, (frame) => `fieldTypes are not defined on the ${frame} Frame, please define them to use insertMany.`)
   }
 };
 

--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -143,11 +143,13 @@ describe('managed encryption', () => {
       return Submission.fromXml(xml)
         .then((partial) => hijacked.SubmissionAttachments.create(partial, {}, []))
         .then(() => {
+          // values to sql query of insertMany are passed as array of arrays
           results[0].values.should.eql([
-            null, null, 'zulu.file', 0, false,
-            null, null, 'alpha.file', 1, false,
-            null, null, 'bravo.file', 2, false,
-            null, null, 'submission.xml.enc', 3, null
+            [null, null, null, null],
+            [null, null, null, null],
+            ['zulu.file', 'alpha.file', 'bravo.file', 'submission.xml.enc'],
+            [0, 1, 2, 3],
+            [false, false, false, null]
           ]);
         });
     }));


### PR DESCRIPTION
Closes #707 

#### What has been done to verify that this works as intended?
Unit test, integration test and manually tested with the form with 25K questions.

#### Why is this the best possible solution? Were any other approaches considered?
Postgresql has a limit of parameters that can be passed in a query. To insert large number of rows it provides `unnest` function. Alternative is to break the rows into batches which is not performant and would require a lot of code changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Test cases related to multiselect question, client audits, form attachments and submission attachments should be executed.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
no

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments