### PR TITLE
Added test for analytics of zero projects

### DIFF
--- a/test/integration/api/analytics.js
+++ b/test/integration/api/analytics.js
@@ -1,4 +1,5 @@
 const { testService } = require('../setup');
+const { sql } = require('slonik');
 
 describe('api: /analytics/preview', () => {
   describe('GET', () => {
@@ -14,6 +15,19 @@ describe('api: /analytics/preview', () => {
             body.system.num_admins.recent.should.equal(1);
             body.projects.length.should.equal(1);
           }))));
+
+    it('should return valid response with empty projects for fresh install ', testService(async (service, container) => {
+      // A fresh install of central has no projects -- delete test fixture forms and projects
+      await container.run(sql`delete from forms`);
+      await container.run(sql`delete from projects`);
+
+      await service.login('alice', (asAlice) =>
+        asAlice.get('/v1/analytics/preview').expect(200)
+          .then(({ body }) => {
+            body.system.num_admins.recent.should.equal(1);
+            body.projects.length.should.equal(0);
+          }));
+    }));
   });
 });
 


### PR DESCRIPTION
This is related to https://github.com/getodk/central-backend/issues/763 but I've set up the issues so this frontend PR (https://github.com/getodk/central-frontend/pull/836) will close it. This specific PR just adds a test.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Didn't change any code, just added a test. I think we added analytics before we removed the default project, and then I was concerned backend was making a malformed response in that empty-project scenario. It's not -- it makes a reasonable response with an empty project array.

#### Why is this the best possible solution? Were any other approaches considered?

Didn't change any code.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Didn't change any code.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced