### PR TITLE
Clear __csrf cookie after logout

### DIFF
--- a/lib/resources/sessions.js
+++ b/lib/resources/sessions.js
@@ -52,12 +52,15 @@ module.exports = (service, endpoint) => {
     auth.canOrReject('session.end', session.actor)
       .then(() => Sessions.terminate(session))
       .then(() => (_, response) => {
-        // revoke the cookie associated w the session, if the session was used to
+        // revoke the cookies associated w the session, if the session was used to
         // terminate itself.
         // TODO: repetitive w above.
-        if (session.token === auth.session.map((s) => s.token).orNull())
+        if (session.token === auth.session.map((s) => s.token).orNull()) {
           response.cookie('__Host-session', 'null', { path: '/', expires: new Date(0),
             httpOnly: true, secure: true, sameSite: 'strict' });
+          response.cookie('__csrf', 'null', { expires: new Date(0),
+            secure: true, sameSite: 'strict' });
+        }
 
         return success;
       });

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -195,7 +195,7 @@ describe('api: /sessions', () => {
           .then((token) => service.delete(`/v1/key/${token}/sessions/${token}`)
             .expect(403)))));
 
-    it('should clear the cookie if successful for the current session', testService((service) =>
+    it('should clear cookies if successful for the current session', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)
@@ -206,12 +206,14 @@ describe('api: /sessions', () => {
             .set('Authorization', 'Bearer ' + token)
             .expect(200)
             .then(({ headers }) => {
-              const cookie = headers['set-cookie'][0];
-              cookie.should.match(/__Host-session=null/);
+              headers['set-cookie'].should.eql([
+                '__Host-session=null; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict',
+                '__csrf=null; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; SameSite=Strict'
+              ]);
             });
         })));
 
-    it('should not clear the cookie if using some other session', testService((service) =>
+    it('should not clear cookies if using some other session', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'alice@getodk.org', password: 'alice' })
         .expect(200)


### PR DESCRIPTION
After a session is created, Backend returns two cookies: `__Host-session` and `__csrf`. The cookies expire at the same time as the session, so if a session expires on its own, the cookies will expire as well and be cleared. If the user logs out the session before it expires, then the `__Host-session` cookie is cleared — but the `__csrf` cookie is not. I don't think that's a huge deal, but I think it's cleaner to clear both cookies together, which is what this PR does.

#### What has been done to verify that this works as intended?

Updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

The change is pretty small.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change isn't really user-facing. It's more about cleaning up after logout. I think the risk of regression is low.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I don't think changes are needed. We discourage the use of cookie auth in the API docs, and we don't document the `__csrf` cookie at all.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced