### PR TITLE
eslint: remove ignore directives for import/no-dynamic-require

### DIFF
--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -4,7 +4,6 @@ const { sql } = require('slonik');
 const { plain } = require('../../util/util');
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 const submitThree = (asAlice) =>

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -9,10 +9,8 @@ const should = require('should');
 const { sql } = require('slonik');
 const { QueryOptions } = require('../../../lib/util/db');
 
-/* eslint-disable import/no-dynamic-require */
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 const Option = require(appRoot + '/lib/util/option');
-/* eslint-enable import/no-dynamic-require */
 
 describe('datasets and entities', () => {
   describe('listing and downloading datasets', () => {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -3,9 +3,7 @@ const { testService } = require('../setup');
 const testData = require('../../data/xml');
 const { sql } = require('slonik');
 
-/* eslint-disable import/no-dynamic-require */
 const { exhaust } = require(appRoot + '/lib/worker/worker');
-/* eslint-enable import/no-dynamic-require */
 
 const testDataset = (test) => testService(async (service, container) => {
   const asAlice = await service.login('alice');

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -3,7 +3,6 @@ const appRoot = require('app-root-path');
 const should = require('should');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 const { sql } = require('slonik');
 

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -7,7 +7,6 @@ const superagent = require('superagent');
 const { DateTime } = require('luxon');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 describe('api: /projects/:id/forms (create, read, update)', () => {

--- a/test/integration/api/forms/versions.js
+++ b/test/integration/api/forms/versions.js
@@ -6,7 +6,6 @@ const { sql } = require('slonik');
 const superagent = require('superagent');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 describe('api: /projects/:id/forms (versions)', () => {

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -4,7 +4,6 @@ const { sql } = require('slonik');
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
 const { QueryOptions } = require('../../../lib/util/db');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 describe('api: /projects', () => {

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -7,9 +7,7 @@ const { testService } = require('../setup');
 const testData = require('../../data/xml');
 const { pZipStreamToFiles } = require('../../util/zip');
 const { map } = require('ramda');
-// eslint-disable-next-line import/no-dynamic-require
 const { Form } = require(appRoot + '/lib/model/frames');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 // utilities used for versioning instances

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -1,6 +1,5 @@
 const appRoot = require('app-root-path');
 const should = require('should');
-// eslint-disable-next-line import/no-dynamic-require
 const { getOrNotFound } = require(appRoot + '/lib/util/promise');
 const { testService } = require('../setup');
 

--- a/test/integration/fixtures/01-users.js
+++ b/test/integration/fixtures/01-users.js
@@ -1,7 +1,5 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { User, Actor, Project } = require(appRoot + '/lib/model/frames');
-// eslint-disable-next-line import/no-dynamic-require
 const { mapSequential } = require(appRoot + '/test/util/util');
 
 module.exports = ({ Assignments, Users, Projects, bcrypt }) => {

--- a/test/integration/fixtures/02-forms.js
+++ b/test/integration/fixtures/02-forms.js
@@ -1,8 +1,6 @@
 
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { mapSequential } = require(appRoot + '/test/util/util');
-// eslint-disable-next-line import/no-dynamic-require
 const { Form } = require(appRoot + '/lib/model/frames');
 const { simple, withrepeat } = require('../../data/xml').forms;
 const forms = [ simple, withrepeat ];

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -3,7 +3,6 @@ const { sql } = require('slonik');
 const { testService, testContainer } = require('../setup');
 const { createReadStream } = require('fs');
 const testData = require('../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 const geoForm = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">

--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -2,17 +2,11 @@ const appRoot = require('app-root-path');
 const { readFileSync } = require('fs');
 const { sql } = require('slonik');
 const { toText } = require('streamtest').v2;
-// eslint-disable-next-line import/no-dynamic-require
 const { testService, testContainerFullTrx, testContainer } = require(appRoot + '/test/integration/setup');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { pZipStreamToFiles } = require(appRoot + '/test/util/zip');
-// eslint-disable-next-line import/no-dynamic-require
 const { Form, Key, Submission } = require(appRoot + '/lib/model/frames');
-// eslint-disable-next-line import/no-dynamic-require
 const { mapSequential } = require(appRoot + '/test/util/util');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 describe('managed encryption', () => {
@@ -80,9 +74,7 @@ describe('managed encryption', () => {
   });
 
   describe('decryptor', () => {
-    // eslint-disable-next-line import/no-dynamic-require
     const { makePubkey, encryptInstance } = require(appRoot + '/test/util/crypto-odk');
-    // eslint-disable-next-line import/no-dynamic-require
     const { generateManagedKey, stripPemEnvelope } = require(appRoot + '/lib/util/crypto');
 
     it('should give a decryptor for the given passphrases', testService((service, { Keys }) =>
@@ -156,7 +148,6 @@ describe('managed encryption', () => {
   });
 
   describe('end-to-end', () => {
-    // eslint-disable-next-line import/no-dynamic-require
     const { extractPubkey, extractVersion, encryptInstance, sendEncrypted, internal } = require(appRoot + '/test/util/crypto-odk');
 
     describe('odk encryption simulation', () => {
@@ -164,7 +155,6 @@ describe('managed encryption', () => {
       // ODK Collect client encryption, i wouldn't feel right not.. testing.. the
       // test code....
       describe('oaep padding', () => {
-        // eslint-disable-next-line import/no-dynamic-require
         const { unpadPkcs1OaepMgf1Sha256 } = require(appRoot + '/lib/util/quarantine/oaep');
         it('should survive a round-trip', () => {
           const input = Buffer.from('0102030405060708090a0b0c0d0e0f1112131415161718191a1b1c1d1e1f2021', 'hex');

--- a/test/integration/other/form-purging.js
+++ b/test/integration/other/form-purging.js
@@ -3,7 +3,6 @@ const appPath = require('app-root-path');
 const { sql } = require('slonik');
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appPath + '/lib/worker/worker');
 
 

--- a/test/integration/other/form-versioning.js
+++ b/test/integration/other/form-versioning.js
@@ -2,7 +2,6 @@ const appPath = require('app-root-path');
 const should = require('should');
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { Blob, Form } = require(appPath + '/lib/model/frames');
 
 describe('form forward versioning', () => {

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -4,9 +4,7 @@ const uuid = require('uuid').v4;
 const config = require('config');
 const { testContainerFullTrx, testServiceFullTrx } = require('../setup');
 const { sql } = require('slonik');
-// eslint-disable-next-line import/no-dynamic-require
 const { Actor, Config } = require(appRoot + '/lib/model/frames');
-// eslint-disable-next-line import/no-dynamic-require
 const { withDatabase } = require(appRoot + '/lib/model/migrate');
 const testData = require('../../data/xml');
 const populateUsers = require('../fixtures/01-users');

--- a/test/integration/other/select-many.js
+++ b/test/integration/other/select-many.js
@@ -2,7 +2,6 @@ const appRoot = require('app-root-path');
 const { sql } = require('slonik');
 const { testService } = require('../setup');
 const testData = require('../../data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 describe('select many value processing', () => {

--- a/test/integration/other/transactions.js
+++ b/test/integration/other/transactions.js
@@ -1,16 +1,10 @@
 const appRoot = require('app-root-path');
 const { sql } = require('slonik');
-// eslint-disable-next-line import/no-dynamic-require
 const { testContainerFullTrx } = require(appRoot + '/test/integration/setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
-// eslint-disable-next-line import/no-dynamic-require
 const { Frame } = require(appRoot + '/lib/model/frame');
-// eslint-disable-next-line import/no-dynamic-require
 const { injector } = require(appRoot + '/lib/model/container');
-// eslint-disable-next-line import/no-dynamic-require
 const { endpointBase } = require(appRoot + '/lib/http/endpoint');
-// eslint-disable-next-line import/no-dynamic-require
 const { noop } = require(appRoot + '/lib/util/util');
 
 describe('transaction integration', () => {

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -5,22 +5,18 @@ const { readdirSync } = require('fs');
 const { join } = require('path');
 const request = require('supertest');
 const { noop } = require(appRoot + '/lib/util/util');
-// eslint-disable-next-line import/no-dynamic-require
 const { task } = require(appRoot + '/lib/task/task');
 
 // knex things.
 const config = require('config');
-// eslint-disable-next-line import/no-dynamic-require
 const { connect } = require(appRoot + '/lib/model/migrate');
 
 // slonik connection pool
-// eslint-disable-next-line import/no-dynamic-require
 const { slonikPool } = require(appRoot + '/lib/external/slonik');
 const db = slonikPool(config.get('test.database'));
 
 // set up our mailer.
 const env = config.get('default.env');
-// eslint-disable-next-line import/no-dynamic-require
 const { mailer } = require(appRoot + '/lib/external/mail');
 const mailConfig = config.get('test.email');
 const mail = mailer(mergeRight(mailConfig, env));
@@ -29,27 +25,22 @@ if (mailConfig.transport !== 'json')
   console.error('WARNING: some tests will not work except with a JSON email transport configuration.');
 
 // set up our xlsform-api mock.
-// eslint-disable-next-line import/no-dynamic-require
 const xlsform = require(appRoot + '/test/util/xlsform');
 
 // set up our sentry mock.
-// eslint-disable-next-line import/no-dynamic-require
 const Sentry = require(appRoot + '/lib/external/sentry').init();
 
 // set up our bcrypt module; possibly mock or not based on params.
 const _bcrypt = (process.env.BCRYPT === 'no')
   ? require('../util/bcrypt-mock')
   : require('bcrypt');
-// eslint-disable-next-line import/no-dynamic-require
 const bcrypt = require(appRoot + '/lib/util/crypto').password(_bcrypt);
 
 // set up our enketo mock.
-// eslint-disable-next-line import/no-dynamic-require
 const { reset: resetEnketo, ...enketo } = require(appRoot + '/test/util/enketo');
 beforeEach(resetEnketo);
 
 // set up odk analytics mock.
-// eslint-disable-next-line import/no-dynamic-require
 const { ODKAnalytics } = require(appRoot + '/test/util/odk-analytics-mock');
 const odkAnalytics = new ODKAnalytics();
 
@@ -57,9 +48,7 @@ const odkAnalytics = new ODKAnalytics();
 const context = { query: {}, transitoryData: new Map(), headers: [] };
 
 // application things.
-// eslint-disable-next-line import/no-dynamic-require
 const { withDefaults } = require(appRoot + '/lib/model/container');
-// eslint-disable-next-line import/no-dynamic-require
 const service = require(appRoot + '/lib/http/service');
 
 // get all our fixture scripts, and set up a function that runs them all.

--- a/test/integration/task/account.js
+++ b/test/integration/task/account.js
@@ -1,11 +1,8 @@
 const appRoot = require('app-root-path');
 const should = require('should');
 const { testTask } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { getOrNotFound } = require(appRoot + '/lib/util/promise');
-// eslint-disable-next-line import/no-dynamic-require
 const { createUser, promoteUser, setUserPassword } = require(appRoot + '/lib/task/account');
-// eslint-disable-next-line import/no-dynamic-require
 const { User } = require(appRoot + '/lib/model/frames');
 
 describe('task: accounts', () => {

--- a/test/integration/task/analytics.js
+++ b/test/integration/task/analytics.js
@@ -1,7 +1,6 @@
 const appRoot = require('app-root-path');
 const should = require('should');
 const { testTask } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { runAnalytics } = require(appRoot + '/lib/task/analytics');
 
 describe('task: analytics', () => {

--- a/test/integration/task/config.js
+++ b/test/integration/task/config.js
@@ -1,8 +1,6 @@
 const appRoot = require('app-root-path');
 const { testTask } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { getOrNotFound } = require(appRoot + '/lib/util/promise');
-// eslint-disable-next-line import/no-dynamic-require
 const { getConfiguration, setConfiguration } = require(appRoot + '/lib/task/config');
 
 describe('task: config', () => {

--- a/test/integration/task/fs.js
+++ b/test/integration/task/fs.js
@@ -5,9 +5,7 @@ const { join } = require('path');
 const tmp = require('tmp');
 const archiver = require('archiver');
 const { testTask } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { generateManagedKey } = require(appRoot + '/lib/util/crypto');
-// eslint-disable-next-line import/no-dynamic-require
 const { encryptToArchive, decryptFromArchive } = require(appRoot + '/lib/task/fs');
 
 describe('task: fs', () => {

--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -1,6 +1,5 @@
 const appRoot = require('app-root-path');
 const { testTask } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { purgeForms } = require(appRoot + '/lib/task/purge');
 
 // The basics of this task are tested here, including returning the count

--- a/test/integration/task/reap-sessions.js
+++ b/test/integration/task/reap-sessions.js
@@ -1,9 +1,7 @@
 const appRoot = require('app-root-path');
 const { sql } = require('slonik');
 const { testTask } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { reapSessions } = require(appRoot + '/lib/task/reap-sessions');
-// eslint-disable-next-line import/no-dynamic-require
 const { Actor } = require(appRoot + '/lib/model/frames');
 
 describe('task: reap-sessions', () => {

--- a/test/integration/task/task.js
+++ b/test/integration/task/task.js
@@ -5,9 +5,7 @@ const { writeFile, symlink } = require('fs');
 const { join } = require('path');
 const { exec } = require('child_process');
 const { identity } = require('ramda');
-// eslint-disable-next-line import/no-dynamic-require
 const { auditing, emailing } = require(appRoot + '/lib/task/task');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
 const tmp = require('tmp');
 

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -4,9 +4,7 @@ const should = require('should');
 
 const { testService } = require('../setup');
 const { QueryOptions } = require('../../../lib/util/db');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml.js');
-// eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 

--- a/test/integration/worker/submission.attachment.update.js
+++ b/test/integration/worker/submission.attachment.update.js
@@ -2,9 +2,7 @@ const appRoot = require('app-root-path');
 const { createReadStream } = require('fs');
 const { sql } = require('slonik');
 const { testService } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml.js');
-// eslint-disable-next-line import/no-dynamic-require
 const worker = require(appRoot + '/lib/worker/submission.attachment.update');
 
 describe('worker: submission.attachment.update', () => {

--- a/test/integration/worker/worker.js
+++ b/test/integration/worker/worker.js
@@ -4,11 +4,8 @@ const { promisify } = require('util');
 const { DateTime, Duration } = require('luxon');
 const { sql } = require('slonik');
 const { testContainerFullTrx, testContainer } = require('../setup');
-// eslint-disable-next-line import/no-dynamic-require
 const { runner, checker, worker } = require(appRoot + '/lib/worker/worker');
-// eslint-disable-next-line import/no-dynamic-require
 const { Audit } = require(appRoot + '/lib/model/frames');
-// eslint-disable-next-line import/no-dynamic-require
 const { insert } = require(appRoot + '/lib/util/db');
 
 describe('worker', () => {

--- a/test/unit/data/analytics.js
+++ b/test/unit/data/analytics.js
@@ -1,7 +1,5 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { buildSubmission, convertObjectToXml, metaWithUuidXml } = require(appRoot + '/lib/data/analytics');
-// eslint-disable-next-line import/no-dynamic-require
 const { Submission } = require(appRoot + '/lib/model/frames');
 
 const data = {

--- a/test/unit/data/attachments.js
+++ b/test/unit/data/attachments.js
@@ -1,10 +1,7 @@
 const appRoot = require('app-root-path');
 const streamTest = require('streamtest').v2;
-// eslint-disable-next-line import/no-dynamic-require
 const { zipStreamToFiles } = require(appRoot + '/test/util/zip');
-// eslint-disable-next-line import/no-dynamic-require
 const { streamAttachments } = require(appRoot + '/lib/data/attachments');
-// eslint-disable-next-line import/no-dynamic-require
 const { zipStreamFromParts } = require(appRoot + '/lib/util/zip');
 
 describe('.zip attachments streaming', () => {

--- a/test/unit/data/briefcase.js
+++ b/test/unit/data/briefcase.js
@@ -1,15 +1,10 @@
 const appRoot = require('app-root-path');
 const uuid = require('uuid').v4;
 const streamTest = require('streamtest').v2;
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const { zipStreamToFiles } = require(appRoot + '/test/util/zip');
-// eslint-disable-next-line import/no-dynamic-require
 const { fieldsFor } = require(appRoot + '/test/util/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const { streamBriefcaseCsvs } = require(appRoot + '/lib/data/briefcase');
-// eslint-disable-next-line import/no-dynamic-require
 const { zipStreamFromParts } = require(appRoot + '/lib/util/zip');
 
 

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -1,14 +1,9 @@
 const appRoot = require('app-root-path');
 const should = require('should');
-// eslint-disable-next-line import/no-dynamic-require
 const { getFormFields } = require(appRoot + '/lib/data/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const { getDataset, validateDatasetName, validatePropertyName } = require(appRoot + '/lib/data/dataset');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
-// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
 
 describe('parsing dataset from entity block', () => {

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -1,11 +1,8 @@
 const should = require('should');
 const appRoot = require('app-root-path');
 const assert = require('assert');
-// eslint-disable-next-line import/no-dynamic-require
 const { parseSubmissionXml, extractEntity, validateEntity, extractSelectedProperties, selectFields, diffEntityData } = require(appRoot + '/lib/data/entity');
-// eslint-disable-next-line import/no-dynamic-require
 const { fieldsFor } = require(appRoot + '/test/util/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
 
 describe('extracting entities from submissions', () => {

--- a/test/unit/data/odata-filter.js
+++ b/test/unit/data/odata-filter.js
@@ -10,10 +10,8 @@
 const appRoot = require('app-root-path');
 const assert = require('assert');
 const { sql } = require('slonik');
-/* eslint-disable import/no-dynamic-require */
 const { odataFilter: _odataFilter } = require(appRoot + '/lib/data/odata-filter');
 const { odataToColumnMap } = require(appRoot + '/lib/data/submission');
-/* eslint-enable import/no-dynamic-require */
 
 const odataFilter = (exp) => _odataFilter(exp, odataToColumnMap);
 

--- a/test/unit/data/odata.js
+++ b/test/unit/data/odata.js
@@ -1,11 +1,7 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { submissionToOData } = require(appRoot + '/lib/data/odata');
-// eslint-disable-next-line import/no-dynamic-require
 const { selectFields } = require(appRoot + '/lib/formats/odata');
-// eslint-disable-next-line import/no-dynamic-require
 const { MockField, fieldsFor } = require(appRoot + '/test/util/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
 
 const __system = {

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -1,10 +1,7 @@
 const appRoot = require('app-root-path');
 const should = require('should');
-// eslint-disable-next-line import/no-dynamic-require
 const { getFormFields, sanitizeFieldsForOdata, SchemaStack, merge, compare, expectedFormAttachments, injectPublicKey, addVersionSuffix, setVersion } = require(appRoot + '/lib/data/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
 
 describe('form schema', () => {

--- a/test/unit/data/submission.js
+++ b/test/unit/data/submission.js
@@ -2,11 +2,8 @@ require('should');
 const appRoot = require('app-root-path');
 const { filter } = require('ramda');
 const { toObjects } = require('streamtest').v2;
-// eslint-disable-next-line import/no-dynamic-require
 const { submissionXmlToFieldStream, getSelectMultipleResponses, _hashedTree, _diffObj, _diffArray, diffSubmissions, _symbols } = require(appRoot + '/lib/data/submission');
-// eslint-disable-next-line import/no-dynamic-require
 const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
 
 describe('submission field streamer', () => {

--- a/test/unit/external/enketo.js
+++ b/test/unit/external/enketo.js
@@ -1,9 +1,7 @@
 const appRoot = require('app-root-path');
 const nock = require('nock');
 const querystring = require('querystring');
-// eslint-disable-next-line import/no-dynamic-require
 const enketo_ = require(appRoot + '/lib/external/enketo');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
 
 describe('external/enketo', () => {

--- a/test/unit/external/sanitize-sentry.js
+++ b/test/unit/external/sanitize-sentry.js
@@ -1,6 +1,5 @@
 require('should');
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl } = require(appRoot + '/lib/external/sentry');
 
 // These cases are based on real requests!

--- a/test/unit/formats/odata.js
+++ b/test/unit/formats/odata.js
@@ -1,11 +1,8 @@
 const appRoot = require('app-root-path');
 const { getFieldTree, getChildren } = require('../../../lib/formats/odata');
 const streamTest = require('streamtest').v2;
-// eslint-disable-next-line import/no-dynamic-require
 const { serviceDocumentFor, edmxFor, rowStreamToOData, singleRowToOData, selectFields } = require(appRoot + '/lib/formats/odata');
-// eslint-disable-next-line import/no-dynamic-require
 const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
-// eslint-disable-next-line import/no-dynamic-require
 const testData = require(appRoot + '/test/data/xml');
 const should = require('should');
 

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -6,13 +6,9 @@ const streamTest = require('streamtest').v2;
 const { always } = require('ramda');
 
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { endpointBase, defaultErrorWriter, Context, defaultResultWriter, openRosaPreprocessor, openRosaBefore, openRosaResultWriter, openRosaErrorWriter, odataPreprocessor, odataBefore } = require(appRoot + '/lib/http/endpoint');
-// eslint-disable-next-line import/no-dynamic-require
 const { PartialPipe } = require(appRoot + '/lib/util/stream');
-// eslint-disable-next-line import/no-dynamic-require
 const { noop } = require(appRoot + '/lib/util/util');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
 
 const createModernResponse = () => {
@@ -586,7 +582,6 @@ describe('endpoints', () => {
     });
 
     describe('resultWriter', () => {
-      // eslint-disable-next-line import/no-dynamic-require
       const { createdMessage } = require(appRoot + '/lib/formats/openrosa');
 
       it('should send the appropriate content with the appropriate header', () => {

--- a/test/unit/http/middleware.js
+++ b/test/unit/http/middleware.js
@@ -1,9 +1,7 @@
 const { createRequest } = require('node-mocks-http');
 
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const middleware = require(appRoot + '/lib/http/middleware');
-// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
 
 describe('middleware', () => {

--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -2,20 +2,13 @@ const should = require('should');
 const { createRequest } = require('node-mocks-http');
 
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const preprocessors = require(appRoot + '/lib/http/preprocessors');
-// eslint-disable-next-line import/no-dynamic-require
 const { Context } = require(appRoot + '/lib/http/endpoint');
-// eslint-disable-next-line import/no-dynamic-require
 const { Session, User, Actor } = require(appRoot + '/lib/model/frames');
-// eslint-disable-next-line import/no-dynamic-require
 const { by } = require(appRoot + '/lib/model/query/auth');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
-// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
 
-// eslint-disable-next-line import/no-dynamic-require
 const bcrypt = require(appRoot + '/lib/util/crypto').password(require('bcrypt'));
 
 describe('preprocessors', () => {

--- a/test/unit/model/frame.js
+++ b/test/unit/model/frame.js
@@ -1,9 +1,7 @@
 const should = require('should');
 const appRoot = require('app-root-path');
 const { sql } = require('slonik');
-// eslint-disable-next-line import/no-dynamic-require
 const { Frame, table, readable, writable, into, aux, embedded } = require(appRoot + '/lib/model/frame');
-// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
 
 describe('Frame', () => {

--- a/test/unit/model/frames/config.js
+++ b/test/unit/model/frames/config.js
@@ -1,6 +1,5 @@
 const appRoot = require('app-root-path');
 const should = require('should');
-// eslint-disable-next-line import/no-dynamic-require
 const { Config } = require(appRoot + '/lib/model/frames');
 const { plain } = require('../../../util/util');
 

--- a/test/unit/model/frames/entity.js
+++ b/test/unit/model/frames/entity.js
@@ -1,5 +1,4 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { Entity } = require(appRoot + '/lib/model/frames');
 
 describe('entity', () => {

--- a/test/unit/model/frames/form.js
+++ b/test/unit/model/frames/form.js
@@ -1,5 +1,4 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { Form, Key } = require(appRoot + '/lib/model/frames');
 
 describe('Form', () => {

--- a/test/unit/model/frames/submission.js
+++ b/test/unit/model/frames/submission.js
@@ -1,5 +1,4 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { Submission } = require(appRoot + '/lib/model/frames');
 const streamTest = require('streamtest').v2;
 

--- a/test/unit/problem.js
+++ b/test/unit/problem.js
@@ -1,5 +1,4 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
 
 // we aren't going to test the many problem types here, only the basic infrastructure.

--- a/test/unit/task/task.js
+++ b/test/unit/task/task.js
@@ -1,8 +1,6 @@
 const appRoot = require('app-root-path');
 const should = require('should');
-// eslint-disable-next-line import/no-dynamic-require
 const { resolve } = require(appRoot + '/lib/util/promise');
-// eslint-disable-next-line import/no-dynamic-require
 const { task } = require(appRoot + '/lib/task/task');
 
 describe('task harness', () => {

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -3,7 +3,6 @@ const { readFileSync } = require('fs');
 const should = require('should');
 const streamTest = require('streamtest').v2;
 const bcrypt = require('bcrypt');
-// eslint-disable-next-line import/no-dynamic-require
 const crypto = require(appRoot + '/lib/util/crypto');
 
 describe('util/crypto', () => {

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -1,13 +1,9 @@
 const appRoot = require('app-root-path');
 const { sql } = require('slonik');
 const { fieldTypes } = require('../../../lib/model/frame');
-// eslint-disable-next-line import/no-dynamic-require
 const { Frame, table, into } = require(appRoot + '/lib/model/frame');
-// eslint-disable-next-line import/no-dynamic-require
 const util = require(appRoot + '/lib/util/db');
-// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
 
 describe('util/db', () => {

--- a/test/unit/util/http.js
+++ b/test/unit/util/http.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const http = require(appRoot + '/lib/util/http');
 
 describe('util/http', () => {

--- a/test/unit/util/promise.js
+++ b/test/unit/util/promise.js
@@ -1,9 +1,6 @@
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { getOrElse, getOrReject, getOrNotFound, timebound, runSequentially } = require(appRoot + '/lib/util/promise');
-// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
 
 describe('getOr', () => {

--- a/test/unit/util/quarantine/oaep.js
+++ b/test/unit/util/quarantine/oaep.js
@@ -1,6 +1,5 @@
 require('should');
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { unpadPkcs1OaepMgf1Sha256 } = require(appRoot + '/lib/util/quarantine/oaep');
 
 describe('crypto: oeap decoding', () => {

--- a/test/unit/util/quarantine/pkcs7.js
+++ b/test/unit/util/quarantine/pkcs7.js
@@ -1,6 +1,5 @@
 require('should');
 const appRoot = require('app-root-path');
-// eslint-disable-next-line import/no-dynamic-require
 const { ge, unpadPkcs7 } = require(appRoot + '/lib/util/quarantine/pkcs7');
 
 describe('crypto: pkcs7 padding decoding', () => {

--- a/test/unit/util/stream.js
+++ b/test/unit/util/stream.js
@@ -1,7 +1,6 @@
 require('should');
 const appPath = require('app-root-path');
 const { Transform } = require('stream');
-// eslint-disable-next-line import/no-dynamic-require
 const { consumeAndBuffer, pipethrough, pipethroughAndBuffer, splitStream, PartialPipe } = require(appPath + '/lib/util/stream');
 const { fromObjects, toObjects } = require('streamtest').v2;
 

--- a/test/unit/util/xml.js
+++ b/test/unit/util/xml.js
@@ -2,9 +2,7 @@ const appRoot = require('app-root-path');
 const streamTest = require('streamtest').v2;
 const { Readable } = require('stream');
 const { always } = require('ramda');
-// eslint-disable-next-line import/no-dynamic-require
 const { traverseXml, Traversal, applyTraversal, findOne, findAll, and, root, node, hasAttr, getAll, attr, text, tree, stripNamespacesFromPath } = require(appRoot + '/lib/util/xml');
-// eslint-disable-next-line import/no-dynamic-require
 const Option = require(appRoot + '/lib/util/option');
 
 const forever = () => forever;

--- a/test/unit/util/zip.js
+++ b/test/unit/util/zip.js
@@ -1,11 +1,8 @@
 const appRoot = require('app-root-path');
 const { createWriteStream } = require('fs');
 const { Transform, Readable } = require('stream');
-// eslint-disable-next-line import/no-dynamic-require
 const { zipStreamToFiles } = require(appRoot + '/test/util/zip');
-// eslint-disable-next-line import/no-dynamic-require
 const { PartialPipe } = require(appRoot + '/lib/util/stream');
-// eslint-disable-next-line import/no-dynamic-require
 const { zipPart, zipStreamFromParts } = require(appRoot + '/lib/util/zip');
 const { fromChunks } = require('streamtest').v2;
 

--- a/test/util/crypto-odk.js
+++ b/test/util/crypto-odk.js
@@ -2,7 +2,6 @@ const appRoot = require('app-root-path');
 const { ceil } = Math;
 const { createPublicKey, publicEncrypt, createHash, randomBytes, createCipheriv } = require('crypto');
 const { RSA_NO_PADDING } = require('crypto').constants;
-// eslint-disable-next-line import/no-dynamic-require
 const { getSubmissionIvs } = require(appRoot + '/lib/util/crypto');
 
 

--- a/test/util/schema.js
+++ b/test/util/schema.js
@@ -1,6 +1,5 @@
 const appRoot = require('app-root-path');
 const { construct } = require('ramda');
-// eslint-disable-next-line import/no-dynamic-require
 const { getFormFields } = require(appRoot + '/lib/data/schema');
 
 // provies a mock FormField instance with its data processing methods, and a boilerplate

--- a/test/util/xlsform.js
+++ b/test/util/xlsform.js
@@ -1,6 +1,5 @@
 const appRoot = require('app-root-path');
 const digest = require('digest-stream');
-// eslint-disable-next-line import/no-dynamic-require
 const Problem = require(appRoot + '/lib/util/problem');
 const testData = require('../data/xml');
 


### PR DESCRIPTION
This rule is now ignored in `test/.eslintrc.js`, so does not need individual ignore directives for every violation.

