### PR TITLE
ETag for entities.csv

### DIFF
--- a/lib/formats/openrosa.js
+++ b/lib/formats/openrosa.js
@@ -76,7 +76,7 @@ const formManifestTemplate = template(200, `<?xml version="1.0" encoding="UTF-8"
 const formManifest = (data) => formManifestTemplate(mergeRight(data, {
   attachments: data.attachments.map((attachment) =>
     attachment.with({ hasSource: attachment.blobId || attachment.datasetId,
-      md5: attachment.blobId ? attachment.aux.openRosa.md5 : md5sum(attachment.aux.openRosa.dsUpdatedAt ?? '1970-01-01'),
+      md5: attachment.blobId ? attachment.aux.openRosa.md5 : md5sum(attachment.aux.openRosa.dsUpdatedAt?.toISOString() ?? '1970-01-01'),
       urlName: encodeURIComponent(attachment.name) }))
 }));
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -50,7 +50,7 @@ const _getAllByProjectId = (fields, extend, options) => sql`
   SELECT ${fields} FROM datasets
   ${extend|| sql`
   LEFT JOIN (
-    SELECT "datasetId", count(1) "entities", max("createdAt") "lastEntity" 
+    SELECT "datasetId", COUNT(1) "entities", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity" 
     FROM entities e 
     GROUP BY "datasetId" 
   ) stats on stats."datasetId" = datasets.id`}

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -24,7 +24,7 @@ const pickFrameFields = (frame, obj) => compose(
 )(obj);
 
 const makeHierarchy = reduce((result, item) => {
-  const dataset = new Dataset(pickFrameFields(Dataset, item));
+  const dataset = new Dataset(pickFrameFields(Dataset, item)).with({ lastEntity: item.lastEntity });
   const property = new Dataset.Property(pickFrameFields(Dataset.Property, item));
 
   return {
@@ -121,11 +121,11 @@ const _getByIdSql = ((fields, datasetId) => sql`
 
 const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     SELECT
-        ${fields}, stats."lastEntity" "datasets!lastEntity"
+        ${fields}
     FROM
         datasets
     LEFT OUTER JOIN (
-      SELECT "datasetId", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity" 
+      SELECT "datasetId", COUNT(1) "entities", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity" 
       FROM entities e 
       GROUP BY "datasetId" 
     ) stats on stats."datasetId" = datasets.id
@@ -197,7 +197,7 @@ const getById = (datasetId) => ({ all }) =>
 
 // Returns only published dataset with its published properties
 const getByName = (datasetName, projectId) => ({ all }) =>
-  all(_getByNameSql(unjoiner(Dataset, Dataset.Property).fields, datasetName, projectId))
+  all(_getByNameSql(unjoiner(Dataset, Dataset.Property, Dataset.Extended).fields, datasetName, projectId))
     .then(makeHierarchy)
     .then(asArray)
     .then(nth(0))

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -121,9 +121,14 @@ const _getByIdSql = ((fields, datasetId) => sql`
 
 const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     SELECT
-        ${fields}
+        ${fields}, stats."lastEntity" "datasets!lastEntity"
     FROM
         datasets
+    LEFT OUTER JOIN (
+      SELECT "datasetId", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity" 
+      FROM entities e 
+      GROUP BY "datasetId" 
+    ) stats on stats."datasetId" = datasets.id
     LEFT OUTER JOIN ds_properties ON
         datasets.id = ds_properties."datasetId" AND ds_properties."publishedAt" IS NOT NULL
     ${includeForms ? sql`

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -11,6 +11,7 @@ const sanitize = require('sanitize-filename');
 const { getOrNotFound } = require('../util/promise');
 const { streamEntityCsv } = require('../data/entity');
 const { contentDisposition } = require('../util/http');
+const { md5sum } = require('../util/crypto');
 
 module.exports = (service, endpoint) => {
   service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
@@ -26,18 +27,26 @@ module.exports = (service, endpoint) => {
       .then(() => Datasets.getDatasetMetadata(params.name, params.projectId)
         .then(getOrNotFound))));
 
-  service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(({ Datasets, Entities, Projects }, { params, auth }, _, response) =>
-    Projects.getById(params.projectId)
-      .then(getOrNotFound)
-      .then((project) => auth.canOrReject('entity.list', project))
-      .then(() => Datasets.getByName(params.name, params.projectId)
-        .then(getOrNotFound)
-        .then((dataset) => Entities.streamForExport(dataset.id)
-          .then((entities) => {
-            const filename = sanitize(dataset.name);
-            const extension = 'csv';
-            response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
-            response.append('Content-Type', 'text/csv');
-            return streamEntityCsv(entities, dataset.properties);
-          })))));
+  service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(async ({ Datasets, Entities, Projects }, { params, auth }, request, response) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('entity.list', project);
+
+    const dataset = await Datasets.getByName(params.name, params.projectId).then(getOrNotFound);
+
+    // Etag logic inspired from https://stackoverflow.com/questions/72334843/custom-computed-etag-for-express-js/72335674#72335674
+    const serverEtag = `"${md5sum(dataset.lastEntity?.toISOString() ?? '1970-01-01')}"`;
+    const clientEtag = request.get('If-None-Match');
+    if (clientEtag?.includes(serverEtag)) { // nginx weakens Etag when gzip is used, so clientEtag is like W/"4e9f0c7e9a8240..."
+      response.status(304);
+      return;
+    }
+    const entities = await Entities.streamForExport(dataset.id);
+    const filename = sanitize(dataset.name);
+    const extension = 'csv';
+    response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
+    response.append('Content-Type', 'text/csv');
+    response.set('ETag', serverEtag);
+    return streamEntityCsv(entities, dataset.properties);
+
+  }));
 };

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4,7 +4,7 @@ const testData = require('../../data/xml');
 const config = require('config');
 const { Form } = require('../../../lib/model/frames');
 const { getOrNotFound } = require('../../../lib/util/promise');
-const { omit, identity, sortBy, prop } = require('ramda');
+const { omit, identity } = require('ramda');
 const should = require('should');
 const { sql } = require('slonik');
 
@@ -432,18 +432,18 @@ describe('datasets and entities', () => {
 
             linkedForms.should.be.eql([{ name: 'withAttachments', xmlFormId: 'withAttachments' }]);
 
-            sortBy(prop('name'), properties.map(({ id, datasetId, publishedAt, ...p }) => {
+            properties.map(({ id, datasetId, publishedAt, ...p }) => {
               id.should.be.aboveOrEqual(1);
               datasetId.should.be.aboveOrEqual(1);
               publishedAt.should.not.be.null();
               return p;
-            })).should.be.eql([
-              { name: 'address', forms: [ { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }, ] },
+            }).should.be.eql([
               { name: 'age', forms: [ { name: 'simpleEntity', xmlFormId: 'simpleEntity' }, ] },
               { name: 'first_name', forms: [
                 { name: 'simpleEntity', xmlFormId: 'simpleEntity' },
                 { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }
-              ] }
+              ] },
+              { name: 'address', forms: [ { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }, ] }
             ]);
 
           });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4,7 +4,7 @@ const testData = require('../../data/xml');
 const config = require('config');
 const { Form } = require('../../../lib/model/frames');
 const { getOrNotFound } = require('../../../lib/util/promise');
-const { omit, identity } = require('ramda');
+const { omit, identity, sortBy, prop } = require('ramda');
 const should = require('should');
 const { sql } = require('slonik');
 
@@ -432,18 +432,18 @@ describe('datasets and entities', () => {
 
             linkedForms.should.be.eql([{ name: 'withAttachments', xmlFormId: 'withAttachments' }]);
 
-            properties.map(({ id, datasetId, publishedAt, ...p }) => {
+            sortBy(prop('name'), properties.map(({ id, datasetId, publishedAt, ...p }) => {
               id.should.be.aboveOrEqual(1);
               datasetId.should.be.aboveOrEqual(1);
               publishedAt.should.not.be.null();
               return p;
-            }).should.be.eql([
+            })).should.be.eql([
+              { name: 'address', forms: [ { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }, ] },
+              { name: 'age', forms: [ { name: 'simpleEntity', xmlFormId: 'simpleEntity' }, ] },
               { name: 'first_name', forms: [
                 { name: 'simpleEntity', xmlFormId: 'simpleEntity' },
                 { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }
-              ] },
-              { name: 'age', forms: [ { name: 'simpleEntity', xmlFormId: 'simpleEntity' }, ] },
-              { name: 'address', forms: [ { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }, ] }
+              ] }
             ]);
 
           });


### PR DESCRIPTION
Closes #770 

## Changes:
- Added ETag in response of entity.csv and logic to return 304 if `If-None-Match` matches serverEtag
- Fix a bug: form manifest crashes if the form has attached dataset with entities in it. Root cause md5sum function expects a string and we were passing a Date object
- Fix: use coalesce of updatedAt and createdAt for timestamp of latest entity

#### What has been done to verify that this works as intended?
- Added integration tests
- Manually tested ETag logic

#### Why is this the best possible solution? Were any other approaches considered?

NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Test ODK Collect's behaviour for forms with dataset attached that has entities in it.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced