### PR TITLE
Prototype of entity_source table connected to entity audits

### DIFF
--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -64,7 +64,7 @@ Entity.Def = Frame.define(
   table('entity_defs', 'def'),
   'id',                         'entityId',
   'createdAt', readable,        'current', readable,
-  'submissionDefId',            'label', readable,
+  'sourceId',                   'label', readable,
   'creatorId', readable,        'userAgent', readable,
   'data', readable,
   embedded('creator'),
@@ -79,7 +79,20 @@ Entity.Def.Metadata = class extends Entity.Def {
   }
 };
 
-Entity.Def.Source = Frame.define(
+// Summary of an entity's source for an API response
+// e.g. { type: 'API', details: null } or
+// { type: 'submission', details: { xmlFormId, instanceId, instanceName }}
+// TODO: combine this with the source frame below
+Entity.Def.SourceSummary = Frame.define(
   'type', readable,             'details', readable
 );
+
+Entity.Def.Source = Frame.define(
+  table('entity_def_sources', 'entityDefSource'),
+  'details', readable,
+  'submissionDefId', 'auditId',
+  embedded('submissionDef'),
+  embedded('audit')
+);
+
 module.exports = { Entity };

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -79,14 +79,6 @@ Entity.Def.Metadata = class extends Entity.Def {
   }
 };
 
-// Summary of an entity's source for an API response
-// e.g. { type: 'API', details: null } or
-// { type: 'submission', details: { xmlFormId, instanceId, instanceName }}
-// TODO: combine this with the source frame below
-Entity.Def.SourceSummary = Frame.define(
-  'type', readable,             'details', readable
-);
-
 Entity.Def.Source = Frame.define(
   table('entity_def_sources', 'entityDefSource'),
   'details', readable,

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -66,7 +66,7 @@ Entity.Def = Frame.define(
   'createdAt', readable,        'current', readable,
   'sourceId',                   'label', readable,
   'creatorId', readable,        'userAgent', readable,
-  'data', readable,
+  'data', readable,             'root',
   embedded('creator'),
   embedded('source')
 );

--- a/lib/model/migrations/20230512-01-add-entity-root.js
+++ b/lib/model/migrations/20230512-01-add-entity-root.js
@@ -1,0 +1,20 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw('ALTER TABLE entity_defs ADD COLUMN "root" BOOLEAN NOT NULL DEFAULT FALSE');
+
+  // This should be all of the entity_defs
+  await db.raw(`update entity_defs set root=true
+  where id in (select min(id) from entity_defs group by "entityId")`);
+};
+
+const down = (db) => db.raw('ALTER TABLE entity_defs DROP COLUMN "root"');
+
+module.exports = { up, down };

--- a/lib/model/migrations/20230512-01-add-entity-source.js
+++ b/lib/model/migrations/20230512-01-add-entity-source.js
@@ -1,0 +1,100 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+/* Steps of this migration
+  1. add new table entity source
+  2. add source id col to entity def
+  3. populate rows of source table and add id in entity def
+  4. remove sub def id from entity def table
+*/
+
+const up = async (db) => {
+  await db.schema.createTable('entity_def_sources', (es) => {
+    es.increments('id');
+    es.integer('auditId');
+    es.foreign('auditId').references('audits.id').onDelete('set null');
+    es.integer('submissionDefId');
+    es.foreign('submissionDefId').references('submission_defs.id').onDelete('set null');
+    es.jsonb('details'); // any info you'd want to have when unlinked (e.g. after submission getting deleted)
+  });
+
+  await db.schema.table('entity_defs', (fd) => {
+    fd.integer('sourceId');
+    fd.foreign('sourceId').references('entity_def_sources.id');
+
+    // TODO: right now in this prototype, this migration is purely additive:
+    // it adds a new table and adds a new column linking to that table.
+    // if we choose to go along with this, we'd also want to remove the
+    // submission def id column from the entity def table after populating
+    // the new table.
+  });
+
+  /* eslint-disable no-await-in-loop */
+  const allEntityDefs = await db.select('id', 'submissionDefId')
+    .from('entity_defs');
+  for (const entityDef of allEntityDefs) {
+    const [ approveEvent ] = await db.select('id', 'details', 'action')
+      .from('audits')
+      .whereRaw(`(details->'submissionDefId'::text) = '${entityDef.submissionDefId}'`)
+      .where({ action: 'submission.update' });
+
+    let triggeringEventId = null;
+    let details = {};
+
+    if (approveEvent) {
+      const [ submissionCreateEvent ] = await db.select('id', 'details', 'action')
+        .from('audits')
+        .whereRaw(`(details->'submissionId'::text) = '${approveEvent.details.submissionId}'`)
+        .where({ action: 'submission.create' });
+
+      triggeringEventId = approveEvent.id;
+      // looking up the creation event to get the instance id in case the submission
+      // has already been deleted
+      details = { submission: { instanceId: submissionCreateEvent.details.instanceId } };
+    }
+
+    const [ sourceId ] = await db.insert({
+      submissionDefId: entityDef.submissionDefId,
+      auditId: triggeringEventId,
+      details
+    })
+      .into('entity_def_sources').returning('id');
+
+    await db.update({ sourceId })
+      .into('entity_defs')
+      .where({ id: entityDef.id });
+  }
+  // Done backfilling
+  await db.schema.table('entity_defs', (ed) => {
+    ed.dropColumn('submissionDefId');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.table('entity_defs', (ed) => {
+    ed.integer('submissionDefId');
+    ed.foreign('submissionDefId').references('submission_defs.id').onDelete('set null');
+  });
+
+  await db.raw(`
+    UPDATE entity_defs set "submissionDefId" = entity_def_sources."submissionDefId"
+      FROM entity_def_sources
+      WHERE entity_defs."sourceId" = entity_def_sources.id
+  `);
+
+  await db.schema.table('entity_defs', (ed) => {
+    ed.dropForeign('sourceId');
+    ed.dropColumn('sourceId');
+  });
+
+  await db.schema.dropTable('entity_def_sources');
+};
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20230512-02-backfill-entity-id.js
+++ b/lib/model/migrations/20230512-02-backfill-entity-id.js
@@ -1,0 +1,23 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = (db) => db.raw(`
+  update audits
+    set details = details || jsonb_build_object('entityId', entities."id") || jsonb_build_object('entityDefId', entity_defs."id")
+    from entities
+    join datasets on entities."datasetId" = datasets.id
+    join entity_defs on entities.id = entity_defs."entityId" and root
+    where
+      audits.action = 'entity.create' and
+      audits."acteeId" = datasets."acteeId" and
+      entities.uuid::text = audits.details->'entity'->>'uuid'`);
+
+const down = () => {};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20230512-03-add-entity-source.js
+++ b/lib/model/migrations/20230512-03-add-entity-source.js
@@ -17,6 +17,7 @@
 const up = async (db) => {
   await db.schema.createTable('entity_def_sources', (es) => {
     es.increments('id');
+    es.string('type', 36).notNull();
     es.integer('auditId');
     es.foreign('auditId').references('audits.id').onDelete('set null');
     es.integer('submissionDefId');
@@ -24,44 +25,71 @@ const up = async (db) => {
     es.jsonb('details'); // any info you'd want to have when unlinked (e.g. after submission getting deleted)
   });
 
-  await db.schema.table('entity_defs', (fd) => {
-    fd.integer('sourceId');
-    fd.foreign('sourceId').references('entity_def_sources.id');
-
-    // TODO: right now in this prototype, this migration is purely additive:
-    // it adds a new table and adds a new column linking to that table.
-    // if we choose to go along with this, we'd also want to remove the
-    // submission def id column from the entity def table after populating
-    // the new table.
+  await db.schema.table('entity_defs', (ed) => {
+    ed.integer('sourceId');
+    ed.foreign('sourceId').references('entity_def_sources.id');
   });
 
   /* eslint-disable no-await-in-loop */
-  const allEntityDefs = await db.select('id', 'submissionDefId')
+  const allEntityDefs = await db.select('id', 'entityId', 'submissionDefId')
     .from('entity_defs');
+
   for (const entityDef of allEntityDefs) {
-    const [ approveEvent ] = await db.select('id', 'details', 'action')
-      .from('audits')
-      .whereRaw(`(details->'submissionDefId'::text) = '${entityDef.submissionDefId}'`)
-      .where({ action: 'submission.update' });
+    // Filling these in for each entity def
+    let submissionDefId;
+    let triggeringAuditId;
+    let details;
 
-    let triggeringEventId = null;
-    let details = {};
-
-    if (approveEvent) {
-      const [ submissionCreateEvent ] = await db.select('id', 'details', 'action')
+    // Get the submissionDefId from the entityDef or from the entity creation event
+    // if the submission was deleted
+    submissionDefId = entityDef.submissionDefId;
+    if (!submissionDefId) {
+      const [ entityCreationEvent ] = await db.select('id', 'details')
         .from('audits')
-        .whereRaw(`(details->'submissionId'::text) = '${approveEvent.details.submissionId}'`)
-        .where({ action: 'submission.create' });
-
-      triggeringEventId = approveEvent.id;
-      // looking up the creation event to get the instance id in case the submission
-      // has already been deleted
-      details = { submission: { instanceId: submissionCreateEvent.details.instanceId } };
+        .whereRaw(`(details->'entityDefId'::text) = '${entityDef.id}'`)
+        .where({ action: 'entity.create' })
+        .limit(1);
+      if (entityCreationEvent)
+        submissionDefId = entityCreationEvent.details.submissionDefId;
     }
 
+    // Look up the approval event for this submission def.
+    // If there happen to be multiple approvals for the same submission def,
+    // take the first one.
+    // But mostly, re-approvals for submissions should be for different defs.
+    const [ approveEvent ] = await db.select('id', 'details', 'action')
+      .from('audits')
+      .whereRaw(`(details->'submissionDefId'::text) = '${submissionDefId}'`)
+      .where({ action: 'submission.update' })
+      .orderBy('loggedAt', 'asc')
+      .limit(1);
+
+    if (approveEvent) {
+      triggeringAuditId = approveEvent.id;
+
+      // the submission creation event will be looked up by the submission id
+      // rather than the submission def id, and this submission id can be found
+      // in the approval event.
+      const [ submissionCreateEvent ] = await db.select('id', 'details', 'action', 'acteeId')
+        .from('audits')
+        .whereRaw(`(details->'submissionId'::text) = '${approveEvent.details.submissionId}'`)
+        .where({ action: 'submission.create' })
+        .limit(1);
+
+      if (submissionCreateEvent)
+        details = {
+          submission: {
+            instanceId: submissionCreateEvent.details.instanceId,
+            formActeeId: submissionCreateEvent.acteeId
+          }
+        };
+    }
+
+    // construct source object with info collected above
     const [ sourceId ] = await db.insert({
-      submissionDefId: entityDef.submissionDefId,
-      auditId: triggeringEventId,
+      type: 'submission',
+      submissionDefId: entityDef.submissionDefId, // insert null if it was null on the entity def
+      auditId: triggeringAuditId,
       details
     })
       .into('entity_def_sources').returning('id');
@@ -91,6 +119,7 @@ const down = async (db) => {
   await db.schema.table('entity_defs', (ed) => {
     ed.dropForeign('sourceId');
     ed.dropColumn('sourceId');
+    ed.dropColumn('root');
   });
 
   await db.schema.dropTable('entity_def_sources');

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -115,23 +115,32 @@ const _getByEntityId = (fields, options, entityId) => sql`
 SELECT ${fields} FROM audits
   LEFT JOIN actors ON actors.id=audits."actorId"
 
-  LEFT JOIN audits triggering_event ON (audits.details->'eventId')::INTEGER = triggering_event.id 
+  LEFT JOIN entity_defs ON (audits.details->'entityDefId')::INTEGER = entity_defs.id
+  LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
+
+  LEFT JOIN audits triggering_event ON entity_def_sources."auditId" = triggering_event.id
   LEFT JOIN actors triggering_event_actor ON triggering_event_actor.id = triggering_event."actorId"
 
+  -- if triggering event has a submissionId defined, look up creation event for that submission
+  -- it has info about the submission and creator we want to show even if the submission is deleted
   LEFT JOIN audits submission_create_event ON (triggering_event.details->'submissionId')::INTEGER = (submission_create_event.details->'submissionId')::INTEGER AND submission_create_event.action = 'submission.create'
   LEFT JOIN actors submission_create_event_actor ON submission_create_event_actor.id = submission_create_event."actorId"
 
+  -- if source submissionDefId is defined:
   LEFT JOIN (
     (
-      SELECT submissions.*, submission_defs."userAgent" FROM submissions
-      JOIN submission_defs ON submissions.id = submission_defs."submissionId" AND root AND submissions."deletedAt" IS NULL
+      SELECT submissions.*, '' as "userAgent"FROM submissions
     ) submissions
-      JOIN forms ON forms.id = submissions."formId" AND forms."deletedAt" IS NULL  
-  ) ON (triggering_event.details->'submissionId')::INTEGER = submissions.id
+    JOIN forms ON forms.id = submissions."formId" AND forms."deletedAt" IS NULL
+    JOIN submission_defs ON submissions.id = submission_defs."submissionId" AND submissions."deletedAt" IS NULL
+  ) on submission_defs.id = entity_def_sources."submissionDefId"
+
   LEFT JOIN actors submission_actor ON submission_actor.id = submissions."submitterId"
-  LEFT JOIN submission_defs on submissions.id = submission_defs."submissionId" and submission_defs.current
   LEFT JOIN actors current_submission_actor on current_submission_actor.id=submission_defs."submitterId"
-  
+
+  -- if some other kind of target object defined, add subquery here
+  -- ...
+
   WHERE (audits.details->'entityId')::INTEGER = ${entityId}
   ORDER BY audits."loggedAt" DESC, audits.id DESC
   ${page(options)}`;
@@ -142,8 +151,9 @@ const getByEntityId = (entityId, options) => ({ all }) => {
     Audit, Actor,
     Option.of(Audit.alias('triggering_event', 'triggeringEvent')), Option.of(Actor.alias('triggering_event_actor', 'triggeringEventActor')),
     Option.of(Audit.alias('submission_create_event', 'submissionCreateEvent')), Option.of(Actor.alias('submission_create_event_actor', 'submissionCreateEventActor')),
-    Option.of(Submission), Option.of(Actor.alias('submission_actor', 'submissionActor')),
-    Option.of(Submission.Def.into('currentVersion')), Option.of(Actor.alias('current_submission_actor', 'currentSubmissionActor')),
+    Option.of(Submission), Option.of(Submission.Def.into('currentVersion')),
+    Option.of(Actor.alias('current_submission_actor', 'currentSubmissionActor')),
+    Option.of(Actor.alias('submission_actor', 'submissionActor')),
     Option.of(Form)
   );
 
@@ -151,8 +161,8 @@ const getByEntityId = (entityId, options) => ({ all }) => {
     .then(map(_unjoiner))
     .then(map(audit => {
 
+      // this could have a more generic name like 'triggering event' that was linked to any kind of entity audit event
       const approval = audit.aux.triggeringEvent
-        .filter(a => a.action === 'submission.update' && a.details.reviewState === 'approved')
         .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
         .map(a => a.forApi());
 
@@ -160,6 +170,8 @@ const getByEntityId = (entityId, options) => ({ all }) => {
         .map(a => a.withAux('actor', audit.aux.submissionCreateEventActor.orNull()))
         .map(a => a.forApi());
 
+      // the 'current version' is actually the linked submission def, so it might not be the submission's
+      // true current version, but it is more relevant to the entity.
       const submission = audit.aux.submission
         .map(s => s.withAux('submitter', audit.aux.submissionActor.orNull()))
         .map(s => s.withAux('currentVersion', audit.aux.currentVersion.map(v => v.withAux('submitter', audit.aux.currentSubmissionActor.orNull()))))
@@ -169,7 +181,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
       const details = mergeLeft(audit.details, {
         approval: approval.orElse(undefined),
         submissionCreate: submissionCreate.orElse(undefined),
-        submission: submission.orElse(undefined),
+        submission: submission.orElse(undefined)
       });
 
       return new Audit({ ...audit, details }, { actor: audit.aux.actor });

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -176,8 +176,6 @@ const getByEntityId = (entityId, options) => ({ all }) => {
         .map(a => a.withAux('actor', audit.aux.submissionCreateEventActor.orNull()))
         .map(a => a.forApi());
 
-      // the 'current version' is actually the linked submission def, so it might not be the submission's
-      // true current version, but it is more relevant to the entity.
       const submission = audit.aux.submission
         .map(s => s.withAux('submitter', audit.aux.submissionActor.orNull()))
         .map(s => s.withAux('currentVersion', audit.aux.currentVersion.map(v => v.withAux('submitter', audit.aux.currentSubmissionActor.orNull()))))

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -129,14 +129,20 @@ SELECT ${fields} FROM audits
   -- if source submissionDefId is defined:
   LEFT JOIN (
     (
-      SELECT submissions.*, '' as "userAgent"FROM submissions
+      SELECT submissions.*, submission_defs."userAgent" FROM submissions
+      JOIN submission_defs ON submissions.id = submission_defs."submissionId" AND root AND submissions."deletedAt" IS NULL
     ) submissions
-    JOIN forms ON forms.id = submissions."formId" AND forms."deletedAt" IS NULL
-    JOIN submission_defs ON submissions.id = submission_defs."submissionId" AND submissions."deletedAt" IS NULL
-  ) on submission_defs.id = entity_def_sources."submissionDefId"
+    JOIN forms
+      ON forms.id = submissions."formId" AND forms."deletedAt" IS NULL
+        AND submissions."deletedAt" IS NULL
+    JOIN submission_defs AS current_submission_def
+      ON submissions.id = current_submission_def."submissionId" AND current
+    JOIN submission_defs AS linked_submission_def
+      ON submissions.id = linked_submission_def."submissionId"
+  ) on linked_submission_def.id = entity_def_sources."submissionDefId"
 
   LEFT JOIN actors submission_actor ON submission_actor.id = submissions."submitterId"
-  LEFT JOIN actors current_submission_actor on current_submission_actor.id=submission_defs."submitterId"
+  LEFT JOIN actors current_submission_actor on current_submission_actor.id=current_submission_def."submitterId"
 
   -- if some other kind of target object defined, add subquery here
   -- ...
@@ -151,7 +157,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
     Audit, Actor,
     Option.of(Audit.alias('triggering_event', 'triggeringEvent')), Option.of(Actor.alias('triggering_event_actor', 'triggeringEventActor')),
     Option.of(Audit.alias('submission_create_event', 'submissionCreateEvent')), Option.of(Actor.alias('submission_create_event_actor', 'submissionCreateEventActor')),
-    Option.of(Submission), Option.of(Submission.Def.into('currentVersion')),
+    Option.of(Submission), Option.of(Submission.Def.alias('current_submission_def', 'currentVersion')),
     Option.of(Actor.alias('current_submission_actor', 'currentSubmissionActor')),
     Option.of(Actor.alias('submission_actor', 'submissionActor')),
     Option.of(Form)

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -33,7 +33,7 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 // standard authenticated API request. The worker has better access to the event
 // actor/initiator and actee/target so it will do the logging itself (including
 // error logging).
-const createNew = (dataset, partial, subDef, userAgentIn, sourceId = null) => ({ one, context }) => {
+const createNew = (dataset, partial, subDef, sourceId, userAgentIn) => ({ one, context }) => {
   let creatorId;
   let userAgent;
   let subDefId;
@@ -71,8 +71,8 @@ select ins.*, def.id as "entityDefId" from ins, def;`)
 createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
   if (!subDef)
     return log('entity.create', dataset, {
-      entityId: newEntity.id, // Added in v2023.3 - not backfilled
-      entityDefId: newEntity.aux.currentVersion.id, // Added in v2023.3 - not backfilled
+      entityId: newEntity.id, // Added in v2023.3 and backfilled
+      entityDefId: newEntity.aux.currentVersion.id, // Added in v2023.3 and backfilled
       entity: { uuid: newEntity.uuid, label: newEntity.aux.currentVersion.label, dataset: dataset.name }
     });
 };
@@ -80,7 +80,7 @@ createNew.audit.withResult = true;
 
 
 // Creates a source entry for entities created through audit events and submissions
-const createSource = (subDefId, eventId, details) => ({ one }) => {
+const createSource = (details = null, subDefId = null, eventId = null) => ({ one }) => {
   const type = (subDefId) ? 'submission' : 'api';
   return one(sql`insert into entity_def_sources ("type", "submissionDefId", "auditId", "details")
   values (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)})
@@ -130,14 +130,14 @@ const _processSubmissionDef = (event) => async ({ Datasets, Entities, Submission
 
   const partial = await Entity.fromParseEntityData(entityData);
 
-  const sourceId = await Entities.createSource(submissionDefId, event.id, { submission: { instanceId: submissionDef.instanceId } });
-  const entity = await Entities.createNew(dataset, partial, submissionDef, null, sourceId);
+  const sourceDetails = { submission: { instanceId: submissionDef.instanceId } };
+  const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id);
+  const entity = await Entities.createNew(dataset, partial, submissionDef, sourceId);
 
   return Audits.log({ id: event.actorId }, 'entity.create', { acteeId: dataset.acteeId },
     {
-      entityId: entity.id, // Added in v2023.3 - not backfilled
-      eventId: event.id, // Added in v2023.3 - not backfilled
-      entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 - not backfilled
+      entityId: entity.id, // Added in v2023.3 and backfilled
+      entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 and backfilled
       entity: { uuid: entity.uuid, label: entity.aux.currentVersion.label, dataset: dataset.name },
       submissionId,
       submissionDefId
@@ -167,7 +167,7 @@ const processSubmissionEvent = (event) => (container) =>
 ////////////////////////////////////////////////////////////////////////////////
 // UPDATING ENTITIES
 
-const createVersion = (dataset, entity, data, label, userAgentIn = null) => ({ context, one }) => {
+const createVersion = (dataset, entity, data, label, sourceId, userAgentIn = null) => ({ context, one }) => {
   // dataset is passed in so the audit log can use its actee id
   const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
   const userAgent = blankStringToNull(userAgentIn);
@@ -176,7 +176,7 @@ const createVersion = (dataset, entity, data, label, userAgentIn = null) => ({ c
   const _unjoiner = unjoiner(Entity, Entity.Def.into('currentVersion'));
 
   return one(sql`
-  with def as (${_defInsert(entity.id, false, creatorId, userAgent, label, json)}),
+  with def as (${_defInsert(entity.id, false, creatorId, userAgent, label, json, sourceId)}),
   upd as (update entity_defs set current=false where entity_defs."entityId" = ${entity.id}),
   entities as (update entities set "updatedAt"=clock_timestamp()
     where "uuid"=${entity.uuid}
@@ -199,6 +199,9 @@ createVersion.audit.withResult = true;
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES
 
+// There is plumbing here for including the entity source submission, but it
+// is not currently in use. Leaving it in place for when we do want to include
+// source information again.
 const _get = (includeSource) => {
   const frames = [Entity];
   if (includeSource) {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -21,8 +21,8 @@ const Problem = require('../../util/problem');
 ////////////////////////////////////////////////////////////////////////////////
 // ENTITY CREATE
 
-const _defInsert = (id, subDefId, creatorId, userAgent, label, json) => sql`insert into entity_defs ("entityId", "submissionDefId", "creatorId", "userAgent", "label", "data", "current", "createdAt")
-  values (${id}, ${subDefId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp())
+const _defInsert = (id, creatorId, userAgent, label, json, sourceId = null) => sql`insert into entity_defs ("entityId", "sourceId", "creatorId", "userAgent", "label", "data", "current", "createdAt")
+  values (${id}, ${sourceId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp())
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 
@@ -32,7 +32,7 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 // standard authenticated API request. The worker has better access to the event
 // actor/initiator and actee/target so it will do the logging itself (including
 // error logging).
-const createNew = (dataset, partial, subDef, userAgentIn) => ({ one, context }) => {
+const createNew = (dataset, partial, subDef, userAgentIn, sourceId = null) => ({ one, context }) => {
   let creatorId;
   let userAgent;
   let subDefId;
@@ -49,7 +49,7 @@ const createNew = (dataset, partial, subDef, userAgentIn) => ({ one, context }) 
   const json = JSON.stringify(partial.def.data);
 
   return one(sql`
-with def as (${_defInsert(nextval, subDefId, creatorId, userAgent, partial.def.label, json)}),
+with def as (${_defInsert(nextval, creatorId, userAgent, partial.def.label, json, sourceId)}),
 ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ${dataset.id}, ${partial.uuid}, def."createdAt", ${creatorId} from def
   returning entities.*)
@@ -71,10 +71,19 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
   if (!subDef)
     return log('entity.create', dataset, {
       entityId: newEntity.id, // Added in v2023.3 - not backfilled
+      entityDefId: newEntity.aux.currentVersion.id, // Added in v2023.3 - not backfilled
       entity: { uuid: newEntity.uuid, label: newEntity.aux.currentVersion.label, dataset: dataset.name }
     });
 };
 createNew.audit.withResult = true;
+
+
+// Creates a source entry for entities created through audit events and submissions
+const createSource = (subDefId, eventId, details) => ({ one }) =>
+  one(sql`insert into entity_def_sources ("submissionDefId", "auditId", "details")
+  values (${subDefId}, ${eventId}, ${JSON.stringify(details)})
+  returning id`)
+    .then((row) => row.id);
 
 
 // Entrypoint to where submissions (a specific version) become entities
@@ -118,12 +127,14 @@ const _processSubmissionDef = (event) => async ({ Datasets, Entities, Submission
 
   const partial = await Entity.fromParseEntityData(entityData);
 
-  const entity = await Entities.createNew(dataset, partial, submissionDef);
+  const sourceId = await Entities.createSource(submissionDefId, event.id, { submission: { instanceId: submissionDef.instanceId } });
+  const entity = await Entities.createNew(dataset, partial, submissionDef, null, sourceId);
 
   return Audits.log({ id: event.actorId }, 'entity.create', { acteeId: dataset.acteeId },
     {
       entityId: entity.id, // Added in v2023.3 - not backfilled
       eventId: event.id, // Added in v2023.3 - not backfilled
+      entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 - not backfilled
       entity: { uuid: entity.uuid, label: entity.aux.currentVersion.label, dataset: dataset.name },
       submissionId,
       submissionDefId
@@ -163,13 +174,13 @@ const createVersion = (dataset, entity, data, label, userAgentIn = null) => ({ c
 
   // TODO: revisit sources.
   // For now, attach a dummy 'api' entity def source to return for PATCH request.
-  const source = new Entity.Def.Source({
+  const source = new Entity.Def.SourceSummary({
     type: 'api',
     details: null
   });
 
   return one(sql`
-  with def as (${_defInsert(entity.id, null, creatorId, userAgent, label, json)}),
+  with def as (${_defInsert(entity.id, creatorId, userAgent, label, json)}),
   upd as (update entity_defs set current=false where entity_defs."entityId" = ${entity.id}),
   entities as (update entities set "updatedAt"=clock_timestamp()
     where "uuid"=${entity.uuid}
@@ -209,7 +220,8 @@ const _get = (includeSource) => {
     LEFT JOIN actors current_version_actors ON current_version_actors.id=entity_defs."creatorId"
   `}
   ${!includeSource ? sql`` : sql`
-    LEFT JOIN submission_defs ON submission_defs.id = entity_defs."submissionDefId"
+    LEFT JOIN entity_def_sources ON entity_defs."sourceId" = entity_def_sources."id"
+    LEFT JOIN submission_defs ON submission_defs.id = entity_def_sources."submissionDefId"
     LEFT JOIN (
       SELECT submissions.*, submission_defs."userAgent" FROM submissions
       JOIN submission_defs ON submissions.id = submission_defs."submissionId" AND root
@@ -227,7 +239,7 @@ const getById = (datasetId, uuid, options = QueryOptions.none) => ({ maybeOne })
       const isSourceSubmission = !!entity.aux.currentVersion.submissionDefId;
 
       // TODO: revisit this when working on POST /entities
-      const source = new Entity.Def.Source({
+      const source = new Entity.Def.SourceSummary({
         type: isSourceSubmission ? 'submission' : 'api',
         details: isSourceSubmission ? {
           xmlFormId: entity.aux.form.xmlFormId,
@@ -251,7 +263,8 @@ const getAll = (datasetId, options = QueryOptions.none) => ({ all }) =>
 const _getDef = extender(Entity.Def, Submission, Submission.Def.into('submissionDef'), Form)(Actor.into('creator'))((fields, extend, options) => sql`
   SELECT ${fields} FROM entities
   JOIN entity_defs ON entities.id = entity_defs."entityId"
-  LEFT JOIN submission_defs ON submission_defs.id = entity_defs."submissionDefId"
+  LEFT JOIN entity_def_sources ON entity_defs."sourceId" = entity_def_sources."id"
+  LEFT JOIN submission_defs ON submission_defs.id = entity_def_sources."submissionDefId"
   LEFT JOIN (
     SELECT submissions.*, submission_defs."userAgent" FROM submissions
     JOIN submission_defs ON submissions.id = submission_defs."submissionId" AND root
@@ -270,7 +283,7 @@ const getAllDefs = (datasetId, uuid, options = QueryOptions.none) => ({ all }) =
       const isSourceSubmission = !!v.submissionDefId;
 
       // TODO: revisit this when working on POST /entities
-      const source = new Entity.Def.Source({
+      const source = new Entity.Def.SourceSummary({
         type: isSourceSubmission ? 'submission' : 'api',
         details: isSourceSubmission ? {
           xmlFormId: v.aux.form.xmlFormId,
@@ -285,10 +298,11 @@ const getAllDefs = (datasetId, uuid, options = QueryOptions.none) => ({ all }) =
 // This will check for an entity related to any def of the same submission
 // as the one specified. Used when trying to reapprove an edited submission.
 const getDefBySubmissionId = (submissionId) => ({ maybeOne }) =>
-  maybeOne(sql`select ed.* from submissions as s
-  join submission_defs as sd on s."id" = sd."submissionId"
-  join entity_defs as ed on ed."submissionDefId" = sd."id"
-  where s.id = ${submissionId} limit 1`)
+  maybeOne(sql`SELECT ed.* FROM submissions AS s
+  JOIN submission_defs AS sd ON s."id" = sd."submissionId"
+  JOIN entity_def_sources AS eds ON eds."submissionDefId" = sd."id"
+  JOIN entity_defs as ed on ed."sourceId" = eds."id"
+  WHERE s.id = ${submissionId} limit 1`)
     .then(map(construct(Entity.Def)));
 
 
@@ -332,6 +346,7 @@ del.audit = (entity, dataset) => (log) => log('entity.delete', entity.with({ act
 
 module.exports = {
   createNew, _processSubmissionDef,
+  createSource,
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,
   createVersion,

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -175,13 +175,6 @@ const createVersion = (dataset, entity, data, label, userAgentIn = null) => ({ c
 
   const _unjoiner = unjoiner(Entity, Entity.Def.into('currentVersion'));
 
-  // TODO: revisit sources.
-  // For now, attach a dummy 'api' entity def source to return for PATCH request.
-  const source = new Entity.Def.SourceSummary({
-    type: 'api',
-    details: null
-  });
-
   return one(sql`
   with def as (${_defInsert(entity.id, false, creatorId, userAgent, label, json)}),
   upd as (update entity_defs set current=false where entity_defs."entityId" = ${entity.id}),
@@ -192,7 +185,7 @@ const createVersion = (dataset, entity, data, label, userAgentIn = null) => ({ c
   join entities on entity_defs."entityId" = entities.id
   `)
     .then(_unjoiner)
-    .then((e) => e.withAux('currentVersion', e.aux.currentVersion.withAux('source', source)));
+    .then((e) => e.withAux('currentVersion', e.aux.currentVersion));
 };
 
 createVersion.audit = (newEntity, dataset, entity) => (log) =>
@@ -239,20 +232,7 @@ const _get = (includeSource) => {
 const getById = (datasetId, uuid, options = QueryOptions.none) => ({ maybeOne }) =>
   _get(true)(maybeOne, options.withCondition({ datasetId, uuid }), isTrue(options.argData?.deleted))
     .then(map((entity) => {
-      const isSourceSubmission = !!entity.aux.currentVersion.submissionDefId;
-
-      // TODO: revisit this when working on POST /entities
-      const source = new Entity.Def.SourceSummary({
-        type: isSourceSubmission ? 'submission' : 'api',
-        details: isSourceSubmission ? {
-          xmlFormId: entity.aux.form.xmlFormId,
-          instanceId: entity.aux.submission.instanceId,
-          instanceName: entity.aux.submissionDef.instanceName
-        } : null
-      });
-
-      const currentVersion = new Entity.Def(entity.aux.currentVersion, { creator: entity.aux.currentVersionCreator, source });
-
+      const currentVersion = new Entity.Def(entity.aux.currentVersion, { creator: entity.aux.currentVersionCreator });
       return new Entity(entity, { currentVersion, creator: entity.aux.creator });
     }));
 
@@ -263,16 +243,9 @@ const getAll = (datasetId, options = QueryOptions.none) => ({ all }) =>
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITY DEFS
 
-const _getDef = extender(Entity.Def, Submission, Submission.Def.into('submissionDef'), Form)(Actor.into('creator'))((fields, extend, options) => sql`
+const _getDef = extender(Entity.Def)(Actor.into('creator'))((fields, extend, options) => sql`
   SELECT ${fields} FROM entities
   JOIN entity_defs ON entities.id = entity_defs."entityId"
-  LEFT JOIN entity_def_sources ON entity_defs."sourceId" = entity_def_sources."id"
-  LEFT JOIN submission_defs ON submission_defs.id = entity_def_sources."submissionDefId"
-  LEFT JOIN (
-    SELECT submissions.*, submission_defs."userAgent" FROM submissions
-    JOIN submission_defs ON submissions.id = submission_defs."submissionId" AND root
-  ) submissions ON submissions.id = submission_defs."submissionId"
-  LEFT JOIN forms ON submissions."formId" = forms.id
   ${extend||sql`
     LEFT JOIN actors ON actors.id=entity_defs."creatorId"
   `}
@@ -282,21 +255,7 @@ const _getDef = extender(Entity.Def, Submission, Submission.Def.into('submission
 
 const getAllDefs = (datasetId, uuid, options = QueryOptions.none) => ({ all }) =>
   _getDef(all, options.withCondition({ datasetId, uuid }))
-    .then(map((v) => {
-      const isSourceSubmission = !!v.submissionDefId;
-
-      // TODO: revisit this when working on POST /entities
-      const source = new Entity.Def.SourceSummary({
-        type: isSourceSubmission ? 'submission' : 'api',
-        details: isSourceSubmission ? {
-          xmlFormId: v.aux.form.xmlFormId,
-          instanceId: v.aux.submission.instanceId,
-          instanceName: v.aux.submissionDef.instanceName
-        } : null
-      });
-
-      return new Entity.Def(v, { creator: v.aux.creator, source });
-    }));
+    .then(map((v) => new Entity.Def(v, { creator: v.aux.creator })));
 
 // This will check for an entity related to any def of the same submission
 // as the one specified. Used when trying to reapprove an edited submission.

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -21,8 +21,9 @@ const Problem = require('../../util/problem');
 ////////////////////////////////////////////////////////////////////////////////
 // ENTITY CREATE
 
-const _defInsert = (id, creatorId, userAgent, label, json, sourceId = null) => sql`insert into entity_defs ("entityId", "sourceId", "creatorId", "userAgent", "label", "data", "current", "createdAt")
-  values (${id}, ${sourceId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp())
+const _defInsert = (id, root, creatorId, userAgent, label, json, sourceId = null) => sql`
+  insert into entity_defs ("entityId", "root", "sourceId", "creatorId", "userAgent", "label", "data", "current", "createdAt")
+  values (${id}, ${root}, ${sourceId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp())
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 
@@ -49,7 +50,7 @@ const createNew = (dataset, partial, subDef, userAgentIn, sourceId = null) => ({
   const json = JSON.stringify(partial.def.data);
 
   return one(sql`
-with def as (${_defInsert(nextval, creatorId, userAgent, partial.def.label, json, sourceId)}),
+with def as (${_defInsert(nextval, true, creatorId, userAgent, partial.def.label, json, sourceId)}),
 ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ${dataset.id}, ${partial.uuid}, def."createdAt", ${creatorId} from def
   returning entities.*)
@@ -79,11 +80,13 @@ createNew.audit.withResult = true;
 
 
 // Creates a source entry for entities created through audit events and submissions
-const createSource = (subDefId, eventId, details) => ({ one }) =>
-  one(sql`insert into entity_def_sources ("submissionDefId", "auditId", "details")
-  values (${subDefId}, ${eventId}, ${JSON.stringify(details)})
+const createSource = (subDefId, eventId, details) => ({ one }) => {
+  const type = (subDefId) ? 'submission' : 'api';
+  return one(sql`insert into entity_def_sources ("type", "submissionDefId", "auditId", "details")
+  values (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)})
   returning id`)
     .then((row) => row.id);
+};
 
 
 // Entrypoint to where submissions (a specific version) become entities
@@ -180,7 +183,7 @@ const createVersion = (dataset, entity, data, label, userAgentIn = null) => ({ c
   });
 
   return one(sql`
-  with def as (${_defInsert(entity.id, creatorId, userAgent, label, json)}),
+  with def as (${_defInsert(entity.id, false, creatorId, userAgent, label, json)}),
   upd as (update entity_defs set current=false where entity_defs."entityId" = ${entity.id}),
   entities as (update entities set "updatedAt"=clock_timestamp()
     where "uuid"=${entity.uuid}

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -84,7 +84,8 @@ module.exports = (service, endpoint) => {
 
     const partial = await Entity.fromJson(body, properties, dataset);
 
-    const entity = await Entities.createNew(dataset, partial, null, headers['user-agent']);
+    const sourceId = await Entities.createSource();
+    const entity = await Entities.createNew(dataset, partial, null, sourceId, headers['user-agent']);
 
     // Entities.createNew doesn't return enough information for a full response so re-fetch.
     return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
@@ -103,7 +104,8 @@ module.exports = (service, endpoint) => {
     const properties = await Datasets.getProperties(dataset.id);
     const partial = Entity.fromJson(body, properties, dataset, entity);
 
-    return Entities.createVersion(dataset, entity, partial.def.data, partial.def.label, headers['user-agent']);
+    const sourceId = await Entities.createSource();
+    return Entities.createVersion(dataset, entity, partial.def.data, partial.def.label, sourceId, headers['user-agent']);
   }));
 
   service.delete('/projects/:projectId/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { auth, params, queryOptions }) => {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -2110,7 +2110,8 @@ describe('datasets and entities', () => {
 
       await container.Forms.purge(true);
 
-      await container.all(sql`select * from entity_defs`)
+      await container.all(sql`SELECT * FROM entity_defs
+        JOIN entity_def_sources ON entity_defs."sourceId" = entity_def_sources.id`)
         .then(eDefs => {
           // Ensures that we are only clearing submissionDefId of entities whose submission/form is purged
           should(eDefs.find(d => d.data.first_name === 'Alice').submissionDefId).be.null();

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -157,9 +157,6 @@ describe('Entities API', () => {
         .then(({ body: person }) => {
           person.should.be.an.Entity();
           person.should.have.property('currentVersion').which.is.an.EntityDef();
-
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
-
           person.currentVersion.should.have.property('data').which.is.eql({
             age: '88',
             first_name: 'Alice'
@@ -176,9 +173,6 @@ describe('Entities API', () => {
         .then(({ body: person }) => {
           person.should.be.an.ExtendedEntity();
           person.should.have.property('currentVersion').which.is.an.ExtendedEntityDef();
-
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
-
           person.currentVersion.should.have.property('data').which.is.eql({
             age: '88',
             first_name: 'Alice'
@@ -199,12 +193,6 @@ describe('Entities API', () => {
         .then(({ body: person }) => {
           person.should.be.an.Entity();
           person.should.have.property('currentVersion').which.is.an.EntityDef();
-
-          // TODO: needs to be revisited after POST/PUT api
-          person.currentVersion.should.have.property('source').which.is.eql({
-            type: 'api',
-            details: null
-          });
 
           person.currentVersion.should.have.property('data').which.is.eql({
             age: '88',
@@ -248,7 +236,6 @@ describe('Entities API', () => {
         .then(({ body: versions }) => {
           versions.forEach(v => {
             v.should.be.an.EntityDef();
-            v.should.have.property('source').which.is.an.EntitySource();
             v.should.have.property('data');
           });
 
@@ -271,7 +258,6 @@ describe('Entities API', () => {
         .then(({ body: versions }) => {
           versions.forEach(v => {
             v.should.be.an.ExtendedEntityDef();
-            v.should.have.property('source').which.is.an.EntitySource();
             v.should.have.property('data');
           });
 
@@ -661,7 +647,6 @@ describe('Entities API', () => {
           person.uuid.should.equal('12345678-1234-4123-8234-111111111aaa');
           person.creatorId.should.equal(5);
           person.should.have.property('currentVersion').which.is.an.EntityDef();
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
           person.currentVersion.should.have.property('label').which.equals('Johnny Doe');
           person.currentVersion.should.have.property('data').which.is.eql({
             first_name: 'Johnny',
@@ -766,14 +751,6 @@ describe('Entities API', () => {
           // Response is the right shape
           person.should.be.an.Entity();
           person.should.have.property('currentVersion').which.is.an.EntityDef();
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
-
-          // Source is correct
-          // TODO: needs to be revisited after POST/PUT api
-          person.currentVersion.should.have.property('source').which.is.eql({
-            type: 'api',
-            details: null
-          });
 
           // Creator id is correct
           person.currentVersion.creatorId.should.equal(6); // bob
@@ -790,10 +767,6 @@ describe('Entities API', () => {
         .expect(200)
         .then(({ body: person }) => {
           person.currentVersion.data.age.should.equal('77');
-          person.currentVersion.should.have.property('source').which.is.eql({
-            type: 'api',
-            details: null
-          });
           person.currentVersion.creatorId.should.equal(6); // bob
           person.creatorId.should.equal(5); // alice - original entity creator
           person.currentVersion.userAgent.should.equal('central/tests');


### PR DESCRIPTION
This PR is heavily inspired/builds directly off of PR #846, introducing an entity audit log endpoint that implicitly reconstructed important information about the context of an entity's creation.

This is a prototype of introducing an explicit entity_source table instead of reconstruction that information.

### What this code does:

1. migration to add `entity_sources` table
   * includes
     * `auditId` (triggering event id)
     * `submissionDefId` (current one kind of triggering object)
     * `details` (a place to store info about the object that we need to persist after object gets deleted)
   * also adds column to `entity_defs` table
   * populates and links new table
   * migration is additive right now - doesn't yet remove `submissionDefId` (essentially our first version of source) from `entity_defs` table
  
3. change entity flow to create and link source when appropriate (when created via submission approval event)

4. new audit query and temp audit resource that pulls information from this source table instead of elsewhere in the audits table. the output is very similar but `submissionCreate` is removed and there are source details instead. 
   * the one new crucial link is all entity events should have a `entityDefId` to fetch the source if such a thing is relevant to an event. 

6. new tests that match the previous entity audit tests. existing tests continue to work especially because previous audit path with implicit sources is still there.

### Why I think it's a good idea

We may be about to enter the Cambrian explosion era of entities, going from one main way they're created to multiple pathways that they are created and updated. Behold!

2022.3 (entities introduced)
- entities are only created though approved submissions

2023.3 (entities expanded -- in progress release)
- create through approved submission
- direct create through submission creation
- create through API
- update through API 
- delete through API 

future release (expanding possibilities even more)
- update through submission?
- create and update and delete through CSV 
- could imagine other things, too, e.g. "make entities out of all non-rejected submissions"? bulk/batch entity actions through API?
- other kinds of actions on entities (archiving, purging)

I think the current audit approach is great for _right now_ (as in, before this work on automatic entity creation from submissions) but having a clearer way to record different kinds of entity sources will be really useful really soon.

### Challenges of implicitly building source:

1. Working through the audit log details to link up entity sources is going to get more complex as the number of ways entities are created and updated increases.
2. Edge cases, like deleted forms/submissions make this even more tricky... many special cases that have to be represented in SQL directly.
3. Events that are linked from other events are also tricky to reason about, involves changing audit detail schema to account for it.
4. Audit details schema is hard to work with - we can't change it after a release if we realize we don't have what we need. It's also under tested.
7. Response data is heavy (e.g. including one audit event about entity creation has two other audit events nested within it: entity approval and submission creation)

### Benefits of explicitly storing entity source in a table:

Main info we want to store:
- what other triggering object made this entity (if exists)
- what triggering event made this entity (if exists)
- what details do we want to keep even if the triggering object is deleted?

With an entity source table, we can
1. Adapt to different kinds of entity sources, both for new entities and updated entities 
2. Maintain an explicit schema that is easier to debug, reason about, test
3. Be able to change the source schema as we go and backfill data if necessary 
4. Could get access to entity source information in other places besides the audit log if/when we need it

----- 
<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced