### PR TITLE
fixes 869: pass property path as array instead of dot delimited string

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -128,7 +128,7 @@ const extractEntity = (body, propertyNames, existingEntity) => {
 
 const _formatRow = (entity, props) => {
   const out = [];
-  for (const p of props) out.push(path(p.split('.'), entity));
+  for (const p of props) out.push(path(p, entity));
   return out;
 };
 
@@ -157,15 +157,15 @@ const _entityTransformer = (header, props) => {
 const streamEntityCsv = (inStream, properties) => {
   // Identifiers
   const header = [ '__id', 'label' ];
-  const props = ['uuid', 'def.label'];
+  const props = ['uuid', 'def.label'].map(e => e.split('.'));
 
   // User defined dataset properties
   header.push(...properties.map(p => p.name));
-  props.push(...properties.map(p => `def.data.${p.name}`));
+  props.push(...properties.map(p => ['def', 'data', p.name]));
 
   // System properties
   header.push(...[ '__createdAt', '__creatorId', '__creatorName', '__updates', '__updatedAt']);
-  props.push(...['createdAt', 'creatorId', 'aux.creator.displayName', 'aux.stats.updates', 'updatedAt']);
+  props.push(...['createdAt', 'creatorId', 'aux.creator.displayName', 'aux.stats.updates', 'updatedAt'].map(e => e.split('.')));
 
   const entityStream = _entityTransformer(header, props);
 
@@ -181,11 +181,11 @@ const streamEntityCsv = (inStream, properties) => {
 const streamEntityCsvAttachment = (inStream, properties) => {
   // Identifiers
   const header = [ 'name', 'label' ];
-  const props = ['uuid', 'def.label'];
+  const props = ['uuid', 'def.label'].map(e => e.split('.'));
 
   // User defined dataset properties
   header.push(...properties.map(p => p.name));
-  props.push(...properties.map(p => `def.data.${p.name}`));
+  props.push(...properties.map(p => ['def', 'data', p.name]));
 
   const entityStream = _entityTransformer(header, props);
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -372,6 +372,37 @@ describe('datasets and entities', () => {
 
       }));
 
+      it('should return csv file for dataset that have dot in its property name', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/age/g, 'the.age'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one.replace(/age/g, 'the.age'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await exhaust(container);
+
+        const result = await asAlice.get('/v1/projects/1/datasets/people/entities.csv')
+          .expect(200)
+          .then(r => r.text);
+
+        const isoRegex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/g;
+
+        result.match(isoRegex).should.have.length(1);
+
+        const withOutTs = result.replace(isoRegex, '');
+        withOutTs.should.be.eql(
+          '__id,label,first_name,the.age,__createdAt,__creatorId,__creatorName,__updates,__updatedAt\n' +
+            '12345678-1234-4123-8234-123456789abc,Alice (88),Alice,88,,5,Alice,0,\n'
+        );
+
+      }));
+
       it('should not return deleted entities', testService(async (service) => {
         const asAlice = await service.login('alice');
 
@@ -1289,6 +1320,40 @@ describe('datasets and entities', () => {
                 headers['content-type'].should.equal('text/csv; charset=utf-8');
                 text.should.equal('name,label,first_name,age\n12345678-1234-4123-8234-123456789abc,Alice (88),Alice,88\n');
               })))));
+
+      it('should return entities csv', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity
+            .replace(/people/g, 'goodone')
+            .replace(/age/g, 'the.age'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one
+            .replace(/people/g, 'goodone')
+            .replace(/age/g, 'the.age'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await exhaust(container);
+
+
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.withAttachments)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+          .expect(200)
+          .then(({ text }) => {
+            text.should.equal('name,label,first_name,the.age\n' +
+          '12345678-1234-4123-8234-123456789abc,Alice (88),Alice,88\n');
+          });
+
+      }));
 
       it('should not return deleted entities', testService(async (service) => {
         const asAlice = await service.login('alice');

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1321,7 +1321,7 @@ describe('datasets and entities', () => {
                 text.should.equal('name,label,first_name,age\n12345678-1234-4123-8234-123456789abc,Alice (88),Alice,88\n');
               })))));
 
-      it('should return entities csv', testService(async (service, container) => {
+      it('should return data for columns that contain valid special characters', testService(async (service, container) => {
         const asAlice = await service.login('alice');
 
         await asAlice.post('/v1/projects/1/forms?publish=true')


### PR DESCRIPTION
Closes #869 

#### What has been done to verify that this works as intended?

Integration Tests 

#### Why is this the best possible solution? Were any other approaches considered?

I could have typed array of array as literal but that looked ugly

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced