### PR TITLE
Update analytics form version in config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/submission",
         "formId": "odk-analytics",
-        "version": "2023.01.22.01"
+        "version": "2023.05.22.01"
       }
     }
   },


### PR DESCRIPTION
This change is needed for getodk/central#410 alongside #889. Updating the form version is part of the checklist in getodk/central#410. I always forget where we need to update the form version, but I'm pretty sure it's this repo, not the `central` repo: I don't see an analytics config in `central`.

I've updated the form version in the config to match the form attached to #889.

#### What has been done to verify that this works as intended?

This is just a config change. Once this PR and #889 are both merged, we'll be able to try out the new metric on staging.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced