### PR TITLE
Remove entity label from audit log and look up info in database

### DIFF
--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -14,7 +14,7 @@ const { extractEntity, validateEntity } = require('../../data/entity');
 
 // These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
-  table('entities'),
+  table('entities', 'entity'),
   'id',                     'uuid', readable,
   'datasetId',
   'createdAt', readable,    'creatorId', readable,

--- a/lib/model/migrations/20211021-remove-hashes-from-audits.js
+++ b/lib/model/migrations/20211021-remove-hashes-from-audits.js
@@ -8,9 +8,9 @@
 // except according to the terms contained in the LICENSE file.
 
 const up = (db) => db.raw(`
-update audits set details=(details #- '{data,password}')
-  where action='user.create'
-    and details->'data'->'password' is not null`);
+UPDATE audits SET details=(details #- '{data,password}')
+  WHERE action='user.create'
+    AND details->'data'->'password' IS NOT NULL`);
 
 const down = () => {};
 

--- a/lib/model/migrations/20230830-01-remove-entity-label-from-audits.js
+++ b/lib/model/migrations/20230830-01-remove-entity-label-from-audits.js
@@ -1,0 +1,17 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = (db) => db.raw(`
+update audits set details=(details #- '{entity,label}')
+  where action='entity.create'`);
+
+const down = () => {};
+
+module.exports = { up, down };
+

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -9,7 +9,7 @@
 
 const { sql } = require('slonik');
 const { map, mergeLeft } = require('ramda');
-const { Actee, Actor, Audit, Dataset, Form, Project, Submission } = require('../frames');
+const { Actee, Actor, Audit, Dataset, Entity, Form, Project, Submission } = require('../frames');
 const { extender, equals, page, QueryOptions, unjoiner } = require('../../util/db');
 const Option = require('../../util/option');
 const { construct } = require('../../util/util');
@@ -99,7 +99,7 @@ const get = (options = QueryOptions.none) => ({ all }) =>
       return new Audit(row, { actor: row.aux.actor, actee: Option.firstDefined(actees) });
     });
   });
-
+/*
 const _getBySubmissionId = extender(Audit)(Option.of(Actor))((fields, extend, options, submissionId) => sql`
 select ${fields} from audits
   ${extend|| sql`left outer join actors on actors.id=audits."actorId"`}
@@ -108,7 +108,50 @@ select ${fields} from audits
   ${page(options)}`);
 const getBySubmissionId = (submissionId, options) => ({ all }) =>
   _getBySubmissionId(all, options, submissionId);
+*/
 
+// TODO: bring back extender???
+const _getBySubmissionId = (fields, options, submissionId) => sql`
+SELECT ${fields} FROM audits
+  left outer join actors on actors.id=audits."actorId"
+
+  -- if event has entity uuid in details
+  -- TOOD: this isn't the current entity def, it's the linked def...
+  LEFT JOIN entities ON (audits.details->'entityId')::INTEGER = entities.id
+  LEFT JOIN entity_defs AS current_entity_def ON (audits.details->'entityDefId')::INTEGER = current_entity_def.id
+  LEFT JOIN datasets ON entities."datasetId" = datasets.id
+
+  WHERE (audits.details->>'submissionId')::INTEGER = ${submissionId}
+
+  ORDER BY audits."loggedAt" DESC, audits.id DESC
+  ${page(options)}`;
+
+const getBySubmissionId = (entityId, options) => ({ all }) => {
+  const _unjoiner = unjoiner(
+    Audit, Actor,
+    Option.of(Entity), Option.of(Entity.Def.alias('current_entity_def', 'currentVersion')),
+    Option.of(Dataset)
+  );
+  return all(_getBySubmissionId(_unjoiner.fields, options, entityId))
+    .then(map(_unjoiner))
+    .then(map(audit => {
+
+      const entity = audit.aux.entity
+        .map(s => s.withAux('currentVersion', audit.aux.currentVersion))
+        .map(s => s.forApi());
+      const dataset = audit.aux.dataset
+        .map(s => s.forApi());
+
+      const details = mergeLeft(audit.details, {
+        dataset: dataset.orElse(undefined)
+      });
+
+      if (entity.isDefined())
+        details.entity = entity.get();
+
+      return new Audit({ ...audit, details }, { actor: audit.aux.actor });
+    }));
+};
 
 
 const _getByEntityId = (fields, options, entityId) => sql`

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -103,7 +103,7 @@ const get = (options = QueryOptions.none) => ({ all }) =>
 const _getBySubmissionId = extender(Audit)(Option.of(Actor), Option.of(Entity), Option.of(Entity.Def.alias('current_entity_def', 'currentVersion')))((fields, extend, options, submissionId) => sql`
 SELECT ${fields} FROM audits
 ${extend|| sql`
-  left outer join actors on actors.id=audits."actorId"
+  LEFT OUTER JOIN actors ON actors.id=audits."actorId"
 
   -- if event references entityId in details
   LEFT JOIN entities ON (audits.details->'entityId')::INTEGER = entities.id AND entities."deletedAt" IS NULL

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -100,7 +100,7 @@ const get = (options = QueryOptions.none) => ({ all }) =>
     });
   });
 
-const _getBySubmissionId = extender(Audit)(Option.of(Actor), Option.of(Entity), Option.of(Entity.Def.alias('current_entity_def', 'currentVersion')), Option.of(Dataset))((fields, extend, options, submissionId) => sql`
+const _getBySubmissionId = extender(Audit)(Option.of(Actor), Option.of(Entity), Option.of(Entity.Def.alias('current_entity_def', 'currentVersion')))((fields, extend, options, submissionId) => sql`
 SELECT ${fields} FROM audits
 ${extend|| sql`
   left outer join actors on actors.id=audits."actorId"
@@ -109,7 +109,6 @@ ${extend|| sql`
   LEFT JOIN entities ON (audits.details->'entityId')::INTEGER = entities.id AND entities."deletedAt" IS NULL
   -- join with current entity def even if there is a specific def linked in event
   LEFT JOIN entity_defs AS current_entity_def ON current_entity_def."entityId" = entities.id AND current
-  LEFT JOIN datasets ON entities."datasetId" = datasets.id
 `}
   WHERE (audits.details->>'submissionId')::INTEGER = ${submissionId}
 
@@ -121,21 +120,14 @@ const getBySubmissionId = (submissionId, options) => ({ all }) => _getBySubmissi
     if (audit.aux.entity == null)
       return audit;
 
-    // If an audit event is about an entity, fill in additional details: dataset and full entity
-    const dataset = audit.aux.dataset
-      .map(s => s.forApi());
-    const details = mergeLeft(audit.details, {
-      dataset: dataset.orElse(undefined)
-    });
-
-    const entity = audit.aux.entity
+    // If an audit event is about an entity, merge in additional entity details
+    const fullEntity = audit.aux.entity
       .map(s => s.withAux('currentVersion', audit.aux.currentVersion))
       .map(s => s.forApi());
 
-    if (entity.isDefined())
-      details.entity = entity.get();
+    const entity = mergeLeft(audit.details.entity, fullEntity.orElse(undefined));
 
-    return new Audit({ ...audit, details }, { actor: audit.aux.actor });
+    return new Audit({ ...audit, details: { ...audit.details, entity } }, { actor: audit.aux.actor });
   }));
 
 

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -99,59 +99,44 @@ const get = (options = QueryOptions.none) => ({ all }) =>
       return new Audit(row, { actor: row.aux.actor, actee: Option.firstDefined(actees) });
     });
   });
-/*
-const _getBySubmissionId = extender(Audit)(Option.of(Actor))((fields, extend, options, submissionId) => sql`
-select ${fields} from audits
-  ${extend|| sql`left outer join actors on actors.id=audits."actorId"`}
-  where (details->'submissionId'::text)=${submissionId}
-  order by "loggedAt" desc, audits.id desc
-  ${page(options)}`);
-const getBySubmissionId = (submissionId, options) => ({ all }) =>
-  _getBySubmissionId(all, options, submissionId);
-*/
 
-// TODO: bring back extender???
-const _getBySubmissionId = (fields, options, submissionId) => sql`
+const _getBySubmissionId = extender(Audit)(Option.of(Actor), Option.of(Entity), Option.of(Entity.Def.alias('current_entity_def', 'currentVersion')), Option.of(Dataset))((fields, extend, options, submissionId) => sql`
 SELECT ${fields} FROM audits
+${extend|| sql`
   left outer join actors on actors.id=audits."actorId"
 
-  -- if event has entity uuid in details
-  -- TOOD: this isn't the current entity def, it's the linked def...
-  LEFT JOIN entities ON (audits.details->'entityId')::INTEGER = entities.id
-  LEFT JOIN entity_defs AS current_entity_def ON (audits.details->'entityDefId')::INTEGER = current_entity_def.id
+  -- if event references entityId in details
+  LEFT JOIN entities ON (audits.details->'entityId')::INTEGER = entities.id AND entities."deletedAt" IS NULL
+  -- join with current entity def even if there is a specific def linked in event
+  LEFT JOIN entity_defs AS current_entity_def ON current_entity_def."entityId" = entities.id AND current
   LEFT JOIN datasets ON entities."datasetId" = datasets.id
-
+`}
   WHERE (audits.details->>'submissionId')::INTEGER = ${submissionId}
 
   ORDER BY audits."loggedAt" DESC, audits.id DESC
-  ${page(options)}`;
+  ${page(options)}`);
 
-const getBySubmissionId = (entityId, options) => ({ all }) => {
-  const _unjoiner = unjoiner(
-    Audit, Actor,
-    Option.of(Entity), Option.of(Entity.Def.alias('current_entity_def', 'currentVersion')),
-    Option.of(Dataset)
-  );
-  return all(_getBySubmissionId(_unjoiner.fields, options, entityId))
-    .then(map(_unjoiner))
-    .then(map(audit => {
+const getBySubmissionId = (submissionId, options) => ({ all }) => _getBySubmissionId(all, options, submissionId)
+  .then(map(audit => {
+    if (audit.aux.entity == null)
+      return audit;
 
-      const entity = audit.aux.entity
-        .map(s => s.withAux('currentVersion', audit.aux.currentVersion))
-        .map(s => s.forApi());
-      const dataset = audit.aux.dataset
-        .map(s => s.forApi());
+    // If an audit event is about an entity, fill in additional details: dataset and full entity
+    const dataset = audit.aux.dataset
+      .map(s => s.forApi());
+    const details = mergeLeft(audit.details, {
+      dataset: dataset.orElse(undefined)
+    });
 
-      const details = mergeLeft(audit.details, {
-        dataset: dataset.orElse(undefined)
-      });
+    const entity = audit.aux.entity
+      .map(s => s.withAux('currentVersion', audit.aux.currentVersion))
+      .map(s => s.forApi());
 
-      if (entity.isDefined())
-        details.entity = entity.get();
+    if (entity.isDefined())
+      details.entity = entity.get();
 
-      return new Audit({ ...audit, details }, { actor: audit.aux.actor });
-    }));
-};
+    return new Audit({ ...audit, details }, { actor: audit.aux.actor });
+  }));
 
 
 const _getByEntityId = (fields, options, entityId) => sql`

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -74,7 +74,7 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
     return log('entity.create', dataset, {
       entityId: newEntity.id, // Added in v2023.3 and backfilled
       entityDefId: newEntity.aux.currentVersion.id, // Added in v2023.3 and backfilled
-      entity: { uuid: newEntity.uuid, dataset: dataset.name } // label removed in 2023.4
+      entity: { uuid: newEntity.uuid, dataset: dataset.name }
     });
 };
 createNew.audit.withResult = true;
@@ -158,7 +158,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
     {
       entityId: entity.id, // Added in v2023.3 and backfilled
       entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 and backfilled
-      entity: { uuid: entity.uuid, dataset: dataset.name }, // label removed in 2023.4
+      entity: { uuid: entity.uuid, dataset: dataset.name },
       submissionId,
       submissionDefId
     });

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -74,7 +74,7 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
     return log('entity.create', dataset, {
       entityId: newEntity.id, // Added in v2023.3 and backfilled
       entityDefId: newEntity.aux.currentVersion.id, // Added in v2023.3 and backfilled
-      entity: { uuid: newEntity.uuid, label: newEntity.aux.currentVersion.label, dataset: dataset.name }
+      entity: { uuid: newEntity.uuid, dataset: dataset.name } // label removed in 2023.4
     });
 };
 createNew.audit.withResult = true;
@@ -158,7 +158,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
     {
       entityId: entity.id, // Added in v2023.3 and backfilled
       entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 and backfilled
-      entity: { uuid: entity.uuid, label: entity.aux.currentVersion.label, dataset: dataset.name },
+      entity: { uuid: entity.uuid, dataset: dataset.name }, // label removed in 2023.4
       submissionId,
       submissionDefId
     });

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -3012,7 +3012,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                 body[2].details.should.eql({ instanceId: 'one', submissionId, submissionDefId: submissionDefIds[1] });
               }))))));
 
-    it.skip('should not expand actor when not extended', testService((service) =>
+    it('should not expand actor when not extended', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms/simple/submissions')
           .send(testData.instances.simple.one)

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -3068,7 +3068,6 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             entityCreate.details.entity.uuid.should.equal('12345678-1234-4123-8234-123456789abc');
             entityCreate.details.entity.should.be.an.Entity();
             entityCreate.details.entity.currentVersion.should.be.an.EntityDef();
-            entityCreate.details.dataset.should.be.a.Dataset();
           });
       }));
 
@@ -3092,7 +3091,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             const entityCreate = body[0];
             entityCreate.details.entity.uuid.should.equal('12345678-1234-4123-8234-123456789abc');
             entityCreate.details.entity.dataset.should.equal('people');
-            entityCreate.details.should.not.have.property('dataset');
+            entityCreate.details.entity.should.not.have.property('currentVersion');
           });
       }));
 
@@ -3147,7 +3146,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             const entityCreate = body[0];
             entityCreate.details.entity.uuid.should.equal('12345678-1234-4123-8234-123456789abc');
             entityCreate.details.entity.dataset.should.equal('people');
-            entityCreate.details.should.not.have.property('dataset');
+            entityCreate.details.entity.should.not.have.property('currentVersion');
             entityCreate.details.entity.should.not.be.an.Entity();
           });
       }));

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -244,7 +244,6 @@ describe('worker: entity', () => {
       createEvent.details.submissionId.should.equal(updateEvent.details.submissionId);
 
       // should contain information about entity
-      createEvent.details.entity.label.should.equal('Alice (88)');
       createEvent.details.entity.dataset.should.equal('people');
       createEvent.details.entity.uuid.should.equal('12345678-1234-4123-8234-123456789abc');
 


### PR DESCRIPTION
Backend part of issue #822 
Frontend PR [here](https://github.com/getodk/central-frontend/pull/850) (Makes small change on frontend to look up `label` from a new place.)

In the same way we look up current information about a submission when we get audit log events for a specific entity (so we can appropriately handle deleted submissions), this does the same thing for entity information.

Previously, the details for an event like `entity.create` contained an `entity` object with `uuid`, `dataset`, _and_ `label`. 

`label` has been removed, so the audit details only contain `uuid` and `dataset` but default.

But through the `getBySubmissionId` query, for events about entities, `details.entity` contains entity data populated from the database. This object has the same structure you'd see elsewhere in the API for getting details about an `entity`, but with the additional `dataset` property that was already in the audit event details. 

```
...
    'action': 'entity.create',
    'details': {'entity': {'createdAt': '2023-08-30T19:16:38.812Z',
                         'creatorId': 5,
                         'currentVersion': {'createdAt': '2023-08-30T19:16:38.812Z',
                                            'creatorId': 5,
                                            'current': True,
                                            'data': {'circumference_cm': '333',
                                                     'geometry': '44.296333 '
                                                                 '-75.364095 0 '
                                                                 '0',
                                                     'species': 'purpleheart'},
                                            'label': '333cm purpleheart',
                                            'userAgent': 'Enketo/6.2.2 '
                                                         'Mozilla/5.0 '
                                                         '(Macintosh; Intel '
                                                         'Mac OS X 10_15_7) '
                                                         'AppleWebKit/537.36 '
                                                         '(KHTML, like Gecko) '
                                                         'Chrome/116.0.0.0 '
                                                         'Safari/537.36'},
                         'dataset': 'trees',
                         'deletedAt': None,
                         'updatedAt': None,
                         'uuid': 'f08a4912-1c45-4dc5-a27a-36a6bb5d2638'},
              'entityDefId': 2,
              'entityId': 2,
              'submissionDefId': 2,
              'submissionId': 2},
...
```

If the entity has been soft deleted or purged, OR if the request is NOT EXTENDED, the details will look like this (closer to how they looked before but now without `label`):
```
'details': {'entity': {'dataset': 'trees',
                     'uuid': 'f08a4912-1c45-4dc5-a27a-36a6bb5d2638'},
          'entityDefId': 2,
          'entityId': 2,
          'submissionDefId': 2,
          'submissionId': 2},
```

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Follows a similar pattern as submission events for entities. Adds more useful info.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Going to make a change on frontend so deleted entities are displayed differently and dont have broken links.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I think this kind of detail about audit log event details isn't documented.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced