### PR TITLE
Add usage metrics for counting entity updates

### DIFF
--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -155,7 +155,7 @@ const metricsTemplate = {
           "recent": 0,
           "total": 0
         },
-        "num_updated_entities": {
+        "num_entity_updates": {
           "recent": 0,
           "total": 0
         }

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -154,6 +154,10 @@ const metricsTemplate = {
         "num_failed_entities": {
           "recent": 0,
           "total": 0
+        },
+        "num_updated_entities": {
+          "recent": 0,
+          "total": 0
         }
       }]
     }

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -370,7 +370,9 @@ SELECT
   COUNT(DISTINCT fd."formId") num_creation_forms,
   COUNT(DISTINCT CASE WHEN f."currentDefId" IS NOT NULL THEN fa."formId" END) num_followup_forms,
   MAX(COALESCE(errors.total, 0)) num_failed_entities_total,
-  MAX(COALESCE(errors.recent, 0)) num_failed_entities_recent
+  MAX(COALESCE(errors.recent, 0)) num_failed_entities_recent,
+  MAX(COALESCE(updates.total, 0)) num_updated_entities_total,
+  MAX(COALESCE(updates.recent, 0)) num_updated_entities_recent
 FROM datasets ds
   LEFT JOIN ds_properties p ON p."datasetId" = ds.id AND p."publishedAt" IS NOT NULL
   LEFT JOIN entities e ON e."datasetId" = ds.id
@@ -392,6 +394,16 @@ FROM datasets ds
     WHERE a."action" = 'entity.create.error'
     GROUP BY dfd."datasetId"
   ) AS errors ON ds.id = errors."datasetId"
+  LEFT JOIN (
+    SELECT
+      COUNT (a.details -> 'entityId'::TEXT) total,
+      SUM (CASE WHEN a."loggedAt" >= current_date - cast(${DAY_RANGE} as int) THEN 1 ELSE 0 END) recent,
+      e."datasetId"
+    FROM audits a
+      JOIN entities e on CAST((a.details ->> 'entityId'::TEXT) AS integer) = e.id
+    WHERE a."action" = 'entity.update.version'
+    GROUP BY e."datasetId"
+  ) as updates ON ds.id = updates."datasetId"
 WHERE ds."publishedAt" IS NOT NULL
 GROUP BY ds.id, ds."projectId"
 `);
@@ -536,7 +548,8 @@ const projectMetrics = () => (({ Analytics }) => Promise.all([
       num_creation_forms: row.num_creation_forms,
       num_followup_forms: row.num_followup_forms,
       num_entities: { total: row.num_entities_total, recent: row.num_entities_recent },
-      num_failed_entities: { total: row.num_failed_entities_total, recent: row.num_failed_entities_recent }
+      num_failed_entities: { total: row.num_failed_entities_total, recent: row.num_failed_entities_recent },
+      num_updated_entities: { total: row.num_updated_entities_total, recent: row.num_updated_entities_recent }
     });
   }
 

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -396,7 +396,7 @@ FROM datasets ds
   ) AS errors ON ds.id = errors."datasetId"
   LEFT JOIN (
     SELECT
-      COUNT (a.details -> 'entityId'::TEXT) total,
+      COUNT (1) total,
       SUM (CASE WHEN a."loggedAt" >= current_date - cast(${DAY_RANGE} as int) THEN 1 ELSE 0 END) recent,
       e."datasetId"
     FROM audits a

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -371,8 +371,8 @@ SELECT
   COUNT(DISTINCT CASE WHEN f."currentDefId" IS NOT NULL THEN fa."formId" END) num_followup_forms,
   MAX(COALESCE(errors.total, 0)) num_failed_entities_total,
   MAX(COALESCE(errors.recent, 0)) num_failed_entities_recent,
-  MAX(COALESCE(updates.total, 0)) num_updated_entities_total,
-  MAX(COALESCE(updates.recent, 0)) num_updated_entities_recent
+  MAX(COALESCE(updates.total, 0)) num_entity_updates_total,
+  MAX(COALESCE(updates.recent, 0)) num_entity_updates_recent
 FROM datasets ds
   LEFT JOIN ds_properties p ON p."datasetId" = ds.id AND p."publishedAt" IS NOT NULL
   LEFT JOIN entities e ON e."datasetId" = ds.id
@@ -549,7 +549,7 @@ const projectMetrics = () => (({ Analytics }) => Promise.all([
       num_followup_forms: row.num_followup_forms,
       num_entities: { total: row.num_entities_total, recent: row.num_entities_recent },
       num_failed_entities: { total: row.num_failed_entities_total, recent: row.num_failed_entities_recent },
-      num_updated_entities: { total: row.num_updated_entities_total, recent: row.num_updated_entities_recent }
+      num_entity_updates: { total: row.num_entity_updates_total, recent: row.num_entity_updates_recent }
     });
   }
 


### PR DESCRIPTION
Backend portion of https://github.com/getodk/central/issues/410
Needs the frontend translation change and the central config version change and the new version of the form to be uploaded.

[odk-analytics.xlsx](https://github.com/getodk/central-backend/files/11566705/odk-analytics.xlsx)


#### What has been done to verify that this works as intended?

Integration Test +

Tried sending local analytics to test server.

![image](https://github.com/getodk/central-backend/assets/447837/c021cfdd-4adf-4529-a6af-dbb9169f1cd8)

#### Why is this the best possible solution? Were any other approaches considered?

NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced