### PR TITLE
Validate savetos on structural fields

### DIFF
--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -82,8 +82,11 @@ const _recurseFormFields = (instance, bindings, repeats, selectMultiples, envelo
       if (binding != null) {
         field.type = binding.type || 'unknown'; // binding should have a type.
         const prop = saveToAttr(binding);
-        if (prop)
+        if (prop) {
+          if (Array.from(repeats).find((repeat) => bindingPath.startsWith(repeat)))
+            throw Problem.user.invalidEntityForm({ reason: 'Currently, entities cannot be populated from fields in repeat groups.' });
           field.propertyName = binding[prop];
+        }
       } else if (tag.children != null) {
         // if we have no binding node but we have children, assume this is a
         // structural node with no repeat or direct data binding; recurse.

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -2080,98 +2080,6 @@ describe('datasets and entities', () => {
           });
       }));
 
-      it.skip('should not break when a saveto/bind is on a field inside a repeat group', testService(async (service, container) => {
-        // Entities made from repeat groups are not yet supported. pyxform throws an error but central does not.
-        // When parsing the corresponding submission, it will pick the last item in the repeat group.
-        const form = `<?xml version="1.0"?>
-        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:entities="http://www.opendatakit.org/xforms/entities" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-          <h:head>
-            <h:title>Repeat Children Entities</h:title>
-            <model entities:entities-version="2022.1.0" odk:xforms-version="1.0.0">
-              <instance>
-                <data id="repeat_entity" version="2">
-                  <num_children/>
-                  <child jr:template="">
-                    <child_name/>
-                  </child>
-                  <child>
-                    <child_name/>
-                  </child>
-                  <meta>
-                    <instanceID/>
-                    <instanceName/>
-                    <entity create="1" dataset="children" id="">
-                      <label/>
-                    </entity>
-                  </meta>
-                </data>
-              </instance>
-              <bind entities:saveto="num_children" nodeset="/data/num_children" type="int"/>
-              <bind entities:saveto="child_name" nodeset="/data/child/child_name" type="string"/>
-              <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
-              <bind calculate=" /data/num_children " nodeset="/data/meta/instanceName" type="string"/>
-              <bind calculate="1" nodeset="/data/meta/entity/@create" readonly="true()" type="string"/>
-              <bind nodeset="/data/meta/entity/@id" readonly="true()" type="string"/>
-              <setvalue event="odk-instance-first-load" readonly="true()" ref="/data/meta/entity/@id" type="string" value="uuid()"/>
-              <bind calculate="concat(&quot;Num children:&quot;,  /data/num_children )" nodeset="/data/meta/entity/label" readonly="true()" type="string"/>
-            </model>
-          </h:head>
-          <h:body>
-            <input ref="/data/num_children">
-              <label>Num Children</label>
-            </input>
-            <group ref="/data/child">
-              <label>Child</label>
-              <repeat nodeset="/data/child">
-                <input ref="/data/child/child_name">
-                  <label>Child Name</label>
-                </input>
-              </repeat>
-            </group>
-          </h:body>
-        </h:html>
-        `;
-        const sub = `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="repeat_entity" version="2">
-          <num_children>3</num_children>
-          <child>
-            <child_name>abby</child_name>
-          </child>
-          <child>
-            <child_name>benny</child_name>
-          </child>
-          <child>
-            <child_name>chelsea</child_name>
-          </child>
-          <meta>
-            <instanceID>uuid:05bba3e0-fd3b-415c-9123-0e22f010de80</instanceID>
-            <instanceName>instance name</instanceName>
-            <entity create="1" dataset="children" id="a930397c-9f27-4f52-aed0-bb2d5bf4b018">
-              <label>Num children:3</label>
-            </entity>
-          </meta>
-        </data>`;
-        const alice = await service.login('alice');
-        await alice.post('/v1/projects/1/forms?publish=true')
-          .send(form)
-          .set('Content-Type', 'application/xml')
-          .expect(200);
-        await alice.post('/v1/projects/1/forms/repeat_entity/submissions')
-          .send(sub)
-          .set('Content-Type', 'application/xml')
-          .expect(200);
-        await exhaust(container);
-        await alice.get('/v1/projects/1/datasets/children/entities/a930397c-9f27-4f52-aed0-bb2d5bf4b018')
-          .expect(200)
-          .then(({ body }) => {
-            body.should.be.an.Entity();
-            body.should.have.property('currentVersion').which.is.an.EntityDef();
-            body.currentVersion.should.have.property('data').which.is.eql({
-              num_children: '3',
-              child_name: 'chelsea'
-            });
-          });
-      }));
-
       it('should throw an error when a saveto is on a field inside a repeat group', testService(async (service) => {
         // Entities made from repeat groups are not yet supported. pyxform also throws an error about this.
         const form = `<?xml version="1.0"?>
@@ -2182,9 +2090,6 @@ describe('datasets and entities', () => {
               <instance>
                 <data id="repeat_entity" version="2">
                   <num_children/>
-                  <child jr:template="">
-                    <child_name/>
-                  </child>
                   <child>
                     <child_name/>
                   </child>

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -2030,6 +2030,148 @@ describe('datasets and entities', () => {
             }));
       }));
 
+      it('should ignore a saveto incorrrectly placed on a bind on a structural field', testService(async (service) => {
+        const alice = await service.login('alice');
+        const xml = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+          <h:head>
+            <model entities:entities-version='2022.1.0'>
+              <instance>
+                <data id="validate_structure">
+                  <name/>
+                  <age/>
+                  <group>
+                    <inner_field/>
+                  </group>
+                  <meta>
+                    <entity dataset="things" id="" create="1">
+                      <label/>
+                    </entity>
+                  </meta>
+                </data>
+              </instance>
+              <bind nodeset="/data/name" type="string" entities:saveto="prop1"/>
+              <bind nodeset="/data/group" entities:saveto="prop2"/>
+              <bind nodeset="/data/group/inner_field" type="string" entities:saveto="prop3"/>
+            </model>
+          </h:head>
+        </h:html>`;
+        await alice.post('/v1/projects/1/forms')
+          .send(xml)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await alice.get('/v1/projects/1/forms/validate_structure/draft/dataset-diff')
+          .expect(200)
+          .then(({ body }) => {
+            const { properties } = body[0];
+            properties.length.should.equal(2);
+            properties[0].name.should.equal('prop1');
+            properties[1].name.should.equal('prop3');
+          });
+        await alice.post('/v1/projects/1/forms/validate_structure/draft/publish')
+          .expect(200);
+        await alice.get('/v1/projects/1/datasets/things')
+          .expect(200)
+          .then(({ body }) => {
+            body.name.should.be.eql('things');
+            const { properties } = body;
+            properties.length.should.equal(2);
+            properties[0].name.should.equal('prop1');
+            properties[1].name.should.equal('prop3');
+          });
+      }));
+
+      it('should not break when a saveto/bind is on a field inside a repeat group', testService(async (service, container) => {
+        // Entities made from repeat groups are not yet supported. pyxform throws an error but central does not.
+        // When parsing the corresponding submission, it will pick the last item in the repeat group.
+        const form = `<?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:entities="http://www.opendatakit.org/xforms/entities" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <h:head>
+            <h:title>Repeat Children Entities</h:title>
+            <model entities:entities-version="2022.1.0" odk:xforms-version="1.0.0">
+              <instance>
+                <data id="repeat_entity" version="2">
+                  <num_children/>
+                  <child jr:template="">
+                    <child_name/>
+                  </child>
+                  <child>
+                    <child_name/>
+                  </child>
+                  <meta>
+                    <instanceID/>
+                    <instanceName/>
+                    <entity create="1" dataset="children" id="">
+                      <label/>
+                    </entity>
+                  </meta>
+                </data>
+              </instance>
+              <bind entities:saveto="num_children" nodeset="/data/num_children" type="int"/>
+              <bind entities:saveto="child_name" nodeset="/data/child/child_name" type="string"/>
+              <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+              <bind calculate=" /data/num_children " nodeset="/data/meta/instanceName" type="string"/>
+              <bind calculate="1" nodeset="/data/meta/entity/@create" readonly="true()" type="string"/>
+              <bind nodeset="/data/meta/entity/@id" readonly="true()" type="string"/>
+              <setvalue event="odk-instance-first-load" readonly="true()" ref="/data/meta/entity/@id" type="string" value="uuid()"/>
+              <bind calculate="concat(&quot;Num children:&quot;,  /data/num_children )" nodeset="/data/meta/entity/label" readonly="true()" type="string"/>
+            </model>
+          </h:head>
+          <h:body>
+            <input ref="/data/num_children">
+              <label>Num Children</label>
+            </input>
+            <group ref="/data/child">
+              <label>Child</label>
+              <repeat nodeset="/data/child">
+                <input ref="/data/child/child_name">
+                  <label>Child Name</label>
+                </input>
+              </repeat>
+            </group>
+          </h:body>
+        </h:html>
+        `;
+        const sub = `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="repeat_entity" version="2">
+          <num_children>3</num_children>
+          <child>
+            <child_name>abby</child_name>
+          </child>
+          <child>
+            <child_name>benny</child_name>
+          </child>
+          <child>
+            <child_name>chelsea</child_name>
+          </child>
+          <meta>
+            <instanceID>uuid:05bba3e0-fd3b-415c-9123-0e22f010de80</instanceID>
+            <instanceName>instance name</instanceName>
+            <entity create="1" dataset="children" id="a930397c-9f27-4f52-aed0-bb2d5bf4b018">
+              <label>Num children:3</label>
+            </entity>
+          </meta>
+        </data>`;
+        const alice = await service.login('alice');
+        await alice.post('/v1/projects/1/forms?publish=true')
+          .send(form)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await alice.post('/v1/projects/1/forms/repeat_entity/submissions')
+          .send(sub)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await exhaust(container);
+        await alice.get('/v1/projects/1/datasets/children/entities/a930397c-9f27-4f52-aed0-bb2d5bf4b018')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.an.Entity();
+            body.should.have.property('currentVersion').which.is.an.EntityDef();
+            body.currentVersion.should.have.property('data').which.is.eql({
+              num_children: '3',
+              child_name: 'chelsea'
+            });
+          });
+      }));
+
       it('should publish dataset when any dataset creating form is published', testService(async (service) => {
         const alice = await service.login('alice');
 

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -569,7 +569,7 @@ describe('form schema', () => {
         });
       });
 
-      it.skip('should allow binds on fields in repeats even if functionality is not correct', () => { // gh cb#670
+      it('should reject binds on fields in repeats', () => { // gh cb#670
         const xml = `
           <?xml version="1.0"?>
           <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
@@ -615,64 +615,77 @@ describe('form schema', () => {
               </group>
             </h:body>
           </h:html>`;
-        return getFormFields(xml).then((schema) => {
-          schema.should.eql([
-            { name: 'name', path: '/name', type: 'string', order: 0, propertyName: 'parent_name' },
-            { name: 'children', path: '/children', type: 'structure', order: 1 },
-            { name: 'child', path: '/children/child', type: 'repeat', order: 2 },
-            { name: 'name', path: '/children/child/name', type: 'string', order: 3, propertyName: 'child_name' },
-            { name: 'toy', path: '/children/child/toy', type: 'repeat', order: 4 },
-            { name: 'name', path: '/children/child/toy/name', type: 'string', order: 5 }
-          ]);
-        });
+        return getFormFields(xml).should.be.rejected().then((p) => p.problemCode.should.equal(400.25));
       });
 
-      it('should allow binds on fields in repeats even if functionality is not correct', () => { // gh cb#670
+      it('should reject binds on fields in nested repeats inside groups', () => { // gh cb#670
         const xml = `
-          <?xml version="1.0"?>
-          <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
-            <h:head>
-              <model>
-                <instance>
-                  <data id="form">
-                    <name/>
-                    <children>
-                      <child>
-                        <name/>
-                        <toy>
-                          <name/>
-                        </toy>
-                      </child>
-                    </children>
-                  </data>
-                </instance>
-                <bind nodeset="/data/name" type="string" entities:saveto="parent_name"/>
-                <bind nodeset="/data/children/child/name" type="string" entities:saveto="child_name"/>
-                <bind nodeset="/data/children/child/toy/name" type="string"/>
-              </model>
-            </h:head>
-            <h:body>
-              <input ref="/data/name">
-                <label>What is your name?</label>
-              </input>
+        <?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:entities="http://www.opendatakit.org/xforms/entities" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <h:head>
+            <h:title>Repeat Children Entities</h:title>
+            <model entities:entities-version="2022.1.0" odk:xforms-version="1.0.0">
+              <instance>
+                <data id="repeat_entity" version="1">
+                  <num_children/>
+                  <children>
+                    <child jr:template="">
+                      <child_name/>
+                      <possessions>
+                        <toys jr:template="">
+                          <toy/>
+                        </toys>
+                      </possessions>
+                    </child>
+                  </children>
+                  <meta>
+                    <instanceID/>
+                    <instanceName/>
+                    <entity create="1" dataset="children" id="">
+                      <label/>
+                    </entity>
+                  </meta>
+                </data>
+              </instance>
+              <bind nodeset="/data/num_children" type="int"/>
+              <bind nodeset="/data/children/child/child_name" type="string"/>
+              <bind entities:saveto="toy_name" nodeset="/data/children/child/possessions/toys/toy" type="string"/>
+              <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+              <bind calculate=" /data/num_children " nodeset="/data/meta/instanceName" type="string"/>
+              <bind calculate="1" nodeset="/data/meta/entity/@create" readonly="true()" type="string"/>
+              <bind nodeset="/data/meta/entity/@id" readonly="true()" type="string"/>
+              <setvalue event="odk-instance-first-load" readonly="true()" ref="/data/meta/entity/@id" type="string" value="uuid()"/>
+              <bind calculate="concat(&quot;Num children:&quot;,  /data/num_children )" nodeset="/data/meta/entity/label" readonly="true()" type="string"/>
+            </model>
+          </h:head>
+          <h:body>
+            <input ref="/data/num_children">
+              <label>Num Children</label>
+            </input>
+            <group ref="/data/children">
+              <label>Children</label>
               <group ref="/data/children/child">
                 <label>Child</label>
                 <repeat nodeset="/data/children/child">
-                  <input ref="/data/children/child/name">
-                    <label>What is the child's name?</label>
+                  <input ref="/data/children/child/child_name">
+                    <label>Child Name</label>
                   </input>
-                  <group ref="/data/children/child/toy">
-                    <label>Child</label>
-                    <repeat nodeset="/data/children/child/toy">
-                      <input ref="/data/children/child/toy/name">
-                        <label>What is the toy's name?</label>
-                      </input>
-                    </repeat>
+                  <group ref="/data/children/child/possessions">
+                    <label>Posessions</label>
+                    <group ref="/data/children/child/possessions/toys">
+                      <label>Toys</label>
+                      <repeat nodeset="/data/children/child/possessions/toys">
+                        <input ref="/data/children/child/possessions/toys/toy">
+                          <label>Toy</label>
+                        </input>
+                      </repeat>
+                    </group>
                   </group>
                 </repeat>
               </group>
-            </h:body>
-          </h:html>`;
+            </group>
+          </h:body>
+        </h:html>`;
         return getFormFields(xml).should.be.rejected().then((p) => p.problemCode.should.equal(400.25));
       });
     });


### PR DESCRIPTION
Closes #670 

We had a number of questions from the issue
- What happens if a `saveto` is on a bind for a structural field, like a group or repeat group?

    * Answer: pyxform is more strict than Central when it comes to dataset/entity schemas in form definitions. If you try to put a `saveto` on a structural field, it will return an error like `Groups and repeats can't be saved as entity properties.`

- What does Central currently allow/disallow, given that pyxform is more strict?

    * Answer: Central is looking for binds with `type` attributes and ignoring other kinds of binds. It doesn't disallow them, though, because sometimes a bind might be used on a structural field for handling relevance (see https://github.com/getodk/central-backend/issues/147). 

- What happens when a `saveto` is on a field within a repeat group?

    * Answer: pxyform doesn't allow this and gives the error `Currently, you can't create entities from repeats. You may only specify save_to values for form fields outside of repeats.'`. In Central through v2023.3, the XML parsing allows this and creates a new dataset property. When parsing a corresponding submission, it saves the field value of the _last_ repeat instance into the entity. This PR adds a check that doesn't even let forms that do this be uploaded.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

This PR is mostly formally checking behavior we informally tested earlier when releasing entities. We have also been assuming most everyone working with entities is making forms in a spreadsheet and has had pyxform, which has been stricter than Central, stop them from making these mistakes. 

The only change to the code I made was adding a check to be more like pyxform where savetos on fields in repeats are no longer allowed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It makes XML parsing around datasets a little stricter, but they probably weren't running into these things anyway. 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced