### PR TITLE
Clarify how often usage reports are sent

### DIFF
--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -603,13 +603,18 @@ const previewMetrics = () => (({ Analytics }) => Promise.all([
   return metrics;
 }));
 
-// Get most recent 'analytics' audit from the past N days
-const AUDIT_SCHEDULE = config.has('default.taskSchedule.analytics')
+// Usage reports are sent on a fixed interval: a usage report is sent a fixed
+// number of days after the previous report. The default is to send a report
+// every 31 days. However, that number is configurable so that usage reporting
+// can be verified during regression testing.
+const ANALYTICS_SCHEDULE = config.has('default.taskSchedule.analytics')
   ? config.get('default.taskSchedule.analytics')
-  : 30; // Default is 30 days
+  : 31; // Default is 31 days
 
+// Returns the latest recent attempt to send a usage report. If there is no
+// recent attempt, then it is time for a new report to be sent.
 const getLatestAudit = () => ({ maybeOne }) => maybeOne(sql`select * from audits
-  where action='analytics' and "loggedAt" >= current_date - cast(${AUDIT_SCHEDULE} as int)
+  where action='analytics' and current_date - "loggedAt"::date < ${ANALYTICS_SCHEDULE}
   order by "loggedAt" desc limit 1`);
 
 module.exports = {


### PR DESCRIPTION
Closes #921. This PR doesn't change the current behavior, but it tries to make that behavior clear. For example, I used to think that usage reports were sent every 30 days. After this PR, usage reports will continue to be sent every 31 days — but I think that fact will be clearer.

#### What has been done to verify that this works as intended?

Updated and new tests.

#### Why is this the best possible solution? Were any other approaches considered?

I considered not making any changes at all. I realized that I could send daily usage reports by setting the `default.taskSchedule.analytics` config to 0 instead of 1. However, I think this PR makes things a little clearer.

I'll also leave a comment about an individual line.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The current behavior is intended to stay the same. I've updated tests to help verify that there hasn't been a change in behavior.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I don't think so. We say in the API docs that usage data is sent monthly, which is consistent with the current interval of 31 days.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced