### PR TITLE
Silence logging from migrations when setting up database in testing

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -4,6 +4,7 @@ const { sql } = require('slonik');
 const { readdirSync } = require('fs');
 const { join } = require('path');
 const request = require('supertest');
+const { noop } = require(appRoot + '/lib/util/util');
 // eslint-disable-next-line import/no-dynamic-require
 const { task } = require(appRoot + '/lib/task/task');
 
@@ -79,10 +80,14 @@ const populate = (container, [ head, ...tail ] = fixtures) =>
 // in that case.
 const initialize = async () => {
   const migrator = connect(config.get('test.database'));
+  const { log } = console;
   try {
     await migrator.raw('drop owned by current_user');
+    // Silence logging from migrations.
+    console.log = noop; // eslint-disable-line no-console
     await migrator.migrate.latest({ directory: appRoot + '/lib/model/migrations' });
   } finally {
+    console.log = log; // eslint-disable-line no-console
     await migrator.destroy();
   }
 


### PR DESCRIPTION
We have a couple of migrations that log messages. I think that logging is helpful for users and in migration tests. However, those messages are also logged whenever the database is reinitialized during testing (whenever `testServiceFullTrx()` or `testContainerFullTrx()` is used). I don't think the logging is useful in that case and actually makes it harder to read the test output. This PR tries to improve that case by silencing logging from migrations only when the database is (re)initialized during testing.

#### What has been done to verify that this works as intended?

Before making this change, I ran a subset of tests and saw logging from migrations. After making this change, that logging was gone. However, other logging continued to come through: I called `console.log()` in a test, and I saw its output.

#### Why is this the best possible solution? Were any other approaches considered?

This is a small change and targeted so that only specific logging is silenced. The migrations didn't have to change. I don't love overwriting `console.log`, but I think it's done safely, because `console.log` is restored in a `finally` block.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change is for testing only.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced