### PR TITLE
test/analytics-queries: increase test timeouts

### DIFF
--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -101,7 +101,11 @@ const submitToForm = (service, user, projectId, xmlFormId, xml, deviceId = 'abcd
 ////////////////////////////////////////////////////////////////////////////////
 // Tests!
 ////////////////////////////////////////////////////////////////////////////////
-describe('analytics task queries', () => {
+// eslint-disable-next-line func-names
+describe('analytics task queries', function () {
+  // increasing timeouts on this set of tests
+  this.timeout(8000);
+
   describe('general server metrics', () => {
     it('should count audit log entries', testContainer(async (container) => {
       // recent "now" audits
@@ -887,11 +891,7 @@ describe('analytics task queries', () => {
     }));
   });
 
-  // eslint-disable-next-line space-before-function-paren, func-names
-  describe('combined analytics', function () {
-    // increasing timeouts on this set of tests
-    this.timeout(8000);
-
+  describe('combined analytics', () => {
     it('should combine system level queries', testService(async (service, container) => {
       // encrypting a project
       await service.login('alice', (asAlice) =>


### PR DESCRIPTION
There are failures of these tests in CI due to timeouts.

CircleCI occasionally:

* https://app.circleci.com/pipelines/github/getodk/central-backend/1741/workflows/7d9014c0-3358-42d0-ad81-32dc2a195ebb/jobs/2583

Github Actions frequently:

* https://github.com/alxndrsn/odk-central-backend/actions/runs/6048978821/job/16415366255#step:7:10856
* https://github.com/alxndrsn/odk-central-backend/actions/runs/6049092424/job/16415712862#step:7:10849
* https://github.com/alxndrsn/odk-central-backend/actions/runs/6049135803/job/16415849308#step:7:10842
* https://github.com/alxndrsn/odk-central-backend/actions/runs/6049985595/job/16418307942#step:7:10862
* https://github.com/alxndrsn/odk-central-backend/actions/runs/6049504238/job/16416917068#step:7:10879
* https://github.com/alxndrsn/odk-central-backend/actions/runs/6087419828/job/16515902635#step:7:10869
* https://github.com/alxndrsn/odk-central-backend/actions/runs/6087485126/job/16516120203#step:7:10890
* https://github.com/alxndrsn/odk-central-backend/actions/runs/6087623353/job/16517132146#step:7:10883

Ref: https://github.com/getodk/central-backend/issues/588
