### PR TITLE
Entity migrations

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -94,7 +94,7 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
 const formatRow = (entity, props) => {
   const out = [];
   out.push(entity.uuid);
-  out.push(entity.label);
+  out.push(entity.def.label);
   for (const prop of props) out.push(entity.def.data[prop]);
   return out;
 };
@@ -144,7 +144,7 @@ const selectFields = (entity, properties, selectedProperties) => {
   }
 
   if (!selectedProperties || selectedProperties.has('label')) {
-    result.label = entity.label;
+    result.label = entity.def.label;
   }
 
   // Handle System properties

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -16,7 +16,7 @@ const { parseSubmissionXml } = require('../../data/entity');
 class Entity extends Frame.define(
   table('entities'),
   'id',                  'uuid',
-  'datasetId',           'label',
+  'datasetId',
   'createdAt',           'creatorId',
   embedded('creator')
 ) {
@@ -44,6 +44,7 @@ Entity.Def = Frame.define(
   'id',                  'entityId',
   'createdAt',           'current',
   'submissionDefId',
+  'label',
   'data'
 );
 

--- a/lib/model/migrations/20230406-01-add-entity-def-fields.js
+++ b/lib/model/migrations/20230406-01-add-entity-def-fields.js
@@ -34,8 +34,7 @@ WHERE entity_defs."submissionDefId" = submission_defs.id;
   // alter table to make new column not null
   await db.raw(`
 ALTER TABLE entity_defs
-ALTER COLUMN "creatorId" SET NOT NULL,
-ALTER COLUMN "userAgent" SET NOT NULL
+ALTER COLUMN "creatorId" SET NOT NULL
 `);
 };
 

--- a/lib/model/migrations/20230406-01-add-entity-def-fields.js
+++ b/lib/model/migrations/20230406-01-add-entity-def-fields.js
@@ -15,14 +15,28 @@ ADD COLUMN "creatorId" integer,
 ADD COLUMN "userAgent" varchar(255)
 `);
 
-  // Assign submission submitter id to entity def creator id
+  // Assign root entity creator id (same as submitter id) to entity def creator id
   await db.raw(`
 UPDATE entity_defs
-set "creatorId" = submission_defs."submitterId",
-"userAgent" = submission_defs."userAgent"
+SET "creatorId" = entities."creatorId"
+FROM entities
+WHERE entity_defs."entityId" = entities.id;
+  `);
+
+  // Assign submission user agent to entity def
+  await db.raw(`
+UPDATE entity_defs
+SET "userAgent" = submission_defs."userAgent"
 FROM submission_defs
 WHERE entity_defs."submissionDefId" = submission_defs.id;
   `);
+
+  // alter table to make new column not null
+  await db.raw(`
+ALTER TABLE entity_defs
+ALTER COLUMN "creatorId" SET NOT NULL,
+ALTER COLUMN "userAgent" SET NOT NULL
+`);
 };
 
 const down = (db) => db.raw(`

--- a/lib/model/migrations/20230406-01-add-entity-def-fields.js
+++ b/lib/model/migrations/20230406-01-add-entity-def-fields.js
@@ -1,0 +1,35 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  // Add columns
+  await db.raw(`
+ALTER TABLE entity_defs
+ADD COLUMN "creatorId" integer,
+ADD COLUMN "userAgent" varchar(255)
+`);
+
+  // Assign submission submitter id to entity def creator id
+  await db.raw(`
+UPDATE entity_defs
+set "creatorId" = submission_defs."submitterId",
+"userAgent" = submission_defs."userAgent"
+FROM submission_defs
+WHERE entity_defs."submissionDefId" = submission_defs.id;
+  `);
+};
+
+const down = (db) => db.raw(`
+ALTER TABLE entity_defs
+DROP COLUMN "creatorId",
+DROP COLUMN "userAgent"
+`);
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20230406-02-move-entity-label-add-deletedAt.js
+++ b/lib/model/migrations/20230406-02-move-entity-label-add-deletedAt.js
@@ -1,0 +1,63 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  // Add columns
+  await db.raw(`
+ALTER TABLE entity_defs
+ADD COLUMN "label" text
+`);
+
+  // Assign label from root entity to entity def
+  // should only be one entity def per entity at the time
+  // of this migration.
+  await db.raw(`
+  UPDATE entity_defs
+  set "label" = entities."label"
+  FROM entities
+  WHERE entity_defs."entityId" = entities.id;
+  `);
+
+  await db.raw(`
+  ALTER TABLE entities
+  DROP COLUMN "label"
+  `);
+
+  await db.raw(`
+  ALTER TABLE entities
+  ADD COLUMN "deletedAt" timestamp
+  `);
+};
+
+const down = async (db) => {
+  await db.raw(`
+  ALTER TABLE entities
+  ADD COLUMN "label" text
+  `);
+
+  await db.raw(`
+  UPDATE entities
+  set "label" = entity_defs."label"
+  FROM entity_defs
+  WHERE entity_defs."entityId" = entities.id;
+    `);
+
+  await db.raw(`
+  ALTER TABLE entity_defs
+  DROP COLUMN "label"
+  `);
+
+  await db.raw(`
+  ALTER TABLE entities
+  DROP COLUMN "deletedAt"
+  `);
+};
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20230406-02-move-entity-label-add-deletedAt.js
+++ b/lib/model/migrations/20230406-02-move-entity-label-add-deletedAt.js
@@ -10,9 +10,9 @@
 const up = async (db) => {
   // Add columns
   await db.raw(`
-ALTER TABLE entity_defs
-ADD COLUMN "label" text
-`);
+  ALTER TABLE entity_defs
+  ADD COLUMN "label" text
+  `);
 
   // Assign label from root entity to entity def
   // should only be one entity def per entity at the time
@@ -24,13 +24,15 @@ ADD COLUMN "label" text
   WHERE entity_defs."entityId" = entities.id;
   `);
 
+  // set label to not null
   await db.raw(`
-  ALTER TABLE entities
-  DROP COLUMN "label"
+  ALTER TABLE entity_defs
+  ALTER COLUMN "label" SET NOT NULL
   `);
 
   await db.raw(`
   ALTER TABLE entities
+  DROP COLUMN "label",
   ADD COLUMN "deletedAt" timestamp
   `);
 };
@@ -55,7 +57,8 @@ const down = async (db) => {
 
   await db.raw(`
   ALTER TABLE entities
-  DROP COLUMN "deletedAt"
+  DROP COLUMN "deletedAt",
+  ALTER COLUMN "label" SET NOT NULL
   `);
 };
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -30,8 +30,8 @@ FROM submission_defs AS sd
   JOIN datasets ON datasets."projectId" = f."projectId"
 WHERE datasets."name" = ${dsName} AND sd."id" = ${subDefId}`;
 
-const _defInsert = (id, partial, subDefId, json) => sql`insert into entity_defs ("entityId", "submissionDefId", "data", "current", "createdAt")
-  values (${id}, ${subDefId}, ${json}, true, clock_timestamp())
+const _defInsert = (id, subDefId, creatorId, userAgent, json) => sql`insert into entity_defs ("entityId", "submissionDefId", "creatorId", "userAgent", "data", "current", "createdAt")
+  values (${id}, ${subDefId}, ${creatorId}, ${userAgent}, ${json}, true, clock_timestamp())
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 
@@ -44,7 +44,7 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 const createNew = (partial, subDef) => ({ one }) => {
   const json = JSON.stringify(partial.def.data);
   return one(sql`
-with def as (${_defInsert(nextval, partial, subDef.id, json)}),
+with def as (${_defInsert(nextval, subDef.id, subDef.submitterId, subDef.userAgent, json)}),
 ds as (${_getDataset(partial.aux.dataset, subDef.id)}),
 ins as (insert into entities (id, "datasetId", "uuid", "label", "createdAt", "creatorId")
   select def."entityId", ds."id", ${partial.uuid}, ${partial.label}, def."createdAt", ${subDef.submitterId} from def

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -30,8 +30,8 @@ FROM submission_defs AS sd
   JOIN datasets ON datasets."projectId" = f."projectId"
 WHERE datasets."name" = ${dsName} AND sd."id" = ${subDefId}`;
 
-const _defInsert = (id, subDefId, creatorId, userAgent, json) => sql`insert into entity_defs ("entityId", "submissionDefId", "creatorId", "userAgent", "data", "current", "createdAt")
-  values (${id}, ${subDefId}, ${creatorId}, ${userAgent}, ${json}, true, clock_timestamp())
+const _defInsert = (id, subDefId, creatorId, userAgent, label, json) => sql`insert into entity_defs ("entityId", "submissionDefId", "creatorId", "userAgent", "label", "data", "current", "createdAt")
+  values (${id}, ${subDefId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp())
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 
@@ -44,10 +44,10 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 const createNew = (partial, subDef) => ({ one }) => {
   const json = JSON.stringify(partial.def.data);
   return one(sql`
-with def as (${_defInsert(nextval, subDef.id, subDef.submitterId, subDef.userAgent, json)}),
+with def as (${_defInsert(nextval, subDef.id, subDef.submitterId, subDef.userAgent, partial.label, json)}),
 ds as (${_getDataset(partial.aux.dataset, subDef.id)}),
-ins as (insert into entities (id, "datasetId", "uuid", "label", "createdAt", "creatorId")
-  select def."entityId", ds."id", ${partial.uuid}, ${partial.label}, def."createdAt", ${subDef.submitterId} from def
+ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
+  select def."entityId", ds."id", ${partial.uuid}, def."createdAt", ${subDef.submitterId} from def
   join ds on ds."subDefId" = def."submissionDefId"
   returning entities.*)
 select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as "dsName" from ins, def, ds;`)
@@ -59,7 +59,8 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as
           submissionDefId: subDef.id,
           createdAt: entityData.createdAt,
           creatorId: subDef.submitterId,
-          data: partial.def.data
+          data: partial.def.data,
+          label: partial.label
         }),
         dataset: { acteeId: dsActeeId, name: dsName }
       }));
@@ -94,7 +95,7 @@ const processSubmissionEvent = (event) => (container) =>
     .then((entity) => {
       if (entity != null) {
         return container.Audits.log({ id: event.actorId }, 'entity.create', { acteeId: entity.aux.dataset.acteeId },
-          { entity: { uuid: entity.uuid, label: entity.label, dataset: entity.aux.dataset.name },
+          { entity: { uuid: entity.uuid, label: entity.def.label, dataset: entity.aux.dataset.name },
             submissionId: event.details.submissionId,
             submissionDefId: event.details.submissionDefId });
       }

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -501,7 +501,7 @@ describe('database migrations: 20230324-01-edit-dataset-verbs.js', function () {
 });
 
 // eslint-disable-next-line func-names
-describe('database migrations: 20230406-01-add-entity-def-fields.js', function () {
+describe('database migrations from 20230406: altering entities and entity_defs', function () {
   this.timeout(10000);
 
   const createEntity = async (service, container) => {
@@ -564,11 +564,14 @@ describe('database migrations: 20230406-01-add-entity-def-fields.js', function (
   }));
 
   it('should move the entity label to the entity_def table', testServiceFullTrx(async (service, container) => {
-    await upToMigration('20230406-02-move-entity-label-add-deletedAt.js', false);
+    await upToMigration('20230406-01-add-entity-def-fields.js', false);
     await populateUsers(container);
     await populateForms(container);
 
     const { newEntity } = await createEntity(service, container);
+
+    // test entity had to be made before applying this migration because of not null creatorId constraint
+    await up(); // applying 20230406-02-move-entity-label-add-deletedAt.js
 
     // Apply the migration!!
     await up();

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -499,3 +499,61 @@ describe('database migrations: 20230324-01-edit-dataset-verbs.js', function () {
     viewer.verbs.length.should.equal(7);
   }));
 });
+
+// eslint-disable-next-line func-names
+describe('database migrations: 20230406-01-add-entity-def-fields.js', function () {
+  this.timeout(10000);
+
+  it('should set entity def creator id and user agent from submission def', testServiceFullTrx(async (service, container) => {
+    await upToMigration('20230406-01-add-entity-def-fields.js', false);
+    await populateUsers(container);
+    await populateForms(container);
+
+    // Get bob's id because bob is going to be the one who
+    // submits the submission
+    const bobId = await service.login('bob', (asBob) =>
+      asBob.get('/v1/users/current').expect(200).then(({ body }) => body.id));
+
+    await service.login('bob', (asBob) =>
+      asBob.post('/v1/projects/1/forms/simple/submissions')
+        .set('Content-Type', 'application/xml')
+        .send(testData.instances.simple.one)
+        .expect(200));
+
+    // Get the submission def id we just submitted.
+    // For this test, it doesn't have to be a real entity submission.
+    const subDef = await container.one(sql`SELECT id, "userAgent" FROM submission_defs WHERE "instanceId" = 'one' LIMIT 1`);
+
+    // Make sure there is a dataset for the entity to be part of.
+    const newDataset = await container.one(sql`
+    INSERT INTO datasets
+    ("acteeId", "name", "projectId", "createdAt")
+    VALUES (${uuid()}, 'trees', 1, now())
+    RETURNING "id"`);
+
+    // Create the entity.
+    // The root entity creator wont change in this migration though it should be
+    // the same as the submitter id.
+    const newEntity = await container.one(sql`
+    INSERT INTO entities (uuid, "datasetId", "label", "creatorId", "createdAt")
+    VALUES (${uuid()}, ${newDataset.id}, 'some label', ${bobId}, now())
+    RETURNING "id"`);
+
+    // Create the entity def and link it to the submission def above.
+    await container.run(sql`
+    INSERT INTO entity_defs ("entityId", "createdAt", "current", "submissionDefId", "data")
+    VALUES (${newEntity.id}, now(), true, ${subDef.id}, '{}')`);
+
+    // Apply the migration!!
+    await up();
+
+    // Look up the entity def again
+    const entityDef = await container.one(sql`SELECT * FROM entity_defs WHERE "entityId" = ${newEntity.id} LIMIT 1`);
+
+    // The creatorId and userAgent should now exist and be set.
+    entityDef.creatorId.should.equal(bobId);
+    entityDef.userAgent.should.equal(subDef.userAgent);
+
+    await down();
+  }));
+});

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -223,9 +223,11 @@ describe('worker: entity', () => {
       const { label } = await container.one(sql`select label from entities where "uuid" = ${createEvent.details.entity.uuid}`);
       label.should.equal('Alice (88)');
 
-      const { data } = await container.one(sql`select data from entity_defs`);
+      const { data, creatorId, userAgent } = await container.one(sql`select data, "creatorId", "userAgent" from entity_defs`);
       data.age.should.equal('88');
       data.first_name.should.equal('Alice');
+      creatorId.should.equal(5); // Alice the user created this entity
+      userAgent.should.not.be.null();
     }));
   });
 

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -220,10 +220,8 @@ describe('worker: entity', () => {
       const { count } = await container.one(sql`select count(*) from entities`);
       count.should.equal(1);
 
-      const { label } = await container.one(sql`select label from entities where "uuid" = ${createEvent.details.entity.uuid}`);
+      const { data, label, creatorId, userAgent } = await container.one(sql`select data, label, "creatorId", "userAgent" from entity_defs`);
       label.should.equal('Alice (88)');
-
-      const { data, creatorId, userAgent } = await container.one(sql`select data, "creatorId", "userAgent" from entity_defs`);
       data.age.should.equal('88');
       data.first_name.should.equal('Alice');
       creatorId.should.equal(5); // Alice the user created this entity

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -196,9 +196,9 @@ describe('extracting entities from submissions', () => {
   describe('selectFields', () => {
     const entity = {
       uuid: 'uuid',
-      label: 'label',
       createdAt: 'createdAt',
       def: {
+        label: 'label',
         data: {
           firstName: 'John',
           lastName: 'Doe'
@@ -269,9 +269,11 @@ describe('extracting entities from submissions', () => {
     it('should return all properties even if entity object does not have all of them', () => {
       const data = {
         uuid: 'uuid',
-        label: 'label',
         createdAt: 'createdAt',
-        def: { data: {} },
+        def: {
+          label: 'label',
+          data: {}
+        },
         aux: {
           creator: {
             id: 'id',


### PR DESCRIPTION
Closes #817 and #818. Also closes #816. 

This PR includes 2 migrations that get the `entities` and `entity_defs` table better set up for ongoing entity work.
1. Adds `creatorId` to `entity_defs` to track who is responsible for each version / update of an entity
2. Adds `userAgent` as well to `entity_defs` to track more context about each version
3. Moves `label` from the root `entities` table to `entity_defs` because it is something that can be updated
4. Adds a `deletedAt` field to `entities` table.

The `creatorId` and `userAgent` are filled from the submissionDefId that we already have linked to each entity. In the future, entities will be able to be created without a submission, which is why we need to store these source fields separately and not implicitly keep them in the submission. Plus, a submission could get deleted when a form is deleted, losing this entity creator info! 

The `label` on `entities` is appropriately moved over to the corresponding `entity_defs` column. For now, before updates have been implemented, there is always only one version of an entity so it is clear what the label is.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, including migration tests.

#### Why is this the best possible solution? Were any other approaches considered?

Lots of discussion. Also trying to keep these migrations as simple as possible.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Not going to change things for users too much except allow us to make progress on entity creates and updates!

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

It will require some doc changes which are being addressed in another PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced