### PR TITLE
Change dataset-diffs to return properties in form question order

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -363,7 +363,11 @@ ORDER BY form_fields."order"
 
 // Used when creating or updating a dataset through the uploading of a form
 // to show the status of the dataset and each property in that dataset.
-const getDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
+
+// This helper function gets just the properties specificed by the saveto binds
+// in a single form definition. It orders the properties by their question order
+// within the form.
+const _getFormSpecificProperties = (projectId, xmlFormId, forDraft) => sql`
   WITH form AS (
     SELECT f.id, f."xmlFormId", fd.id "formDefId", fd."schemaId"
     FROM forms f
@@ -380,21 +384,50 @@ const getDiff = (projectId, xmlFormId, forDraft) => ({ all }) => all(sql`
     SELECT 
       dp.*, 
       dpf.*, 
-      dp."publishedAt" IS NULL "isNew"
+      dp."publishedAt" IS NULL "isNew",
+      ff.order "formFieldOrder"
     FROM ds_properties dp 
     JOIN ds ON ds.id = dp."datasetId"
     LEFT JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id
+    JOIN form f ON dpf."formDefId" = f."formDefId"
+    JOIN form_fields ff ON f."schemaId" = ff."schemaId"
+      AND dpf."path" = ff."path"
   )
-  SELECT ds.name "datasetName", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew", TRUE = ANY(ARRAY_AGG(f.id IS NOT NULL)) "inForm"
+  SELECT ds.name "datasetName", ds.id "datasetId", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew"
   FROM ds
   LEFT JOIN properties p on ds.id = p."datasetId"
-  LEFT JOIN form f ON f."formDefId" = p."formDefId"
   ${forDraft ? sql`` : sql`WHERE p.id IS NULL OR NOT p."isNew"`}
-  GROUP BY ds.name, ds."isNew", p.name, p."isNew"
-  ORDER BY p.name
-`)
-  .then(reduceBy((acc, { propertyName, isPropertyNew, inForm }) => (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm }) : acc), [], (row) => `${row.datasetName},${row.isDatasetNew}`))
-  .then(r => Object.keys(r).map(k => ({ name: k.split(',')[0], isNew: forDraft ? k.split(',')[1] === 'true' : undefined, properties: r[k] })));
+  ORDER BY ds.id ASC, p."formFieldOrder" ASC
+`;
+
+const getDiff = (projectId, xmlFormId, forDraft) => async ({ all, Datasets }) => {
+  // This fetches all the dataset properties described in a specific form def/version, the one
+  // the diff is about. The diff can be used for a draft def or the latest current def.
+  // There may be multiple datasets in a form (though not technically possible as of july 2023)
+  // so properties are grouped by their dataset, under a key: 'datasetName,datasetId,isDatasetNew'
+  const propsByDataset = await all(_getFormSpecificProperties(projectId, xmlFormId, forDraft))
+    .then(reduceBy((acc, { propertyName, isPropertyNew }) =>
+      (propertyName ? acc.concat({ name: propertyName, isNew: forDraft ? isPropertyNew : undefined, inForm: true }) : acc),
+    [],
+    (row) => `${row.datasetName},${row.datasetId},${row.isDatasetNew}`));
+
+  // This loops through each of the found datasets above, asks the database for _all_ the published properties
+  // of that dataset, and then combines the inForm properties with the remaining dataset properties
+  // in a clean way (i.e. properties NOT in the form, but already published in the dataset will be returned
+  // at the beginning of the list in their correct order.
+  const funcPerDataset = Object.keys(propsByDataset).map((k) => Datasets.getProperties(k.split(',')[1])
+    .then((publishedProps) => {
+      const formPropSet = propsByDataset[k].map(({ name }) => name);
+      const allProps = publishedProps.reduce((acc, { name }) => (!formPropSet.includes(name) ? acc.concat({ name, isNew: forDraft ? false : undefined, inForm: false }) : acc), []).concat(propsByDataset[k]);
+      return {
+        name: k.split(',')[0],
+        isNew: forDraft ? k.split(',')[2] === 'true' : undefined,
+        properties: allProps
+      };
+    }));
+
+  return Promise.all(funcPerDataset);
+};
 
 const update = (datasets, data) => ({ one }) => one(updater(datasets, data)).then(construct(Dataset));
 update.audit = (datasets, data, autoConvert) => (log) => log('dataset.update', datasets, { data, autoConvert });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1570,8 +1570,8 @@ describe('datasets and entities', () => {
                     name: 'people',
                     isNew: true,
                     properties: [
-                      { name: 'age', isNew: true, inForm: true },
-                      { name: 'first_name', isNew: true, inForm: true }
+                      { name: 'first_name', isNew: true, inForm: true },
+                      { name: 'age', isNew: true, inForm: true }
                     ]
                   }
                 ]);
@@ -1596,8 +1596,8 @@ describe('datasets and entities', () => {
                       name: 'people',
                       isNew: false,
                       properties: [
-                        { name: 'age', isNew: false, inForm: true },
-                        { name: 'first_name', isNew: false, inForm: true }
+                        { name: 'first_name', isNew: false, inForm: true },
+                        { name: 'age', isNew: false, inForm: true }
                       ]
                     }
                   ]);
@@ -1623,12 +1623,68 @@ describe('datasets and entities', () => {
                     name: 'people',
                     isNew: false,
                     properties: [
-                      { name: 'age', isNew: false, inForm: true },
                       { name: 'first_name', isNew: false, inForm: false },
-                      { name: 'lastName', isNew: true, inForm: true }
+                      { name: 'lastName', isNew: true, inForm: true },
+                      { name: 'age', isNew: false, inForm: true }
                     ]
                   }]);
                 }))));
+      }));
+
+      it('should return properties in the same order they appear as questions in the form', testService(async (service) => {
+        await service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.multiPropertyEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1/forms/multiPropertyEntity/draft/dataset-diff')
+              .expect(200)
+              .then(({ body }) => {
+                body.should.be.eql([
+                  {
+                    name: 'foo',
+                    isNew: true,
+                    properties: [
+                      { name: 'b_q1', isNew: true, inForm: true },
+                      { name: 'd_q2', isNew: true, inForm: true },
+                      { name: 'a_q3', isNew: true, inForm: true },
+                      { name: 'c_q4', isNew: true, inForm: true }
+                    ]
+                  }
+                ]);
+              })));
+      }));
+
+      it('should return ordered properties including properties not in the form', testService(async (service) => {
+        await service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms?publish=true')
+            .send(testData.forms.multiPropertyEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/multiPropertyEntity/draft')
+              .send(testData.forms.multiPropertyEntity
+                .replace('orx:version="1.0"', 'orx:version="2.0"') // update version
+                .replace('entities:saveto="b_q1"', '') // remove q1 bind from form
+                .replace('entities:saveto="a_q3"', 'entities:saveto="x_q3"')) // change q3 bind
+              .expect(200))
+            .then(() => asAlice.get('/v1/projects/1/forms/multiPropertyEntity/draft/dataset-diff')
+              .expect(200)
+              .then(({ body }) => {
+                //console.log(body);
+                body.should.be.eql([
+                  {
+                    name: 'foo',
+                    isNew: false,
+                    properties: [
+                      { name: 'b_q1', isNew: false, inForm: false },
+                      { name: 'a_q3', isNew: false, inForm: false },
+                      { name: 'd_q2', isNew: false, inForm: true },
+                      { name: 'x_q3', isNew: true, inForm: true },
+                      { name: 'c_q4', isNew: false, inForm: true }
+                    ]
+                  }
+                ]);
+              })));
       }));
 
       it('should return dataset name only if no property mapping is defined', testService(async (service) => {
@@ -1686,8 +1742,8 @@ describe('datasets and entities', () => {
                       name: 'people',
                       isNew: true,
                       properties: [
-                        { name: 'age', isNew: true, inForm: true },
-                        { name: 'first_name', isNew: true, inForm: true }
+                        { name: 'first_name', isNew: true, inForm: true },
+                        { name: 'age', isNew: true, inForm: true }
                       ]
                     }])))))));
 
@@ -1772,8 +1828,8 @@ describe('datasets and entities', () => {
                   {
                     name: 'people',
                     properties: [
-                      { name: 'age', inForm: true },
-                      { name: 'first_name', inForm: true }
+                      { name: 'first_name', inForm: true },
+                      { name: 'age', inForm: true }
                     ]
                   }
                 ]);
@@ -1797,9 +1853,9 @@ describe('datasets and entities', () => {
                   body.should.be.eql([{
                     name: 'people',
                     properties: [
-                      { name: 'age', inForm: true },
                       { name: 'first_name', inForm: false },
-                      { name: 'last_name', inForm: true }
+                      { name: 'last_name', inForm: true },
+                      { name: 'age', inForm: true }
                     ]
                   }]);
                 }))));
@@ -1822,8 +1878,8 @@ describe('datasets and entities', () => {
                   body.should.be.eql([{
                     name: 'people',
                     properties: [
-                      { name: 'age', inForm: true },
-                      { name: 'first_name', inForm: true }
+                      { name: 'first_name', inForm: true },
+                      { name: 'age', inForm: true }
                     ]
                   }]);
                 }))));
@@ -2342,9 +2398,9 @@ describe('datasets and entities', () => {
             name: 'people',
             isNew: false,
             properties: [
-              { name: 'age', isNew: false, inForm: true },
               { name: 'first_name', isNew: false, inForm: false },
-              { name: 'last_name', isNew: true, inForm: true }
+              { name: 'last_name', isNew: true, inForm: true },
+              { name: 'age', isNew: false, inForm: true }
             ]
           }]);
         });


### PR DESCRIPTION
Closes #708 

Ordering the dataset properties is really tricky because of how they're represented in the database. The gist of this change is that when querying the `dataset-diff` endpoint, that is done relative to a specific form, a specific _version_ of that form, even, so the order of the properties should match the order of the fields in that version of the form and be grouped together, and the order of the rest of the properties really isn't as important. (These properties are not even shown on Frontend.) Or if the order if the rest of the properties does seem important, I want that to be determined by the one other chunk of code dedicated to ordering dataset properties for a whole dataset.

Given all that, I split the query from one massive query into 
1) getting just the properties from the specific version of the form in question and 
2) the rest of the properties in the dataset, queried using the other dataset property getter that was finessed in PR #780

Using the `Datasets.getProperties` getter only gets published properties but that is fine because any _unpublished_ properties will only be part of the diff because they are part of that specific form.  

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added a few new tests and changed other tests to have properties expected in the right order.

#### Why is this the best possible solution? Were any other approaches considered?

I don't know, I think the overall approach is sound - this query needed to be split up because I kept getting hung up on it in other contexts - but I don't know if I _love_ the code I've come up with. It's a weird mixture of an async/await and Promise.all and I don't know if it's any easier to understand than what was there before (but what was there before didn't have the right ordering.)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I think the main thing this will impact is having the properties show up in a clearer order on the form draft and form status pages that describe dataset things.

This code works for draft forms and non-draft forms and published/unpublished datasets and properties so there might be MORE tests we want to add, such as:
- making sure if you reorder questions, the diff looks right (i have a test that removes and renames something but not for just moving)
- more tests of when things get deleted?

There are also existential questions like:
1) if the dataset properties have an order, and your form moves things around, what does that even mean for the ordering within the diff, let alone the dataset properties... i think we covered this already with going on the order that matches the order in which the properties were originally added to the dataset.

2) if you delete a bind/remove the property from that form, the dataset info panel on the form doesn't mention deleted properties anymore, but _old versions of the form_ could still fill in those properties? That seems like a (hopefully rare) issue that someone might run into and go a little bit crazy about because they can't see anywhere how that dataset property is getting filled in.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Will check, maybe add a note about the ordering.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced