### PR TITLE
Move prep work from Forms to Datasets.createOrMerge

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -89,39 +89,50 @@ SELECT "action" FROM ds
 `;
 
 // Creates or merges dataset, properties and field mapping.
-// Expects dataset:Frame auxed with `formDefId`, `schemaId`,
-// and array of field:Frame auxed with `propertyName`
-const createOrMerge = (dataset, fields, publish = false) => ({ one, Actees, Datasets, Projects }) =>
-  Promise.all([
-    Projects.getById(dataset.projectId).then((o) => o.get()),
-    Datasets.get(dataset.projectId, dataset.name)
-  ])
-    .then(([project, datasetOption]) =>
-      (datasetOption.isDefined()
-        ? datasetOption.get().acteeId
-        : Actees.provision('dataset', project).then((actee) => (actee.id))))
-    .then((acteeId) =>
-      one(_createOrMerge(dataset, fields, acteeId, publish))
-        .catch(error => {
-          if (error.constraint === 'ds_property_fields_dspropertyid_formdefid_unique') {
-            throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single Dataset Property.' });
-          }
-          throw error;
-        }))
-    .then((result) => Datasets.get(dataset.projectId, dataset.name).then((ds) => ds.get())
-      .then((ds) => ((publish === true)
-        ? Datasets.getProperties(ds.id).then(properties => ({ ...ds, properties }))
-        : ds.with({ action: result.action }))));
+const createOrMerge = (name, projectId, formDefId, schemaId, fields, publish) => async ({ one, Actees, Datasets, Projects }) => {
+  // Fetching project again because new form endpoint has it and update form does not.
+  const project = await Projects.getById(projectId).then((o) => o.get());
+  const existingDataset = await Datasets.get(project.id, name);
+  const acteeId = existingDataset.isDefined()
+    ? existingDataset.get().acteeId
+    : await Actees.provision('dataset', project).then((actee) => (actee.id));
+  const partial = new Dataset({ name, projectId: project.id }, { formDefId });
 
-createOrMerge.audit = (dataset, _, fields, publish) => (log) =>
+  // Prepare dataset properties from form fields:
+  let dsPropertyFields = fields.filter((field) => (field.propertyName));
+
+  if (dsPropertyFields.filter((field) => field.propertyName === 'name' || field.propertyName === 'label').length > 0)
+    throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
+
+  dsPropertyFields = dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId, formDefId }));
+
+  // Insert or update
+  const result = await one(_createOrMerge(partial, dsPropertyFields, acteeId, publish))
+    .catch(error => {
+      if (error.constraint === 'ds_property_fields_dspropertyid_formdefid_unique') {
+        throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single Dataset Property.' });
+      }
+      throw error;
+    });
+
+  // Fetch dataset again with properties in order to write audit log
+  const ds = await Datasets.get(project.id, name).then((o) => o.get());
+
+  const publishedProperties = ((publish === true)
+    ? await Datasets.getProperties(ds.id)
+    : null);
+
+  return ds.with({ action: result.action, fields: dsPropertyFields, properties: publishedProperties });
+};
+
+createOrMerge.audit = (dataset, name, projectId, formDefId, schemaId, fields, publish) => (log) =>
   ((dataset.action === 'created')
-    ? log('dataset.create', dataset, { fields: fields.map((f) => [f.path, f.propertyName]) })
-    : log('dataset.update', dataset, { fields: fields.map((f) => [f.path, f.propertyName]) }))
+    ? log('dataset.create', dataset, { fields: dataset.fields.map((f) => [f.path, f.propertyName]) })
+    : log('dataset.update', dataset, { fields: dataset.fields.map((f) => [f.path, f.propertyName]) }))
     .then(() => ((publish === true)
       ? log('dataset.update.publish', dataset, { properties: dataset.properties.map(p => p.name) })
       : null));
 createOrMerge.audit.withResult = true;
-
 
 ////////////////////////////////////////////////////////////////////////////
 // DATASET (AND DATASET PROPERTY) PUBLISH

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -88,8 +88,16 @@ ${isNilOrEmpty(fields) ? sql`` : _insertProperties(fields, publish)}
 SELECT "action" FROM ds
 `;
 
-// Creates or merges dataset, properties and field mapping.
-const createOrMerge = (name, projectId, formDefId, schemaId, fields, publish) => async ({ one, Actees, Datasets, Projects }) => {
+// Takes the dataset name and field->property mappings defined in a form
+// and creates or updates the named dataset.
+// Arguments:
+// * dataset name
+// * form (a Form frame or object containing projectId, formDefId, and schemaId)
+// * array of field objects and property names that were parsed from the form xml
+// * publish flag saying whether or not to immediately publish the dataset
+const createOrMerge = (name, form, fields, publish) => async ({ one, Actees, Datasets, Projects }) => {
+  const { projectId } = form;
+  const { id: formDefId, schemaId } = form.def;
   // Fetching project again because new form endpoint has it and update form does not.
   const project = await Projects.getById(projectId).then((o) => o.get());
   const existingDataset = await Datasets.get(project.id, name);
@@ -125,7 +133,7 @@ const createOrMerge = (name, projectId, formDefId, schemaId, fields, publish) =>
   return ds.with({ action: result.action, fields: dsPropertyFields, properties: publishedProperties });
 };
 
-createOrMerge.audit = (dataset, name, projectId, formDefId, schemaId, fields, publish) => (log) =>
+createOrMerge.audit = (dataset, name, form, fields, publish) => (log) =>
   ((dataset.action === 'created')
     ? log('dataset.create', dataset, { fields: dataset.fields.map((f) => [f.path, f.propertyName]) })
     : log('dataset.update', dataset, { fields: dataset.fields.map((f) => [f.path, f.propertyName]) }))

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -85,7 +85,7 @@ const isNilOrEmpty = either(isNil, isEmpty);
 const _createOrMerge = (dataset, fields, acteeId, publish) => sql`
 ${_insertDatasetDef(dataset, acteeId, true, publish)}
 ${isNilOrEmpty(fields) ? sql`` : _insertProperties(fields, publish)}
-SELECT "action" FROM ds
+SELECT "action", "id" FROM ds
 `;
 
 // Takes the dataset name and field->property mappings defined in a form
@@ -98,23 +98,29 @@ SELECT "action" FROM ds
 const createOrMerge = (name, form, fields, publish) => async ({ one, Actees, Datasets, Projects }) => {
   const { projectId } = form;
   const { id: formDefId, schemaId } = form.def;
-  // Fetching project again because new form endpoint has it and update form does not.
-  const project = await Projects.getById(projectId).then((o) => o.get());
-  const existingDataset = await Datasets.get(project.id, name);
+
+  // Provision acteeId if necessary.
+  // Need to check for existing dataset, and if not found, need to also
+  // fetch the project since the dataset will be an actee child of the project.
+  const existingDataset = await Datasets.get(projectId, name);
   const acteeId = existingDataset.isDefined()
     ? existingDataset.get().acteeId
-    : await Actees.provision('dataset', project).then((actee) => (actee.id));
-  const partial = new Dataset({ name, projectId: project.id }, { formDefId });
+    : await Projects.getById(projectId).then((o) => o.get())
+      .then((project) => Actees.provision('dataset', project))
+      .then((actee) => (actee.id));
+  const partial = new Dataset({ name, projectId, acteeId }, { formDefId });
 
   // Prepare dataset properties from form fields:
+  // Step 1: Filter to only fields with property name binds
   let dsPropertyFields = fields.filter((field) => (field.propertyName));
-
+  // Step 2: Disallow properties to be named "name" or "label"
   if (dsPropertyFields.filter((field) => field.propertyName === 'name' || field.propertyName === 'label').length > 0)
     throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
-
+  // Step 3: Build Form Field frames to handle dataset property field insertion
   dsPropertyFields = dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId, formDefId }));
 
-  // Insert or update
+  // Insert or update: update dataset, dataset properties, and links to fields and current form
+  // result contains action (created or updated) and the id of the dataset.
   const result = await one(_createOrMerge(partial, dsPropertyFields, acteeId, publish))
     .catch(error => {
       if (error.constraint === 'ds_property_fields_dspropertyid_formdefid_unique') {
@@ -123,14 +129,14 @@ const createOrMerge = (name, form, fields, publish) => async ({ one, Actees, Dat
       throw error;
     });
 
-  // Fetch dataset again with properties in order to write audit log
-  const ds = await Datasets.get(project.id, name).then((o) => o.get());
-
+  // Fetch all published properties for this dataset, even beyond what is defined in this form.
   const publishedProperties = ((publish === true)
-    ? await Datasets.getProperties(ds.id)
+    ? await Datasets.getProperties(result.id)
     : null);
 
-  return ds.with({ action: result.action, fields: dsPropertyFields, properties: publishedProperties });
+  // Partial contains acteeId which is needed for auditing.
+  // Additional form fields and properties needed for audit logging as well.
+  return partial.with({ action: result.action, fields: dsPropertyFields, properties: publishedProperties });
 };
 
 createOrMerge.audit = (dataset, name, form, fields, publish) => (log) =>

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -96,7 +96,7 @@ const createNew = (partial, project, publish = false) => async ({ run, Datasets,
 
   // Update datasets and properties if defined
   if (datasetName.isDefined()) {
-    await Datasets.createOrMerge(datasetName.get(), project.id, savedForm.def.id, savedForm.def.schemaId, fields, publish);
+    await Datasets.createOrMerge(datasetName.get(), savedForm, fields, publish);
   }
 
   // Return the final saved form
@@ -230,7 +230,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
 
   // Update datasets and properties if defined
   if (datasetName.isDefined())
-    await Datasets.createOrMerge(datasetName.get(), form.projectId, savedDef.id, savedDef.schemaId, fieldsForInsert, publish);
+    await Datasets.createOrMerge(datasetName.get(), new Form(form, { def: savedDef }), fieldsForInsert, publish);
   return savedDef;
 };
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -11,7 +11,7 @@ const config = require('config');
 const { sql } = require('slonik');
 const { map } = require('ramda');
 const { Frame, into } = require('../frame');
-const { Actor, Blob, Form, Dataset } = require('../frames');
+const { Actor, Blob, Form } = require('../frames');
 const { getFormFields, merge, compare } = require('../../data/schema');
 const { getDataset } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
@@ -70,7 +70,7 @@ const createNew = (partial, project, publish = false) => async ({ run, Datasets,
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form XML for fields and entity/dataset definitions
-  const [fields, dataset] = await Promise.all([
+  const [fields, datasetName] = await Promise.all([
     getFormFields(partial.xml),
     (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml)) // Don't parse dataset schema if Form has encryption key
   ]);
@@ -95,15 +95,8 @@ const createNew = (partial, project, publish = false) => async ({ run, Datasets,
   ]);
 
   // Update datasets and properties if defined
-  if (dataset.isDefined()) {
-    const dsPropertyFields = fields.filter((field) => (field.propertyName));
-    if (dsPropertyFields.filter((field) => field.propertyName === 'name' || field.propertyName === 'label').length > 0)
-      throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
-    await Datasets.createOrMerge(
-      new Dataset({ name: dataset.get(), projectId: project.id }, { formDefId: savedForm.def.id }),
-      dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId: savedForm.def.schemaId, formDefId: savedForm.def.id })),
-      publish
-    );
+  if (datasetName.isDefined()) {
+    await Datasets.createOrMerge(datasetName.get(), project.id, savedForm.def.id, savedForm.def.schemaId, fields, publish);
   }
 
   // Return the final saved form
@@ -179,7 +172,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form fields and dataset/entity definition from form XML
-  const [fields, dataset] = await Promise.all([
+  const [fields, datasetName] = await Promise.all([
     getFormFields(partial.xml),
     (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml))
   ]);
@@ -236,13 +229,8 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   ]);
 
   // Update datasets and properties if defined
-  if (dataset.isDefined())
-    await Datasets.createOrMerge(
-      new Dataset({ name: dataset.get(), projectId: form.projectId }, { formDefId: savedDef.id }),
-      fields.filter((field) => (field.propertyName)).map((field) => new Form.Field({ schemaId, ...field }, { propertyName: field.propertyName, formDefId: savedDef.id })),
-      publish
-    );
-
+  if (datasetName.isDefined())
+    await Datasets.createOrMerge(datasetName.get(), form.projectId, savedDef.id, savedDef.schemaId, fieldsForInsert, publish);
   return savedDef;
 };
 


### PR DESCRIPTION
Closes #793

Changes the interface between Forms.createNew and Forms.createVersion that updates Datasets. Now `Datasets.createOrMerge` takes raw arguments from Forms and builds and filters what it needs itself. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests have remained the same.

#### Why is this the best possible solution? Were any other approaches considered?

It was a little awkward making the Forms query module filter out the form fields and build a partial Dataset object to pass the name and project id through. Now the code in the Forms module is simpler. If more changes need to happen on Dataset creation, they can happen within the Dataset query module. The function in the query module is also now async/await and a bit easier to follow.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No changes to users.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No changes to docs.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced