### PR TITLE
auth: make string manipulation code clearer

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -64,7 +64,7 @@ const sessionHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
   // Standard Bearer token auth:
   } else if (!isBlank(authHeader) && authHeader.startsWith('Bearer')) {
     // auth by the bearer token we found:
-    return authBySessionToken(authHeader.slice(7), () => reject(Problem.user.authenticationFailed()));
+    return authBySessionToken(authHeader.substring(7), () => reject(Problem.user.authenticationFailed()));
 
   // Basic Auth, which is allowed over HTTPS only:
   } else if (!isBlank(authHeader) && authHeader.startsWith('Basic')) {
@@ -75,7 +75,7 @@ const sessionHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
       return reject(Problem.user.httpsOnly());
 
     // we have to use a regex rather than .split(':') in case the password contains :s.
-    const plainCredentials = Buffer.from(authHeader.slice(6), 'base64').toString('utf8');
+    const plainCredentials = Buffer.from(authHeader.substring(6), 'base64').toString('utf8');
     const match = /^([^:]+):(.+)$/.exec(plainCredentials);
     if (match == null) return reject(Problem.user.authenticationFailed());
     const [ , email, password ] = match;


### PR DESCRIPTION
Use `.substring()` in preference to `.slice()` when manipulating Strings to make code's intention clearer.
