### PR TITLE
Rename getter functions in Dataset query module

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -10,8 +10,7 @@
 const { sql } = require('slonik');
 const { extender, QueryOptions, equals } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
-const { isEmpty, isNil, either, reduceBy, groupBy } = require('ramda');
-const R = require('ramda');
+const { isEmpty, isNil, either, reduceBy, groupBy, uniqWith, equals: rEquals } = require('ramda');
 
 const Problem = require('../../util/problem');
 const { construct } = require('../../util/util');
@@ -216,9 +215,9 @@ const getByProjectAndName = (projectId, name, publishedOnly = false, extended = 
 
 // Gets the dataset information, properties (including which forms each property comes from),
 // and which forms consume the dataset via CSV attachment.
-const getDatasetMetadata = (datasetName, projectId) => async ({ all, Datasets }) => {
+const getMetadata = (dataset) => async ({ all, Datasets }) => {
 
-  const _getLinkedForms = () => sql`
+  const _getLinkedForms = (datasetName, projectId) => sql`
     SELECT DISTINCT f."xmlFormId", coalesce(fd.name, f."xmlFormId") "name" FROM form_attachments fa
     JOIN forms f ON f.id = fa."formId"
     JOIN form_defs fd ON f."currentDefId" = fd.id
@@ -228,9 +227,8 @@ const getDatasetMetadata = (datasetName, projectId) => async ({ all, Datasets })
       AND ds."publishedAt" IS NOT NULL
   `;
 
-  const dataset = await Datasets.getByProjectAndName(projectId, datasetName).then((o) => o.get());
   const properties = await Datasets.getPublishedProperties(dataset.id, true);
-  const linkedForms = await all(_getLinkedForms(datasetName, projectId));
+  const linkedForms = await all(_getLinkedForms(dataset.name, dataset.projectId));
 
   const propertiesMap = new Map();
   for (const property of properties) {
@@ -290,7 +288,7 @@ const getPublishedProperties = (datasetId, includeForms = false) => ({ all }) =>
 `)
   .then((rows) => (includeForms
     ? rows.map(({ formName, xmlFormId, ...row }) => new Dataset.Property(row, { formName, xmlFormId }))
-    : R.uniqWith(R.equals, rows).map(construct(Dataset.Property))));
+    : uniqWith(rEquals, rows).map(construct(Dataset.Property))));
 
 // Returns list of Fields augmented by dataset property name.
 // This it used by the submission XML parser to create an entity from a submission.
@@ -357,7 +355,7 @@ const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
 module.exports = {
   createOrMerge, publishIfExists,
   getAllByProjectId, getByProjectAndName,
-  getDatasetMetadata,
+  getMetadata,
   getPublishedProperties, getFieldsByFormDefId,
   getDatasetDiff
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -110,7 +110,7 @@ const createOrMerge = (dataset, fields, publish = false) => ({ one, Actees, Data
         }))
     .then((result) => Datasets.get(dataset.projectId, dataset.name).then((ds) => ds.get())
       .then((ds) => ((publish === true)
-        ? Datasets.getPublishedProperties(ds.id).then(properties => ({ ...ds, properties }))
+        ? Datasets.getProperties(ds.id).then(properties => ({ ...ds, properties }))
         : ds.with({ action: result.action }))));
 
 createOrMerge.audit = (dataset, _, fields, publish) => (log) =>
@@ -227,7 +227,7 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
       AND ds."publishedAt" IS NOT NULL
   `;
 
-  const properties = await Datasets.getPublishedProperties(dataset.id, true);
+  const properties = await Datasets.getProperties(dataset.id, true);
   const linkedForms = await all(_getLinkedForms(dataset.name, dataset.projectId));
 
   const propertiesMap = new Map();
@@ -266,7 +266,7 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
 // their published timestamps and field order within a single form.
 // If 'includeForms' is true, Dataset.Properties will be duplicated for each
 // form that writes that field in the dataset.
-const getPublishedProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
+const getProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
   SELECT
       ds_properties.* ${includeForms ? sql`, form_defs."name" as "formName", forms."xmlFormId"` : sql``}
   FROM
@@ -318,7 +318,7 @@ ORDER BY form_fields."order"
 
 // Used when creating or updating a dataset through the uploading of a form
 // to show the status of the dataset and each property in that dataset.
-const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
+const getDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
   WITH form AS (
     SELECT f.id, f."xmlFormId", fd.id "formDefId", fd."schemaId"
     FROM forms f
@@ -356,6 +356,6 @@ module.exports = {
   createOrMerge, publishIfExists,
   getList, get,
   getMetadata,
-  getPublishedProperties, getFieldsByFormDefId,
-  getDatasetDiff
+  getProperties, getFieldsByFormDefId,
+  getDiff
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -8,55 +8,18 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { unjoiner, extender, QueryOptions, equals } = require('../../util/db');
+const { extender, QueryOptions, equals } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
-const { map, reduce, compose, pickBy, startsWith, nthArg, assoc, keys, curry, nth, isEmpty, isNil, either, reduceBy, groupBy } = require('ramda');
-const { construct } = require('../../util/util');
-const Option = require('../../util/option');
+const { isEmpty, isNil, either, reduceBy, groupBy } = require('ramda');
+const R = require('ramda');
+
 const Problem = require('../../util/problem');
+const { construct } = require('../../util/util');
 
-// It removes prefix from all the key of an object
-const removePrefix = curry((prefix, obj) => compose(reduce((acc, key) => assoc(key.replace(prefix, ''), obj[key], acc), {}), keys)(obj));
+////////////////////////////////////////////////////////////////////////////
+// DATASET CREATE AND UPDATE
 
-const pickFrameFields = (frame, obj) => compose(
-  removePrefix(`${frame.def.from}!`),
-  pickBy(compose(startsWith(`${frame.def.from}!`), nthArg(1)))
-)(obj);
-
-const makeHierarchy = reduce((result, item) => {
-  const dataset = new Dataset(pickFrameFields(Dataset, item)).with({ lastEntity: item.lastEntity });
-  const property = new Dataset.Property(pickFrameFields(Dataset.Property, item));
-
-  return {
-    ...result,
-    [dataset.id]: {
-      ...dataset,
-      properties: !property.id ? { ...(result[dataset.id]?.properties || {}) } : {
-        ...(result[dataset.id]?.properties || {}),
-        [property.id]: property
-      }
-    }
-  };
-}, {});
-
-const asArray = compose(map(d => ({ ...d, properties: Object.values(d.properties) })), Object.values);
-
-// should be moved to util.js or we already have similar func somewhere?
-const isNilOrEmpty = either(isNil, isEmpty);
-
-////////////////////////////////////////////////////////////////////////////////
-// SQL Queries
-const _getAllByProjectId = (fields, extend, options) => sql`
-  SELECT ${fields} FROM datasets
-  ${extend|| sql`
-  LEFT JOIN (
-    SELECT "datasetId", COUNT(1) "entities", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity" 
-    FROM entities e 
-    GROUP BY "datasetId" 
-  ) stats on stats."datasetId" = datasets.id`}
-  WHERE "publishedAt" IS NOT NULL AND ${equals(options.condition)}
-`;
-
+// createOrUpdate is called from Forms.createNew and Forms.createVersion
 const _insertDatasetDef = (dataset, acteeId, withDsDefsCTE, publish) => sql`
   WITH ds_ins AS (
     INSERT INTO datasets (id, name, "projectId", "createdAt", "acteeId", "publishedAt")
@@ -117,59 +80,13 @@ update_ds_properties AS (
 ` : sql``}
 `;
 
+// should be moved to util.js or we already have similar func somewhere?
+const isNilOrEmpty = either(isNil, isEmpty);
+
 const _createOrMerge = (dataset, fields, acteeId, publish) => sql`
 ${_insertDatasetDef(dataset, acteeId, true, publish)}
 ${isNilOrEmpty(fields) ? sql`` : _insertProperties(fields, publish)}
 SELECT "action" FROM ds
-`;
-
-const _getByIdSql = ((fields, datasetId) => sql`
-       SELECT
-           ${fields}
-       FROM
-           datasets
-       LEFT OUTER JOIN ds_properties ON
-           datasets.id = ds_properties."datasetId"
-       WHERE datasets.id = ${datasetId}
-    `);
-
-const _getByNameSql = ((fields, datasetName, projectId, includeForms) => sql`
-    SELECT
-        ${fields}
-    FROM
-        datasets
-    LEFT OUTER JOIN (
-      SELECT "datasetId", COUNT(1) "entities", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity" 
-      FROM entities e 
-      GROUP BY "datasetId" 
-    ) stats on stats."datasetId" = datasets.id
-    LEFT OUTER JOIN ds_properties ON
-        datasets.id = ds_properties."datasetId" AND ds_properties."publishedAt" IS NOT NULL
-    LEFT OUTER JOIN ds_property_fields ON
-        ds_properties.id = ds_property_fields."dsPropertyId"
-    LEFT OUTER JOIN form_fields ON
-        ds_property_fields.path = form_fields.path
-        AND ds_property_fields."schemaId" = form_fields."schemaId"
-    ${includeForms ? sql`
-    LEFT OUTER JOIN forms ON
-        ds_property_fields."formDefId" = forms."currentDefId"
-    LEFT JOIN form_defs ON 
-        forms."currentDefId" = form_defs.id
-    ` : sql``}
-    WHERE datasets.name = ${datasetName}
-      AND datasets."projectId" = ${projectId}
-      AND datasets."publishedAt" IS NOT NULL
-    ORDER BY ds_properties."publishedAt", form_fields.order, ds_properties.id
- `);
-
-const _getLinkedForms = (datasetName, projectId) => sql`
-  SELECT DISTINCT f."xmlFormId", coalesce(fd.name, f."xmlFormId") "name" FROM form_attachments fa
-  JOIN forms f ON f.id = fa."formId"
-  JOIN form_defs fd ON f."currentDefId" = fd.id
-  JOIN datasets ds ON ds.id = fa."datasetId"
-  WHERE ds.name = ${datasetName} 
-    AND ds."projectId" = ${projectId}
-    AND ds."publishedAt" IS NOT NULL 
 `;
 
 // Creates or merges dataset, properties and field mapping.
@@ -192,10 +109,10 @@ const createOrMerge = (dataset, fields, publish = false) => ({ one, Actees, Data
           }
           throw error;
         }))
-    .then((result) => Datasets.getByProjectAndName(dataset.projectId, dataset.name)
+    .then((result) => Datasets.getByProjectAndName(dataset.projectId, dataset.name).then((ds) => ds.get())
       .then((ds) => ((publish === true)
-        ? Datasets.getPublishedProperties(ds.get().id).then(properties => ({ ...ds.get(), properties }))
-        : ds.get().with({ action: result.action }))));
+        ? Datasets.getPublishedProperties(ds.id).then(properties => ({ ...ds, properties }))
+        : ds.with({ action: result.action }))));
 
 createOrMerge.audit = (dataset, _, fields, publish) => (log) =>
   ((dataset.action === 'created')
@@ -206,136 +123,12 @@ createOrMerge.audit = (dataset, _, fields, publish) => (log) =>
       : null));
 createOrMerge.audit.withResult = true;
 
-// Returns dataset along with it properties and field mappings
-const getById = (datasetId) => ({ all }) =>
-  all(_getByIdSql(unjoiner(Dataset, Dataset.Property).fields, datasetId))
-    .then(makeHierarchy)
-    .then(asArray)
-    .then(nth(0));
 
-// Returns only published dataset with its published properties
-const getByName = (datasetName, projectId) => ({ all }) =>
-  all(_getByNameSql(unjoiner(Dataset, Dataset.Property, Dataset.Extended).fields, datasetName, projectId))
-    .then(makeHierarchy)
-    .then(asArray)
-    .then(nth(0))
-    .then(Option.of);
+////////////////////////////////////////////////////////////////////////////
+// DATASET (AND DATASET PROPERTY) PUBLISH
 
-// Returns dataset properties, creation forms and followup forms
-const getDatasetMetadata = (datasetName, projectId) => ({ all }) =>
-  Promise.all([
-    all(_getByNameSql(unjoiner(Dataset, Dataset.Property, Form, Form.Def).fields, datasetName, projectId, true)),
-    all(_getLinkedForms(datasetName, projectId))
-  ])
-    .then(([dsPropForms, linkedForms]) => { //dsPropForms is an array of rows that contains datasets, ds_properties, forms and form_defs columns
-
-      if (!dsPropForms || dsPropForms.length === 0) return null;
-
-      const propertiesMap = new Map();
-
-      const result = {
-        ...new Dataset(pickFrameFields(Dataset, dsPropForms[0])).forApi(),
-        linkedForms
-      };
-
-      // Lets populate dataset properties
-      for (const row of dsPropForms) {
-        const propertyName = row['ds_properties!name'];
-
-        // put property in the map if not there yet
-        if (!propertiesMap.has(propertyName)) {
-          propertiesMap.set(propertyName, {
-            ...new Dataset.Property(pickFrameFields(Dataset.Property, row)),
-            forms: []
-          });
-        }
-
-        const property = propertiesMap.get(propertyName);
-
-        // populate forms
-        if (row['forms!xmlFormId']) {
-          property.forms.push({
-            xmlFormId: row['forms!xmlFormId'],
-            name: row['form_defs!name'] || row['forms!xmlFormId']
-          });
-        }
-      }
-
-      // map to array conversion
-      result.properties = Array.from(propertiesMap.values());
-
-      return result;
-    })
-    .then(Option.of);
-
-// Returns list of dataset for a given projectId
-// Properties and field mappings are not returned
-
-
-const getAllByProjectId = (projectId, queryOptions = QueryOptions.none) => ({ all }) => extender(Dataset)(Dataset.Extended)(_getAllByProjectId)(all, queryOptions.withCondition({ projectId }));
-
-
-// Returns list of Fields augmented by dataset property name OR entity creation information
-// including label.
-const getFieldsByFormDefId = (formDefId) => ({ all }) => all(sql`
-SELECT
-  form_fields.*, ds_properties."name" as "propertyName"
-FROM
-  form_fields
-JOIN form_schemas fs ON fs.id = form_fields."schemaId"
-JOIN form_defs ON fs.id = form_defs."schemaId"
-JOIN dataset_form_defs ON
-  dataset_form_defs."formDefId" = form_defs."id"
-LEFT OUTER JOIN ds_property_fields ON
-  ds_property_fields."schemaId" = form_fields."schemaId"
-    AND ds_property_fields."path" = form_fields."path"
-LEFT OUTER JOIN ds_properties ON
-  ds_properties."id" = ds_property_fields."dsPropertyId"
-WHERE form_defs."id" = ${formDefId}
-  AND (ds_properties."id" IS NOT NULL OR form_fields."path" LIKE '/meta/entity%')
-ORDER BY form_fields."order"
-`)
-  .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName })));
-
-const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
-  WITH form AS (
-    SELECT f.id, f."xmlFormId", fd.id "formDefId", fd."schemaId"
-    FROM forms f
-    JOIN form_defs fd ON fd.id = f.${forDraft ? sql.identifier(['draftDefId']) : sql.identifier(['currentDefId'])}
-    WHERE "projectId" = ${projectId} AND "xmlFormId" = ${xmlFormId} AND f."deletedAt" IS NULL
-  ),
-  ds AS (
-    SELECT d.id, d.name, dd."formDefId", d."publishedAt" IS NULL "isNew"
-    FROM datasets d
-    JOIN dataset_form_defs dd ON dd."datasetId" = d.id
-    JOIN form f ON f."formDefId" = dd."formDefId"
-  ),
-  properties AS (
-    SELECT 
-      dp.*, 
-      dpf.*, 
-      dp."publishedAt" IS NULL "isNew"
-    FROM ds_properties dp 
-    JOIN ds ON ds.id = dp."datasetId"
-    LEFT JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id
-  )
-  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew", TRUE = ANY(ARRAY_AGG(f.id IS NOT NULL)) "inForm"
-  FROM ds
-  LEFT JOIN properties p on ds.id = p."datasetId"
-  LEFT JOIN form f ON f."formDefId" = p."formDefId"
-  ${forDraft ? sql`` : sql`WHERE p.id IS NULL OR NOT p."isNew"`}
-  GROUP BY ds.name, ds."isNew", p.name, p."isNew"
-  ORDER BY p.name
-`)
-  .then(reduceBy((acc, { propertyName, isPropertyNew, inForm }) => (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
-  .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: forDraft ? k.split(',')[1] === 'true' : undefined, properties: r[k] })));
-
-const getByProjectAndName = (projectId, name, excludeUnpublished = false) => ({ maybeOne }) => maybeOne(sql`
-SELECT * FROM datasets WHERE "projectId" = ${projectId} AND name = ${name} ${excludeUnpublished ? sql`AND "publishedAt" IS NOT NULL` : sql``}`)
-  .then(map(construct(Dataset)));
-
-const getPublishedProperties = (id) => ({ all }) => all(sql`
-SELECT * FROM ds_properties WHERE "datasetId" = ${id} AND "publishedAt" IS NOT NULL ORDER BY name`);
+// Called by Forms.publish.
+// createOrMerge may also publish datasets and properties within datasets.
 
 const publishIfExists = (formDefId, publishedAt) => ({ all }) => all(sql`
 WITH properties_update as (
@@ -389,10 +182,180 @@ publishIfExists.audit = (properties) => (log) => {
 
 publishIfExists.audit.withResult = true;
 
+
+////////////////////////////////////////////////////////////////////////////
+// DATASET GETTERS
+
+const _get = extender(Dataset)(Dataset.Extended)((fields, extend, options, publishedOnly = false) => sql`
+  SELECT ${fields} FROM datasets
+  ${extend|| sql`
+  LEFT JOIN (
+    SELECT "datasetId", COUNT(1) "entities", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity"
+    FROM entities e
+    GROUP BY "datasetId"
+  ) stats on stats."datasetId" = datasets.id`}
+  WHERE ${equals(options.condition)}
+    ${publishedOnly ? sql`AND "publishedAt" IS NOT NULL` : sql``}
+  ORDER BY name ASC
+`);
+
+// Get all published datasets for a specific project.
+const getAllByProjectId = (projectId, options = QueryOptions.none) => ({ all }) =>
+  _get(all, options.withCondition({ projectId }), true);
+
+// Get a dataset by it's project id and name. Commonly used in a resource.
+const getByProjectAndName = (projectId, name, publishedOnly = false) => ({ maybeOne }) =>
+  _get(maybeOne, QueryOptions.none.withCondition({ projectId, name }), publishedOnly);
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// DATASET METADATA GETTERS
+
+// Gets the dataset information, properties (including which forms each property comes from),
+// and which forms consume the dataset via CSV attachment.
+const getDatasetMetadata = (datasetName, projectId) => async ({ all, Datasets }) => {
+
+  const _getLinkedForms = () => sql`
+    SELECT DISTINCT f."xmlFormId", coalesce(fd.name, f."xmlFormId") "name" FROM form_attachments fa
+    JOIN forms f ON f.id = fa."formId"
+    JOIN form_defs fd ON f."currentDefId" = fd.id
+    JOIN datasets ds ON ds.id = fa."datasetId"
+    WHERE ds.name = ${datasetName}
+      AND ds."projectId" = ${projectId}
+      AND ds."publishedAt" IS NOT NULL
+  `;
+
+  const dataset = await Datasets.getByProjectAndName(projectId, datasetName).then((o) => o.get());
+  const properties = await Datasets.getPublishedProperties(dataset.id, true);
+  const linkedForms = await all(_getLinkedForms(datasetName, projectId));
+
+  const propertiesMap = new Map();
+  for (const property of properties) {
+    // put property in the map if not there yet
+    if (!propertiesMap.has(property.name)) {
+      propertiesMap.set(property.name, {
+        ...property,
+        forms: []
+      });
+    }
+
+    // populate forms for each property
+    propertiesMap.get(property.name).forms.push({
+      xmlFormId: property.aux.xmlFormId,
+      // TODO: check that returning null name works ok in frontend.
+      name: property.aux.formName
+        ? property.aux.formName
+        : property.aux.xmlFormId
+    });
+  }
+
+  // return all dataset metadata
+  return {
+    ...dataset.forApi(),
+    linkedForms,
+    properties: Array.from(propertiesMap.values())
+  };
+};
+
+
+////////////////////////////////////////////////////////////////////////////
+// DATASET PROPERTY GETTERS
+
+// Returns a list of published properties for a dataset, ordered by
+// their published timestamps and field order within a single form.
+// If 'includeForms' is true, Dataset.Properties will be duplicated for each
+// form that writes that field in the dataset.
+const getPublishedProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
+  SELECT
+      ds_properties.* ${includeForms ? sql`, form_defs."name" as "formName", forms."xmlFormId"` : sql``}
+  FROM
+    ds_properties
+  LEFT OUTER JOIN ds_property_fields ON
+      ds_properties.id = ds_property_fields."dsPropertyId"
+  LEFT OUTER JOIN form_fields ON
+      ds_property_fields.path = form_fields.path
+      AND ds_property_fields."schemaId" = form_fields."schemaId"
+  ${includeForms ? sql`
+  LEFT OUTER JOIN forms ON
+      ds_property_fields."formDefId" = forms."currentDefId"
+  LEFT JOIN form_defs ON
+      forms."currentDefId" = form_defs.id
+  ` : sql``}
+  WHERE ds_properties."datasetId" = ${datasetId}
+    AND ds_properties."publishedAt" IS NOT NULL
+  ORDER BY ds_properties."publishedAt", form_fields.order, ds_properties.id
+`)
+  .then((rows) => (includeForms
+    ? rows.map(({ formName, xmlFormId, ...row }) => new Dataset.Property(row, { formName, xmlFormId }))
+    : R.uniqWith(R.equals, rows).map(construct(Dataset.Property))));
+
+// Returns list of Fields augmented by dataset property name.
+// This it used by the submission XML parser to create an entity from a submission.
+const getFieldsByFormDefId = (formDefId) => ({ all }) => all(sql`
+SELECT
+  form_fields.*, ds_properties."name" as "propertyName"
+FROM
+  form_fields
+JOIN form_schemas fs ON fs.id = form_fields."schemaId"
+JOIN form_defs ON fs.id = form_defs."schemaId"
+JOIN dataset_form_defs ON
+  dataset_form_defs."formDefId" = form_defs."id"
+LEFT OUTER JOIN ds_property_fields ON
+  ds_property_fields."schemaId" = form_fields."schemaId"
+    AND ds_property_fields."path" = form_fields."path"
+LEFT OUTER JOIN ds_properties ON
+  ds_properties."id" = ds_property_fields."dsPropertyId"
+WHERE form_defs."id" = ${formDefId}
+  AND (ds_properties."id" IS NOT NULL OR form_fields."path" LIKE '/meta/entity%')
+ORDER BY form_fields."order"
+`)
+  .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName })));
+
+
+////////////////////////////////////////////////////////////////////////////
+// DATASET DIFF
+
+// Used when creating or updating a dataset through the uploading of a form
+// to show the status of the dataset and each property in that dataset.
+const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
+  WITH form AS (
+    SELECT f.id, f."xmlFormId", fd.id "formDefId", fd."schemaId"
+    FROM forms f
+    JOIN form_defs fd ON fd.id = f.${forDraft ? sql.identifier(['draftDefId']) : sql.identifier(['currentDefId'])}
+    WHERE "projectId" = ${projectId} AND "xmlFormId" = ${xmlFormId} AND f."deletedAt" IS NULL
+  ),
+  ds AS (
+    SELECT d.id, d.name, dd."formDefId", d."publishedAt" IS NULL "isNew"
+    FROM datasets d
+    JOIN dataset_form_defs dd ON dd."datasetId" = d.id
+    JOIN form f ON f."formDefId" = dd."formDefId"
+  ),
+  properties AS (
+    SELECT 
+      dp.*, 
+      dpf.*, 
+      dp."publishedAt" IS NULL "isNew"
+    FROM ds_properties dp 
+    JOIN ds ON ds.id = dp."datasetId"
+    LEFT JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id
+  )
+  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew", TRUE = ANY(ARRAY_AGG(f.id IS NOT NULL)) "inForm"
+  FROM ds
+  LEFT JOIN properties p on ds.id = p."datasetId"
+  LEFT JOIN form f ON f."formDefId" = p."formDefId"
+  ${forDraft ? sql`` : sql`WHERE p.id IS NULL OR NOT p."isNew"`}
+  GROUP BY ds.name, ds."isNew", p.name, p."isNew"
+  ORDER BY p.name
+`)
+  .then(reduceBy((acc, { propertyName, isPropertyNew, inForm }) => (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
+  .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: forDraft ? k.split(',')[1] === 'true' : undefined, properties: r[k] })));
+
+
 module.exports = {
   createOrMerge, publishIfExists,
-  getById, getAllByProjectId, getByName,
-  getFieldsByFormDefId, getPublishedProperties,
-  getDatasetDiff, getByProjectAndName,
-  getDatasetMetadata
+  getAllByProjectId, getByProjectAndName,
+  getDatasetMetadata,
+  getPublishedProperties, getFieldsByFormDefId,
+  getDatasetDiff
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -94,7 +94,7 @@ SELECT "action" FROM ds
 const createOrMerge = (dataset, fields, publish = false) => ({ one, Actees, Datasets, Projects }) =>
   Promise.all([
     Projects.getById(dataset.projectId).then((o) => o.get()),
-    Datasets.getByProjectAndName(dataset.projectId, dataset.name)
+    Datasets.get(dataset.projectId, dataset.name)
   ])
     .then(([project, datasetOption]) =>
       (datasetOption.isDefined()
@@ -108,7 +108,7 @@ const createOrMerge = (dataset, fields, publish = false) => ({ one, Actees, Data
           }
           throw error;
         }))
-    .then((result) => Datasets.getByProjectAndName(dataset.projectId, dataset.name).then((ds) => ds.get())
+    .then((result) => Datasets.get(dataset.projectId, dataset.name).then((ds) => ds.get())
       .then((ds) => ((publish === true)
         ? Datasets.getPublishedProperties(ds.id).then(properties => ({ ...ds, properties }))
         : ds.with({ action: result.action }))));
@@ -203,7 +203,7 @@ const getList = (projectId, options = QueryOptions.none) => ({ all }) =>
   _get(all, options.withCondition({ projectId }), true);
 
 // Get a dataset by it's project id and name. Commonly used in a resource.
-const getByProjectAndName = (projectId, name, publishedOnly = false, extended = false) => ({ maybeOne }) => {
+const get = (projectId, name, publishedOnly = false, extended = false) => ({ maybeOne }) => {
   const options = extended ? QueryOptions.extended : QueryOptions.none;
   return _get(maybeOne, options.withCondition({ projectId, name }), publishedOnly);
 };
@@ -354,7 +354,7 @@ const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
 
 module.exports = {
   createOrMerge, publishIfExists,
-  getList, getByProjectAndName,
+  getList, get,
   getMetadata,
   getPublishedProperties, getFieldsByFormDefId,
   getDatasetDiff

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -204,8 +204,10 @@ const getAllByProjectId = (projectId, options = QueryOptions.none) => ({ all }) 
   _get(all, options.withCondition({ projectId }), true);
 
 // Get a dataset by it's project id and name. Commonly used in a resource.
-const getByProjectAndName = (projectId, name, publishedOnly = false) => ({ maybeOne }) =>
-  _get(maybeOne, QueryOptions.none.withCondition({ projectId, name }), publishedOnly);
+const getByProjectAndName = (projectId, name, publishedOnly = false, extended = false) => ({ maybeOne }) => {
+  const options = extended ? QueryOptions.extended : QueryOptions.none;
+  return _get(maybeOne, options.withCondition({ projectId, name }), publishedOnly);
+};
 
 
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -199,7 +199,7 @@ const _get = extender(Dataset)(Dataset.Extended)((fields, extend, options, publi
 `);
 
 // Get all published datasets for a specific project.
-const getAllByProjectId = (projectId, options = QueryOptions.none) => ({ all }) =>
+const getList = (projectId, options = QueryOptions.none) => ({ all }) =>
   _get(all, options.withCondition({ projectId }), true);
 
 // Get a dataset by it's project id and name. Commonly used in a resource.
@@ -354,7 +354,7 @@ const getDatasetDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
 
 module.exports = {
   createOrMerge, publishIfExists,
-  getAllByProjectId, getByProjectAndName,
+  getList, getByProjectAndName,
   getMetadata,
   getPublishedProperties, getFieldsByFormDefId,
   getDatasetDiff

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -58,7 +58,7 @@ const createNew = (xml, form, itemsets) => ({ Blobs, Datasets, run }) =>
     .then((expected) => [expected])
     .then(itemsetsHack(Blobs, itemsets))
     .then((expected) =>
-      Datasets.getAllByProjectId(form.projectId)
+      Datasets.getList(form.projectId)
         .then(datasets => {
           const dsHashtable = datasets.reduce((acc, ds) => Object.assign(acc, { [`${ds.name}.csv`]: ds }), {});
           const ids = { formId: form.id, formDefId: form.def.id };
@@ -77,7 +77,7 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
   ])
     .then(ignoringResult(itemsetsHack(Blobs, itemsets)))
     .then(([expecteds, extants]) =>
-      Datasets.getAllByProjectId(form.projectId)
+      Datasets.getList(form.projectId)
         .then(datasets => {
           const dsHashtable = datasets.reduce((acc, ds) => Object.assign(acc, { [`${ds.name}.csv`]: ds }), {});
           // deal with attachments. match up extant ones with now-expected ones,

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -21,7 +21,7 @@ module.exports = (service, endpoint) => {
       .then(() => Datasets.getList(params.id, queryOptions))));
 
   service.get('/projects/:projectId/datasets/:name', endpoint(({ Datasets }, { params, auth }) =>
-    Datasets.getByProjectAndName(params.projectId, params.name)
+    Datasets.get(params.projectId, params.name)
       .then(getOrNotFound)
       .then((dataset) => auth.canOrReject('dataset.read', dataset)
         .then(() => Datasets.getMetadata(dataset)))));
@@ -30,7 +30,7 @@ module.exports = (service, endpoint) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
 
-    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true, true).then(getOrNotFound);
+    const dataset = await Datasets.get(params.projectId, params.name, true, true).then(getOrNotFound);
     const properties = await Datasets.getPublishedProperties(dataset.id);
     const { lastEntity } = dataset.forApi();
 

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -31,7 +31,7 @@ module.exports = (service, endpoint) => {
     await auth.canOrReject('entity.list', project);
 
     const dataset = await Datasets.get(params.projectId, params.name, true, true).then(getOrNotFound);
-    const properties = await Datasets.getPublishedProperties(dataset.id);
+    const properties = await Datasets.getProperties(dataset.id);
     const { lastEntity } = dataset.forApi();
 
     // Etag logic inspired from https://stackoverflow.com/questions/72334843/custom-computed-etag-for-express-js/72335674#72335674

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -30,11 +30,12 @@ module.exports = (service, endpoint) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
 
-    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
+    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true, true).then(getOrNotFound);
     const properties = await Datasets.getPublishedProperties(dataset.id);
+    const { lastEntity } = dataset.forApi();
 
     // Etag logic inspired from https://stackoverflow.com/questions/72334843/custom-computed-etag-for-express-js/72335674#72335674
-    const serverEtag = `"${md5sum(dataset.lastEntity?.toISOString() ?? '1970-01-01')}"`;
+    const serverEtag = `"${md5sum(lastEntity?.toISOString() ?? '1970-01-01')}"`;
     const clientEtag = request.get('If-None-Match');
     if (clientEtag?.includes(serverEtag)) { // nginx weakens Etag when gzip is used, so clientEtag is like W/"4e9f0c7e9a8240..."
       response.status(304);

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -23,8 +23,8 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name', endpoint(({ Datasets }, { params, auth }) =>
     Datasets.getByProjectAndName(params.projectId, params.name)
       .then(getOrNotFound)
-      .then((dataset) => auth.canOrReject('dataset.read', dataset))
-      .then(() => Datasets.getDatasetMetadata(params.name, params.projectId))));
+      .then((dataset) => auth.canOrReject('dataset.read', dataset)
+        .then(() => Datasets.getMetadata(dataset)))));
 
   service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(async ({ Datasets, Entities, Projects }, { params, auth }, request, response) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -20,18 +20,18 @@ module.exports = (service, endpoint) => {
       .then((project) => auth.canOrReject('dataset.list', project))
       .then(() => Datasets.getAllByProjectId(params.id, queryOptions))));
 
-  service.get('/projects/:projectId/datasets/:name', endpoint(({ Datasets, Projects }, { params, auth }) =>
-    Projects.getById(params.projectId)
+  service.get('/projects/:projectId/datasets/:name', endpoint(({ Datasets }, { params, auth }) =>
+    Datasets.getByProjectAndName(params.projectId, params.name)
       .then(getOrNotFound)
-      .then((project) => auth.canOrReject('dataset.read', project))
-      .then(() => Datasets.getDatasetMetadata(params.name, params.projectId)
-        .then(getOrNotFound))));
+      .then((dataset) => auth.canOrReject('dataset.read', dataset))
+      .then(() => Datasets.getDatasetMetadata(params.name, params.projectId))));
 
   service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(async ({ Datasets, Entities, Projects }, { params, auth }, request, response) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
 
-    const dataset = await Datasets.getByName(params.name, params.projectId).then(getOrNotFound);
+    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
+    const properties = await Datasets.getPublishedProperties(dataset.id);
 
     // Etag logic inspired from https://stackoverflow.com/questions/72334843/custom-computed-etag-for-express-js/72335674#72335674
     const serverEtag = `"${md5sum(dataset.lastEntity?.toISOString() ?? '1970-01-01')}"`;
@@ -46,7 +46,7 @@ module.exports = (service, endpoint) => {
     response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
     response.append('Content-Type', 'text/csv');
     response.set('ETag', serverEtag);
-    return streamEntityCsv(entities, dataset.properties);
+    return streamEntityCsv(entities, properties);
 
   }));
 };

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -18,7 +18,7 @@ module.exports = (service, endpoint) => {
     Projects.getById(params.id, queryOptions)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('dataset.list', project))
-      .then(() => Datasets.getAllByProjectId(params.id, queryOptions))));
+      .then(() => Datasets.getList(params.id, queryOptions))));
 
   service.get('/projects/:projectId/datasets/:name', endpoint(({ Datasets }, { params, auth }) =>
     Datasets.getByProjectAndName(params.projectId, params.name)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -283,12 +283,12 @@ module.exports = (service, endpoint) => {
               ? Blobs.getById(attachment.blobId)
                 .then(getOrNotFound)
                 .then((blob) => binary(blob.contentType, attachment.name, blob.content))
-              : Datasets.getById(attachment.datasetId, params.projectId)
-                .then((dataset) => Entities.streamForExport(attachment.datasetId)
+              : Datasets.getPublishedProperties(attachment.datasetId)
+                .then((properties) => Entities.streamForExport(attachment.datasetId)
                   .then((entities) => {
                     response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
                     response.append('Content-Type', 'text/csv');
-                    return streamEntityCsv(entities, dataset.properties);
+                    return streamEntityCsv(entities, properties);
                   }))))))));
   };
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -166,7 +166,7 @@ module.exports = (service, endpoint) => {
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId
         ? [] // return empty array if encryption is enabled
-        : Datasets.getDatasetDiff(params.projectId, params.id, true)))));
+        : Datasets.getDiff(params.projectId, params.id, true)))));
 
   service.get('/projects/:projectId/forms/:id/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
     Promise.all([
@@ -186,7 +186,7 @@ module.exports = (service, endpoint) => {
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId
         ? [] // return empty array if encryption is enabled
-        : Datasets.getDatasetDiff(params.projectId, params.id, false)))));
+        : Datasets.getDiff(params.projectId, params.id, false)))));
 
   service.patch('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Datasets, FormAttachments, Forms }, { auth, params, body }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
@@ -283,7 +283,7 @@ module.exports = (service, endpoint) => {
               ? Blobs.getById(attachment.blobId)
                 .then(getOrNotFound)
                 .then((blob) => binary(blob.contentType, attachment.name, blob.content))
-              : Datasets.getPublishedProperties(attachment.datasetId)
+              : Datasets.getProperties(attachment.datasetId)
                 .then((properties) => Entities.streamForExport(attachment.datasetId)
                   .then((entities) => {
                     response.append('Content-Disposition', contentDisposition(`${attachment.name}`));

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -193,7 +193,7 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then((form) => Promise.all([
-        Datasets.getByProjectAndName(params.projectId, params.name.replace(/\.csv$/i, ''), true)
+        Datasets.get(params.projectId, params.name.replace(/\.csv$/i, ''), true)
           .then(getOrNotFound)
           .then((dataset) => auth.canOrReject('entity.list', dataset)),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)

--- a/lib/resources/odata-entities.js
+++ b/lib/resources/odata-entities.js
@@ -26,7 +26,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name.svc', endpoint.odata.json(async ({ Datasets, Projects, env }, { auth, params, originalUrl }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
-    await Datasets.getByName(params.name, params.projectId).then(getOrNotFound);
+    await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
     return contentType('application/json; odata.metadata=minimal')(serviceDocument(env.domain, originalUrl));
   }));
 
@@ -34,19 +34,21 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name.svc/([$])metadata', endpoint.odata.xml(async ({ Datasets, Projects }, { auth, params }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
-    const dataset = await Datasets.getByName(params.name, params.projectId).then(getOrNotFound);
-    return xml(edmxForEntities(params.name, dataset.properties));
+    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
+    const properties = await Datasets.getPublishedProperties(dataset.id);
+    return xml(edmxForEntities(params.name, properties));
   }));
 
   // serves the odata feed for the entities
   service.get('/projects/:projectId/datasets/:name.svc/Entities', endpoint.odata.json(async ({ Datasets, Entities, Projects, env }, { auth, params, originalUrl, query }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
-    const dataset = await Datasets.getByName(params.name, params.projectId).then(getOrNotFound);
+    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
+    const properties = await Datasets.getPublishedProperties(dataset.id);
     const options = QueryOptions.fromODataRequestEntities(query);
     const count = await Entities.countByDatasetId(dataset.id, options);
     const entities = await Entities.streamForExport(dataset.id, options);
-    return json(streamEntityOdata(entities, dataset.properties, env.domain, originalUrl, query, count));
+    return json(streamEntityOdata(entities, properties, env.domain, originalUrl, query, count));
   }));
 
 

--- a/lib/resources/odata-entities.js
+++ b/lib/resources/odata-entities.js
@@ -26,7 +26,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name.svc', endpoint.odata.json(async ({ Datasets, Projects, env }, { auth, params, originalUrl }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
-    await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
+    await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
     return contentType('application/json; odata.metadata=minimal')(serviceDocument(env.domain, originalUrl));
   }));
 
@@ -34,7 +34,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name.svc/([$])metadata', endpoint.odata.xml(async ({ Datasets, Projects }, { auth, params }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
-    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
+    const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
     const properties = await Datasets.getPublishedProperties(dataset.id);
     return xml(edmxForEntities(params.name, properties));
   }));
@@ -43,7 +43,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name.svc/Entities', endpoint.odata.json(async ({ Datasets, Entities, Projects, env }, { auth, params, originalUrl, query }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
-    const dataset = await Datasets.getByProjectAndName(params.projectId, params.name, true).then(getOrNotFound);
+    const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
     const properties = await Datasets.getPublishedProperties(dataset.id);
     const options = QueryOptions.fromODataRequestEntities(query);
     const count = await Entities.countByDatasetId(dataset.id, options);

--- a/lib/resources/odata-entities.js
+++ b/lib/resources/odata-entities.js
@@ -35,7 +35,7 @@ module.exports = (service, endpoint) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
-    const properties = await Datasets.getPublishedProperties(dataset.id);
+    const properties = await Datasets.getProperties(dataset.id);
     return xml(edmxForEntities(params.name, properties));
   }));
 
@@ -44,7 +44,7 @@ module.exports = (service, endpoint) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
-    const properties = await Datasets.getPublishedProperties(dataset.id);
+    const properties = await Datasets.getProperties(dataset.id);
     const options = QueryOptions.fromODataRequestEntities(query);
     const count = await Entities.countByDatasetId(dataset.id, options);
     const entities = await Entities.streamForExport(dataset.id, options);

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -356,10 +356,8 @@ should.Assertion.add('Dataset', function assertDataset() {
 should.Assertion.add('ExtendedDataset', function assertExtendedDataset() {
   this.params = { operator: 'to be an extended Dataset' };
 
-  Object.keys(this.obj).should.containDeep([ 'projectId', 'name', 'createdAt', 'entities', 'lastEntity' ]);
-  this.obj.projectId.should.be.a.Number();
-  this.obj.name.should.be.a.String();
-  this.obj.createdAt.should.be.an.isoDate();
+  this.obj.should.be.a.Dataset();
+  Object.keys(this.obj).should.containDeep([ 'entities', 'lastEntity' ]);
   this.obj.entities.should.be.a.Number();
   if (this.obj.lastEntity != null) this.obj.lastEntity.should.be.an.isoDate();
 });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -772,7 +772,7 @@ describe('datasets and entities', () => {
   </manifest>`);
               })))));
 
-      it.skip('should return md5 of last Entity timestamp in the manifest', testService(async (service, container) => {
+      it('should return md5 of last Entity timestamp in the manifest', testService(async (service, container) => {
         const asAlice = await service.login('alice');
 
         await asAlice.post('/v1/projects/1/forms?publish=true')

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -772,7 +772,7 @@ describe('datasets and entities', () => {
   </manifest>`);
               })))));
 
-      it('should return md5 of last Entity timestamp in the manifest', testService(async (service, container) => {
+      it.skip('should return md5 of last Entity timestamp in the manifest', testService(async (service, container) => {
         const asAlice = await service.login('alice');
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
@@ -1580,32 +1580,6 @@ describe('datasets and entities', () => {
             }));
       }));
 
-      it('should update a dataset with new form draft', testService(async (service, { Datasets }) => {
-        // Upload a form and then create a new draft version
-        await service.login('alice', (asAlice) =>
-          asAlice.post('/v1/projects/1/forms?publish=true')
-            .send(testData.forms.simpleEntity)
-            .set('Content-Type', 'application/xml')
-            .expect(200)
-            .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
-              .expect(200)
-              .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
-                .set('X-Extended-Metadata', 'true')
-                .expect(200)
-                .then(({ body }) => {
-                  body.entityRelated.should.equal(true);
-                }))));
-
-        // Get all datasets by projectId
-        const datasetId = await Datasets.getAllByProjectId(1)
-          .then(result => result[0].id);
-
-        await Datasets.getById(datasetId)
-          .then(result => {
-            result.properties.length.should.be.eql(2);
-          });
-      }));
-
       it('should be able to upload multiple drafts', testService(async (service) => {
         // Upload a form and then create a new draft version
         await service.login('alice', (asAlice) =>
@@ -1712,7 +1686,7 @@ describe('datasets and entities', () => {
 
         await Audits.getLatestByAction('dataset.update.publish')
           .then(o => o.get())
-          .then(audit => audit.details.should.eql({ properties: ['age', 'first_name'] }));
+          .then(audit => audit.details.should.eql({ properties: ['first_name', 'age'] }));
 
         await asAlice.post('/v1/projects/1/forms')
           .send(testData.forms.simpleEntity

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -451,10 +451,10 @@ describe('worker: entity', () => {
       const { text } = await asAlice.get('/v1/projects/1/datasets/foo/entities.csv');
 
       const csv = text.split('\n');
-      csv[0].includes('name,label,b_q1,d_q2,a_q3,c_q4,f_q1,e_q2').should.equal(true);
-      csv[1].includes(',one,,,y,z,w,x').should.equal(true);
-      csv[2].includes(',two,a,b,c,d,,').should.equal(true);
-      csv[3].includes(',one,w,x,y,z,,').should.equal(true);
+      csv[0].includes('name,label,f_q1,e_q2,a_q3,c_q4,b_q1,d_q2').should.equal(true);
+      csv[1].includes(',one,w,x,y,z,,').should.equal(true);
+      csv[2].includes(',two,,,c,d,a,b').should.equal(true);
+      csv[3].includes(',one,,,y,z,w,x').should.equal(true);
     }));
   });
 });


### PR DESCRIPTION
Closes #691 

The diff looks like a mess because I changed a bunch and moved things around. Here's the new organization:

#### Creating/updating

`Datasets.createOrMerge` and `Datasets.publishIfExists` used by the Forms query module.
This is mostly the same as before but there's an issue #793 for refactoring.

#### Simplified Dataset getters

Get all datasets for a project or get a single dataset. These return minimal information about Datasets -- just the metadata, really, or the "extended" metadata consisting of entity counts and last entity timestamp. They can be used for auth checks and listing basic information about Datasets on frontend. More complicated stuff about Datasets (including properties) is accessed below. 

One observation here is that these are called by a resources where the project id and dataset name is known. By having a simple call here to get and check the metadata, we can separate out the more complicated dataset queries after we know we have access to the dataset.

#### Complex Dataset getters

Another observation is  that certain things like getting the right list of dataset properties in order can be really tricky, so making these more modular will hopefully help with reusability, understandability, and maintainability, even if it means 2 or 3 queries instead of 1. I don't think any of these are too performance-critical.

**_Metadata_** 

Properties and lists of forms that produce and consume datasets.

**_Properties_**

This is probably the most important thing about any given dataset, and the most complicated to compute. I'm trying to have all the property SQL focused here so it doesn't have to be duplicated.

**_Diffs_**

Conveying how a form changes a dataset. This one is called based on the project and xmlformid so it doesn't really intersect with any of the other functions, except it also returns information about properties. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Mostly the same tests as before.

#### Why is this the best possible solution? Were any other approaches considered?

I hope it's going to be easier to maintain and use.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Doesn't impact users.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced