### PR TITLE
Add endpoint to delete current session

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,12 @@ Finally, **system information and configuration** is available via a set of spec
 
 Here major and breaking changes to the API are listed by version.
 
+### ODK Central v2023.4
+
+**Added**:
+
+- [DELETE /sessions/current](/reference/authentication/session-authentication/logging-out-current-session) logs out the current session.
+
 ### ODK Central v2023.3
 
 **Added**:
@@ -387,7 +393,7 @@ _(There is not really anything at `/v1/example`; this section only demonstrates 
 
 #### Logging out [DELETE /v1/sessions/{token}]
 
-Logging out is not strictly necessary for Web Users; all sessions expire 24 hours after they are created. But it can be a good idea, in case someone else manages to steal your token. It is also the way Public Link and App User access is revoked. To do so, issue a `DELETE` request to that token resource.
+Logging out is not strictly necessary for Web Users; all sessions expire 24 hours after they are created. But it can be a good idea, in case someone else manages to steal your token. It is also the way Public Link and App User access are revoked. To do so, issue a `DELETE` request to that token resource.
 
 + Parameters
     + token: `lSpAIeksRu1CNZs7!qjAot2T17dPzkrw9B4iTtpj7OoIJBmXvnHM8z8Ka4QPEjR7` (string, required) - The session bearer token, obtained at login time.
@@ -419,9 +425,6 @@ Only the session that was used to authenticate the request is logged out. If the
 
 + Response 403 (application/json)
     + Attributes (Error 403)
-
-+ Response 404 (application/json)
-    + Attributes (Error 404)
 
 ## HTTPS Basic Authentication [/v1/example]
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -387,7 +387,7 @@ _(There is not really anything at `/v1/example`; this section only demonstrates 
 
 #### Logging out [DELETE /v1/sessions/{token}]
 
-Logging out is not strictly necessary for Web Users; all sessions expire 24 hours after they are created. But it can be a good idea, in case someone else manages to steal your token. It is also the way Public Link and App User access are revoked. To do so, issue a `DELETE` request to that token resource.
+Logging out is not strictly necessary for Web Users; all sessions expire 24 hours after they are created. But it can be a good idea, in case someone else manages to steal your token. It is also the way Public Link and App User access is revoked. To do so, issue a `DELETE` request to that token resource.
 
 + Parameters
     + token: `lSpAIeksRu1CNZs7!qjAot2T17dPzkrw9B4iTtpj7OoIJBmXvnHM8z8Ka4QPEjR7` (string, required) - The session bearer token, obtained at login time.
@@ -402,6 +402,26 @@ Logging out is not strictly necessary for Web Users; all sessions expire 24 hour
 
 + Response 403 (application/json)
     + Attributes (Error 403)
+
+#### Logging out current session [DELETE /v1/sessions/current]
+
+This endpoint causes the current session to log itself out. Logging out is not strictly necessary for Web Users; all sessions expire 24 hours after they are created. But it can be a good idea, in case someone else manages to steal your token.
+
+Only the session that was used to authenticate the request is logged out. If the Actor associated with the session has other sessions as well, those are not logged out.
+
++ Request
+    + Headers
+
+            Authorization: Bearer lSpAIeksRu1CNZs7!qjAot2T17dPzkrw9B4iTtpj7OoIJBmXvnHM8z8Ka4QPEjR7
+
++ Response 200 (application/json)
+    + Attributes (Success)
+
++ Response 403 (application/json)
+    + Attributes (Error 403)
+
++ Response 404 (application/json)
+    + Attributes (Error 404)
 
 ## HTTPS Basic Authentication [/v1/example]
 

--- a/lib/resources/sessions.js
+++ b/lib/resources/sessions.js
@@ -48,24 +48,30 @@ module.exports = (service, endpoint) => {
   service.get('/sessions/restore', endpoint((_, { auth }) =>
     auth.session.orElse(Problem.user.notFound())));
 
+  const logOut = (Sessions, auth, session) =>
+    auth.canOrReject('session.end', session.actor)
+      .then(() => Sessions.terminate(session))
+      .then(() => (_, response) => {
+        // revoke the cookie associated w the session, if the session was used to
+        // terminate itself.
+        // TODO: repetitive w above.
+        if (session.token === auth.session.map((s) => s.token).orNull())
+          response.cookie('__Host-session', 'null', { path: '/', expires: new Date(0),
+            httpOnly: true, secure: true, sameSite: 'strict' });
+
+        return success;
+      });
+
+  service.delete('/sessions/current', endpoint(({ Sessions }, { auth }) =>
+    auth.session.map(session => logOut(Sessions, auth, session))
+      .orElse(Problem.user.notFound())));
+
   // here we always throw a 403 even if the token doesn't exist to prevent
   // information leakage.
   // TODO: but a timing attack still exists here. :(
   service.delete('/sessions/:token', endpoint(({ Sessions }, { auth, params }) =>
     Sessions.getByBearerToken(params.token)
       .then(getOrReject(Problem.user.insufficientRights()))
-      .then((session) => auth.canOrReject('session.end', session.actor)
-        .then(() => Sessions.terminate(session))
-        .then(() => (_, response) => {
-          // revoke the cookie associated w the session, if the session was used to
-          // terminate itself.
-          // TODO: repetitive w above.
-          if (session.token === auth.session.map((s) => s.token).orNull())
-            response.cookie('__Host-session', 'null', { path: '/', expires: new Date(0),
-              httpOnly: true, secure: true, sameSite: 'strict' });
-
-          return success;
-        }))));
-
+      .then(session => logOut(Sessions, auth, session))));
 };
 


### PR DESCRIPTION
This PR adds an endpoint to delete the current session, making it easy to log out without specifying the token of the current session in the URL. We will probably use this endpoint in Frontend, but I also imagine that some API users would find it convenient.

#### What has been done to verify that this works as intended?

New tests. I copied some of the tests of DELETE /v1/sessions/:token. I didn't copy all the tests, since the two endpoints call a shared function: I think the tests of DELETE /v1/sessions/:token provide good coverage of that shared behavior.

#### Why is this the best possible solution? Were any other approaches considered?

I created a shared function because I think there's enough logic shared between DELETE /v1/sessions/:token and the new DELETE /v1/sessions/current to warrant one. DELETE /v1/sessions/current ends up being quite short and looks very similar to GET /v1/sessions/restore.

I chose the path &hellip;/current to be similar to another endpoint we have, /v1/users/current.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

API users will be able to use the new endpoint. The DELETE /v1/sessions/:token endpoint was modified, but much of its code was copied as-is to the shared function. Existing tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced