### PR TITLE
Change name of approval event in entity audits to something more generic

### DIFF
--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -167,7 +167,6 @@ const getByEntityId = (entityId, options) => ({ all }) => {
     .then(map(_unjoiner))
     .then(map(audit => {
 
-      // this could have a more generic name like 'triggering event' that was linked to any kind of entity audit event
       const sourceEvent = audit.aux.triggeringEvent
         .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
         .map(a => a.forApi());

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -168,7 +168,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
     .then(map(audit => {
 
       // this could have a more generic name like 'triggering event' that was linked to any kind of entity audit event
-      const approval = audit.aux.triggeringEvent
+      const sourceEvent = audit.aux.triggeringEvent
         .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
         .map(a => a.forApi());
 
@@ -183,7 +183,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
         .map(s => mergeLeft(s, { xmlFormId: audit.aux.form.map(f => f.xmlFormId).orNull() }));
 
       const details = mergeLeft(audit.details, {
-        approval: approval.orElse(undefined),
+        sourceEvent: sourceEvent.orElse(undefined),
         submissionCreate: submissionCreate.orElse(undefined),
         submission: submission.orElse(undefined)
       });

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -369,9 +369,9 @@ describe('Entities API', () => {
           logs[1].action.should.be.eql('entity.create');
           logs[1].actor.displayName.should.be.eql('Alice');
 
-          logs[1].details.approval.should.be.an.Audit();
-          logs[1].details.approval.actor.displayName.should.be.eql('Alice');
-          logs[1].details.approval.loggedAt.should.be.isoDate();
+          logs[1].details.sourceEvent.should.be.an.Audit();
+          logs[1].details.sourceEvent.actor.displayName.should.be.eql('Alice');
+          logs[1].details.sourceEvent.loggedAt.should.be.isoDate();
 
           logs[1].details.submission.should.be.a.Submission();
           logs[1].details.submission.xmlFormId.should.be.eql('simpleEntity');
@@ -449,9 +449,9 @@ describe('Entities API', () => {
           logs[0].action.should.be.eql('entity.create');
           logs[0].actor.displayName.should.be.eql('Alice');
 
-          logs[0].details.approval.should.be.an.Audit();
-          logs[0].details.approval.actor.displayName.should.be.eql('Alice');
-          logs[0].details.approval.loggedAt.should.be.isoDate();
+          logs[0].details.sourceEvent.should.be.an.Audit();
+          logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
+          logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
 
           logs[0].details.should.not.have.property('submission');
 
@@ -475,9 +475,9 @@ describe('Entities API', () => {
           logs[0].action.should.be.eql('entity.create');
           logs[0].actor.displayName.should.be.eql('Alice');
 
-          logs[0].details.approval.should.be.an.Audit();
-          logs[0].details.approval.actor.displayName.should.be.eql('Alice');
-          logs[0].details.approval.loggedAt.should.be.isoDate();
+          logs[0].details.sourceEvent.should.be.an.Audit();
+          logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
+          logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
 
           logs[0].details.should.not.have.property('submission');
 
@@ -571,10 +571,10 @@ describe('Entities API', () => {
           logs[0].action.should.be.eql('entity.create');
           logs[0].actor.displayName.should.be.eql('Alice');
 
-          logs[0].details.approval.should.be.an.Audit();
-          logs[0].details.approval.actor.displayName.should.be.eql('Alice');
-          logs[0].details.approval.loggedAt.should.be.isoDate();
-          logs[0].details.approval.notes.should.be.eql('create entity'); // this confirms that it's the second approval
+          logs[0].details.sourceEvent.should.be.an.Audit();
+          logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
+          logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
+          logs[0].details.sourceEvent.notes.should.be.eql('create entity'); // this confirms that it's the second approval
 
           logs[0].details.submission.should.be.a.Submission();
           logs[0].details.submission.xmlFormId.should.be.eql('simpleEntity');


### PR DESCRIPTION
The entity source table contains the id of a source event that created that entity def. Originally, it was just a submission approval event, but now other types of events, namely `submission.create`, can also make an entity. Instead of calling it `approval` in the API response, we wanted to give it a more generic name.

Went with `sourceEvent` but other options could include `triggeringEvent` or `event`.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

This will need docs changes in the other docs PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced