### PR TITLE
fixes #701: don't start transaction for POST submission.csv

### DIFF
--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -34,7 +34,7 @@ const Problem = require('../util/problem');
 
 // determines if a request needs a transaction.
 const phony = (request) => {
-  if (/submissions\.csv\.zip$/i.test(request.path)) return true;
+  if (/submissions\.csv(\.zip)?$/i.test(request.path)) return true;
   return false;
 };
 const isWriteRequest = (request) => !phony(request) &&

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -361,20 +361,20 @@ describe('endpoints', () => {
             .then(() => { transacted.should.equal(false); });
         })));
 
-      it('should not initiate a transaction given a nonwrite POST', () => {
-        let transacted = false;
-        const container = {
-          transacting(cb) { transacted = true; return cb(); },
-          with() { return container; }
-        };
+      it('should not initiate a transaction given a nonwrite POST', () =>
+        Promise.all([
+          '/projects/1/forms/encrypted/submissions.csv',
+          '/projects/1/forms/encrypted/submissions.csv.zip'
+        ].map((path) => {
+          let transacted = false;
+          const container = {
+            transacting(cb) { transacted = true; return cb(); },
+            with() { return container; }
+          };
 
-        const request = {
-          method: 'POST',
-          path: '/projects/1/forms/encrypted/submissions.csv.zip'
-        };
-        return endpointBase({ resultWriter: noop })(container)(always(true))(request)
-          .then(() => { transacted.should.equal(false); });
-      });
+          return endpointBase({ resultWriter: noop })(container)(always(true))({ method: 'POST', path })
+            .then(() => { transacted.should.equal(false); });
+        })));
 
       it('should reject on the transacting promise on preprocessor failure', () => {
         // we still check the transacted flag just to be sure the rejectedWith assertion runs.


### PR DESCRIPTION
Closes #701

#### What has been done to verify that this works as intended?

Manually tested downloading csv file of encrypted form with 1K submissions

#### Why is this the best possible solution? Were any other approaches considered?

We don't need to start database transaction for downloading of csv file, just like we don't start it for zip download

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

None

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced