### PR TITLE
Changing how password used in soak test

### DIFF
--- a/soak-tester/scripts/ci-soak-test
+++ b/soak-tester/scripts/ci-soak-test
@@ -16,7 +16,7 @@ fail_job() {
 
 make base
 
-node ./lib/bin/cli.js user-create  -u "$userEmail" -p "$userPassword"
+echo "$userPassword" | node ./lib/bin/cli.js user-create  -u "$userEmail"
 node ./lib/bin/cli.js user-promote -u "$userEmail"
 
 make run >backend.log 2>&1 &


### PR DESCRIPTION
When we took out the password argument from the cli tool, the soak test stopped working with this error: `ERROR: Unknown option -p` 


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced