### PR TITLE
Entity updating via PATCH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 .idea/
 /.eslintcache
 /.pgbadger/
+.vscode

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -17,7 +17,7 @@ const { PartialPipe } = require('../util/stream');
 const Problem = require('../util/problem');
 const { submissionXmlToFieldStream } = require('./submission');
 const { nextUrlFor, getServiceRoot, jsonDataFooter, extractPaging } = require('../util/odata');
-const { sanitizeOdataIdentifier } = require('../util/util');
+const { isBlank, sanitizeOdataIdentifier } = require('../util/util');
 
 const odataToColumnMap = new Map([
   ['__system/createdAt', 'entities.createdAt'],
@@ -86,6 +86,26 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
     }
   });
 });
+
+////////////////////////////////////////////////////////////////////////////
+// PARSING JSON FOR UPDATING ENTITIES
+
+const parseUpdateJson = (entity, properties, body) => {
+  const { data: newData } = body;
+
+  const { data } = { ...entity.aux.currentVersion };
+  let { label } = entity.aux.currentVersion;
+
+  const propSet = new Set(properties.map(p => p.name));
+  for (const [k, v] of Object.entries(newData)) {
+    if (k === 'label') label = v;
+    else if (propSet.has(k))
+      data[k] = isBlank(v) ? '' : v;
+    else
+      throw Problem.user.entityViolation({ reason: `You specified the dataset property [${k}] which does not exist.` });
+  }
+  return { data, label };
+};
 
 
 ////////////////////////////////////////////////////////////////////////////
@@ -239,6 +259,7 @@ const streamEntityOdata = (inStream, properties, domain, originalUrl, query, tab
 
 module.exports = {
   parseSubmissionXml, validateEntity,
+  parseUpdateJson,
   streamEntityCsv, streamEntityOdata,
   odataToColumnMap,
   extractSelectedProperties, selectFields

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -12,6 +12,7 @@
 // entities.
 
 const csv = require('csv-stringify');
+const { clone } = require('ramda');
 const { Transform } = require('stream');
 const { PartialPipe } = require('../util/stream');
 const Problem = require('../util/problem');
@@ -93,7 +94,7 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
 const parseUpdateJson = (entity, properties, body) => {
   const { data: newData } = body;
 
-  const { data } = { ...entity.aux.currentVersion };
+  const data = clone(entity.aux.currentVersion.data);
   let { label } = entity.aux.currentVersion;
 
   const propSet = new Set(properties.map(p => p.name));

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -31,8 +31,8 @@ class Entity extends Frame.define(
           return null; // entity create was false
         const { uuid, label, dataset } = entityData.system;
         const { data } = entityData;
-        return new Entity.Partial({ uuid, label }, {
-          def: new Entity.Def({ data }),
+        return new Entity.Partial({ uuid }, {
+          def: new Entity.Def({ data, label }),
           dataset
         });
       });

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -139,7 +139,7 @@ const _update = (partial) => ({ one }) => {
     .then(_unjoiner);
 };
 
-const createVersion = (entity, data, userAgent) => async ({ context, Datasets, Entities }) => {
+const createVersion = (dataset, entity, data, userAgent) => async ({ context, Datasets, Entities }) => {
   const actorId = context.auth.actor.map((actor) => actor.id).orNull();
 
   const properties = await Datasets.getProperties(entity.datasetId);
@@ -164,6 +164,10 @@ const createVersion = (entity, data, userAgent) => async ({ context, Datasets, E
   return Entities._update(partial)
     .then((e) => e.withAux('currentVersion', e.aux.currentVersion.withAux('source', source)));
 };
+
+createVersion.audit = (newEntity, dataset) => (log) =>
+  log('entity.update.version', dataset, { entityDefId: newEntity.aux.currentVersion.id, uuid: newEntity.uuid, dataset: dataset.name });
+createVersion.audit.withResult = true;
 
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -117,6 +117,46 @@ const processSubmissionEvent = (event) => (container) =>
           errorMessage: err.message,
           problem: (err.isProblem === true) ? err : null }));
 
+
+////////////////////////////////////////////////////////////////////////////////
+// UPDATING ENTITIES
+
+const _update = (partial) => ({ one }) => {
+  const _unjoiner = unjoiner(Entity, Entity.Def.into('currentVersion'));
+  const json = JSON.stringify(partial.aux.data);
+
+  return one(sql`
+  with def as (${_defInsert(partial.id, null, partial.aux.creatorId, partial.aux.userAgent, partial.aux.label, json)}),
+  upd as (update entity_defs set current=false
+    from def
+    where entity_defs."entityId" = ${partial.id} and entity_defs."id" <> def.id),
+  entities as (update entities set "updatedAt"=clock_timestamp()
+    where "uuid"=${partial.uuid}
+    returning *)
+  select ${_unjoiner.fields} from def as entity_defs
+  join entities on entity_defs."entityId" = entities.id
+  `)
+    .then(_unjoiner);
+};
+
+const createVersion = (entity, data, userAgent) => async ({ context, Datasets, Entities }) => {
+  const actorId = context.auth.actor.map((actor) => actor.id).orNull();
+
+  const properties = await Datasets.getProperties(entity.datasetId);
+
+  // TODO: do more elaborate things here
+  const defData = { ...entity.aux.currentVersion.data };
+  for (const prop of properties) {
+    if (data[prop.name])
+      defData[prop.name] = data[prop.name];
+  }
+  const { label } = entity.aux.currentVersion;
+
+  const partial = new Entity(entity, { data: defData, creatorId: actorId, userAgent, label });
+
+  return Entities._update(partial);
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES
 
@@ -150,7 +190,7 @@ const _get = (includeSource) => {
 };
 
 const getById = (datasetId, uuid, options = QueryOptions.none) => ({ maybeOne }) =>
-  _get(true)(maybeOne, options.withCondition({ datasetId, uuid }), isTrue(options.argData.deleted))
+  _get(true)(maybeOne, options.withCondition({ datasetId, uuid }), isTrue(options.argData?.deleted))
     .then(map((entity) => {
       const isSourceSubmission = !!entity.aux.currentVersion.submissionDefId;
 
@@ -249,6 +289,8 @@ module.exports = {
   createNew, _processSubmissionDef,
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,
+  createVersion, _update,
+
   countByDatasetId, getById,
   getAll, getAllDefs
 };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -302,7 +302,6 @@ module.exports = {
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,
   createVersion, _update,
-
   countByDatasetId, getById,
   getAll, getAllDefs
 };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -11,7 +11,7 @@ const { sql } = require('slonik');
 const { Actor, Entity, Submission, Form } = require('../frames');
 const { equals, extender, unjoiner, page } = require('../../util/db');
 const { map } = require('ramda');
-const { construct } = require('../../util/util');
+const { blankStringToNull, construct } = require('../../util/util');
 const { QueryOptions } = require('../../util/db');
 const { odataFilter } = require('../../data/odata-filter');
 const { odataToColumnMap } = require('../../data/entity');
@@ -45,7 +45,7 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 const createNew = (partial, subDef) => ({ one }) => {
   const json = JSON.stringify(partial.def.data);
   return one(sql`
-with def as (${_defInsert(nextval, subDef.id, subDef.submitterId, subDef.userAgent, partial.label, json)}),
+with def as (${_defInsert(nextval, subDef.id, subDef.submitterId, subDef.userAgent, partial.def.label, json)}),
 ds as (${_getDataset(partial.aux.dataset, subDef.id)}),
 ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ds."id", ${partial.uuid}, def."createdAt", ${subDef.submitterId} from def
@@ -61,7 +61,7 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as
           createdAt: entityData.createdAt,
           creatorId: subDef.submitterId,
           data: partial.def.data,
-          label: partial.label
+          label: partial.def.label
         }),
         dataset: { acteeId: dsActeeId, name: dsName }
       }));
@@ -121,38 +121,13 @@ const processSubmissionEvent = (event) => (container) =>
 ////////////////////////////////////////////////////////////////////////////////
 // UPDATING ENTITIES
 
-const _update = (partial) => ({ one }) => {
+const createVersion = (dataset, entity, data, label, userAgentIn = null) => ({ context, one }) => {
+  // dataset is passed in so the audit log can use its actee id
+  const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
+  const userAgent = blankStringToNull(userAgentIn);
+  const json = JSON.stringify(data);
+
   const _unjoiner = unjoiner(Entity, Entity.Def.into('currentVersion'));
-  const json = JSON.stringify(partial.aux.data);
-
-  return one(sql`
-  with def as (${_defInsert(partial.id, null, partial.aux.creatorId, partial.aux.userAgent, partial.aux.label, json)}),
-  upd as (update entity_defs set current=false
-    from def
-    where entity_defs."entityId" = ${partial.id} and entity_defs."id" <> def.id),
-  entities as (update entities set "updatedAt"=clock_timestamp()
-    where "uuid"=${partial.uuid}
-    returning *)
-  select ${_unjoiner.fields} from def as entity_defs
-  join entities on entity_defs."entityId" = entities.id
-  `)
-    .then(_unjoiner);
-};
-
-const createVersion = (dataset, entity, data, userAgent) => async ({ context, Datasets, Entities }) => {
-  const actorId = context.auth.actor.map((actor) => actor.id).orNull();
-
-  const properties = await Datasets.getProperties(entity.datasetId);
-
-  // TODO: do more elaborate things here
-  const defData = { ...entity.aux.currentVersion.data };
-  for (const prop of properties) {
-    if (data[prop.name])
-      defData[prop.name] = data[prop.name];
-  }
-  const { label } = entity.aux.currentVersion;
-
-  const partial = new Entity(entity, { data: defData, creatorId: actorId, userAgent, label });
 
   // TODO: revisit sources.
   // For now, attach a dummy 'api' entity def source to return for PATCH request.
@@ -161,7 +136,16 @@ const createVersion = (dataset, entity, data, userAgent) => async ({ context, Da
     details: null
   });
 
-  return Entities._update(partial)
+  return one(sql`
+  with def as (${_defInsert(entity.id, null, creatorId, userAgent, label, json)}),
+  upd as (update entity_defs set current=false where entity_defs."entityId" = ${entity.id}),
+  entities as (update entities set "updatedAt"=clock_timestamp()
+    where "uuid"=${entity.uuid}
+    returning *)
+  select ${_unjoiner.fields} from def as entity_defs
+  join entities on entity_defs."entityId" = entities.id
+  `)
+    .then(_unjoiner)
     .then((e) => e.withAux('currentVersion', e.aux.currentVersion.withAux('source', source)));
 };
 
@@ -301,7 +285,7 @@ module.exports = {
   createNew, _processSubmissionDef,
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,
-  createVersion, _update,
+  createVersion,
   countByDatasetId, getById,
   getAll, getAllDefs
 };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -154,7 +154,15 @@ const createVersion = (entity, data, userAgent) => async ({ context, Datasets, E
 
   const partial = new Entity(entity, { data: defData, creatorId: actorId, userAgent, label });
 
-  return Entities._update(partial);
+  // TODO: revisit sources.
+  // For now, attach a dummy 'api' entity def source to return for PATCH request.
+  const source = new Entity.Def.Source({
+    type: 'api',
+    details: null
+  });
+
+  return Entities._update(partial)
+    .then((e) => e.withAux('currentVersion', e.aux.currentVersion.withAux('source', source)));
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -10,6 +10,7 @@
 const { getOrNotFound, reject } = require('../util/promise');
 const { success } = require('../util/http');
 const Problem = require('../util/problem');
+const { parseUpdateJson } = require('../data/entity');
 
 const getActor = () => ({
   id: 1,
@@ -254,8 +255,10 @@ module.exports = (service, endpoint) => {
 
     const entity = await Entities.getById(dataset.id, params.uuid).then(getOrNotFound);
 
-    // TODO: going to come back and change how data gets parsed from body
-    return Entities.createVersion(dataset, entity, body.data, headers['user-agent']);
+    const properties = await Datasets.getProperties(dataset.id);
+    const { data, label } = parseUpdateJson(entity, properties, body);
+
+    return Entities.createVersion(dataset, entity, data, label, headers['user-agent']);
   }));
 
   service.delete('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions }) => {

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -254,7 +254,8 @@ module.exports = (service, endpoint) => {
 
     const entity = await Entities.getById(dataset.id, params.uuid).then(getOrNotFound);
 
-    return Entities.createVersion(entity, body, headers['user-agent']);
+    // TODO: going to come back and change how data gets parsed from body
+    return Entities.createVersion(entity, body.data, headers['user-agent']);
   }));
 
   service.delete('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions }) => {

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -8,7 +8,6 @@
 // except according to the terms contained in the LICENSE file.
 
 const { getOrNotFound, reject } = require('../util/promise');
-const { mergeLeft } = require('ramda');
 const { success } = require('../util/http');
 const Problem = require('../util/problem');
 
@@ -247,45 +246,15 @@ module.exports = (service, endpoint) => {
 
   }));
 
-  service.patch('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions, body, headers }) => {
+  service.patch('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { auth, body, headers, params }) => {
 
-    await Projects.getById(params.id, queryOptions).then(getOrNotFound);
+    const dataset = await Datasets.get(params.id, params.name).then(getOrNotFound);
 
-    const originalData = {
-      uuid: '10000000-0000-0000-0000-000000000001',
-      label: 'Johnny Doe',
-      firstName: 'Johnny',
-      lastName: 'Doe',
-      city: 'Toronto'
-    };
+    await auth.canOrReject('entity.update', dataset);
 
-    const { uuid, label, ...data } = mergeLeft(body, originalData);
+    const entity = await Entities.getById(dataset.id, params.uuid).then(getOrNotFound);
 
-    const updatedAt = new Date();
-
-    const userAgent = headers['user-agent'];
-
-    const entity = {
-      ...getEntity(1),
-      uuid,
-      createdAt: '2023-01-01T09:00:00.000Z',
-      updatedAt,
-      currentVersion: {
-        ...getEntityDef(),
-        userAgent,
-        versionNumber: 2,
-        source: {
-          type: 'api',
-          details: null
-        },
-        label,
-        createdAt: updatedAt,
-        data
-      }
-    };
-
-    return entity;
-
+    return Entities.createVersion(entity, body, headers['user-agent']);
   }));
 
   service.delete('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions }) => {

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -255,7 +255,7 @@ module.exports = (service, endpoint) => {
     const entity = await Entities.getById(dataset.id, params.uuid).then(getOrNotFound);
 
     // TODO: going to come back and change how data gets parsed from body
-    return Entities.createVersion(entity, body.data, headers['user-agent']);
+    return Entities.createVersion(dataset, entity, body.data, headers['user-agent']);
   }));
 
   service.delete('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions }) => {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -399,6 +399,7 @@ describe('Entities API', () => {
         .send({
           data: { age: '77' }
         })
+        .set('User-Agent', 'central/tests')
         .expect(200)
         .then(({ body: person }) => {
           // Response is the right shape
@@ -417,6 +418,8 @@ describe('Entities API', () => {
           person.currentVersion.creatorId.should.equal(6); // bob
           person.creatorId.should.equal(5); // alice - original entity creator
 
+          person.currentVersion.userAgent.should.equal('central/tests');
+
           // Updated date makes sense
           person.updatedAt.should.be.a.recentIsoDate();
         });
@@ -431,6 +434,7 @@ describe('Entities API', () => {
           });
           person.currentVersion.creatorId.should.equal(6); // bob
           person.creatorId.should.equal(5); // alice - original entity creator
+          person.currentVersion.userAgent.should.equal('central/tests');
           person.updatedAt.should.be.a.recentIsoDate();
         });
     }));

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -397,7 +397,7 @@ describe('Entities API', () => {
 
       await asBob.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
         .send({
-          age: '77'
+          data: { age: '77' }
         })
         .expect(200)
         .then(({ body: person }) => {
@@ -442,7 +442,7 @@ describe('Entities API', () => {
 
         await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
           .send({
-            age: '77'
+            data: { age: '77' }
           })
           .expect(200)
           .then(({ body: person }) => {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -462,6 +462,21 @@ describe('Entities API', () => {
       // should let fields be set to empty strings
       // it should reject if property is not present in dataset.publishedProperties
     });
+
+    it('should log the entity update event in the audit log', testEntities(async (service, container) => {
+      const asBob = await service.login('bob');
+
+      await asBob.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+        .send({
+          data: { age: '77' }
+        })
+        .expect(200);
+
+      const audit = await container.Audits.getLatestByAction('entity.update.version').then(a => a.get());
+      audit.actorId.should.equal(6);
+      audit.details.uuid.should.eql('12345678-1234-4123-8234-123456789abc');
+      audit.details.dataset.should.eql('people');
+    }));
   });
 
   describe('DELETE /datasets/:name/entities/:uuid', () => {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -375,22 +375,21 @@ describe('Entities API', () => {
 
   describe('PATCH /datasets/:name/entities/:uuid', () => {
 
-    it('should partially update an Entity', testService(async (service) => {
+    it('should partially update an Entity', testEntities(async (service) => {
       const asAlice = await service.login('alice');
 
-      await asAlice.patch('/v1/projects/1/datasets/People/entities/10000000-0000-0000-0000-000000000001')
+      await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
         .send({
-          city: 'Boston'
+          age: '77'
         })
         .expect(200)
         .then(({ body: person }) => {
           person.should.be.an.Entity();
           person.should.have.property('currentVersion').which.is.an.EntityDef();
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
+          //person.currentVersion.should.have.property('source').which.is.an.EntitySource();
           person.currentVersion.should.have.property('data').which.is.eql({
-            firstName: 'Johnny',
-            lastName: 'Doe',
-            city: 'Boston'
+            first_name: 'Alice',
+            age: '77'
           });
         });
     }));


### PR DESCRIPTION
This PR is part of working on issue #797, allowing entities to be updated.

New data can be sent in `{ data: { age: '44' } }` in the body of a `PATCH` request to a specific entity. It will update the entity, save the API authenticator as the creator ID, indicate that the source of the update was the API, and add an audit log event.

If a field is provided that is active in the dataset, the request will be rejected.

The label can also be updated: `{ data: { label: 'New Label' } }`.

There's no notion of versionNumbers in here yet.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Docs in a separate PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced