### PR TITLE
Mock bcrypt during `make test-integration`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-full: lint
 
 .PHONY: test-integration
 test-integration: node_version
-	npx mocha --recursive test/integration --exit
+	env BCRYPT=no npx mocha --recursive test/integration --exit
 
 .PHONY: test-unit
 test-unit: node_version

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@ debug: base
 
 .PHONY: test
 test: lint
-	env BCRYPT=no npx mocha --recursive --exit
+	BCRYPT=no npx mocha --recursive --exit
 .PHONY: test-full
 test-full: lint
 	npx mocha --recursive --exit
 
 .PHONY: test-integration
 test-integration: node_version
-	env BCRYPT=no npx mocha --recursive test/integration --exit
+	BCRYPT=no npx mocha --recursive test/integration --exit
 
 .PHONY: test-unit
 test-unit: node_version


### PR DESCRIPTION
We have a few different makefile rules related to testing: `test`, `test-full`, `test-integration`, and `test-unit`. `test-full` is what's run in CircleCI, but `test` is much faster because it mocks bcrypt. `test-integration` and `test-unit` run a subset of tests, and I believe they're only run locally. However, unlike `test`, they don't mock bcrypt. I've noticed that this makes `test-integration` take a long time. I often run `test-integration`, and it'd be nice if it mocked bcrypt so that it was faster. Another way to put it is that I think `test-integration` should be a subset of `test` rather than a subset of `test-full`. I think it's important that tests in CircleCI don't mock bcrypt, but while iterating on development locally, it's nice to be able to run tests more quickly.

I thought about mocking bcrypt in `test-unit` as well, but unlike `test-integration`, `test-unit` runs quite quickly, so I don't think it needs it.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced