### PR TITLE
Removed some boilerplate code about PUT and RESTORE for entities

### DIFF
--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -13,23 +13,6 @@ const { Entity } = require('../model/frames');
 const Problem = require('../util/problem');
 const { diffEntityData } = require('../data/entity');
 
-const getEntityDef = () => ({
-  versionNumber: 1,
-  label: '',
-  current: true,
-  createdAt: '2023-01-01T09:00:00.000Z',
-  creatorId: 1,
-  userAgent: 'Postman'
-});
-
-const getEntity = (i) => ({
-  uuid: `00000000-0000-0000-0000-00000000000${i}`,
-  createdAt: '2023-01-01T09:00:00.000Z',
-  updatedAt: null,
-  deletedAt: null,
-  creatorId: 1
-});
-
 module.exports = (service, endpoint) => {
 
   service.get('/projects/:projectId/datasets/:name/entities', endpoint(async ({ Datasets, Entities }, { params, auth, queryOptions }) => {
@@ -62,30 +45,6 @@ module.exports = (service, endpoint) => {
     if (defs.length === 0) return reject(Problem.user.notFound());
 
     return defs;
-  }));
-
-  // May not be needed for now
-  service.get('/projects/:id/datasets/:name/entities/:uuid/versions/:versionNumber', endpoint(async ({ Projects }, { params, queryOptions }) => {
-
-    await Projects.getById(params.id, queryOptions).then(getOrNotFound);
-
-    return {
-      ...getEntityDef(),
-      current: false,
-      source: {
-        type: 'api',
-        details: null
-      },
-      data: {
-        firstName: 'Janie',
-        lastName: 'Doe',
-        city: 'Toronto'
-      },
-      versionNumber: params.versionNumber,
-      label: 'Janie Doe',
-      createdAt: new Date()
-    };
-
   }));
 
   service.get('/projects/:projectId/datasets/:name/entities/:uuid/diffs', endpoint(async ({ Datasets, Entities }, { params, auth, queryOptions }) => {
@@ -131,39 +90,6 @@ module.exports = (service, endpoint) => {
     return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
   }));
 
-  service.put('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Projects }, { params, queryOptions, body, headers }) => {
-
-    await Projects.getById(params.id, queryOptions).then(getOrNotFound);
-
-    const { uuid, label, ...data } = body;
-
-    const updatedAt = new Date();
-
-    const userAgent = headers['user-agent'];
-
-    const entity = {
-      ...getEntity(1),
-      uuid,
-      createdAt: '2023-01-01T09:00:00.000Z',
-      updatedAt,
-      currentVersion: {
-        ...getEntityDef(),
-        userAgent,
-        versionNumber: 2,
-        source: {
-          type: 'api',
-          details: null
-        },
-        label,
-        createdAt: updatedAt,
-        data
-      }
-    };
-
-    return entity;
-
-  }));
-
   service.patch('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { auth, body, headers, params, query }) => {
 
     const dataset = await Datasets.get(params.id, params.name).then(getOrNotFound);
@@ -191,32 +117,6 @@ module.exports = (service, endpoint) => {
     await Entities.del(entity, dataset);
 
     return success();
-
-  }));
-
-  // Lowest priority
-  service.post('/projects/:id/datasets/:name/entities/:uuid/restore', endpoint(async ({ Projects }, { params, queryOptions }) => {
-
-    await Projects.getById(params.id, queryOptions).then(getOrNotFound);
-
-    const entity = getEntity(1);
-    entity.updatedAt = '2023-01-02T09:00:00.000Z';
-    entity.currentVersion = {
-      ...getEntityDef(),
-      source: {
-        type: 'api',
-        details: null
-      },
-      data: {
-        firstName: 'Jane',
-        lastName: 'Roe',
-        city: 'Toronto'
-      },
-      versionNumber: 1,
-      label: 'Jane Roe',
-      createdAt: '2023-01-03T09:00:00.000Z'
-    };
-    return entity;
 
   }));
 };

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -689,39 +689,6 @@ describe('Entities API', () => {
     }));
   });
 
-  describe('PUT /datasets/:name/entities/:uuid', () => {
-
-    it('should update an Entity', testService(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.put('/v1/projects/1/datasets/People/entities/10000000-0000-0000-0000-000000000001')
-        .send({
-          uuid: '10000000-0000-0000-0000-000000000001',
-          label: 'Richard Roe',
-          firstName: 'Richard',
-          lastName: 'Roe',
-          city: 'Toronto'
-        })
-        .expect(200)
-        .then(({ body: person }) => {
-          person.should.be.an.Entity();
-          person.should.have.property('currentVersion').which.is.an.EntityDef();
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
-          person.currentVersion.should.have.property('data').which.is.eql({
-            firstName: 'Richard',
-            lastName: 'Roe',
-            city: 'Toronto'
-          });
-        });
-    }));
-
-    // it should reject if uuid is not found
-    // it should reject if uuid in queryParam and body don't match
-    // it should reject if uuid or label is missing
-    // it should reject if property is not present in dataset.publishedProperties
-    // it should reject if user don't have permission
-  });
-
   describe('PATCH /datasets/:name/entities/:uuid', () => {
     it('should return notfound if the dataset does not exist', testEntities(async (service) => {
       const asAlice = await service.login('alice');
@@ -1038,32 +1005,6 @@ describe('Entities API', () => {
         });
 
     }));
-
-  });
-
-  // Lowest Priority
-  describe.skip('POST /datasets/:name/entities/:uuid/restore', () => {
-
-    it('should restore a deleted Entity', testService(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/People/entities/10000000-0000-0000-0000-000000000001/restore')
-        .expect(200)
-        .then(({ body: person }) => {
-          person.should.be.an.Entity();
-          person.should.have.property('currentVersion').which.is.an.EntityDef();
-          person.currentVersion.should.have.property('source').which.is.an.EntitySource();
-          person.currentVersion.should.have.property('data').which.is.eql({
-            firstName: 'Jane',
-            lastName: 'Roe',
-            city: 'Toronto'
-          });
-        });
-    }));
-
-    // it should reject if uuid is not found or is not deleted
-    // it should reject if body is not empty
-    // it should reject if user don't have permission
 
   });
 });


### PR DESCRIPTION
Closes #855 

Getting things cleaned up for release 
- we've decided NOT to include a PUT endpoint for updating entities as the functionality is covered by the PATCH endpoint
- removes the RESTORE endpoint (could bring back later)
- removes an endpoint about entity version numbers (could bring back, not included in this release)

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced