### PR TITLE
Return dataset metadata properties and entities in order

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -159,7 +159,7 @@ const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
       AND datasets."publishedAt" IS NOT NULL
-    ORDER BY ds_properties."publishedAt", form_fields.order
+    ORDER BY ds_properties."publishedAt", form_fields.order, ds_properties.id
  `);
 
 const _getLinkedForms = (datasetName, projectId) => sql`

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -107,6 +107,14 @@ insert_property_fields AS (
   INSERT INTO ds_property_fields ("dsPropertyId", "formDefId", "schemaId", "path")
   SELECT "dsPropertyId", "formDefId"::integer, "schemaId"::integer, path FROM all_properties
 )
+${publish ? sql`
+,
+update_ds_properties AS (
+  UPDATE ds_properties SET "publishedAt" = clock_timestamp()
+  FROM all_properties
+  WHERE ds_properties.id = all_properties."dsPropertyId" AND ds_properties."publishedAt" IS NULL
+)
+` : sql``}
 `;
 
 const _createOrMerge = (dataset, fields, acteeId, publish) => sql`

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -137,9 +137,12 @@ const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     ) stats on stats."datasetId" = datasets.id
     LEFT OUTER JOIN ds_properties ON
         datasets.id = ds_properties."datasetId" AND ds_properties."publishedAt" IS NOT NULL
-    ${includeForms ? sql`
     LEFT OUTER JOIN ds_property_fields ON
         ds_properties.id = ds_property_fields."dsPropertyId"
+    LEFT OUTER JOIN form_fields ON
+        ds_property_fields.path = form_fields.path
+        AND ds_property_fields."schemaId" = form_fields."schemaId"
+    ${includeForms ? sql`
     LEFT OUTER JOIN forms ON
         ds_property_fields."formDefId" = forms."currentDefId"
     LEFT JOIN form_defs ON 
@@ -148,6 +151,7 @@ const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
       AND datasets."publishedAt" IS NOT NULL
+    ORDER BY ds_property_fields."schemaId", form_fields.order
  `);
 
 const _getLinkedForms = (datasetName, projectId) => sql`

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -159,7 +159,7 @@ const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
     WHERE datasets.name = ${datasetName}
       AND datasets."projectId" = ${projectId}
       AND datasets."publishedAt" IS NOT NULL
-    ORDER BY ds_property_fields."schemaId", form_fields.order
+    ORDER BY ds_properties."publishedAt", form_fields.order
  `);
 
 const _getLinkedForms = (datasetName, projectId) => sql`
@@ -345,12 +345,14 @@ WITH properties_update as (
   JOIN form_defs fd ON fs."id" = fd."schemaId"
   WHERE fd."id" = ${formDefId}
   AND dpf."dsPropertyId" = dp.id
+  AND dp."publishedAt" IS NULL
   RETURNING dp.*
 ), datasets_update as (
   UPDATE datasets ds SET "publishedAt" = ${publishedAt}
   FROM dataset_form_defs dfd
   WHERE dfd."formDefId" = ${formDefId}
   AND dfd."datasetId" = ds.id
+  AND ds."publishedAt" IS NULL
   RETURNING *
 )
 -- selecting following for publish.audit

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -147,7 +147,7 @@ WHERE
   entities."datasetId" = ${datasetId}
   AND entity_defs.current=true
   AND  ${odataFilter(options.filter, odataToColumnMap)}
-ORDER BY entities."createdAt" desc, entities.id desc
+ORDER BY entities."createdAt" DESC, entities.id DESC
 ${page(options)}`)
     .then(stream.map(_exportUnjoiner));
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -147,7 +147,7 @@ WHERE
   entities."datasetId" = ${datasetId}
   AND entity_defs.current=true
   AND  ${odataFilter(options.filter, odataToColumnMap)}
-ORDER BY entities.id
+ORDER BY entities."createdAt" desc, entities.id desc
 ${page(options)}`)
     .then(stream.map(_exportUnjoiner));
 

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -368,12 +368,12 @@ module.exports = {
   </h:head>
 </h:html>`,
 
-    multiPropertyForm: `<?xml version="1.0"?>
+    multiPropertyEntity: `<?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
   <h:head>
     <model entities:entities-version="2022.1.0">
       <instance>
-        <data id="multiPropertyForm" orx:version="1.0">
+        <data id="multiPropertyEntity" orx:version="1.0">
           <q1/>
           <q2/>
           <q3/>
@@ -603,6 +603,32 @@ module.exports = {
           <name>John</name>
           <age>40</age>
         </data>`
+    },
+    multiPropertyEntity: {
+      one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="multiPropertyEntity" version="1.0">
+        <meta>
+          <instanceID>one</instanceID>
+          <entities:entity dataset="foo" id="uuid:12345678-1234-4123-8234-123456789aaa" create="1">
+            <entities:label>one</entities:label>
+          </entities:entity>
+        </meta>
+        <q1>w</q1>
+        <q2>x</q2>
+        <q3>y</q3>
+        <q4>z</q4>
+      </data>`,
+      two: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="multiPropertyEntity" version="1.0">
+        <meta>
+          <instanceID>two</instanceID>
+          <entities:entity dataset="foo" id="uuid:12345678-1234-4123-8234-123456789bbb" create="1">
+            <entities:label>two</entities:label>
+          </entities:entity>
+        </meta>
+        <q1>a</q1>
+        <q2>b</q2>
+        <q3>c</q3>
+        <q4>d</q4>
+      </data>`,
     },
     groupRepeat: {
       one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="groupRepeat">

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -368,6 +368,31 @@ module.exports = {
   </h:head>
 </h:html>`,
 
+    multiPropertyForm: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model entities:entities-version="2022.1.0">
+      <instance>
+        <data id="multiPropertyForm" orx:version="1.0">
+          <q1/>
+          <q2/>
+          <q3/>
+          <q4/>
+          <meta>
+            <entity dataset="foo" id="" create="">
+              <label/>
+            </entity>
+          </meta>
+        </data>
+      </instance>
+      <bind entities:saveto="a_q3" nodeset="/data/q3" type="string"/>
+      <bind entities:saveto="b_q1" nodeset="/data/q1" type="string"/>
+      <bind entities:saveto="c_q4" nodeset="/data/q4" type="string"/>
+      <bind entities:saveto="d_q2" nodeset="/data/q2" type="string"/>
+    </model>
+  </h:head>
+</h:html>`,
+
     groupRepeat: `<?xml version="1.0"?>
     <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
         <h:head>

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -438,11 +438,11 @@ describe('datasets and entities', () => {
               publishedAt.should.not.be.null();
               return p;
             }).should.be.eql([
-              { name: 'age', forms: [ { name: 'simpleEntity', xmlFormId: 'simpleEntity' }, ] },
               { name: 'first_name', forms: [
                 { name: 'simpleEntity', xmlFormId: 'simpleEntity' },
                 { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }
               ] },
+              { name: 'age', forms: [ { name: 'simpleEntity', xmlFormId: 'simpleEntity' }, ] },
               { name: 'address', forms: [ { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }, ] }
             ]);
 
@@ -479,6 +479,60 @@ describe('datasets and entities', () => {
             linkedForms.should.be.eql([{ name: 'withAttachments', xmlFormId: 'withAttachments' }]);
           });
 
+      }));
+
+      it('should return properties of a dataset in order', testService(async (service) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.multiPropertyForm)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/foo')
+          .expect(200)
+          .then(({ body }) => {
+            const { properties } = body;
+            properties.map((p) => p.name)
+              .should.be.eql([
+                'b_q1',
+                'd_q2',
+                'a_q3',
+                'c_q4'
+              ]);
+          });
+      }));
+
+      it('should return dataset properties from multiple forms in order', testService(async (service) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.multiPropertyForm)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.multiPropertyForm
+            .replace('multiPropertyForm', 'multiPropertyForm2')
+            .replace('b_q1', 'f_q1')
+            .replace('d_q2', 'e_q2'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/foo')
+          .expect(200)
+          .then(({ body }) => {
+            const { properties } = body;
+            properties.map((p) => p.name)
+              .should.be.eql([
+                'b_q1',
+                'd_q2',
+                'a_q3',
+                'c_q4',
+                'f_q1',
+                'e_q2'
+              ]);
+          });
       }));
     });
   });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -11,7 +11,6 @@ const { sql } = require('slonik');
 /* eslint-disable import/no-dynamic-require */
 const { createEntityFromSubmission } = require(appRoot + '/lib/worker/entity');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
-const { purgeForms } = require(appRoot + '/lib/task/purge');
 /* eslint-enable import/no-dynamic-require */
 
 describe('datasets and entities', () => {
@@ -537,7 +536,7 @@ describe('datasets and entities', () => {
       }));
 
       // Test is broken because unpublished properties from previous form don't get properly published in new form.
-      it.skip('should return dataset properties from multiple forms in different published states in order', testService(async (service) => {
+      it('should return dataset properties from multiple forms in different published states in order', testService(async (service, { Forms }) => {
         const asAlice = await service.login('alice', identity);
 
         await asAlice.post('/v1/projects/1/forms')
@@ -556,7 +555,7 @@ describe('datasets and entities', () => {
         await asAlice.delete('/v1/projects/1/forms/multiPropertyForm')
           .expect(200);
 
-        await purgeForms(true);
+        await Forms.purge(true);
 
         await asAlice.get('/v1/projects/1/datasets/foo')
           .expect(200)

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -485,7 +485,7 @@ describe('datasets and entities', () => {
         const asAlice = await service.login('alice', identity);
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.multiPropertyForm)
+          .send(testData.forms.multiPropertyEntity)
           .set('Content-Type', 'application/xml')
           .expect(200);
 
@@ -507,13 +507,13 @@ describe('datasets and entities', () => {
         const asAlice = await service.login('alice', identity);
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.multiPropertyForm)
+          .send(testData.forms.multiPropertyEntity)
           .set('Content-Type', 'application/xml')
           .expect(200);
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.multiPropertyForm
-            .replace('multiPropertyForm', 'multiPropertyForm2')
+          .send(testData.forms.multiPropertyEntity
+            .replace('multiPropertyEntity', 'multiPropertyEntity2')
             .replace('b_q1', 'f_q1')
             .replace('d_q2', 'e_q2'))
           .set('Content-Type', 'application/xml')
@@ -535,24 +535,23 @@ describe('datasets and entities', () => {
           });
       }));
 
-      // Test is broken because unpublished properties from previous form don't get properly published in new form.
       it('should return dataset properties from multiple forms in different published states in order', testService(async (service, { Forms }) => {
         const asAlice = await service.login('alice', identity);
 
         await asAlice.post('/v1/projects/1/forms')
-          .send(testData.forms.multiPropertyForm)
+          .send(testData.forms.multiPropertyEntity)
           .set('Content-Type', 'application/xml')
           .expect(200);
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.multiPropertyForm
-            .replace('multiPropertyForm', 'multiPropertyForm2')
+          .send(testData.forms.multiPropertyEntity
+            .replace('multiPropertyEntity', 'multiPropertyEntity2')
             .replace('b_q1', 'f_q1')
             .replace('d_q2', 'e_q2'))
           .set('Content-Type', 'application/xml')
           .expect(200);
 
-        await asAlice.delete('/v1/projects/1/forms/multiPropertyForm')
+        await asAlice.delete('/v1/projects/1/forms/multiPropertyEntity')
           .expect(200);
 
         await Forms.purge(true);

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -535,7 +535,49 @@ describe('datasets and entities', () => {
           });
       }));
 
-      it('should return dataset properties from multiple forms in different published states in order', testService(async (service, { Forms }) => {
+      it('should return dataset properties from multiple forms including updated form with updated schema', testService(async (service) => {
+        const asAlice = await service.login('alice', identity);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.multiPropertyEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.multiPropertyEntity
+            .replace('multiPropertyEntity', 'multiPropertyEntity2')
+            .replace('b_q1', 'f_q1')
+            .replace('d_q2', 'e_q2'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms/multiPropertyEntity/draft')
+          .send(testData.forms.multiPropertyEntity
+            .replace('orx:version="1.0"', 'orx:version="2.0"')
+            .replace('b_q1', 'g_q1'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms/multiPropertyEntity/draft/publish').expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/foo')
+          .expect(200)
+          .then(({ body }) => {
+            const { properties } = body;
+            properties.map((p) => p.name)
+              .should.be.eql([
+                'b_q1',
+                'd_q2',
+                'a_q3',
+                'c_q4',
+                'f_q1',
+                'e_q2',
+                'g_q1'
+              ]);
+          });
+      }));
+
+      it('should return dataset properties when purged draft form shares some properties', testService(async (service, { Forms }) => {
         const asAlice = await service.login('alice', identity);
 
         await asAlice.post('/v1/projects/1/forms')


### PR DESCRIPTION
Closes #779, #767 and #675 

Dataset properties when returned for a specific dataset (not in a diff) or for the header of a CSV are ordered first in published order, and then the order they are found in the form. 

Things get a little complicated when multiple forms share properties, but as much as possible, properties are grouped with the form fields they came from. 

Entities in the CSV and in the OData endpoint are returned in reverse chronological order like submissions with the newest entity at the top.

This PR also fixes an issue with setting the publishedAt field on relevant dataset properties when they already exist but are unpublished.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests. 

#### Why is this the best possible solution? Were any other approaches considered?

One original suggestion was to order the properties by their property id, but there can be a situation where
- form 1 has properties A, B, C, D
- form 2 has properties A, B, (doesn't make new properties for C and D because they are already there and have lower id)
- form 1 gets deleted and purged before being published
- form 2 gets published
- property id order is C, D, A, B

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Makes entities table look cleaner. 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced