### PR TITLE
fixes 433: convert latin1 to utf for filenames return by multer

### DIFF
--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -25,6 +25,8 @@ const { resolve } = require('../util/promise');
 const { isBlank, noargs } = require('../util/util');
 const { zipStreamFromParts } = require('../util/zip');
 
+const XML_SUBMISSION_FILE = 'xml_submission_file';
+
 // multipart things:
 const multipart = multer({ storage: multer.memoryStorage() });
 
@@ -33,11 +35,11 @@ const bodyParser = require('body-parser');
 const formParser = bodyParser.urlencoded({ extended: false });
 
 // util funcs for openRosaSubmission below, mostly just moving baked logic/data off for perf.
-const missingXmlProblem = Problem.user.missingMultipartField({ field: 'xml_submission_file' });
+const missingXmlProblem = Problem.user.missingMultipartField({ field: XML_SUBMISSION_FILE });
 const findMultipart = (files) => {
   if (files == null) throw missingXmlProblem;
   for (let i = 0; i < files.length; i += 1)
-    if (files[i].fieldname === 'xml_submission_file')
+    if (files[i].fieldname === XML_SUBMISSION_FILE)
       return files[i];
   throw missingXmlProblem;
 };
@@ -64,8 +66,22 @@ module.exports = (service, endpoint) => {
         .then(getOrNotFound)
         .then(always({ code: 204, body: '' }))));
 
+    // Temporary solution to https://github.com/expressjs/multer/issues/1104
+    // Multer uses latin1 encoding for filename and fieldname
+    const multerUtf = (request, _, next) => {
+      request.files = request.files?.map(f => {
+        if (f.fieldname === XML_SUBMISSION_FILE) return f;
+        return {
+          ...f,
+          originalname: Buffer.from(f.originalname, 'latin1').toString('utf8'),
+          fieldname: Buffer.from(f.fieldname, 'latin1').toString('utf8')
+        };
+      });
+      next();
+    };
+
     // Nonstandard REST; OpenRosa-specific API.
-    service.post(path, multipart.any(), endpoint.openRosa(({ Forms, Submissions, SubmissionAttachments }, { params, files, auth, query, headers }) =>
+    service.post(path, multipart.any(), multerUtf, endpoint.openRosa(({ Forms, Submissions, SubmissionAttachments }, { params, files, auth, query, headers }) =>
       Submission.fromXml(findMultipart(files).buffer)
         .then((partial) => getForm(auth, params, partial.xmlFormId, Forms, partial.def.version)
           .catch(forceAuthFailed)

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -543,7 +543,8 @@ module.exports = {
     binaryType: {
       one: instance('binaryType', 'bone', '<file1>my_file1.mp4</file1>'),
       two: instance('binaryType', 'btwo', '<file2>here_is_file2.jpg</file2>'),
-      both: instance('binaryType', 'both', '<file1>my_file1.mp4</file1><file2>here_is_file2.jpg</file2>')
+      both: instance('binaryType', 'both', '<file1>my_file1.mp4</file1><file2>here_is_file2.jpg</file2>'),
+      unicode: instance('binaryType', 'both', '<file1>fîlé2</file1><file2>f😂le3صادق</file2>'),
     },
     encrypted: {
       // TODO: the jpg binary associated with this sample blob is >3MB. will replace


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/433

## Root cause:

Multer is parsing filename with latin1 encoding instead of UTF-8. https://github.com/expressjs/multer/issues/1104

#### What has been done to verify that this works as intended?

- Tested locally + integration test

#### Why is this the best possible solution? Were any other approaches considered?

Created local middleware to convert latin1 encoding to utf8

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is localized changed, if submission are tested from Enketo and Collect are tested then we should be good

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

None

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced