### PR TITLE
Do not export individual client audit attachments in .csv.zip

### DIFF
--- a/lib/model/query/submission-attachments.js
+++ b/lib/model/query/submission-attachments.js
@@ -204,6 +204,7 @@ where submission_defs.current=true
   and "deletedAt" is null
   and ${odataFilter(options.filter, odataToColumnMap)}
   and submission_attachments.name is distinct from submission_defs."encDataAttachmentName"
+  and submission_attachments."isClientAudit" is not true
   and (form_defs."keyId" is null or form_defs."keyId" in (${keyIdCondition(keyIds)}))`);
 
 module.exports = {

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1859,10 +1859,8 @@ describe('api: /forms/:id/submissions', () => {
           .then(() => exhaust(container))
           .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
             .then((result) => {
-              result.filenames.should.containDeep([
+              result.filenames.should.eql([
                 'audits.csv',
-                'media/audit.csv',
-                'media/log.csv',
                 'audits - audit.csv'
               ]);
 
@@ -1898,10 +1896,8 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             .expect(201))
           .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
             .then((result) => {
-              result.filenames.should.containDeep([
+              result.filenames.should.eql([
                 'audits.csv',
-                'media/audit.csv',
-                'media/log.csv',
                 'audits - audit.csv'
               ]);
 
@@ -1936,9 +1932,8 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
               .expect(201))
             .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip?$filter=__system/submitterId eq 5'))
               .then((result) => {
-                result.filenames.should.containDeep([
+                result.filenames.should.eql([
                   'audits.csv',
-                  'media/audit.csv',
                   'audits - audit.csv'
                 ]);
 
@@ -1973,9 +1968,8 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
             .expect(201))
           .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip?$filter=__system/reviewState eq \'approved\''))
             .then((result) => {
-              result.filenames.should.containDeep([
+              result.filenames.should.eql([
                 'audits.csv',
-                'media/audit.csv',
                 'audits - audit.csv'
               ]);
 
@@ -2009,9 +2003,8 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
             .expect(200)
             .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
               .then((result) => {
-                result.filenames.should.containDeep([
+                result.filenames.should.eql([
                   'audits.csv',
-                  'media/audit.csv',
                   'audits - audit.csv'
                 ]);
 
@@ -2042,9 +2035,8 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             .expect(200)
             .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
               .then((result) => {
-                result.filenames.should.containDeep([
+                result.filenames.should.eql([
                   'audits.csv',
-                  'media/audit.csv',
                   'audits - audit.csv'
                 ]);
 
@@ -2071,9 +2063,8 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             .expect(200)
             .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
               .then((result) => {
-                result.filenames.should.containDeep([
+                result.filenames.should.eql([
                   'audits.csv',
-                  'media/audit.csv',
                   'audits - audit.csv'
                 ]);
 
@@ -2101,9 +2092,8 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
             .expect(200)
             .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
               .then((result) => {
-                result.filenames.should.containDeep([
+                result.filenames.should.eql([
                   'audits.csv',
-                  'media/audit.csv',
                   'audits - audit.csv'
                 ]);
 
@@ -2140,9 +2130,8 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
               .expect(200)
               .then(() => pZipStreamToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
                 .then((result) => {
-                  result.filenames.should.containDeep([
+                  result.filenames.should.eql([
                     'audits.csv',
-                    'media/audit.csv',
                     'audits - audit.csv'
                   ]);
 

--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -405,10 +405,8 @@ describe('managed encryption', () => {
             .then(({ body }) => body[0].id))
           .then((keyId) => pZipStreamToFiles(asAlice.get(`/v1/projects/1/forms/audits/submissions.csv.zip?${keyId}=supersecret`))
             .then((result) => {
-              result.filenames.should.containDeep([
+              result.filenames.should.eql([
                 'audits.csv',
-                'media/audit.csv',
-                'media/audit.csv',
                 'audits - audit.csv'
               ]);
 


### PR DESCRIPTION
The submissions.csv.zip exports client audit logs in two ways:

1. It exports each submission's individual client audit log along with other submission attachments (via `SubmissionAttachments.streamForExport()`).
2. It combines all client audit logs into a single CSV file (via `ClientAudits.streamForExport()`).

If we're doing (2), then I think we don't really need to do (1). Exporting both (1) and (2) effectively exports each client audit log twice. For some forms, there can be more client audit log data than actual submission data, in which case exporting both ends up adding quite a bit of redundant data.

Note that the individual client audit logs aren't easily accessible from the .zip. Typically, each client audit log has the same name: audit.csv. That means that each log is written to the same path in the .zip: media/audit.csv. Apparently the .zip spec allows multiple files to be written to the same path, but the end result is that most users won't know how to access these files (or even know that there are multiple files to access). And again, there shouldn't be the need to access the individual files, because they're already combined elsewhere.

This PR excludes individual client audit log attachments from the submissions.csv.zip.

#### What has been done to verify that this works as intended?

I had to change tests in ways that were expected. After making those changes, tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

Just one line changed in lib/, but I'll leave a comment about that line.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Hopefully this PR just reduces the size of the submissions.csv.zip. `SubmissionAttachments.streamForExport()` looks to be used in only one place, the submissions.csv.zip endpoint.

I sort of doubt that anyone is accessing the individual client audit logs in the submissions.csv.zip, in large part because they're not easy to access. If someone really needs to access an individual client audit log, they can still do so using the individual submission attachment endpoint (at least for an unencrypted form).

If this does end up being an issue for someone, we could come back and add a flag to control whether to include individual client audit log attachments. But I think we should start with the simplest approach, which I'm hopeful will be enough.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I don't see client audit logs mentioned in the API docs.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced