### PR TITLE
tests: double explicit timeouts

### DIFF
--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -853,7 +853,7 @@ describe('analytics task queries', () => {
   // eslint-disable-next-line space-before-function-paren, func-names
   describe('combined analytics', function () {
     // increasing timeouts on this set of tests
-    this.timeout(4000);
+    this.timeout(8000);
 
     it('should combine system level queries', testService(async (service, container) => {
       // encrypting a project

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -42,7 +42,7 @@ const down = () => withTestDatabase((migrator) =>
 // new column to exist.
 // eslint-disable-next-line space-before-function-paren, func-names
 describe.skip('database migrations', function() {
-  this.timeout(4000);
+  this.timeout(8000);
 
   it('should purge deleted forms via migration', testServiceFullTrx(async (service, container) => {
     await upToMigration('20220121-01-form-cascade-delete.js');
@@ -202,7 +202,7 @@ describe.skip('database migrations', function() {
 
 // eslint-disable-next-line space-before-function-paren, func-names
 describe('datbase migrations: removing default project', function() {
-  this.timeout(4000);
+  this.timeout(8000);
 
   it('should put old forms into project', testServiceFullTrx(async (service, container) => {
     // before 20181206-01-add-projects.js
@@ -240,7 +240,7 @@ describe('datbase migrations: removing default project', function() {
 
 // eslint-disable-next-line space-before-function-paren, func-names
 describe('datbase migrations: intermediate form schema', function() {
-  this.timeout(10000);
+  this.timeout(20000);
 
   it('should test migration', testServiceFullTrx(async (service, container) => {
     // before 20230109-01-add-form-schema.js
@@ -370,7 +370,7 @@ describe('datbase migrations: intermediate form schema', function() {
 
 // eslint-disable-next-line func-names, space-before-function-paren
 describe('database migrations: 20230123-01-remove-google-backups', function() {
-  this.timeout(10000);
+  this.timeout(20000);
 
   beforeEach(() => upToMigration('20230123-01-remove-google-backups.js', false));
 
@@ -465,7 +465,7 @@ describe('database migrations: 20230123-01-remove-google-backups', function() {
 
 // eslint-disable-next-line func-names
 describe('database migrations: 20230324-01-edit-dataset-verbs.js', function () {
-  this.timeout(10000);
+  this.timeout(20000);
 
   it('should add dataset/entity read verbs with raw sql', testServiceFullTrx(async (service, container) => {
     await upToMigration('20230324-01-edit-dataset-verbs.js', false);
@@ -502,7 +502,7 @@ describe('database migrations: 20230324-01-edit-dataset-verbs.js', function () {
 
 // eslint-disable-next-line func-names
 describe('database migrations from 20230406: altering entities and entity_defs', function () {
-  this.timeout(10000);
+  this.timeout(20000);
 
   const createEntity = async (service, container) => {
     // Get bob's id because bob is going to be the one who


### PR DESCRIPTION
As discussed at https://github.com/getodk/central-backend/issues/588#issuecomment-1523024085, this enables `make test` to pass on my machine.

Scope could possibly be narrowed to these tests:

```
  1) datbase migrations: removing default project
       should put old forms into project:
     Error: Timeout of 4000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/odk/odk-central-backend/test/integration/other/migrations.js)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)

  2) datbase migrations: intermediate form schema
       should test migration:
     Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/odk/odk-central-backend/test/integration/other/migrations.js)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)
```
