### PR TITLE
fixes #858: Submission frame should be reinstantiated

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -163,7 +163,10 @@ order by path asc, value asc`)
 
 // Helper function to assign submission.currentVersionSubmitter to submission.currentVersion.submitter
 // Current there is no way to create such complex object using `extender` and `unjoiner` framework functions
-const assignCurrentVersionSubmitter = (x) => x.withAux('currentVersion', x.aux.currentVersion.withAux('submitter', x.aux.currentVersionSubmitter));
+//
+// New instance of Submission is created to remove all aux objects from it (except submitter).
+// If those aux's are kept then properties of aux are merged at the root level cb#858
+const assignCurrentVersionSubmitter = (x) => (new Submission(x, { submitter: x.aux.submitter })).withAux('currentVersion', x.aux.currentVersion.withAux('submitter', x.aux.currentVersionSubmitter));
 
 const _get = extender(Submission, Submission.Def.into('currentVersion'))(Actor.into('submitter'), Actor.alias('current_version_actors', 'currentVersionSubmitter'))((fields, extend, options, projectId, xmlFormId, draft) => sql`
   select ${fields} from 


### PR DESCRIPTION
Closes #858 

#### What has been done to verify that this works as intended?

Added integration test

#### Why is this the best possible solution? Were any other approaches considered?

Other option was to change the behaviour of `forApi()` but looks too risky to me

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None, I'll create a separate PR to verify/fix same for entities

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced