### PR TITLE
Add dataset.read and entity.read verbs.

### DIFF
--- a/lib/model/migrations/20230324-01-edit-dataset-verbs.js
+++ b/lib/model/migrations/20230324-01-edit-dataset-verbs.js
@@ -7,27 +7,25 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { without } = require('ramda');
+const up = (db) => db.raw(`
+UPDATE roles
+SET verbs = verbs || '["dataset.read", "entity.read"]'::jsonb
+WHERE system in ('admin', 'manager', 'viewer')
+`).then(() => db.raw(`
+UPDATE roles
+SET verbs = verbs || '["entity.create", "entity.update"]'::jsonb
+WHERE system in ('admin', 'manager')
+`));
 
-/* eslint-disable no-await-in-loop */
-
-const up = async (db) => {
-  // grant rights.
-  for (const system of [ 'admin', 'manager', 'viewer' ]) {
-    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
-    const newVerbs = verbs.concat([ 'dataset.read', 'entity.read' ]);
-    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
-  }
-};
-
-const down = async (db) => {
-  // revoke rights.
-  for (const system of [ 'admin', 'manager', 'viewer' ]) {
-    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
-    const newVerbs = without([ 'dataset.read', 'entity.read' ], verbs);
-    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
-  }
-};
+const down = (db) => db.raw(`
+UPDATE roles
+SET verbs = (verbs - 'dataset.read' - 'entity.read')
+WHERE system in ('admin', 'manager', 'viewer')
+`).then(() => db.raw(`
+UPDATE roles
+SET verbs = (verbs - 'entity.create' - 'entity.update')
+WHERE system in ('admin', 'manager')
+`));
 
 module.exports = { up, down };
 

--- a/lib/model/migrations/20230324-01-edit-dataset-verbs.js
+++ b/lib/model/migrations/20230324-01-edit-dataset-verbs.js
@@ -1,0 +1,33 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { without } = require('ramda');
+
+/* eslint-disable no-await-in-loop */
+
+const up = async (db) => {
+  // grant rights.
+  for (const system of [ 'admin', 'manager', 'viewer' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = verbs.concat([ 'dataset.read', 'entity.read' ]);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+};
+
+const down = async (db) => {
+  // revoke rights.
+  for (const system of [ 'admin', 'manager', 'viewer' ]) {
+    const [{ verbs }] = await db.select('verbs').from('roles').where({ system });
+    const newVerbs = without([ 'dataset.read', 'entity.read' ], verbs);
+    await db.update({ verbs: JSON.stringify(newVerbs) }).into('roles').where({ system });
+  }
+};
+
+module.exports = { up, down };
+

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -23,7 +23,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/datasets/:name', endpoint(({ Datasets, Projects }, { params, auth }) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
-      .then((project) => auth.canOrReject('dataset.list', project))
+      .then((project) => auth.canOrReject('dataset.read', project))
       .then(() => Datasets.getDatasetMetadata(params.name, params.projectId)
         .then(getOrNotFound))));
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -135,7 +135,7 @@ module.exports = (service, endpoint) => {
   // Entity/Dataset-specific endpoint that is used to show how publishing
   // a form will change any datasets mentioned in the form.
   // Even though there are dataset-related permissions, we will use a combination of dataset access and
-  // form modification verbs for authorization. Though form.update and dataset.read will likely be part
+  // form modification verbs for authorization. Though form.update and dataset.list will likely be part
   // of the same role, we want to use the combined authorization strength. One scenario where they are
   // different is if a user has been assigned a higher auth role on a specific form but not a project,
   // which can be done through the API: projects/.../forms/.../assignments
@@ -161,7 +161,7 @@ module.exports = (service, endpoint) => {
       .then(([form, project]) =>
         Promise.all([
           auth.canOrReject('form.update', form),
-          auth.canOrReject('dataset.read', project)
+          auth.canOrReject('dataset.list', project)
         ]))
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId
@@ -181,7 +181,7 @@ module.exports = (service, endpoint) => {
       .then(([form, project]) =>
         Promise.all([
           auth.canOrReject('form.update', form),
-          auth.canOrReject('dataset.read', project)
+          auth.canOrReject('dataset.list', project)
         ]))
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -135,7 +135,7 @@ module.exports = (service, endpoint) => {
   // Entity/Dataset-specific endpoint that is used to show how publishing
   // a form will change any datasets mentioned in the form.
   // Even though there are dataset-related permissions, we will use a combination of dataset access and
-  // form modification verbs for authorization. Though form.update and dataset.list will likely be part
+  // form modification verbs for authorization. Though form.update and dataset.read will likely be part
   // of the same role, we want to use the combined authorization strength. One scenario where they are
   // different is if a user has been assigned a higher auth role on a specific form but not a project,
   // which can be done through the API: projects/.../forms/.../assignments
@@ -161,7 +161,7 @@ module.exports = (service, endpoint) => {
       .then(([form, project]) =>
         Promise.all([
           auth.canOrReject('form.update', form),
-          auth.canOrReject('dataset.list', project)
+          auth.canOrReject('dataset.read', project)
         ]))
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId
@@ -181,7 +181,7 @@ module.exports = (service, endpoint) => {
       .then(([form, project]) =>
         Promise.all([
           auth.canOrReject('form.update', form),
-          auth.canOrReject('dataset.list', project)
+          auth.canOrReject('dataset.read', project)
         ]))
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1326,7 +1326,7 @@ describe('api: /projects?forms=true', () => {
           body.length.should.equal(1);
           body[0].should.be.a.Project();
           const { formList, verbs } = body[0];
-          verbs.length.should.equal(44);
+          verbs.length.should.equal(46);
           formList.length.should.equal(2);
           const form = formList[0];
           form.should.be.a.ExtendedForm();
@@ -1390,7 +1390,7 @@ describe('api: /projects?forms=true', () => {
             body.length.should.equal(2);
             // First project
             body[0].formList.length.should.equal(2);
-            body[0].verbs.length.should.equal(29);
+            body[0].verbs.length.should.equal(31);
             // Second project
             body[1].formList.length.should.equal(1);
             body[1].verbs.length.should.be.lessThan(5); // 4 for data collector

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -69,7 +69,7 @@ describe('api: /projects', () => {
               .set('X-Extended-Metadata', 'true')
               .expect(200)
               .then(({ body }) => {
-                body.verbs.length.should.be.greaterThan(43);
+                body.verbs.length.should.equal(46);
                 body.should.be.a.Project();
                 body.name.should.equal('Default Project');
               }))))));
@@ -370,7 +370,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
-            body.verbs.length.should.be.greaterThan(39);
+            body.verbs.length.should.equal(46);
             body.verbs.should.containDeep([ 'user.password.invalidate', 'project.delete' ]);
           }))));
 
@@ -381,7 +381,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
-            body.verbs.length.should.be.lessThan(30);
+            body.verbs.length.should.equal(31);
             body.verbs.should.containDeep([ 'assignment.create', 'project.delete', 'dataset.list' ]);
             body.verbs.should.not.containDeep([ 'project.create' ]);
           }))));

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -69,7 +69,7 @@ describe('api: /projects', () => {
               .set('X-Extended-Metadata', 'true')
               .expect(200)
               .then(({ body }) => {
-                body.verbs.length.should.be.greaterThan(39);
+                body.verbs.length.should.be.greaterThan(43);
                 body.should.be.a.Project();
                 body.name.should.equal('Default Project');
               }))))));
@@ -381,7 +381,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
-            body.verbs.length.should.be.lessThan(28);
+            body.verbs.length.should.be.lessThan(30);
             body.verbs.should.containDeep([ 'assignment.create', 'project.delete', 'dataset.list' ]);
             body.verbs.should.not.containDeep([ 'project.create' ]);
           }))));
@@ -398,13 +398,11 @@ describe('api: /projects', () => {
               .expect(200)
               .then(({ body }) => {
                 body.verbs.should.eqlInAnyOrder([
-                  // eslint-disable-next-line no-multi-spaces
-                  'project.read',      // from role(s): formfill
-                  // eslint-disable-next-line no-multi-spaces
-                  'form.list',         // from role(s): formfill
-                  // eslint-disable-next-line no-multi-spaces
-                  'form.read',         // from role(s): formfill
-                  'submission.create', // from role(s): formfill
+                  // following verbs from role: formfill
+                  'project.read',
+                  'form.list',
+                  'form.read',
+                  'submission.create',
                 ]);
               }))))));
 
@@ -422,21 +420,19 @@ describe('api: /projects', () => {
               .expect(200)
               .then(({ body }) => {
                 body.verbs.should.eqlInAnyOrder([
-                  // eslint-disable-next-line no-multi-spaces
-                  'project.read',      // from role(s): formfill, viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'form.list',         // from role(s): formfill, viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'form.read',         // from role(s): formfill, viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'submission.read',   // from role(s): viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'submission.list',   // from role(s): viewer
-                  'submission.create', // from role(s): formfill
-                  // eslint-disable-next-line no-multi-spaces
-                  'dataset.list',      // from role(s): viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'entity.list',      // from role(s): viewer
+                  // following roles from formfill + viewer:
+                  'project.read',
+                  'form.list',
+                  'form.read',
+                  // following roles from formfill only:
+                  'submission.create',
+                  // following roles from viewer only:
+                  'submission.read',
+                  'submission.list',
+                  'dataset.list',
+                  'dataset.read',
+                  'entity.list',
+                  'entity.read'
                 ]);
               }))))));
   });
@@ -1330,7 +1326,7 @@ describe('api: /projects?forms=true', () => {
           body.length.should.equal(1);
           body[0].should.be.a.Project();
           const { formList, verbs } = body[0];
-          verbs.length.should.equal(42);
+          verbs.length.should.equal(44);
           formList.length.should.equal(2);
           const form = formList[0];
           form.should.be.a.ExtendedForm();
@@ -1394,7 +1390,7 @@ describe('api: /projects?forms=true', () => {
             body.length.should.equal(2);
             // First project
             body[0].formList.length.should.equal(2);
-            body[0].verbs.length.should.equal(27);
+            body[0].verbs.length.should.equal(29);
             // Second project
             body[1].formList.length.should.equal(1);
             body[1].verbs.length.should.be.lessThan(5); // 4 for data collector
@@ -1439,21 +1435,19 @@ describe('api: /projects?forms=true', () => {
                 body.length.should.equal(1);
                 const { verbs } = body[0];
                 verbs.should.eqlInAnyOrder([
-                  // eslint-disable-next-line no-multi-spaces
-                  'form.list',         // from role(s): formfill, viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'form.read',         // from role(s): formfill, viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'project.read',      // from role(s): formfill, viewer
-                  'submission.create', // from role(s): formfill
-                  // eslint-disable-next-line no-multi-spaces
-                  'submission.list',   // from role(s): viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'submission.read',   // from role(s): viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'dataset.list',     // from role(s): viewer
-                  // eslint-disable-next-line no-multi-spaces
-                  'entity.list'      // from role(s): viewer
+                  // following roles from formfill + viewer:
+                  'project.read',
+                  'form.list',
+                  'form.read',
+                  // following roles from formfill only:
+                  'submission.create',
+                  // following roles from viewer only:
+                  'submission.read',
+                  'submission.list',
+                  'dataset.list',
+                  'dataset.read',
+                  'entity.list',
+                  'entity.read'
                 ]);
               }))))));
   });
@@ -1484,21 +1478,19 @@ describe('api: /projects?forms=true', () => {
             const project = body[0];
             project.id.should.equal(1);
             project.verbs.should.eqlInAnyOrder([
-              // eslint-disable-next-line no-multi-spaces
-              'project.read',     // from role(s): viewer
-              // eslint-disable-next-line no-multi-spaces
-              'form.list',        // from role(s): viewer
-              // eslint-disable-next-line no-multi-spaces
-              'form.read',        // from role(s): viewer, app-user
-              // eslint-disable-next-line no-multi-spaces
-              'submission.read',  // from role(s): viewer
-              // eslint-disable-next-line no-multi-spaces
-              'submission.list',  // from role(s): viewer
-              'submission.create', // from role(s): app-user
-              // eslint-disable-next-line no-multi-spaces
-              'dataset.list',  // from role(s): viewer
-              // eslint-disable-next-line no-multi-spaces
-              'entity.list'   // from role(s): viewer
+              // following roles from app-user + viewer:
+              'form.read',
+              // following roles from app-user only:
+              'submission.create',
+              // following roles from viewer only:
+              'project.read',
+              'form.list',
+              'submission.read',
+              'submission.list',
+              'dataset.list',
+              'dataset.read',
+              'entity.list',
+              'entity.read'
             ]);
           }))))));
 });


### PR DESCRIPTION
Closes #794 

Adds `dataset.read` and `entity.read` verbs for reading individual datasets and (eventually) entities to the list of verbs for Admins, Managers, and Project Viewers.

Also adds `entity.create` and `entity.update` verbs for Admins and Managers to be ready for entity creating/updating!

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Something we've needed for a little while.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect. In some places, `dataset.list` was used in place of `dataset.read` but the same roles have the same verbs so it doesn't really change anything.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No, verbs aren't individually listed in the docs.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced