### PR TITLE
Fix entity bug where the wrong properties of an entity are populated

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -347,7 +347,7 @@ JOIN form_defs ON fs.id = form_defs."schemaId"
 JOIN dataset_form_defs ON
   dataset_form_defs."formDefId" = form_defs."id"
 LEFT OUTER JOIN ds_property_fields ON
-  ds_property_fields."schemaId" = form_fields."schemaId"
+  ds_property_fields."formDefId" = form_defs."id"
     AND ds_property_fields."path" = form_fields."path"
 LEFT OUTER JOIN ds_properties ON
   ds_properties."id" = ds_property_fields."dsPropertyId"

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -584,6 +584,7 @@ module.exports = {
                 </meta>
                 <name>Alice</name>
                 <age>88</age>
+                <hometown>Chicago</hometown>
                 </data>`,
       two: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="1.0">
               <meta>
@@ -595,6 +596,7 @@ module.exports = {
             </meta>
             <name>Jane</name>
             <age>30</age>
+            <hometown>Boston</hometown>
           </data>`,
       three: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="1.0">
           <meta>
@@ -606,6 +608,7 @@ module.exports = {
           </meta>
           <name>John</name>
           <age>40</age>
+          <hometown>Toronto</hometown>
         </data>`,
       four: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="1.0">
           <meta>
@@ -617,6 +620,7 @@ module.exports = {
           </meta>
           <name>Robert</name>
           <age>18</age>
+          <hometown>Seattle</hometown>
         </data>`
     },
     multiPropertyEntity: {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -2155,29 +2155,6 @@ describe('datasets and entities', () => {
   });
 
   describe('form schemas and dataset properties', () => {
-    it.skip('should allow an entity binding to be removed from a form field', testService(async (service) => {
-      const asAlice = await service.login('alice');
-
-      // Upload a version of the form with just name and age mapped to dataset properties
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .set('Content-Type', 'application/xml')
-        .send(testData.forms.simpleEntity)
-        .expect(200);
-
-      // Upload a new version of the form with saveto moved from age to hometown
-      const x = testData.forms.simpleEntity
-        .replace('<bind nodeset="/data/age" type="int" entities:saveto="age"/>', '<bind nodeset="/data/age" type="int">')
-        .replace('<bind nodeset="/data/hometown" type="string"/>', '<bind nodeset="/data/hometown" type="string" entities:saveto="hometown"/>');
-      await asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
-        .set('Content-Type', 'application/xml')
-        .send(x)
-        .expect(200);
-      // BUG: when i try to remove the binding from 'age', I get an error message about 'hometown':
-      // 400.17 message:
-      // The form you have uploaded attempts to change the type of the field at /hometown. In a previous version, it had the type string.
-      // Please either return that field to its previous type, or rename the field so it lives at a new path.'
-    }));
-
     it('should populate entity properties based on correct form schema', testService(async (service, container) => {
       const asAlice = await service.login('alice');
 
@@ -2195,11 +2172,10 @@ describe('datasets and entities', () => {
       await exhaust(container);
 
       // Upload a new version of the form with saveto added to hometown
-      const x = testData.forms.simpleEntity
-        .replace('<bind nodeset="/data/hometown" type="string"/>', '<bind nodeset="/data/hometown" type="string" entities:saveto="hometown"/>');
       await asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
         .set('Content-Type', 'application/xml')
-        .send(x)
+        .send(testData.forms.simpleEntity
+          .replace('<bind nodeset="/data/hometown" type="string"/>', '<bind nodeset="/data/hometown" type="string" entities:saveto="hometown"/>'))
         .expect(200);
 
       await asAlice.post('/v1/projects/1/forms/simpleEntity/draft/publish?version=2.0')
@@ -2219,6 +2195,24 @@ describe('datasets and entities', () => {
 
       await exhaust(container);
 
+      // Upload a new version of the form with saveto removed from age
+      await asAlice.post('/v1/projects/1/forms/simpleEntity/draft')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.simpleEntity
+          .replace('<bind nodeset="/data/age" type="int" entities:saveto="age"/>', '<bind nodeset="/data/age" type="int"/>')
+          .replace('<bind nodeset="/data/hometown" type="string"/>', '<bind nodeset="/data/hometown" type="string" entities:saveto="hometown"/>'))
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/simpleEntity/draft/publish?version=3.0')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+        .send(testData.instances.simpleEntity.four.replace('version="1.0"', 'version="3.0"'))
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
       // Submission 1 - should just have name and age
       await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
         .expect(200)
@@ -2233,11 +2227,18 @@ describe('datasets and entities', () => {
           person.currentVersion.should.have.property('data').which.is.eql({ age: '30', first_name: 'Jane' });
         });
 
-      // Submission 3 - should have hometown filled in, too
+      // Submission 3 - should have name, age and hometown filled in
       await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789bbb')
         .expect(200)
         .then(({ body: person }) => {
           person.currentVersion.should.have.property('data').which.is.eql({ age: '40', hometown: 'Toronto', first_name: 'John' });
+        });
+
+      // Submission 4 - should have name and hometown filled in, NO age
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ccc')
+        .expect(200)
+        .then(({ body: person }) => {
+          person.currentVersion.should.have.property('data').which.is.eql({ first_name: 'Robert', hometown: 'Seattle' });
         });
     }));
   });


### PR DESCRIPTION
On Slack, @lognaturel identified a bug where a form field that populates an entity property is not updated if it’s changed by a new form version.

> For example, let’s say my form has fields `form` and `form_name`. I put a `save_to` on `form_name`. Then I realize I made a mistake and change the `save_to` to `form`. New submissions using the new form definition still save `form_name`.

It seemed like the fields being used to parse entity properties from a submission weren't filtered to just the properties in that specific form def/schema.

Looking into it more, this was indeed the case: when looking up fields by the submission's form def id, dataset property fields were joined via the form schema, but the schema doesn't change when just the entity bindings change (but maybe it should??)

Luckily (probably because of this exact situation) the `ds_property_fields` table still has a `formDefId` column, which we can go back to using for this join.

(Edit - Done) Leaving in draft mode while I look into
- [X] a bug that may be related about not being able to remove a binding (no bug except in my test -- I was just missing a closing '/' in my xml replace)
- [X] any other places that might be joining property fields on `schemaId` when it would be better to use the `formDefId` 
    - The only other place schema is used in a join like this is in `Dataset.getProperties`, but it gets properties for the entire dataset and has its own ways of grouping and ordering the properties. Also, the formDefId is not always available in the query. We have a lot of tests around getting dataset properties with this function so I think it can stay the way it is.


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Since the form schema doesn't change when just the dataset bindings change, we can't use the `schemaId` when joining dataset properties and form fields. Switch back to using the more specific `formDefId` that we still have on `dataset_property_fields`. 

Maybe the schema _should_ change in these cases.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Addresses a bug.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced