### PR TITLE
eslint: allow function use before define

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
     "no-nested-ternary": "off",
     "no-restricted-syntax": "off",
     "no-underscore-dangle": "off",
+    "no-use-before-define": ["error", { "functions": false } ],
     "nonblock-statement-body-position": "off",
     "object-curly-newline": [ "error", {
       "ObjectExpression": { "consistent": true },


### PR DESCRIPTION
We don't currently have any instances of this violation.

Per eslint docs:

> Function declarations are hoisted, so it’s safe.

See: https://eslint.org/docs/latest/rules/no-use-before-define
