### PR TITLE
Order dataset properties in metadata and diff

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -126,9 +126,12 @@ const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
         datasets
     LEFT OUTER JOIN ds_properties ON
         datasets.id = ds_properties."datasetId" AND ds_properties."publishedAt" IS NOT NULL
-    ${includeForms ? sql`
     LEFT OUTER JOIN ds_property_fields ON
         ds_properties.id = ds_property_fields."dsPropertyId"
+    LEFT OUTER JOIN form_fields ON
+        ds_property_fields.path = form_fields.path
+        AND ds_property_fields."schemaId" = form_fields."schemaId"
+    ${includeForms ? sql`
     LEFT OUTER JOIN forms ON
         ds_property_fields."formDefId" = forms."currentDefId"
     LEFT JOIN form_defs ON 
@@ -137,6 +140,7 @@ const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
       AND datasets."publishedAt" IS NOT NULL
+    ORDER BY ds_property_fields."schemaId", form_fields.order
  `);
 
 const _getLinkedForms = (datasetName, projectId) => sql`
@@ -274,6 +278,9 @@ ORDER BY form_fields."order"
 `)
   .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName })));
 
+// There's an attempt at ordering properties in the diff:
+// - properties in the active form are put in order of how the fields appear in the form
+// - properties form other forms are shown alphabetically
 const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
   WITH form AS (
     SELECT f.id, f."xmlFormId", fd.id "formDefId", fd."schemaId"
@@ -291,18 +298,23 @@ const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
     SELECT 
       dp.*, 
       dpf.*, 
-      dp."publishedAt" IS NULL "isNew"
+      dp."publishedAt" IS NULL "isNew",
+      form_fields.order,
+      form_fields."formId"
     FROM ds_properties dp 
     JOIN ds ON ds.id = dp."datasetId"
     LEFT JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id
+    LEFT OUTER JOIN form_fields ON dpf.path = form_fields.path
+      AND dpf."schemaId" = form_fields."schemaId"
   )
-  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew", TRUE = ANY(ARRAY_AGG(f.id IS NOT NULL)) "inForm"
+  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew", TRUE = ANY(ARRAY_AGG(f.id IS NOT NULL)) "inForm",
+    MAX((CASE WHEN f.id = p."formId" THEN p.order ELSE null END)) "formOrder"
   FROM ds
   LEFT JOIN properties p on ds.id = p."datasetId"
   LEFT JOIN form f ON f."formDefId" = p."formDefId"
   ${forDraft ? sql`` : sql`WHERE p.id IS NULL OR NOT p."isNew"`}
   GROUP BY ds.name, ds."isNew", p.name, p."isNew"
-  ORDER BY p.name
+  ORDER BY "formOrder", p.name
 `)
   .then(reduceBy((acc, { propertyName, isPropertyNew, inForm }) => (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
   .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: forDraft ? k.split(',')[1] === 'true' : undefined, properties: r[k] })));

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -368,6 +368,31 @@ module.exports = {
   </h:head>
 </h:html>`,
 
+    multiPropertyForm: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model entities:entities-version="2022.1.0">
+      <instance>
+        <data id="multiPropertyForm" orx:version="1.0">
+          <q1/>
+          <q2/>
+          <q3/>
+          <q4/>
+          <meta>
+            <entity dataset="foo" id="" create="">
+              <label/>
+            </entity>
+          </meta>
+        </data>
+      </instance>
+      <bind entities:saveto="a_q3" nodeset="/data/q3" type="string"/>
+      <bind entities:saveto="b_q1" nodeset="/data/q1" type="string"/>
+      <bind entities:saveto="c_q4" nodeset="/data/q4" type="string"/>
+      <bind entities:saveto="d_q2" nodeset="/data/q2" type="string"/>
+    </model>
+  </h:head>
+</h:html>`,
+
     groupRepeat: `<?xml version="1.0"?>
     <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
         <h:head>


### PR DESCRIPTION
Closes #708 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests and some trying it out through the frontend.

#### Why is this the best possible solution? Were any other approaches considered?

The modification to the dataset metadata query in `_getByNameSql` feels good. It uses the schema ID and order so everything will be grouped by form version and then properly ordered. While doing this, I was thinking, maybe if the dataset properties or property fields had their own concept of order, this other join wouldn't be necessary.

The changes I made to `getDatasetDiff` don't feel as good, was fighting with many selection layers, grouping, aggregating, etc. and have a solution that orders the fields of the form being diffed. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Will make things better for users!

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

We talked about writing down that the order of properties and entities will be guaranteed. 

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes