### PR TITLE
Fixes: testing form that consumes dataset

### DIFF
--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -17,10 +17,13 @@ const { expectedFormAttachments } = require('../../data/schema');
 const { Frame, into } = require('../frame');
 const { Blob, Form } = require('../frames');
 const { unjoiner, insertMany } = require('../../util/db');
-const { ignoringResult, resolve } = require('../../util/promise');
+const { ignoringResult, resolve, getOrNotFound, reject } = require('../../util/promise');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
-
+const { binary, contentDisposition, withEtag } = require('../../util/http');
+const { streamEntityCsvAttachment } = require('../../data/entity');
+const { md5sum } = require('../../util/crypto');
+const Problem = require('../../util/problem');
 
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING ATTACHMENT SLOTS
@@ -141,10 +144,32 @@ select ${_unjoinMd5.fields} from form_attachments
   where "formDefId"=${formDefId}`)
   .then(map(_unjoinMd5));
 
+const streamAttachment = (attachment, response) => async ({ Blobs, Datasets, Entities }) => {
+  if (attachment.blobId == null && attachment.datasetId == null) {
+    return reject(Problem.user.notFound());
+  } else if (attachment.blobId != null) {
+    const blob = await Blobs.getById(attachment.blobId).then(getOrNotFound);
+    return withEtag(`"${blob.md5}"`, () => binary(blob.contentType, attachment.name, blob.content));
+  } else {
+    const dataset = await Datasets.getById(attachment.datasetId, true).then(getOrNotFound);
+    const properties = await Datasets.getProperties(attachment.datasetId);
+    const { lastEntity } = dataset.forApi();
+
+    const serverEtag = md5sum(lastEntity?.toISOString() ?? '1970-01-01');
+
+    return withEtag(serverEtag, async () => {
+      const entities = await Entities.streamForExport(attachment.datasetId);
+      response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
+      response.append('Content-Type', 'text/csv');
+      return streamEntityCsvAttachment(entities, properties);
+    });
+  }
+};
 
 module.exports = {
   createNew, createVersion,
   update,
-  getAllByFormDefId, getByFormDefIdAndName, getAllByFormDefIdForOpenRosa
+  getAllByFormDefId, getByFormDefIdAndName,
+  getAllByFormDefIdForOpenRosa, streamAttachment
 };
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -17,13 +17,10 @@ const { expectedFormAttachments } = require('../../data/schema');
 const { Frame, into } = require('../frame');
 const { Blob, Form } = require('../frames');
 const { unjoiner, insertMany } = require('../../util/db');
-const { ignoringResult, resolve, getOrNotFound, reject } = require('../../util/promise');
+const { ignoringResult, resolve } = require('../../util/promise');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
-const { binary, contentDisposition, withEtag } = require('../../util/http');
-const { streamEntityCsvAttachment } = require('../../data/entity');
-const { md5sum } = require('../../util/crypto');
-const Problem = require('../../util/problem');
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING ATTACHMENT SLOTS
@@ -144,32 +141,10 @@ select ${_unjoinMd5.fields} from form_attachments
   where "formDefId"=${formDefId}`)
   .then(map(_unjoinMd5));
 
-const streamAttachment = (attachment, response) => async ({ Blobs, Datasets, Entities }) => {
-  if (attachment.blobId == null && attachment.datasetId == null) {
-    return reject(Problem.user.notFound());
-  } else if (attachment.blobId != null) {
-    const blob = await Blobs.getById(attachment.blobId).then(getOrNotFound);
-    return withEtag(`"${blob.md5}"`, () => binary(blob.contentType, attachment.name, blob.content));
-  } else {
-    const dataset = await Datasets.getById(attachment.datasetId, true).then(getOrNotFound);
-    const properties = await Datasets.getProperties(attachment.datasetId);
-    const { lastEntity } = dataset.forApi();
-
-    const serverEtag = md5sum(lastEntity?.toISOString() ?? '1970-01-01');
-
-    return withEtag(serverEtag, async () => {
-      const entities = await Entities.streamForExport(attachment.datasetId);
-      response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
-      response.append('Content-Type', 'text/csv');
-      return streamEntityCsvAttachment(entities, properties);
-    });
-  }
-};
 
 module.exports = {
   createNew, createVersion,
   update,
-  getAllByFormDefId, getByFormDefIdAndName,
-  getAllByFormDefIdForOpenRosa, streamAttachment
+  getAllByFormDefId, getByFormDefIdAndName, getAllByFormDefIdForOpenRosa
 };
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -12,15 +12,13 @@ const { identity } = require('ramda');
 const { Blob, Form } = require('../model/frames');
 const { ensureDef } = require('../model/frame');
 const { QueryOptions } = require('../util/db');
-const { isTrue, xml, binary, contentDisposition, withEtag } = require('../util/http');
+const { isTrue, xml, binary } = require('../util/http');
 const Problem = require('../util/problem');
 const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
 const { getOrNotFound, reject, resolve, rejectIf } = require('../util/promise');
 const { success } = require('../util/http');
 const { formList, formManifest } = require('../formats/openrosa');
 const { noargs, isPresent, isBlank } = require('../util/util');
-const { streamEntityCsvAttachment } = require('../data/entity');
-const { md5sum } = require('../util/crypto');
 
 // excel-related util funcs/data used below:
 const isExcel = (contentType) => (contentType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') || (contentType === 'application/vnd.ms-excel');
@@ -273,33 +271,12 @@ module.exports = (service, endpoint) => {
         .then((form) => auth.canOrReject('form.read', form))
         .then((form) => FormAttachments.getAllByFormDefId(form.def.id))));
 
-    service.get(`${base}/attachments/:name`, endpoint(({ Blobs, FormAttachments, Forms, Datasets, Entities }, { params, auth }, request, response) =>
+    service.get(`${base}/attachments/:name`, endpoint(({ FormAttachments, Forms }, { params, auth }, request, response) =>
       getInstance(Forms, params)
         .then((form) => auth.canOrReject('form.read', form))
         .then((form) => FormAttachments.getByFormDefIdAndName(form.def.id, params.name)
           .then(getOrNotFound)
-          .then(async (attachment) => {
-            if (attachment.blobId == null && attachment.datasetId == null) {
-              return reject(Problem.user.notFound());
-            } else if (attachment.blobId != null) {
-              const blob = await Blobs.getById(attachment.blobId).then(getOrNotFound);
-              return withEtag(`"${blob.md5}"`, () => binary(blob.contentType, attachment.name, blob.content));
-            } else {
-              const dataset = await Datasets.getById(attachment.datasetId, true).then(getOrNotFound);
-              const properties = await Datasets.getProperties(attachment.datasetId);
-              const { lastEntity } = dataset.forApi();
-
-              const serverEtag = md5sum(lastEntity?.toISOString() ?? '1970-01-01');
-
-              return withEtag(serverEtag, async () => {
-                const entities = await Entities.streamForExport(attachment.datasetId);
-                response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
-                response.append('Content-Type', 'text/csv');
-                return streamEntityCsvAttachment(entities, properties);
-              });
-            }
-
-          }))));
+          .then(attachment => FormAttachments.streamAttachment(attachment, response)))));
   };
 
   // the linter literally won't let me break this apart..
@@ -429,17 +406,13 @@ module.exports = (service, endpoint) => {
       .then(checkFormToken(params.key))
       .then((form) => xml(form.xml))));
 
-  service.get('/test/:key/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Blobs, FormAttachments, Forms }, { params }) =>
+  service.get('/test/:key/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ FormAttachments, Forms }, { params }, request, response) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))
       .then((form) => FormAttachments.getByFormDefIdAndName(form.def.id, params.name)
         .then(getOrNotFound)
-        .then((attachment) => ((attachment.blobId == null)
-          ? reject(Problem.user.notFound())
-          : Blobs.getById(attachment.blobId)
-            .then(getOrNotFound)
-            .then((blob) => binary(blob.contentType, attachment.name, blob.content)))))));
+        .then(attachment => FormAttachments.streamAttachment(attachment, response)))));
 };
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -12,19 +12,45 @@ const { identity } = require('ramda');
 const { Blob, Form } = require('../model/frames');
 const { ensureDef } = require('../model/frame');
 const { QueryOptions } = require('../util/db');
-const { isTrue, xml, binary } = require('../util/http');
+const { isTrue, xml, binary, contentDisposition, withEtag } = require('../util/http');
 const Problem = require('../util/problem');
 const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
 const { getOrNotFound, reject, resolve, rejectIf } = require('../util/promise');
 const { success } = require('../util/http');
 const { formList, formManifest } = require('../formats/openrosa');
 const { noargs, isPresent, isBlank } = require('../util/util');
+const { streamEntityCsvAttachment } = require('../data/entity');
+const { md5sum } = require('../util/crypto');
 
 // excel-related util funcs/data used below:
 const isExcel = (contentType) => (contentType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') || (contentType === 'application/vnd.ms-excel');
 const excelMimeTypes = {
   xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+};
+
+const streamAttachment = async (container, attachment, response) => {
+  const { Blobs, Datasets, Entities } = container;
+
+  if (attachment.blobId == null && attachment.datasetId == null) {
+    return reject(Problem.user.notFound());
+  } else if (attachment.blobId != null) {
+    const blob = await Blobs.getById(attachment.blobId).then(getOrNotFound);
+    return withEtag(`${blob.md5}`, () => binary(blob.contentType, attachment.name, blob.content));
+  } else {
+    const dataset = await Datasets.getById(attachment.datasetId, true).then(getOrNotFound);
+    const properties = await Datasets.getProperties(attachment.datasetId);
+    const { lastEntity } = dataset.forApi();
+
+    const serverEtag = md5sum(lastEntity?.toISOString() ?? '1970-01-01');
+
+    return withEtag(serverEtag, async () => {
+      const entities = await Entities.streamForExport(attachment.datasetId);
+      response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
+      response.append('Content-Type', 'text/csv');
+      return streamEntityCsvAttachment(entities, properties);
+    });
+  }
 };
 
 module.exports = (service, endpoint) => {
@@ -271,12 +297,14 @@ module.exports = (service, endpoint) => {
         .then((form) => auth.canOrReject('form.read', form))
         .then((form) => FormAttachments.getAllByFormDefId(form.def.id))));
 
-    service.get(`${base}/attachments/:name`, endpoint(({ FormAttachments, Forms }, { params, auth }, request, response) =>
-      getInstance(Forms, params)
+    service.get(`${base}/attachments/:name`, endpoint((container, { params, auth }, request, response) => {
+      const { FormAttachments, Forms } = container;
+      return getInstance(Forms, params)
         .then((form) => auth.canOrReject('form.read', form))
         .then((form) => FormAttachments.getByFormDefIdAndName(form.def.id, params.name)
           .then(getOrNotFound)
-          .then(attachment => FormAttachments.streamAttachment(attachment, response)))));
+          .then(attachment => streamAttachment(container, attachment, response)));
+    }));
   };
 
   // the linter literally won't let me break this apart..
@@ -406,13 +434,16 @@ module.exports = (service, endpoint) => {
       .then(checkFormToken(params.key))
       .then((form) => xml(form.xml))));
 
-  service.get('/test/:key/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ FormAttachments, Forms }, { params }, request, response) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+  service.get('/test/:key/projects/:projectId/forms/:id/draft/attachments/:name', endpoint((container, { params }, request, response) => {
+    const { FormAttachments, Forms } = container;
+    return Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))
       .then((form) => FormAttachments.getByFormDefIdAndName(form.def.id, params.name)
         .then(getOrNotFound)
-        .then(attachment => FormAttachments.streamAttachment(attachment, response)))));
+        .then(attachment => streamAttachment(container, attachment, response)));
+  }));
+
 };
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1319,6 +1319,28 @@ describe('datasets and entities', () => {
                 text.should.equal('name,label,first_name,age\n12345678-1234-4123-8234-123456789abc,Alice (88),Alice,88\n');
               })))));
 
+      it('should return entities csv for testing', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await createBothForms(asAlice);
+
+        await asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one.replace(/people/g, 'goodone'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await exhaust(container);
+
+        const token = await asAlice.get('/v1/projects/1/forms/withAttachments/draft')
+          .expect(200)
+          .then(({ body }) => body.draftToken);
+
+        await service.get(`/v1/test/${token}/projects/1/forms/withAttachments/draft/attachments/goodone.csv`)
+          .expect(200)
+          .then(({ text }) => { text.should.equal('name,label,first_name,age\n12345678-1234-4123-8234-123456789abc,Alice (88),Alice,88\n'); });
+
+      }));
+
       it('should return data for columns that contain valid special characters', testService(async (service, container) => {
         const asAlice = await service.login('alice');
 


### PR DESCRIPTION
# Changes
- added dataset download ability to testing endpoint
- moved the common logic to query module

#### What has been done to verify that this works as intended?

Integration test + verified running it locally

#### Why is this the best possible solution? Were any other approaches considered?

I could have kept the common logic in resource module but that would entail passing 6+ parameters to new function because we container is only injected in query module.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced