### PR TITLE
fixes #464: always return source forms

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -259,8 +259,20 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
       AND ds."publishedAt" IS NOT NULL
   `;
 
+  const _getSourceForms = (datasetName, projectId) => sql`
+    SELECT DISTINCT f."xmlFormId", coalesce(fd.name, f."xmlFormId") "name" FROM datasets ds
+    JOIN dataset_form_defs dfd ON ds.id = dfd."datasetId"    
+    JOIN form_defs fd ON dfd."formDefId" = fd.id
+    JOIN forms f ON fd.id = f."currentDefId"
+    WHERE ds.name = ${datasetName}
+      AND ds."projectId" = ${projectId}
+      AND ds."publishedAt" IS NOT NULL
+      AND f."deletedAt" IS NULL
+  `;
+
   const properties = await Datasets.getProperties(dataset.id, true);
   const linkedForms = await all(_getLinkedForms(dataset.name, dataset.projectId));
+  const sourceForms = await all(_getSourceForms(dataset.name, dataset.projectId));
 
   const propertiesMap = new Map();
   for (const property of properties) {
@@ -290,6 +302,7 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
   return {
     ...dataset.forApi(),
     linkedForms,
+    sourceForms,
     properties: Array.from(propertiesMap.values())
   };
 };

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -891,7 +891,7 @@ describe('datasets and entities', () => {
           });
       }));
 
-      // bug #464
+      // bug central#464
       it('should return source form that does not set any property', testService(async (service) => {
         const asAlice = await service.login('alice');
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -541,7 +541,7 @@ describe('datasets and entities', () => {
           .expect(200)
           .then(({ body }) => {
 
-            const { createdAt, linkedForms, properties, ...ds } = body;
+            const { createdAt, linkedForms, properties, sourceForms, ...ds } = body;
 
             ds.should.be.eql({
               name: 'people',
@@ -552,6 +552,10 @@ describe('datasets and entities', () => {
             createdAt.should.not.be.null();
 
             linkedForms.should.be.eql([{ name: 'withAttachments', xmlFormId: 'withAttachments' }]);
+
+            sourceForms.should.be.eql([
+              { name: 'simpleEntity', xmlFormId: 'simpleEntity' },
+              { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' } ]);
 
             properties.map(({ publishedAt, ...p }) => {
               publishedAt.should.be.isoDate();
@@ -885,6 +889,23 @@ describe('datasets and entities', () => {
               }
             ]);
           });
+      }));
+
+      // bug #464
+      it('should return source form that does not set any property', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity.replace(/entities:saveto.*/g, '/>'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/people')
+          .expect(200)
+          .then(({ body }) => {
+            body.sourceForms.should.be.eql([ { name: 'simpleEntity', xmlFormId: 'simpleEntity' } ]);
+          });
+
       }));
 
     });


### PR DESCRIPTION
Closes getodk/central#464

#### What has been done to verify that this works as intended?

Integration tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

This is the simplest solution, other thing that could do was return properties without forms and a separate field to specify relation between sourceForm and properties

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Should be done in #949 

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced