### PR TITLE
Use postgres 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: cimg/node:16.19.1
-      - image: cimg/postgres:9.6
+      - image: cimg/postgres:14.6
         environment:
           POSTGRES_PASSWORD: odktest
 

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -12,7 +12,7 @@ jobs:
     services:
       # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
       postgres:
-        image: postgres:9.6
+        image: postgres:14.6
         env:
           POSTGRES_PASSWORD: odktest
         ports:

--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,15 @@ lint: node_version
 
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres
-	docker start odk-postgres || (docker run -d --name odk-postgres -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:9.6 && sleep 5 && node lib/bin/create-docker-databases.js)
+	docker start odk-postgres14 || (docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.6 && sleep 5 && node lib/bin/create-docker-databases.js)
 
 .PHONY: stop-docker-postgres
 stop-docker-postgres:
-	docker stop odk-postgres || true
+	docker stop odk-postgres14 || true
 
 .PHONY: rm-docker-postgres
 rm-docker-postgres: stop-docker-postgres
-	docker rm odk-postgres || true
+	docker rm odk-postgres14 || true
 
 .PHONY: check-file-headers
 check-file-headers:

--- a/docs/api.md
+++ b/docs/api.md
@@ -466,7 +466,7 @@ Presently, it is possible to create and list `User`s in the system, as well as t
 
 Currently, there are no paging or filtering options, so listing `User`s will get you every User in the system, every time.
 
-Optionally, a `q` querystring parameter may be provided to filter the returned users by any given string. The search is performed via a [trigram similarity index](https://www.postgresql.org/docs/9.6/pgtrgm.html) over both the Email and Display Name fields, and results are ordered by match score, best matches first. Note that short search terms (less than 4 or 5 characters) may not return any results. Try a longer search if nothing is appearing.
+Optionally, a `q` querystring parameter may be provided to filter the returned users by any given string. The search is performed via a [trigram similarity index](https://www.postgresql.org/docs/14/pgtrgm.html) over both the Email and Display Name fields, and results are ordered by match score, best matches first. Note that short search terms (less than 4 or 5 characters) may not return any results. Try a longer search if nothing is appearing.
 
 If a `q` parameter is given, and it exactly matches an email address that exists in the system, that user's details will always be returned, even for actors who cannot `user.list`. The request must still authenticate as a valid Actor. This allows non-Administrators to choose a user for an action (eg grant rights) without allowing full search.
 


### PR DESCRIPTION
Match what the standard setup will be starting with 2023.2. There are no changes needed to the code so we might as well start doing this now.

#### What has been done to verify that this works as intended?
Nothing, CI should be enough.

#### Why is this the best possible solution? Were any other approaches considered?
We could wait until we're ready to release backend but I don't see any advantage in that. I used 14.6 which is the [latest available from CircleCI](https://circleci.com/developer/images/image/cimg/postgres). This matches our [recommendations in docs](https://github.com/getodk/docs/pull/1577/files#diff-c3ac24ca7534cc83beec0c8af79032b0aff1d9010803759e057192dcd4739952R205).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None, this is CI only.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments