### PR TITLE
Make Authorization header checks tighter

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -7,7 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { isBlank, noop, without } = require('../util/util');
+const { isBlank, isPresent, noop, without } = require('../util/util');
 const { isTrue } = require('../util/http');
 const Problem = require('../util/problem');
 const { QueryOptions } = require('../util/db');
@@ -62,12 +62,12 @@ const authHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
       });
 
   // Standard Bearer token auth:
-  } else if (!isBlank(authHeader) && authHeader.startsWith('Bearer ')) {
+  } else if (isPresent(authHeader) && authHeader.startsWith('Bearer ')) {
     // auth by the bearer token we found:
     return authBySessionToken(authHeader.substring(7), () => reject(Problem.user.authenticationFailed()));
 
   // Basic Auth, which is allowed over HTTPS only:
-  } else if (!isBlank(authHeader) && authHeader.startsWith('Basic ')) {
+  } else if (isPresent(authHeader) && authHeader.startsWith('Basic ')) {
     // fail the request unless we are under HTTPS.
     // this logic does mean that if we are not under nginx it is possible to fool the server.
     // but it is the user's prerogative to undertake this bypass, so their security is in their hands.
@@ -93,7 +93,7 @@ const authHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
         }));
 
   // Authorization header supplied, but in an unrecognised format:
-  } else if (!isBlank(authHeader)) {
+  } else if (isPresent(authHeader)) {
     return reject(Problem.user.authenticationFailed());
 
   // Cookie Auth, which is more relaxed about not doing anything on failures.

--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -62,12 +62,12 @@ const authHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
       });
 
   // Standard Bearer token auth:
-  } else if (!isBlank(authHeader) && authHeader.startsWith('Bearer')) {
+  } else if (!isBlank(authHeader) && authHeader.startsWith('Bearer ')) {
     // auth by the bearer token we found:
     return authBySessionToken(authHeader.substring(7), () => reject(Problem.user.authenticationFailed()));
 
   // Basic Auth, which is allowed over HTTPS only:
-  } else if (!isBlank(authHeader) && authHeader.startsWith('Basic')) {
+  } else if (!isBlank(authHeader) && authHeader.startsWith('Basic ')) {
     // fail the request unless we are under HTTPS.
     // this logic does mean that if we are not under nginx it is possible to fool the server.
     // but it is the user's prerogative to undertake this bypass, so their security is in their hands.
@@ -91,6 +91,10 @@ const authHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
 
           return reject(Problem.user.authenticationFailed());
         }));
+
+  // Authorization header supplied, but in an unrecognised format:
+  } else if (!isBlank(authHeader)) {
+    return reject(Problem.user.authenticationFailed());
 
   // Cookie Auth, which is more relaxed about not doing anything on failures.
   // but if the method is anything but GET we will need to check the CSRF token.

--- a/soak-tester/index.js
+++ b/soak-tester/index.js
@@ -16,7 +16,7 @@ import { program } from 'commander';
 
 const _log = (...args) => console.log(`[${new Date().toISOString()}]`, '[soak-tester]', ...args);
 const log  = (...args) => true  && _log('INFO',   ...args);
-log.debug  = (...args) => true && _log('DEBUG',  ...args);
+log.debug  = (...args) => false && _log('DEBUG',  ...args);
 log.info   = log;
 log.error  = (...args) => true  && _log('ERROR',  ...args);
 log.report = (...args) => true  && _log('REPORT', ...args);
@@ -239,19 +239,15 @@ async function apiPost(path, body, headers) {
   return res.json();
 }
 
-async function apiFetch(method, path, body, extraHeaders) {
+async function apiFetch(method, path, body, headers) {
   const url = `${serverUrl}/v1/${path}`;
 
   const Authorization = bearerToken ? `Bearer ${bearerToken}` : `Basic ${base64(`${userEmail}:${userPassword}`)}`;
 
-  const headers = { Authorization, ...extraHeaders };
-
-  log.debug('apiFetch()', { method, url, headers, body });
-
   const res = await fetch(url, {
     method,
     body,
-    headers,
+    headers: { Authorization, ...headers },
   });
   log.debug(method, res.url, '->', res.status);
   if(!res.ok) throw new Error(`${res.status}: ${await res.text()}`);

--- a/soak-tester/index.js
+++ b/soak-tester/index.js
@@ -246,7 +246,7 @@ async function apiFetch(method, path, body, extraHeaders) {
 
   const headers = { Authorization, ...extraHeaders };
 
-  log.debug('apiFetch()', { methor, url, headers, body });
+  log.debug('apiFetch()', { method, url, headers, body });
 
   const res = await fetch(url, {
     method,

--- a/soak-tester/index.js
+++ b/soak-tester/index.js
@@ -239,15 +239,19 @@ async function apiPost(path, body, headers) {
   return res.json();
 }
 
-async function apiFetch(method, path, body, headers) {
+async function apiFetch(method, path, body, extraHeaders) {
   const url = `${serverUrl}/v1/${path}`;
 
   const Authorization = bearerToken ? `Bearer ${bearerToken}` : `Basic ${base64(`${userEmail}:${userPassword}`)}`;
 
+  const headers = { Authorization, ...extraHeaders };
+
+  log.debug('apiFetch()', { methor, url, headers, body });
+
   const res = await fetch(url, {
     method,
     body,
-    headers: { Authorization, ...headers },
+    headers,
   });
   log.debug(method, res.url, '->', res.status);
   if(!res.ok) throw new Error(`${res.status}: ${await res.text()}`);

--- a/soak-tester/index.js
+++ b/soak-tester/index.js
@@ -49,7 +49,7 @@ async function soakTest() {
   fs.mkdirSync(logPath, { recursive:true });
 
   log.info('Creating session...');
-  const { token } = await apiPostJson('sessions', { email:userEmail, password:userPassword }, { Authorization:undefined });
+  const { token } = await apiPostJson('sessions', { email:userEmail, password:userPassword }, { Authorization:null });
   bearerToken = token;
 
   log.info('Creating project...');
@@ -239,15 +239,19 @@ async function apiPost(path, body, headers) {
   return res.json();
 }
 
-async function apiFetch(method, path, body, headers) {
+async function apiFetch(method, path, body, extraHeaders) {
   const url = `${serverUrl}/v1/${path}`;
 
   const Authorization = bearerToken ? `Bearer ${bearerToken}` : `Basic ${base64(`${userEmail}:${userPassword}`)}`;
 
+  const headers = { Authorization, ...extraHeaders };
+  // unset null/undefined Authorization value to prevent fetch() from stringifying it:
+  if(headers.Authorization == null) delete headers.Authorization;
+
   const res = await fetch(url, {
     method,
     body,
-    headers: { Authorization, ...headers },
+    headers,
   });
   log.debug(method, res.url, '->', res.status);
   if(!res.ok) throw new Error(`${res.status}: ${await res.text()}`);

--- a/soak-tester/index.js
+++ b/soak-tester/index.js
@@ -16,7 +16,7 @@ import { program } from 'commander';
 
 const _log = (...args) => console.log(`[${new Date().toISOString()}]`, '[soak-tester]', ...args);
 const log  = (...args) => true  && _log('INFO',   ...args);
-log.debug  = (...args) => false && _log('DEBUG',  ...args);
+log.debug  = (...args) => true && _log('DEBUG',  ...args);
 log.info   = log;
 log.error  = (...args) => true  && _log('ERROR',  ...args);
 log.report = (...args) => true  && _log('REPORT', ...args);

--- a/soak-tester/index.js
+++ b/soak-tester/index.js
@@ -49,7 +49,7 @@ async function soakTest() {
   fs.mkdirSync(logPath, { recursive:true });
 
   log.info('Creating session...');
-  const { token } = await apiPostJson('sessions', { email:userEmail, password:userPassword }, { Authorization:null });
+  const { token } = await apiPostJson('sessions', { email:userEmail, password:userPassword }, { Authorization:undefined });
   bearerToken = token;
 
   log.info('Creating project...');

--- a/test/integration/other/bearer-auth.js
+++ b/test/integration/other/bearer-auth.js
@@ -1,7 +1,7 @@
 const { testService } = require('../setup');
 
 describe('bearer authentication', () => {
-  it('should reject 401 if the key format is wrong', testService((service) => // gh329
+  it('should reject 401 if the header format is wrong', testService((service) => // gh329
     service.get('/v1/users/current')
       .set('Authorization', 'Bearer: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
       .expect(401)));

--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -44,14 +44,11 @@ describe('preprocessors', () => {
         should.not.exist(context);
       }));
 
-    it('should do nothing if Authorization mode is not Bearer or Basic', () =>
+    it('should fail the request if unsupported Authorization header is supplied', () =>
       Promise.resolve(authHandler(
         { Auth, Sessions: mockSessions() },
         new Context(createRequest({ headers: { Authorization: 'Digest aabbccddeeff123' }, fieldKey: Option.none() }))
-      )).then((context) => {
-        // preprocessors return nothing if they have no changes to make to the context.
-        should.not.exist(context);
-      }));
+      )).should.be.rejectedWith(Problem, { problemCode: 401.2 }));
 
     describe('Bearer auth', () => {
       it('should ignore bearer auth if a field key is present', () =>


### PR DESCRIPTION
Include trailing space in checks for `Basic` and `Bearer` prefixes in Authorization headers.  This space is already assumed to exist in subsequent parsing code.
    
An extra check is added for requests which _provide_ the Authorization header, but in an unrecognised format.  This ensures that a 401 header is still sent in preference to 404, as per #329.  It also changes the response code for unsupported auth-schemes _when they do not start with either `Bearer` or `Basic`_.