### PR TITLE
Add ability to specify CSRF token in header

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -118,14 +118,22 @@ const authHandler = ({ Sessions, Users, Auth, bcrypt }, context) => {
       // if authentication failed anyway, just do nothing.
       if ((cxt == null) || !cxt.auth.session.isDefined()) return;
 
+      // The CSRF token may be specified in a header or in the request body. We
+      // used to require the token to be in the request body, but that isn't
+      // compatible with all request bodies (for example, a file). There are
+      // times when Central specifies the token in a header, and other times
+      // when it specifies it in the request body: it depends on the use case.
+      const csrf = cxt.headers['x-csrf-token'] ?? cxt.body.__csrf;
+
       // if csrf missing or mismatch; fail outright.
-      const csrf = cxt.body.__csrf;
       if (isBlank(csrf) || (cxt.auth.session.get().csrf !== decodeURIComponent(csrf)))
         return reject(Problem.user.authenticationFailed());
 
-      // delete the token off the body so it doesn't mess with downstream
-      // payload expectations.
-      return cxt.with({ body: without([ '__csrf' ], cxt.body) });
+      return cxt.headers['x-csrf-token'] != null
+        ? cxt
+        // delete the token off the body so it doesn't mess with downstream
+        // payload expectations.
+        : cxt.with({ body: without([ '__csrf' ], cxt.body) });
     });
   }
 };

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -271,7 +271,19 @@ describe('api: /sessions', () => {
 
   // this isn't exactly the right place for this but i just want to check the
   // whole stack in addition to the unit tests.
-  describe('cookie CSRF auth', () => {
+  describe('CSRF protection for cookie auth used for non-GET requests', () => {
+    it('should reject with a 403 if session token is invalid', testService(async (service) => {
+      const { body: session } = await service.post('/v1/sessions')
+        .send({ email: 'alice@getodk.org', password: 'alice' })
+        .expect(200);
+      await service.post('/v1/projects')
+        .send({ name: 'my project' })
+        .set('X-Forwarded-Proto', 'https')
+        .set('Cookie', '__Host-session=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+        .set('X-Csrf-Token', session.csrf)
+        .expect(403);
+    }));
+
     it('should reject if the CSRF token is missing', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'alice@getodk.org', password: 'alice' })
@@ -282,25 +294,53 @@ describe('api: /sessions', () => {
           .set('Cookie', '__Host-session=' + body.token)
           .expect(401))));
 
-    it('should reject if the CSRF token is wrong', testService((service) =>
-      service.post('/v1/sessions')
-        .send({ email: 'alice@getodk.org', password: 'alice' })
-        .expect(200)
-        .then(({ body }) => service.post('/v1/projects')
-          .send({ name: 'my project', __csrf: 'nope' })
-          .set('X-Forwarded-Proto', 'https')
-          .set('Cookie', '__Host-session=' + body.token)
-          .expect(401))));
+    describe('CSRF token in the request body', () => {
+      it('should reject if the CSRF token is wrong', testService((service) =>
+        service.post('/v1/sessions')
+          .send({ email: 'alice@getodk.org', password: 'alice' })
+          .expect(200)
+          .then(({ body }) => service.post('/v1/projects')
+            .send({ name: 'my project', __csrf: 'nope' })
+            .set('X-Forwarded-Proto', 'https')
+            .set('Cookie', '__Host-session=' + body.token)
+            .expect(401))));
 
-    it('should succeed if the CSRF token is correct', testService((service) =>
-      service.post('/v1/sessions')
-        .send({ email: 'alice@getodk.org', password: 'alice' })
-        .expect(200)
-        .then(({ body }) => service.post('/v1/projects')
-          .send({ name: 'my project', __csrf: body.csrf })
+      it('should succeed if the CSRF token is correct', testService((service) =>
+        service.post('/v1/sessions')
+          .send({ email: 'alice@getodk.org', password: 'alice' })
+          .expect(200)
+          .then(({ body }) => service.post('/v1/projects')
+            .send({ name: 'my project', __csrf: body.csrf })
+            .set('X-Forwarded-Proto', 'https')
+            .set('Cookie', '__Host-session=' + body.token)
+            .expect(200))));
+    });
+
+    describe('CSRF token in a header', () => {
+      it('should reject if the token is incorrect', testService(async (service) => {
+        const { body: session } = await service.post('/v1/sessions')
+          .send({ email: 'alice@getodk.org', password: 'alice' })
+          .expect(200);
+        await service.post('/v1/projects')
+          .send({ name: 'my project' })
           .set('X-Forwarded-Proto', 'https')
-          .set('Cookie', '__Host-session=' + body.token)
-          .expect(200))));
+          .set('Cookie', `__Host-session=${session.token}`)
+          .set('X-Csrf-Token', 'nope')
+          .expect(401);
+      }));
+
+      it('should succeed if the token is correct', testService(async (service) => {
+        const { body: session } = await service.post('/v1/sessions')
+          .send({ email: 'alice@getodk.org', password: 'alice' })
+          .expect(200);
+        await service.post('/v1/projects')
+          .send({ name: 'my project' })
+          .set('X-Forwarded-Proto', 'https')
+          .set('Cookie', `__Host-session=${session.token}`)
+          .set('X-Csrf-Token', session.csrf)
+          .expect(200);
+      }));
+    });
   });
 });
 


### PR DESCRIPTION
If a non-GET request is sent, and a session cookie is used to authenticate, then the CSRF token associated with the session must also be provided. Right now, the CSRF token is expected to be in the request body. For example, Frontend provides the CSRF token from the iframe form in the [`SubmissionDownload`](https://github.com/getodk/central-frontend/blob/0a3d8d265da634dbc43f0ae7e0c0eff3ec69044a/src/components/submission/download.vue#L213-L258) component. Enketo also provides the CSRF token when using cookie auth.

However, I think the expectation that the CSRF token is in the request body doesn't work for all requests. The main issue that comes to mind is file uploads. For example, I think requiring the CSRF token to be in the request body would be an obstacle to using cookie auth to upload a form definition or form attachment.

This PR makes it possible to use cookie auth in such cases by allowing the CSRF token to be specified in a header instead of the request body.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I don't love that there are now two ways to specify the CSRF token. I thought about removing support for CSRF tokens in the request body so that there would be only one way to specify the token (via the header). However, that wouldn't work for HTML form submission like from the iframe form. I also didn't want to change anything about our Enketo integration.

I also don't think this PR adds that much complexity. Only two lines of code were changed.

If a user of cookie auth has a choice between specifying the token in the header vs. in the request body, specifying it in the header is probably slightly better. That's because it doesn't require the token to be removed from the request body.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

During regression testing, we will verify that the parts of Central that rely on cookie auth continue to work.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I don't think changes are needed. We discourage the use of cookie auth in the API docs, and we don't document any requirements around the CSRF token.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced