### PR TITLE
Rename authHandler to reflect wider responsibilities

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -14,15 +14,15 @@ const { QueryOptions } = require('../util/db');
 const { reject, getOrReject } = require('../util/promise');
 
 
-// injects an empty/anonymous auth session into the request context.
-const emptySessionInjector = ({ Auth }, context) => context.with({ auth: Auth.by(null) });
+// injects an empty/anonymous auth object into the request context.
+const emptyAuthInjector = ({ Auth }, context) => context.with({ auth: Auth.by(null) });
 
 // if one of (Bearer|Basic|Cookie) credentials are provided in the correct conditions
-// then authHandler injects the appropriate session information to the context
+// then authHandler injects the appropriate auth information to the context
 // given the appropriate credentials. if credentials are given but don't match a
-// session, aborts the request with a 401.
+// session or user, aborts the request with a 401.
 //
-// otherwise, nothing is done. n.b. this means you must use the emptySessionInjector
+// otherwise, nothing is done. n.b. this means you must use the emptyAuthInjector
 // in conjunction with this function!
 //
 // TODO?: repetitive, but deduping it makes it even harder to understand.
@@ -150,5 +150,5 @@ const queryOptionsHandler = (_, context) => {
 };
 
 
-module.exports = { emptySessionInjector, authHandler, queryOptionsHandler };
+module.exports = { emptyAuthInjector, authHandler, queryOptionsHandler };
 

--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -18,7 +18,7 @@ const { reject, getOrReject } = require('../util/promise');
 const emptySessionInjector = ({ Auth }, context) => context.with({ auth: Auth.by(null) });
 
 // if one of (Bearer|Basic|Cookie) credentials are provided in the correct conditions
-// then sessionHandler injects the appropriate session information to the context
+// then authHandler injects the appropriate session information to the context
 // given the appropriate credentials. if credentials are given but don't match a
 // session, aborts the request with a 401.
 //
@@ -26,7 +26,7 @@ const emptySessionInjector = ({ Auth }, context) => context.with({ auth: Auth.by
 // in conjunction with this function!
 //
 // TODO?: repetitive, but deduping it makes it even harder to understand.
-const sessionHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
+const authHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
   const authBySessionToken = (token, onFailure = noop) => Sessions.getByBearerToken(token)
     .then((session) => {
       if (!session.isDefined()) return onFailure();
@@ -150,5 +150,5 @@ const queryOptionsHandler = (_, context) => {
 };
 
 
-module.exports = { emptySessionInjector, sessionHandler, queryOptionsHandler };
+module.exports = { emptySessionInjector, authHandler, queryOptionsHandler };
 

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -49,8 +49,8 @@ module.exports = (container) => {
   // and for easier transaction management.
 
   const { builder } = require('./endpoint');
-  const { emptySessionInjector, sessionHandler, queryOptionsHandler } = require('./preprocessors');
-  const endpoint = builder(container, [ emptySessionInjector, sessionHandler, queryOptionsHandler ]);
+  const { emptySessionInjector, authHandler, queryOptionsHandler } = require('./preprocessors');
+  const endpoint = builder(container, [ emptySessionInjector, authHandler, queryOptionsHandler ]);
 
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -49,8 +49,8 @@ module.exports = (container) => {
   // and for easier transaction management.
 
   const { builder } = require('./endpoint');
-  const { emptySessionInjector, authHandler, queryOptionsHandler } = require('./preprocessors');
-  const endpoint = builder(container, [ emptySessionInjector, authHandler, queryOptionsHandler ]);
+  const { emptyAuthInjector, authHandler, queryOptionsHandler } = require('./preprocessors');
+  const endpoint = builder(container, [ emptyAuthInjector, authHandler, queryOptionsHandler ]);
 
 
   ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `sessionHandler` function handles more than just sessions, so it seems appropriate to rename it `authHandler`.

It currently handles authentication via:

* session token in Authorization header & cookie
* field key
* HTTP basic auth

For GET/HEAD requests using session-based authentication via Cookie header, this function also checks the CSRF token.