### PR TITLE
Create entity via POST

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -34,10 +34,14 @@ const odataToColumnMap = new Map([
 // and assemble a valid entity data object. System properties like dataset
 // label, uuid are in entity.system while the contents from the bound form
 // fields are in enttiy.data.
-const validateEntity = (entity) => {
+//
+// Since validateEntity is also used on entities parsed from JSON, which
+// don't include dataset or create flag (these are implicit) we have made
+// these specific validation checks optional (but turned on by default).
+const validateEntity = (entity, checkDataset = true, checkCreate = true) => {
   const { dataset, label, id } = entity.system;
 
-  if (!dataset || dataset.trim() === '')
+  if (checkDataset && (!dataset || dataset.trim() === ''))
     throw Problem.user.entityViolation({ reason: 'Dataset empty or missing.' });
 
   if (!label || label.trim() === '')
@@ -52,7 +56,7 @@ const validateEntity = (entity) => {
   const uuid = matches[2].toLowerCase();
 
   // If create is not an allowed value of true, don't return entity data
-  if (!(entity.system.create === '1' || entity.system.create === 'true' || entity.system.create === 1))
+  if (checkCreate && !(entity.system.create === '1' || entity.system.create === 'true'))
     return null;
 
   const newEntity = { ...entity };
@@ -88,6 +92,42 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
     }
   });
 });
+
+// Can be used to parse new entities and entity updates from
+// request data in the form of JSON.
+const parseJson = (existingEntity, body, propertyNames) => {
+  const bodyKeys = ['label', 'uuid', 'data'];
+  if (Object.keys(body).filter(k => !bodyKeys.includes(k)).length > 0)
+    throw Problem.user.invalidEntity({ reason: 'Unrecognized fields included in request.' });
+
+  let entity;
+  if (existingEntity) {
+    entity = clone(existingEntity);
+    entity.system.id = entity.system.uuid;
+    delete entity.system.uuid;
+  } else {
+    entity = { system: Object.create(null), data: Object.create(null) };
+    entity.system.id = body.uuid;
+    entity.system.label = body.label; // label will come in under body for new entities
+  }
+
+  const { data } = body;
+
+  if (data == null)
+    throw Problem.user.invalidEntity({ reason: 'No entity data provided.' });
+
+  for (const [k, v] of Object.entries(data)) {
+    if (k === 'label') entity.system.label = v; // label will come in under data for updated entities
+    else if (propertyNames.includes(k)) {
+      if (typeof v !== 'string')
+        throw Problem.user.invalidEntity({ reason: `Property value for  [${k}] is not a string.` });
+      entity.data[k] = isBlank(v) ? '' : v;
+    } else
+      throw Problem.user.invalidEntity({ reason: `You specified the dataset property [${k}] which does not exist.` });
+  }
+
+  return validateEntity(entity, false, false);
+};
 
 const parseCreateJson = (body, properties, datasetName) => new Promise((resolve, reject) => {
   const entity = { system: Object.create(null), data: Object.create(null) };
@@ -314,6 +354,7 @@ const diffEntityData = (defData) => {
 
 module.exports = {
   parseSubmissionXml, validateEntity,
+  parseJson,
   parseCreateJson, parseUpdateJson,
   streamEntityCsv, streamEntityOdata,
   odataToColumnMap,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -95,7 +95,7 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
 
 // Can be used to parse new entities and entity updates from
 // request data in the form of JSON.
-const parseJson = (existingEntity, body, propertyNames) => {
+const extractEntity = (body, propertyNames, existingEntity) => {
   const bodyKeys = ['label', 'uuid', 'data'];
   if (Object.keys(body).filter(k => !bodyKeys.includes(k)).length > 0)
     throw Problem.user.invalidEntity({ reason: 'Unrecognized fields included in request.' });
@@ -307,7 +307,7 @@ const diffEntityData = (defData) => {
 
 module.exports = {
   parseSubmissionXml, validateEntity,
-  parseJson,
+  extractEntity,
   streamEntityCsv, streamEntityOdata,
   odataToColumnMap,
   extractSelectedProperties, selectFields,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -127,56 +127,6 @@ const parseJson = (existingEntity, body, propertyNames) => {
   return validateEntity(entity, false, false);
 };
 
-const parseCreateJson = (body, properties, datasetName) => new Promise((resolve, reject) => {
-  const entity = { system: Object.create(null), data: Object.create(null) };
-
-  try {
-    const { uuid, create, data } = body;
-
-    entity.system.dataset = datasetName;
-    entity.system.id = uuid;
-    entity.system.create = create;
-
-    const propSet = new Set(properties.map(p => p.name));
-    for (const [k, v] of Object.entries(data)) {
-      if (k === 'label') entity.system.label = v;
-      else if (propSet.has(k))
-        entity.data[k] = isBlank(v) ? '' : v;
-      else
-        throw Problem.user.invalidEntity({ reason: `You specified the dataset property [${k}] which does not exist.` });
-    }
-  } catch (err) {
-    throw Problem.user.invalidEntity({ reason: 'Problem parsing JSON.' });
-  }
-
-  try {
-    return resolve(validateEntity(entity));
-  } catch (err) {
-    return reject(err);
-  }
-});
-
-////////////////////////////////////////////////////////////////////////////
-// PARSING JSON FOR UPDATING ENTITIES
-
-const parseUpdateJson = (entity, properties, body) => {
-  const { data: newData } = body;
-
-  const data = clone(entity.aux.currentVersion.data);
-  let { label } = entity.aux.currentVersion;
-
-  const propSet = new Set(properties.map(p => p.name));
-  for (const [k, v] of Object.entries(newData)) {
-    if (k === 'label') label = v;
-    else if (propSet.has(k))
-      data[k] = isBlank(v) ? '' : v;
-    else // TODO: maybe this should be a different problem.
-      throw Problem.user.entityViolation({ reason: `You specified the dataset property [${k}] which does not exist.` });
-  }
-  return { data, label };
-};
-
-
 ////////////////////////////////////////////////////////////////////////////
 // ENTITY STREAMING
 
@@ -353,7 +303,6 @@ const diffEntityData = (defData) => {
 module.exports = {
   parseSubmissionXml, validateEntity,
   parseJson,
-  parseCreateJson, parseUpdateJson,
   streamEntityCsv, streamEntityOdata,
   odataToColumnMap,
   extractSelectedProperties, selectFields,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -89,6 +89,31 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
   });
 });
 
+const parseCreateJson = (body, properties, datasetName) => new Promise((resolve, reject) => {
+  const { data } = body;
+
+  const entity = { system: Object.create(null), data: Object.create(null) };
+
+  entity.system.dataset = datasetName;
+
+  const propSet = new Set(properties.map(p => p.name));
+  for (const [k, v] of Object.entries(data)) {
+    if (k === 'label') entity.system.label = v;
+    else if (k === 'uuid') entity.system.id = v;
+    else if (k === 'create') entity.system.create = v;
+    else if (propSet.has(k))
+      entity.data[k] = isBlank(v) ? '' : v;
+    else
+      throw Problem.user.entityViolation({ reason: `You specified the dataset property [${k}] which does not exist.` });
+  }
+
+  try {
+    return resolve(validateEntity(entity));
+  } catch (err) {
+    return reject(err);
+  }
+});
+
 ////////////////////////////////////////////////////////////////////////////
 // PARSING JSON FOR UPDATING ENTITIES
 
@@ -285,7 +310,7 @@ const diffEntityData = (defData) => {
 
 module.exports = {
   parseSubmissionXml, validateEntity,
-  parseUpdateJson,
+  parseCreateJson, parseUpdateJson,
   streamEntityCsv, streamEntityOdata,
   odataToColumnMap,
   extractSelectedProperties, selectFields,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -18,7 +18,7 @@ const { PartialPipe } = require('../util/stream');
 const Problem = require('../util/problem');
 const { submissionXmlToFieldStream } = require('./submission');
 const { nextUrlFor, getServiceRoot, jsonDataFooter, extractPaging } = require('../util/odata');
-const { isBlank, sanitizeOdataIdentifier } = require('../util/util');
+const { sanitizeOdataIdentifier } = require('../util/util');
 
 const odataToColumnMap = new Map([
   ['__system/createdAt', 'entities.createdAt'],
@@ -107,6 +107,10 @@ const parseJson = (existingEntity, body, propertyNames) => {
     delete entity.system.uuid;
   } else {
     entity = { system: Object.create(null), data: Object.create(null) };
+    if (body.uuid && typeof body.uuid !== 'string')
+      throw Problem.user.invalidEntity({ reason: 'Value for [uuid] is not a string.' });
+    if (body.label && typeof body.label !== 'string')
+      throw Problem.user.invalidEntity({ reason: 'Value for [label] is not a string.' });
     entity.system.id = body.uuid;
     entity.system.label = body.label; // label will come in under body for new entities
   }
@@ -115,12 +119,13 @@ const parseJson = (existingEntity, body, propertyNames) => {
     throw Problem.user.invalidEntity({ reason: 'No entity data provided.' });
 
   for (const [k, v] of Object.entries(body.data)) {
+    if (typeof v !== 'string')
+      throw Problem.user.invalidEntity({ reason: `Property value for [${k}] is not a string.` });
+
     if (k === 'label') entity.system.label = v; // label will come in under data for updated entities
-    else if (propertyNames.includes(k)) {
-      if (typeof v !== 'string')
-        throw Problem.user.invalidEntity({ reason: `Property value for [${k}] is not a string.` });
-      entity.data[k] = isBlank(v) ? '' : v;
-    } else
+    else if (propertyNames.includes(k))
+      entity.data[k] = v;
+    else
       throw Problem.user.invalidEntity({ reason: `You specified the dataset property [${k}] which does not exist.` });
   }
 

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -118,7 +118,7 @@ const parseJson = (existingEntity, body, propertyNames) => {
     if (k === 'label') entity.system.label = v; // label will come in under data for updated entities
     else if (propertyNames.includes(k)) {
       if (typeof v !== 'string')
-        throw Problem.user.invalidEntity({ reason: `Property value for  [${k}] is not a string.` });
+        throw Problem.user.invalidEntity({ reason: `Property value for [${k}] is not a string.` });
       entity.data[k] = isBlank(v) ? '' : v;
     } else
       throw Problem.user.invalidEntity({ reason: `You specified the dataset property [${k}] which does not exist.` });

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -52,7 +52,7 @@ const validateEntity = (entity) => {
   const uuid = matches[2].toLowerCase();
 
   // If create is not an allowed value of true, don't return entity data
-  if (!(entity.system.create === '1' || entity.system.create === 'true'))
+  if (!(entity.system.create === '1' || entity.system.create === 'true' || entity.system.create === 1))
     return null;
 
   const newEntity = { ...entity };
@@ -90,21 +90,25 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
 });
 
 const parseCreateJson = (body, properties, datasetName) => new Promise((resolve, reject) => {
-  const { data } = body;
-
   const entity = { system: Object.create(null), data: Object.create(null) };
 
-  entity.system.dataset = datasetName;
+  try {
+    const { uuid, create, data } = body;
 
-  const propSet = new Set(properties.map(p => p.name));
-  for (const [k, v] of Object.entries(data)) {
-    if (k === 'label') entity.system.label = v;
-    else if (k === 'uuid') entity.system.id = v;
-    else if (k === 'create') entity.system.create = v;
-    else if (propSet.has(k))
-      entity.data[k] = isBlank(v) ? '' : v;
-    else
-      throw Problem.user.entityViolation({ reason: `You specified the dataset property [${k}] which does not exist.` });
+    entity.system.dataset = datasetName;
+    entity.system.id = uuid;
+    entity.system.create = create;
+
+    const propSet = new Set(properties.map(p => p.name));
+    for (const [k, v] of Object.entries(data)) {
+      if (k === 'label') entity.system.label = v;
+      else if (propSet.has(k))
+        entity.data[k] = isBlank(v) ? '' : v;
+      else
+        throw Problem.user.invalidEntity({ reason: `You specified the dataset property [${k}] which does not exist.` });
+    }
+  } catch (err) {
+    throw Problem.user.invalidEntity({ reason: 'Problem parsing JSON.' });
   }
 
   try {
@@ -128,7 +132,7 @@ const parseUpdateJson = (entity, properties, body) => {
     if (k === 'label') label = v;
     else if (propSet.has(k))
       data[k] = isBlank(v) ? '' : v;
-    else
+    else // TODO: maybe this should be a different problem.
       throw Problem.user.entityViolation({ reason: `You specified the dataset property [${k}] which does not exist.` });
   }
   return { data, label };

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -111,12 +111,10 @@ const parseJson = (existingEntity, body, propertyNames) => {
     entity.system.label = body.label; // label will come in under body for new entities
   }
 
-  const { data } = body;
-
-  if (data == null)
+  if (body.data == null)
     throw Problem.user.invalidEntity({ reason: 'No entity data provided.' });
 
-  for (const [k, v] of Object.entries(data)) {
+  for (const [k, v] of Object.entries(body.data)) {
     if (k === 'label') entity.system.label = v; // label will come in under data for updated entities
     else if (propertyNames.includes(k)) {
       if (typeof v !== 'string')

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -20,7 +20,7 @@ class Entity extends Frame.define(
   'createdAt', readable,    'creatorId', readable,
   'updatedAt', readable,    'deletedAt', readable,
   embedded('creator'),
-  embedded('currentVersion'),
+  embedded('currentVersion')
 ) {
   get def() { return this.aux.def; }
 

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -10,7 +10,7 @@
 /* eslint-disable no-multi-spaces */
 
 const { embedded, Frame, readable, table } = require('../frame');
-const { parseJson, parseSubmissionXml } = require('../../data/entity');
+const { extractEntity, parseSubmissionXml } = require('../../data/entity');
 
 // These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
@@ -23,18 +23,6 @@ class Entity extends Frame.define(
   embedded('currentVersion')
 ) {
   get def() { return this.aux.def; }
-
-  // internal JSON data representation used for entity parsing
-  // and entity validation
-  get systemData() {
-    return {
-      data: this.aux.currentVersion.data,
-      system: {
-        label: this.aux.currentVersion.label,
-        uuid: this.uuid
-      }
-    };
-  }
 
   static fromSubmissionXml(xml, fields) {
     return parseSubmissionXml(fields, xml)
@@ -50,11 +38,17 @@ class Entity extends Frame.define(
       });
   }
 
-  static fromJson(oldEntityData, body, properties, dataset) {
+  static fromJson(body, properties, dataset, oldEntity) {
     const propertyNames = properties.map(p => p.name);
-    const entityData = (!oldEntityData)
-      ? parseJson(null, body, propertyNames)
-      : parseJson(oldEntityData, body, propertyNames);
+    const entityData = (!oldEntity)
+      ? extractEntity(body, propertyNames)
+      : extractEntity(body, propertyNames, {
+        data: oldEntity.aux.currentVersion.data,
+        system: {
+          label: oldEntity.aux.currentVersion.label,
+          uuid: oldEntity.uuid
+        }
+      });
     const { uuid, label } = entityData.system;
     const { data } = entityData;
     return new Entity.Partial({ uuid, datasetId: dataset.id }, {

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -10,7 +10,7 @@
 /* eslint-disable no-multi-spaces */
 
 const { embedded, Frame, readable, table } = require('../frame');
-const { parseSubmissionXml } = require('../../data/entity');
+const { parseCreateJson, parseSubmissionXml } = require('../../data/entity');
 
 // These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
@@ -20,7 +20,8 @@ class Entity extends Frame.define(
   'createdAt', readable,    'creatorId', readable,
   'updatedAt', readable,    'deletedAt', readable,
   embedded('creator'),
-  embedded('currentVersion')
+  embedded('currentVersion'),
+  embedded('dataset') // used on occasion when entire dataset attached to entity
 ) {
   get def() { return this.aux.def; }
 
@@ -34,6 +35,21 @@ class Entity extends Frame.define(
         return new Entity.Partial({ uuid }, {
           def: new Entity.Def({ data, label }),
           dataset
+        });
+      });
+  }
+
+  static fromJson(body, properties, dataset) {
+    // TODO: could also have optional existing entity here to decide if it should be updated or not
+    return parseCreateJson(body, properties, dataset.name)
+      .then((entityData) => {
+        if (!entityData)
+          return null; // entity create was false
+        const { uuid, label, datasetName } = entityData.system;
+        const { data } = entityData;
+        return new Entity.Partial({ uuid, datasetId: dataset.id }, {
+          def: new Entity.Def({ data, label }),
+          dataset: datasetName
         });
       });
   }

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -40,7 +40,6 @@ class Entity extends Frame.define(
   }
 
   static fromJson(body, properties, dataset) {
-    // TODO: could also have optional existing entity here to decide if it should be updated or not
     return parseCreateJson(body, properties, dataset.name)
       .then((entityData) => {
         if (!entityData)

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -25,6 +25,18 @@ class Entity extends Frame.define(
 ) {
   get def() { return this.aux.def; }
 
+  // internal JSON data representation used for entity parsing
+  // and entity validation
+  get systemData() {
+    return {
+      data: this.aux.currentVersion.data,
+      system: {
+        label: this.aux.currentVersion.label,
+        uuid: this.uuid
+      }
+    };
+  }
+
   static fromSubmissionXml(xml, fields) {
     return parseSubmissionXml(fields, xml)
       .then((entityData) => {
@@ -39,16 +51,17 @@ class Entity extends Frame.define(
       });
   }
 
-  static fromJson(existingEntity, body, properties, dataset) {
-    if (!existingEntity) {
-      const entityData = parseJson(null, body, properties.map(p => p.name));
-      const { uuid, label, datasetName } = entityData.system;
-      const { data } = entityData;
-      return new Entity.Partial({ uuid, datasetId: dataset.id }, {
-        def: new Entity.Def({ data, label }),
-        dataset: datasetName
-      });
-    }
+  static fromJson(oldEntityData, body, properties, dataset) {
+    const propertyNames = properties.map(p => p.name);
+    const entityData = (!oldEntityData)
+      ? parseJson(null, body, propertyNames)
+      : parseJson(oldEntityData, body, propertyNames);
+    const { uuid, label } = entityData.system;
+    const { data } = entityData;
+    return new Entity.Partial({ uuid, datasetId: dataset.id }, {
+      def: new Entity.Def({ data, label }),
+      dataset: dataset.name
+    });
   }
 }
 

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -10,7 +10,7 @@
 /* eslint-disable no-multi-spaces */
 
 const { embedded, Frame, readable, table } = require('../frame');
-const { parseCreateJson, parseSubmissionXml } = require('../../data/entity');
+const { parseJson, parseSubmissionXml } = require('../../data/entity');
 
 // These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
@@ -39,18 +39,16 @@ class Entity extends Frame.define(
       });
   }
 
-  static fromJson(body, properties, dataset) {
-    return parseCreateJson(body, properties, dataset.name)
-      .then((entityData) => {
-        if (!entityData)
-          return null; // entity create was false
-        const { uuid, label, datasetName } = entityData.system;
-        const { data } = entityData;
-        return new Entity.Partial({ uuid, datasetId: dataset.id }, {
-          def: new Entity.Def({ data, label }),
-          dataset: datasetName
-        });
+  static fromJson(existingEntity, body, properties, dataset) {
+    if (!existingEntity) {
+      const entityData = parseJson(null, body, properties.map(p => p.name));
+      const { uuid, label, datasetName } = entityData.system;
+      const { data } = entityData;
+      return new Entity.Partial({ uuid, datasetId: dataset.id }, {
+        def: new Entity.Def({ data, label }),
+        dataset: datasetName
       });
+    }
   }
 }
 

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -21,7 +21,6 @@ class Entity extends Frame.define(
   'updatedAt', readable,    'deletedAt', readable,
   embedded('creator'),
   embedded('currentVersion'),
-  embedded('dataset') // used on occasion when entire dataset attached to entity
 ) {
   get def() { return this.aux.def; }
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { Actor, Entity, Submission, Form } = require('../frames');
+const { Actor, Dataset, Entity, Submission, Form } = require('../frames');
 const { equals, extender, unjoiner, page, markDeleted } = require('../../util/db');
 const { map } = require('ramda');
 const { blankStringToNull, construct } = require('../../util/util');
@@ -23,13 +23,16 @@ const { isTrue } = require('../../util/http');
 // Submission-defining entitiies contain the dataset name as a string
 // so we will look up the dataset id by name (unique within a project)
 // and project id (from submission def -> submission -> form def -> form)
-const _getDataset = (dsName, subDefId) => sql`
-SELECT datasets."id", sd."id" as "subDefId", datasets."acteeId", datasets."name"
-FROM submission_defs AS sd
+const _getDataset = (dsName, subDefId, dsId) => sql`
+SELECT datasets."id", datasets."acteeId", datasets."name"
+${subDefId != null
+    ? sql`FROM submission_defs AS sd
   JOIN form_defs AS fd ON sd."formDefId" = fd."id"
   JOIN forms AS f ON fd."formId" = f."id"
   JOIN datasets ON datasets."projectId" = f."projectId"
-WHERE datasets."name" = ${dsName} AND sd."id" = ${subDefId}`;
+  WHERE datasets."name" = ${dsName} AND sd."id" = ${subDefId}`
+    : sql`FROM datasets
+  WHERE datasets."id" = ${dsId}`}`;
 
 const _defInsert = (id, subDefId, creatorId, userAgent, label, json) => sql`insert into entity_defs ("entityId", "submissionDefId", "creatorId", "userAgent", "label", "data", "current", "createdAt")
   values (${id}, ${subDefId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp())
@@ -42,28 +45,41 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 // standard authenticated API request. The worker has better access to the event
 // actor/initiator and actee/target so it will do the logging itself (including
 // error logging).
-const createNew = (partial, subDef) => ({ one }) => {
+const createNew = (partial, subDef, userAgentIn) => ({ one, context }) => {
+  let creatorId;
+  let userAgent;
+
+  // Only if subDef exists and has a non-null id, overwrite creatorId and userAgent
+  if (subDef?.id != null)
+    ({ submitterId: creatorId, userAgent } = subDef);
+  else {
+    creatorId = context.auth.actor.map((actor) => actor.id).orNull();
+    userAgent = blankStringToNull(userAgentIn);
+  }
+
   const json = JSON.stringify(partial.def.data);
+
   return one(sql`
-with def as (${_defInsert(nextval, subDef.id, subDef.submitterId, subDef.userAgent, partial.def.label, json)}),
-ds as (${_getDataset(partial.aux.dataset, subDef.id)}),
+with def as (${_defInsert(nextval, subDef.id, creatorId, userAgent, partial.def.label, json)}),
+ds as (${_getDataset(partial.aux.dataset, subDef.id, partial.datasetId)}),
 ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
-  select def."entityId", ds."id", ${partial.uuid}, def."createdAt", ${subDef.submitterId} from def
-  join ds on ds."subDefId" = def."submissionDefId"
+  select def."entityId", ds."id", ${partial.uuid}, def."createdAt", ${creatorId} from def, ds
   returning entities.*)
 select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as "dsName" from ins, def, ds;`)
     .then(({ entityDefId, dsActeeId, dsName, ...entityData }) => // TODO/HACK: reassembly inspired by Submissions.createNew
       new Entity(entityData, {
-        def: new Entity.Def({
+        currentVersion: new Entity.Def({
           id: entityDefId,
           entityId: entityData.id,
           submissionDefId: subDef.id,
           createdAt: entityData.createdAt,
-          creatorId: subDef.submitterId,
+          creatorId,
           data: partial.def.data,
-          label: partial.def.label
+          label: partial.def.label,
+          current: true,
+          userAgent
         }),
-        dataset: { acteeId: dsActeeId, name: dsName }
+        dataset: new Dataset({ acteeId: dsActeeId, name: dsName })
       }));
 };
 
@@ -86,8 +102,7 @@ const _processSubmissionDef = (submissionDefId, submissionId) => async ({ Datase
   // If no data was returned, e.g. if create flag was not set, then don't continue
   if (!partial)
     return null;
-  const entity = await Entities.createNew(partial, submissionDef);
-  return entity;
+  return Entities.createNew(partial, submissionDef);
 };
 
 const processSubmissionEvent = (event) => (container) =>
@@ -96,7 +111,7 @@ const processSubmissionEvent = (event) => (container) =>
     .then((entity) => {
       if (entity != null) {
         return container.Audits.log({ id: event.actorId }, 'entity.create', { acteeId: entity.aux.dataset.acteeId },
-          { entity: { uuid: entity.uuid, label: entity.def.label, dataset: entity.aux.dataset.name },
+          { entity: { uuid: entity.uuid, label: entity.aux.currentVersion.label, dataset: entity.aux.dataset.name },
             submissionId: event.details.submissionId,
             submissionDefId: event.details.submissionDefId });
       }

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -82,6 +82,13 @@ select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as
 };
 
 
+createNew.audit = (newEntity, partial, subDef) => (log) => {
+  if (!subDef)
+    return log('entity.create', newEntity.aux.dataset, { entityDefId: newEntity.aux.currentVersion.id, uuid: newEntity.uuid, dataset: newEntity.aux.dataset.name });
+};
+createNew.audit.withResult = true;
+
+
 // Entrypoint to where submissions (a specific version) become entities
 const _processSubmissionDef = (submissionDefId, submissionId) => async ({ Datasets, Entities, Submissions }) => {
   const existingEntity = await Entities.getDefBySubmissionId(submissionId);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -48,36 +48,34 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 const createNew = (partial, subDef, userAgentIn) => ({ one, context }) => {
   let creatorId;
   let userAgent;
+  let subDefId;
 
-  // Only if subDef exists and has a non-null id, overwrite creatorId and userAgent
-  if (subDef?.id != null)
-    ({ submitterId: creatorId, userAgent } = subDef);
+  // Set creatorId and userAgent from submission def if it exists
+  if (subDef != null && subDef.id != null)
+    ({ id: subDefId, submitterId: creatorId, userAgent } = subDef);
   else {
     creatorId = context.auth.actor.map((actor) => actor.id).orNull();
     userAgent = blankStringToNull(userAgentIn);
+    subDefId = null;
   }
 
   const json = JSON.stringify(partial.def.data);
 
   return one(sql`
-with def as (${_defInsert(nextval, subDef.id, creatorId, userAgent, partial.def.label, json)}),
-ds as (${_getDataset(partial.aux.dataset, subDef.id, partial.datasetId)}),
+with def as (${_defInsert(nextval, subDefId, creatorId, userAgent, partial.def.label, json)}),
+ds as (${_getDataset(partial.aux.dataset, subDefId, partial.datasetId)}),
 ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ds."id", ${partial.uuid}, def."createdAt", ${creatorId} from def, ds
   returning entities.*)
 select ins.*, def.id as "entityDefId", ds."acteeId" as "dsActeeId", ds."name" as "dsName" from ins, def, ds;`)
-    .then(({ entityDefId, dsActeeId, dsName, ...entityData }) => // TODO/HACK: reassembly inspired by Submissions.createNew
+    .then(({ entityDefId, dsActeeId, dsName, ...entityData }) => // TODO/HACK: reassemble just enough to log audit event
       new Entity(entityData, {
         currentVersion: new Entity.Def({
           id: entityDefId,
           entityId: entityData.id,
-          submissionDefId: subDef.id,
-          createdAt: entityData.createdAt,
-          creatorId,
+          submissionDefId: subDefId,
           data: partial.def.data,
-          label: partial.def.label,
-          current: true,
-          userAgent
+          label: partial.def.label
         }),
         dataset: new Dataset({ acteeId: dsActeeId, name: dsName })
       }));

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -11,7 +11,7 @@ const { getOrNotFound, reject } = require('../util/promise');
 const { isTrue, success } = require('../util/http');
 const { Entity } = require('../model/frames');
 const Problem = require('../util/problem');
-const { parseUpdateJson, diffEntityData } = require('../data/entity');
+const { diffEntityData } = require('../data/entity');
 
 const getActor = () => ({
   id: 1,
@@ -246,9 +246,9 @@ module.exports = (service, endpoint) => {
     if (!isTrue(query.force)) return reject(Problem.internal.notImplemented({ feature: '(updating an entity without ?force=true flag)' }));
 
     const properties = await Datasets.getProperties(dataset.id);
-    const { data, label } = parseUpdateJson(entity, properties, body);
+    const partial = Entity.fromJson(entity.systemData, body, properties, dataset);
 
-    return Entities.createVersion(dataset, entity, data, label, headers['user-agent']);
+    return Entities.createVersion(dataset, entity, partial.def.data, partial.def.label, headers['user-agent']);
   }));
 
   service.delete('/projects/:projectId/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { auth, params, queryOptions }) => {

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -9,6 +9,7 @@
 
 const { getOrNotFound, reject } = require('../util/promise');
 const { isTrue, success } = require('../util/http');
+const { Entity } = require('../model/frames');
 const Problem = require('../util/problem');
 const { parseUpdateJson, diffEntityData } = require('../data/entity');
 
@@ -185,35 +186,31 @@ module.exports = (service, endpoint) => {
     ];
   }));
 
-  service.post('/projects/:id/datasets/:name/entities', endpoint(async ({ Projects }, { params, queryOptions, body, headers }) => {
+  service.post('/projects/:id/datasets/:name/entities', endpoint(async ({ Datasets, Entities }, { auth, body, headers, params }) => {
 
-    await Projects.getById(params.id, queryOptions).then(getOrNotFound);
+    const dataset = await Datasets.get(params.id, params.name).then(getOrNotFound);
 
-    const { uuid, label, ...data } = body;
+    await auth.canOrReject('entity.create', dataset);
 
-    const date = new Date();
+    const properties = await Datasets.getProperties(dataset.id);
 
-    const userAgent = headers['user-agent'];
+    const partial = await Entity.fromJson(body, properties, dataset);
 
-    const entity = {
-      ...getEntity(1),
-      uuid,
-      createdAt: date,
-      currentVersion: {
-        ...getEntityDef(),
-        sourceId: userAgent,
-        source: {
-          type: 'api',
-          details: null
-        },
-        label,
-        createdAt: date,
-        data
-      }
-    };
+    // Pass fake subDef with null id
+    return Entities.createNew(partial, { id: null }, headers['user-agent']);
 
-    return entity;
+    /*
+    // Return simple api source attached to currentVersion
+    // TODO: do somethign different when revisiting entity source
+    const source = new Entity.Def.Source({
+      type: 'api',
+      details: null
+    });
 
+    // set .aux.dataset to null so it doesn't get sent to v.forApi()
+    // also set dummy source
+    return entity.withAux('dataset', null).withAux('currentVersion', entity.aux.currentVersion.withAux('source', source));
+    */
   }));
 
   service.put('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions, body, headers }) => {

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -194,14 +194,11 @@ module.exports = (service, endpoint) => {
 
     const properties = await Datasets.getProperties(dataset.id);
 
-    const partial = await Entity.fromJson(body, properties, dataset);
-    if (!partial) // Can happen if create != 'true' or '1'
-      throw Problem.user.invalidEntity({ reason: 'Could not create entity.' });
+    const partial = await Entity.fromJson(null, body, properties, dataset);
 
     const entity = await Entities.createNew(partial, null, headers['user-agent']);
 
-    // Entities.createNew doesn't return enough information for a full response
-    // so we re-fetch the entity.
+    // Entities.createNew doesn't return enough information for a full response so re-fetch.
     return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
   }));
 

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -195,22 +195,14 @@ module.exports = (service, endpoint) => {
     const properties = await Datasets.getProperties(dataset.id);
 
     const partial = await Entity.fromJson(body, properties, dataset);
+    if (!partial) // Can happen if create != 'true' or '1'
+      throw Problem.user.invalidEntity({ reason: 'Could not create entity.' });
 
-    // Pass fake subDef with null id
-    return Entities.createNew(partial, { id: null }, headers['user-agent']);
+    const entity = await Entities.createNew(partial, null, headers['user-agent']);
 
-    /*
-    // Return simple api source attached to currentVersion
-    // TODO: do somethign different when revisiting entity source
-    const source = new Entity.Def.Source({
-      type: 'api',
-      details: null
-    });
-
-    // set .aux.dataset to null so it doesn't get sent to v.forApi()
-    // also set dummy source
-    return entity.withAux('dataset', null).withAux('currentVersion', entity.aux.currentVersion.withAux('source', source));
-    */
+    // Entities.createNew doesn't return enough information for a full response
+    // so we re-fetch the entity.
+    return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
   }));
 
   service.put('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions, body, headers }) => {

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -194,7 +194,7 @@ module.exports = (service, endpoint) => {
 
     const properties = await Datasets.getProperties(dataset.id);
 
-    const partial = await Entity.fromJson(null, body, properties, dataset);
+    const partial = await Entity.fromJson(body, properties, dataset);
 
     const entity = await Entities.createNew(partial, null, headers['user-agent']);
 
@@ -246,7 +246,7 @@ module.exports = (service, endpoint) => {
     if (!isTrue(query.force)) return reject(Problem.internal.notImplemented({ feature: '(updating an entity without ?force=true flag)' }));
 
     const properties = await Datasets.getProperties(dataset.id);
-    const partial = Entity.fromJson(entity.systemData, body, properties, dataset);
+    const partial = Entity.fromJson(body, properties, dataset, entity);
 
     return Entities.createVersion(dataset, entity, partial.def.data, partial.def.label, headers['user-agent']);
   }));

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -111,6 +111,9 @@ const problems = {
     // meta group in form definition is missing
     missingMeta: problem(400.27, () => 'The form does not contain a \'meta\' group.'),
 
+    // problem parsing the entity data (probably JSON) itself
+    invalidEntity: problem(400.28, ({ reason }) => `The entity is invalid. ${reason}`),
+
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -412,115 +412,6 @@ describe('Entities API', () => {
         });
     }));
 
-    it('should log the entity create event in the audit log', testEntities(async (service, container) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({
-          uuid: '12345678-1234-4123-8234-111111111aaa',
-          label: 'Johnny Doe',
-          data: {
-            first_name: 'Johnny',
-            age: '22'
-          }
-        });
-
-      const audit = await container.Audits.getLatestByAction('entity.create').then(a => a.get());
-      audit.actorId.should.equal(5);
-      audit.details.uuid.should.eql('12345678-1234-4123-8234-111111111aaa');
-      audit.details.dataset.should.eql('people');
-    }));
-
-    it('should reject if the uuid is missing', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({
-          label: 'Johnny Doe',
-          data: {
-            first_name: 'Johnny',
-            age: '22'
-          }
-        })
-        .expect(409); // this could be 400 problem instead but that involves changing other entity processing code
-    }));
-
-    it('should reject if the uuid is blank', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({
-          uuid: '',
-          label: 'Johnny Doe',
-          data: {
-            first_name: 'Johnny',
-            age: '22'
-          }
-        })
-        .expect(409); // this could be 400 problem instead but that involves changing other entity processing code
-    }));
-
-
-    it('should reject if the uuid is invalid', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({
-          uuid: 'abdc-not-a-uuid',
-          label: 'Johnny Doe',
-          data: {
-            first_name: 'Johnny',
-            age: '22'
-          }
-        })
-        .expect(409); // this could be 400 problem instead but that involves changing other entity processing code
-    }));
-
-    it('should reject if the label is missing', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({
-          uuid: '12345678-1234-4123-8234-111111111aaa',
-          data: {
-            first_name: 'Johnny',
-            age: '22'
-          }
-        })
-        .expect(409); // this could be 400 problem instead but that involves changing other entity processing code
-    }));
-
-    it('should reject if the label is blank', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({
-          uuid: '12345678-1234-4123-8234-111111111aaa',
-          label: '',
-          data: {
-            first_name: 'Johnny',
-            age: '22'
-          }
-        })
-        .expect(409); // this could be 400 problem instead but that involves changing other entity processing code
-    }));
-
-
-    it('should reject if the label is null', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({
-          uuid: '12345678-1234-4123-8234-111111111aaa',
-          label: null,
-          data: {
-            first_name: 'Johnny',
-            age: '22'
-          }
-        })
-        .expect(409); // this could be 400 problem instead but that involves changing other entity processing code
-    }));
-
     it('should reject if uuid is not unique', testEntities(async (service) => {
       // Use testEntities here vs. testDataset to prepopulate with 2 entities
       const asAlice = await service.login('alice');
@@ -550,6 +441,25 @@ describe('Entities API', () => {
           }
         })
         .expect(400);
+    }));
+
+    it('should log the entity create event in the audit log', testEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-111111111aaa',
+          label: 'Johnny Doe',
+          data: {
+            first_name: 'Johnny',
+            age: '22'
+          }
+        });
+
+      const audit = await container.Audits.getLatestByAction('entity.create').then(a => a.get());
+      audit.actorId.should.equal(5);
+      audit.details.uuid.should.eql('12345678-1234-4123-8234-111111111aaa');
+      audit.details.dataset.should.eql('people');
     }));
   });
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -723,14 +723,14 @@ describe('Entities API', () => {
           });
       }));
 
-      it.skip('should reject if updating the label to be empty', testEntities(async (service) => {
+      it('should reject if updating the label to be empty', testEntities(async (service) => {
         const asAlice = await service.login('alice');
 
         await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?force=true')
           .send({
             data: { label: '' }
           })
-          .expect(400);
+          .expect(409);
       }));
 
       it('should update an entity with additional properties', testEntities(async (service) => {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -352,24 +352,29 @@ describe('Entities API', () => {
 
     it('should create an Entity', testService(async (service) => {
       const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simpleEntity)
+        .expect(200);
 
-      await asAlice.post('/v1/projects/1/datasets/People/entities')
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
         .send({
-          uuid: '10000000-0000-0000-0000-000000000001',
-          label: 'Johnny Doe',
-          firstName: 'Johnny',
-          lastName: 'Doe',
-          city: 'Toronto'
+          data: {
+            uuid: '12345678-1234-4123-8234-123456789abc',
+            create: 'true',
+            label: 'Johnny Doe',
+            first_name: 'Johnny',
+            age: '22'
+          }
         })
         .expect(200)
         .then(({ body: person }) => {
           person.should.be.an.Entity();
           person.should.have.property('currentVersion').which.is.an.EntityDef();
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
+          //person.currentVersion.should.have.property('source').which.is.an.EntitySource();
+          person.currentVersion.should.have.property('label').which.equals('Johnny Doe');
           person.currentVersion.should.have.property('data').which.is.eql({
-            firstName: 'Johnny',
-            lastName: 'Doe',
-            city: 'Toronto'
+            first_name: 'Johnny',
+            age: '22'
           });
         });
     }));

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -783,24 +783,17 @@ describe('Entities API', () => {
           });
       }));
 
-      it('should transform null property to empty string', testEntities(async (service) => {
+      it('should not accept null property', testEntities(async (service) => {
         const asAlice = await service.login('alice');
-        const newData = { age: '88', first_name: '' };
 
         await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?force=true')
           .send({
             data: { first_name: null }
           })
-          .expect(200)
-          .then(({ body: person }) => {
-            person.currentVersion.should.have.property('data').which.is.eql(newData);
-          });
-
-        // re-get entity to check data
-        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
-          .expect(200)
-          .then(({ body: person }) => {
-            person.currentVersion.should.have.property('data').which.is.eql(newData);
+          .expect(400)
+          .then(({ body }) => {
+            body.code.should.equal(400.28);
+            body.message.should.equal('The entity is invalid. Property value for [first_name] is not a string.');
           });
       }));
 
@@ -811,9 +804,10 @@ describe('Entities API', () => {
           .send({
             data: { favorite_candy: 'chocolate' }
           })
-          .expect(409)
+          .expect(400)
           .then(({ body }) => {
-            body.code.should.equal(409.14);
+            body.code.should.equal(400.28);
+            body.message.should.equal('The entity is invalid. You specified the dataset property [favorite_candy] which does not exist.');
           });
       }));
     });

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -412,6 +412,25 @@ describe('Entities API', () => {
         });
     }));
 
+    it('should log the entity create event in the audit log', testEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-111111111aaa',
+          label: 'Johnny Doe',
+          data: {
+            first_name: 'Johnny',
+            age: '22'
+          }
+        });
+
+      const audit = await container.Audits.getLatestByAction('entity.create').then(a => a.get());
+      audit.actorId.should.equal(5);
+      audit.details.uuid.should.eql('12345678-1234-4123-8234-111111111aaa');
+      audit.details.dataset.should.eql('people');
+    }));
+
     it('should reject if the uuid is missing', testDataset(async (service) => {
       const asAlice = await service.login('alice');
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -367,7 +367,7 @@ describe('Entities API', () => {
         .expect(404);
     }));
 
-    it('should reject if the user cannot read', testDataset(async (service) => {
+    it('should reject if the user cannot write', testDataset(async (service) => {
       const asChelsea = await service.login('chelsea');
 
       await asChelsea.post('/v1/projects/1/datasets/people/entities')

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -204,11 +204,11 @@ describe('api: /datasets/:name.svc', () => {
         .then(({ body }) => body.value[0]);
 
       await asAlice.patch(`/v1/projects/1/datasets/people/entities/${firstEntity.__id}?force=true`)
-        .send({ data: { age: 22 } })
+        .send({ data: { age: '22' } })
         .expect(200);
 
       await asAlice.patch(`/v1/projects/1/datasets/people/entities/${firstEntity.__id}?force=true`)
-        .send({ data: { age: 44 } })
+        .send({ data: { age: '44' } })
         .expect(200);
 
       await asAlice.get('/v1/projects/1/datasets/people.svc/Entities')
@@ -241,7 +241,7 @@ describe('api: /datasets/:name.svc', () => {
         .then(({ body }) => body.value[0]);
 
       await asAlice.patch(`/v1/projects/1/datasets/people/entities/${lastEntity.__id}?force=true`)
-        .send({ data: { age: 22 } })
+        .send({ data: { age: '22' } })
         .expect(200);
 
       await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?$filter=__system/updatedAt gt ${lastEntity.__system.createdAt}`)

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -191,6 +191,91 @@ describe('extracting entities from submissions', () => {
           data: { age: '88', first_name: 'Alice' }
         });
       });
+
+      it('should parse subset of dataset properties', () => {
+        const body = {
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Alice (88)',
+          data: { first_name: 'Alice' }
+        };
+        const propertyNames = ['age', 'first_name'];
+        const entity = parseJson(null, body, propertyNames);
+        should(entity).eql({
+          system: {
+            label: 'Alice (88)',
+            uuid: '12345678-1234-4123-8234-123456789abc'
+          },
+          data: { first_name: 'Alice' }
+        });
+      });
+
+      it('should reject if uuid is missing', () => {
+        const body = {
+          label: 'Alice (88)',
+          data: { age: '88', first_name: 'Alice' }
+        };
+        const propertyNames = ['age', 'first_name'];
+        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+          err.problemCode.should.equal(409.14);
+          err.message.should.equal('There was a problem with entity processing: ID empty or missing.');
+          return true;
+        });
+      });
+
+      it('should reject if label is missing', () => {
+        const body = {
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          data: { age: '88', first_name: 'Alice' }
+        };
+        const propertyNames = ['age', 'first_name'];
+        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+          err.problemCode.should.equal(409.14);
+          err.message.should.equal('There was a problem with entity processing: Label empty or missing.');
+          return true;
+        });
+      });
+
+      it('should reject if data is missing', () => {
+        const body = {
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Label',
+        };
+        const propertyNames = ['age', 'first_name'];
+        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+          err.problemCode.should.equal(400.28);
+          err.message.should.equal('The entity is invalid. No entity data provided.');
+          return true;
+        });
+      });
+
+      it('should reject if data contains unknown properties', () => {
+        const body = {
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Label',
+          data: { favorite_food: 'pizza' }
+        };
+        const propertyNames = ['age', 'first_name'];
+        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+          err.problemCode.should.equal(400.28);
+          err.message.should.equal('The entity is invalid. You specified the dataset property [favorite_food] which does not exist.');
+          return true;
+        });
+      });
+
+
+      it('should reject if data is not a string', () => {
+        const body = {
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Label',
+          data: { age: 99 }
+        };
+        const propertyNames = ['age'];
+        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+          err.problemCode.should.equal(400.28);
+          err.message.should.equal('The entity is invalid. Property value for [age] is not a string.');
+          return true;
+        });
+      });
     });
 
     describe('updated entities', () => {
@@ -275,6 +360,27 @@ describe('extracting entities from submissions', () => {
         assert.throws(() => { parseJson(existingEntity, body, propertyNames); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. No entity data provided.');
+          return true;
+        });
+      });
+
+      it('should reject if label update is null or empty string', () => {
+        const existingEntity = {
+          system: {
+            uuid: '12345678-1234-4123-8234-123456789abc',
+            label: 'Alice (88)',
+          },
+          data: { first_name: 'Alice' }
+        };
+        const propertyNames = ['first_name'];
+        assert.throws(() => { parseJson(existingEntity, { data: { label: '' } }, propertyNames); }, (err) => {
+          err.problemCode.should.equal(409.14);
+          err.message.should.equal('There was a problem with entity processing: Label empty or missing.');
+          return true;
+        });
+        assert.throws(() => { parseJson(existingEntity, { data: { label: null } }, propertyNames); }, (err) => {
+          err.problemCode.should.equal(409.14);
+          err.message.should.equal('There was a problem with entity processing: Label empty or missing.');
           return true;
         });
       });

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -2,7 +2,7 @@ const should = require('should');
 const appRoot = require('app-root-path');
 const assert = require('assert');
 // eslint-disable-next-line import/no-dynamic-require
-const { parseSubmissionXml, parseJson, validateEntity, extractSelectedProperties, selectFields, diffEntityData } = require(appRoot + '/lib/data/entity');
+const { parseSubmissionXml, extractEntity, validateEntity, extractSelectedProperties, selectFields, diffEntityData } = require(appRoot + '/lib/data/entity');
 // eslint-disable-next-line import/no-dynamic-require
 const { fieldsFor } = require(appRoot + '/test/util/schema');
 // eslint-disable-next-line import/no-dynamic-require
@@ -150,7 +150,7 @@ describe('extracting entities from submissions', () => {
     });
   });
 
-  describe('parseJson', () => {
+  describe('extractEntity', () => {
     // Used to compare entity structure when Object.create(null) used.
     beforeEach(() => {
       should.config.checkProtoEql = false;
@@ -167,7 +167,7 @@ describe('extracting entities from submissions', () => {
         extra: 'field'
       };
       const propertyNames = ['first_name'];
-      assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+      assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
         err.problemCode.should.equal(400.28);
         err.message.should.equal('The entity is invalid. Unrecognized fields included in request.');
         return true;
@@ -182,7 +182,7 @@ describe('extracting entities from submissions', () => {
           data: { age: '88', first_name: 'Alice' }
         };
         const propertyNames = ['age', 'first_name'];
-        const entity = parseJson(null, body, propertyNames);
+        const entity = extractEntity(body, propertyNames);
         should(entity).eql({
           system: {
             label: 'Alice (88)',
@@ -199,7 +199,7 @@ describe('extracting entities from submissions', () => {
           data: { first_name: 'Alice' }
         };
         const propertyNames = ['age', 'first_name'];
-        const entity = parseJson(null, body, propertyNames);
+        const entity = extractEntity(body, propertyNames);
         should(entity).eql({
           system: {
             label: 'Alice (88)',
@@ -215,7 +215,7 @@ describe('extracting entities from submissions', () => {
           data: { age: '88', first_name: 'Alice' }
         };
         const propertyNames = ['age', 'first_name'];
-        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
           err.problemCode.should.equal(409.14);
           err.message.should.equal('There was a problem with entity processing: ID empty or missing.');
           return true;
@@ -228,7 +228,7 @@ describe('extracting entities from submissions', () => {
           data: { age: '88', first_name: 'Alice' }
         };
         const propertyNames = ['age', 'first_name'];
-        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
           err.problemCode.should.equal(409.14);
           err.message.should.equal('There was a problem with entity processing: Label empty or missing.');
           return true;
@@ -242,7 +242,7 @@ describe('extracting entities from submissions', () => {
           data: { age: '88', first_name: 'Alice' }
         };
         const propertyNames = ['age', 'first_name'];
-        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. Value for [label] is not a string.');
           return true;
@@ -255,7 +255,7 @@ describe('extracting entities from submissions', () => {
           label: 'Label',
         };
         const propertyNames = ['age', 'first_name'];
-        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. No entity data provided.');
           return true;
@@ -269,7 +269,7 @@ describe('extracting entities from submissions', () => {
           data: { favorite_food: 'pizza' }
         };
         const propertyNames = ['age', 'first_name'];
-        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. You specified the dataset property [favorite_food] which does not exist.');
           return true;
@@ -284,7 +284,7 @@ describe('extracting entities from submissions', () => {
           data: { age: 99 }
         };
         const propertyNames = ['age'];
-        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. Property value for [age] is not a string.');
           return true;
@@ -298,7 +298,7 @@ describe('extracting entities from submissions', () => {
           data: { age: null }
         };
         const propertyNames = ['age'];
-        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. Property value for [age] is not a string.');
           return true;
@@ -319,7 +319,7 @@ describe('extracting entities from submissions', () => {
           data: { age: '99', first_name: 'Alice', label: 'New Label' }
         };
         const propertyNames = ['age', 'first_name'];
-        const entity = parseJson(existingEntity, body, propertyNames);
+        const entity = extractEntity(body, propertyNames, existingEntity);
         should(entity).eql({
           system: {
             label: 'New Label',
@@ -341,7 +341,7 @@ describe('extracting entities from submissions', () => {
           data: { first_name: 'New Name' }
         };
         const propertyNames = ['first_name'];
-        const entity = parseJson(existingEntity, body, propertyNames);
+        const entity = extractEntity(body, propertyNames, existingEntity);
         should(entity).eql({
           system: {
             label: 'Alice (88)',
@@ -363,7 +363,7 @@ describe('extracting entities from submissions', () => {
           data: { label: 'New Label' }
         };
         const propertyNames = ['first_name'];
-        const entity = parseJson(existingEntity, body, propertyNames);
+        const entity = extractEntity(body, propertyNames, existingEntity);
         should(entity).eql({
           system: {
             label: 'New Label',
@@ -385,7 +385,7 @@ describe('extracting entities from submissions', () => {
           label: 'Label is not supposed to get updated in body, should be in data.'
         };
         const propertyNames = ['first_name'];
-        assert.throws(() => { parseJson(existingEntity, body, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity(body, propertyNames, existingEntity); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. No entity data provided.');
           return true;
@@ -401,12 +401,12 @@ describe('extracting entities from submissions', () => {
           data: { first_name: 'Alice' }
         };
         const propertyNames = ['first_name'];
-        assert.throws(() => { parseJson(existingEntity, { data: { label: '' } }, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity({ data: { label: '' } }, propertyNames, existingEntity); }, (err) => {
           err.problemCode.should.equal(409.14);
           err.message.should.equal('There was a problem with entity processing: Label empty or missing.');
           return true;
         });
-        assert.throws(() => { parseJson(existingEntity, { data: { label: null } }, propertyNames); }, (err) => {
+        assert.throws(() => { extractEntity({ data: { label: null } }, propertyNames, existingEntity); }, (err) => {
           err.problemCode.should.equal(400.28);
           err.message.should.equal('The entity is invalid. Property value for [label] is not a string.');
           return true;

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -235,6 +235,20 @@ describe('extracting entities from submissions', () => {
         });
       });
 
+      it('should reject if label is not a string', () => {
+        const body = {
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 1234,
+          data: { age: '88', first_name: 'Alice' }
+        };
+        const propertyNames = ['age', 'first_name'];
+        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+          err.problemCode.should.equal(400.28);
+          err.message.should.equal('The entity is invalid. Value for [label] is not a string.');
+          return true;
+        });
+      });
+
       it('should reject if data is missing', () => {
         const body = {
           uuid: '12345678-1234-4123-8234-123456789abc',
@@ -268,6 +282,20 @@ describe('extracting entities from submissions', () => {
           uuid: '12345678-1234-4123-8234-123456789abc',
           label: 'Label',
           data: { age: 99 }
+        };
+        const propertyNames = ['age'];
+        assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
+          err.problemCode.should.equal(400.28);
+          err.message.should.equal('The entity is invalid. Property value for [age] is not a string.');
+          return true;
+        });
+      });
+
+      it('should reject if data value is null', () => {
+        const body = {
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Label',
+          data: { age: null }
         };
         const propertyNames = ['age'];
         assert.throws(() => { parseJson(null, body, propertyNames); }, (err) => {
@@ -379,8 +407,8 @@ describe('extracting entities from submissions', () => {
           return true;
         });
         assert.throws(() => { parseJson(existingEntity, { data: { label: null } }, propertyNames); }, (err) => {
-          err.problemCode.should.equal(409.14);
-          err.message.should.equal('There was a problem with entity processing: Label empty or missing.');
+          err.problemCode.should.equal(400.28);
+          err.message.should.equal('The entity is invalid. Property value for [label] is not a string.');
           return true;
         });
       });


### PR DESCRIPTION
Closes #798 

Allows entities to be created via POST request to `/v1/projects/:projectId/datasets/:datasetName/entities`

Sample payload may look like this, with uuid, label, and data. Provided properties must be a subset of existing dataset properties. Values of label and data must be _strings_ (numbers must be in quotes and null/empty values must be empty strings: `''`)

```
uuid: '12345678-1234-4123-8234-111111111aaa',
label: 'Johnny Doe',
data: {
  first_name: 'Johnny',
  age: '22'
}
```

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Wanted to double-check the format of the incoming entity with other folks.
- Should label be in or out of the data block?
- Should the outer fields be in a meta block? It would match the submission xml a bit more but i don't know how much it matters.

I tried to reuse the same validation used by entities created through submissions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

New feature in the realm of entities!

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Will need to make sure PR #812 is consistent with this code.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced