### PR TITLE
Validation of entity/dataset property names

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -32,9 +32,8 @@ const validateDatasetName = (name) => {
 
 
 const validatePropertyName = (name) => {
-  // eslint-disable-next-line no-console
-  console.log('validating property name', name);
-  // Regex explanation:
+  // Regex explanation
+  // (similar to above dataset name check with some slight differences)
   // Check for a match with a valid string
   //   (?!__) is negative lookahead to check string does not start with double underscore __
   //   (?!name$)(?!label$) negative lookahead for "name" and "label" specifically
@@ -42,7 +41,7 @@ const validatePropertyName = (name) => {
   //   [\p{L}\d\\._-]* more characters from valid starting character set, digits, hyphens, and '.'
   // If there's a match, return true (valid)!
   // Non-letter unicode characters also not currently allowed
-  const match = /^(?!__)(?!name$)(?!label$)[\p{L}_][\p{L}\d\\._-]*$/u.exec(name.trim());
+  const match = /^(?!__)(?!name$)(?!label$)[\p{L}_][\p{L}\d._-]*$/u.exec(name);
 
   return (match !== null);
 };

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -30,6 +30,23 @@ const validateDatasetName = (name) => {
   return (match !== null);
 };
 
+
+const validatePropertyName = (name) => {
+  // eslint-disable-next-line no-console
+  console.log('validating property name', name);
+  // Regex explanation:
+  // Check for a match with a valid string
+  //   (?!__) is negative lookahead to check string does not start with double underscore __
+  //   (?!name$)(?!label$) negative lookahead for "name" and "label" specifically
+  //   [\p{L}_] valid start character of unicode letter or _ (no :)
+  //   [\p{L}\d\\._-]* more characters from valid starting character set, digits, hyphens, and '.'
+  // If there's a match, return true (valid)!
+  // Non-letter unicode characters also not currently allowed
+  const match = /^(?!__)(?!name$)(?!label$)[\p{L}_][\p{L}\d\\._-]*$/u.exec(name.trim());
+
+  return (match !== null);
+};
+
 // Here we are looking for dataset-registrating information within the <entity> tag.
 // We mainly need the dataset name, but we also do a bit of validation:
 //   1. namespace validation:
@@ -63,4 +80,4 @@ const getDataset = (xml) => {
   });
 };
 
-module.exports = { getDataset, validateDatasetName };
+module.exports = { getDataset, validateDatasetName, validatePropertyName };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -10,6 +10,7 @@
 const { sql } = require('slonik');
 const { extender, QueryOptions, equals } = require('../../util/db');
 const { Dataset, Form } = require('../frames');
+const { validatePropertyName } = require('../../data/dataset');
 const { isEmpty, isNil, either, reduceBy, groupBy, uniqWith, equals: rEquals } = require('ramda');
 
 const Problem = require('../../util/problem');
@@ -113,8 +114,8 @@ const createOrMerge = (name, form, fields, publish) => async ({ one, Actees, Dat
   // Prepare dataset properties from form fields:
   // Step 1: Filter to only fields with property name binds
   let dsPropertyFields = fields.filter((field) => (field.propertyName));
-  // Step 2: Disallow properties to be named "name" or "label"
-  if (dsPropertyFields.filter((field) => field.propertyName === 'name' || field.propertyName === 'label').length > 0)
+  // Step 2: Check for invalid property names
+  if (dsPropertyFields.filter((field) => !validatePropertyName(field.propertyName)).length > 0)
     throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
   // Step 3: Build Form Field frames to handle dataset property field insertion
   dsPropertyFields = dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId, formDefId }));

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1659,41 +1659,6 @@ describe('datasets and entities', () => {
             }));
       }));
 
-      it('should update a dataset with a new draft and be able to upload multiple drafts', testService(async (service) => {
-        const asAlice = await service.login('alice');
-
-        // Upload a form and then create a new draft version
-        await asAlice.post('/v1/projects/1/forms?publish=true')
-          .send(testData.forms.simpleEntity)
-          .set('Content-Type', 'application/xml')
-          .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
-            .expect(200)
-            .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
-              .send(testData.forms.simpleEntity)
-              .set('Content-Type', 'application/xml')
-              .expect(200))
-            .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
-              .set('X-Extended-Metadata', 'true')
-              .expect(200)
-              .then(({ body }) => {
-                body.entityRelated.should.equal(true);
-              })));
-
-        await asAlice.get('/v1/projects/1/datasets')
-          .expect(200)
-          .then(({ body }) => {
-            body[0].name.should.be.eql('people');
-          });
-
-        await asAlice.get('/v1/projects/1/datasets/people')
-          .expect(200)
-          .then(({ body }) => {
-            body.name.should.be.eql('people');
-            body.properties.length.should.be.eql(2);
-          });
-      }));
-
       it('should not let multiple fields to be mapped to a single property', testService(async (service) => {
         await service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms')
@@ -1732,6 +1697,59 @@ describe('datasets and entities', () => {
           });
 
       }));
+
+      describe('updating datasets through new form drafts', () => {
+        it('should update a dataset with a new draft and be able to upload multiple drafts', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          // Upload a form and then create a new draft version
+          await asAlice.post('/v1/projects/1/forms?publish=true')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
+              .expect(200)
+              .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
+                .send(testData.forms.simpleEntity)
+                .set('Content-Type', 'application/xml')
+                .expect(200))
+              .then(() => asAlice.get('/v1/projects/1/forms/simpleEntity/draft')
+                .set('X-Extended-Metadata', 'true')
+                .expect(200)
+                .then(({ body }) => {
+                  body.entityRelated.should.equal(true);
+                })));
+
+          await asAlice.get('/v1/projects/1/datasets')
+            .expect(200)
+            .then(({ body }) => {
+              body[0].name.should.be.eql('people');
+            });
+
+          await asAlice.get('/v1/projects/1/datasets/people')
+            .expect(200)
+            .then(({ body }) => {
+              body.name.should.be.eql('people');
+              body.properties.length.should.be.eql(2);
+            });
+        }));
+
+        it('should return a Problem if updated form has invalid dataset properties', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await asAlice.post('/v1/projects/1/forms?publish=true')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
+              .send(testData.forms.simpleEntity.replace('first_name', 'name'))
+              .set('Content-Type', 'application/xml')
+              .expect(400)
+              .then(({ body }) => {
+                body.code.should.equal(400.25);
+                body.details.reason.should.equal('Invalid Dataset property.');
+              }));
+        }));
+      });
     });
 
     describe('dataset audit logging at /projects/:id/forms POST', () => {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1610,6 +1610,17 @@ describe('datasets and entities', () => {
               body.details.reason.should.equal('Invalid Dataset property.');
             }))));
 
+      it('should return a Problem if the savetos reference invalid properties (extra whitespace)', testService((service) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.simpleEntity.replace('first_name', '  first_name  '))
+            .set('Content-Type', 'text/xml')
+            .expect(400)
+            .then(({ body }) => {
+              body.code.should.equal(400.25);
+              body.details.reason.should.equal('Invalid Dataset property.');
+            }))));
+
       it('should return the created form upon success', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms')

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -3,7 +3,7 @@ const should = require('should');
 // eslint-disable-next-line import/no-dynamic-require
 const { getFormFields } = require(appRoot + '/lib/data/schema');
 // eslint-disable-next-line import/no-dynamic-require
-const { getDataset, validateDatasetName } = require(appRoot + '/lib/data/dataset');
+const { getDataset, validateDatasetName, validatePropertyName } = require(appRoot + '/lib/data/dataset');
 // eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
 // eslint-disable-next-line import/no-dynamic-require
@@ -273,5 +273,69 @@ describe('dataset name validation', () => {
 
   it('should allow a valid name', () => {
     validateDatasetName('good_dataset_name').should.equal(true);
+  });
+});
+
+describe('property name validation', () => {
+  // ALLOW
+  it('should allow name with underscore', () => {
+    validatePropertyName('first_name').should.equal(true);
+  });
+
+  it('should allow name with period', () => {
+    validatePropertyName('first.name').should.equal(true);
+  });
+
+  it('should allow name with hyphen', () => {
+    validatePropertyName('first-name').should.equal(true);
+  });
+
+  it('should allow name starting with single underscore', () => {
+    validatePropertyName('_age').should.equal(true);
+  });
+
+  it('should allow name containing "name" but not exactly matching', () => {
+    validatePropertyName('name.of.child').should.equal(true);
+  });
+
+  it('should allow name containing "label" but not exactly matching', () => {
+    validatePropertyName('final_label').should.equal(true);
+  });
+
+  it('should allow name with unicode letters', () => {
+    validateDatasetName('bébés').should.equal(true);
+  });
+
+  // REJECT
+  it('should reject property named "name"', () => {
+    validatePropertyName('name').should.equal(false);
+  });
+
+  it('should reject property named "label"', () => {
+    validatePropertyName('label').should.equal(false);
+  });
+
+  it('should reject names starting number', () => {
+    validatePropertyName('123bad').should.equal(false);
+  });
+
+  it('should reject names starting with double underscore __', () => {
+    validatePropertyName('__bad').should.equal(false);
+  });
+
+  it('should reject names starting with other disallowed characters', () => {
+    validatePropertyName('-bad').should.equal(false);
+  });
+
+  it('should reject names starting with : colon', () => {
+    validatePropertyName(':badprop').should.equal(false);
+  });
+
+  it('should reject names containing a : colon', () => {
+    validatePropertyName('bad:prop').should.equal(false);
+  });
+
+  it('should reject name with unicode', () => {
+    validateDatasetName('unicode÷divide').should.equal(false);
   });
 });

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -315,6 +315,14 @@ describe('property name validation', () => {
     validatePropertyName('label').should.equal(false);
   });
 
+  it('should reject name with whitespace at the ends', () => {
+    validatePropertyName(' bad_whitespace ').should.equal(false);
+  });
+
+  it('should reject name with spaces in the middle', () => {
+    validatePropertyName('first name').should.equal(false);
+  });
+
   it('should reject names starting number', () => {
     validatePropertyName('123bad').should.equal(false);
   });

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -335,8 +335,12 @@ describe('property name validation', () => {
     validatePropertyName('__bad').should.equal(false);
   });
 
-  it('should reject names starting with other disallowed characters', () => {
+  it('should reject names starting with other disallowed characters like -', () => {
     validatePropertyName('-bad').should.equal(false);
+  });
+
+  it('should reject names starting with other disallowed characters like .', () => {
+    validatePropertyName('.bad').should.equal(false);
   });
 
   it('should reject names starting with : colon', () => {

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -323,6 +323,10 @@ describe('property name validation', () => {
     validatePropertyName('first name').should.equal(false);
   });
 
+  it('should reject property with slash', () => {
+    validatePropertyName('bad\name').should.equal(false);
+  });
+
   it('should reject names starting number', () => {
     validatePropertyName('123bad').should.equal(false);
   });


### PR DESCRIPTION
Closes #688 by adding validation to the entity/dataset property names. These are checked when the form with the dataset definition is uploaded. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, including tests that were already there.

#### Why is this the best possible solution? Were any other approaches considered?

Similar to dataset name validation approach.

The main tricky part of this validation is that while the dataset metadata is parsed from the form XML in one place, which can easily included the dataset metadata validation, the properties are parsed as part of the form field parsing, which doesn't seem like an appropriate place for dataset property validation. Thus this validation happens all the way inside the `Datasets.createOrMerge` query function, far from the other bit of dataset validation. Maybe that validation should be moved? 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Limits the set of allowable dataset/entity property names. Probably won't change things too much for users. Pyxform was already doing this validation, and most dataset/entity forms are likely made as an XLSX file.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

This particular xform entity schema is in a different API.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced