### PR TITLE
Enumerator should be able to access only open Form

### DIFF
--- a/lib/model/migrations/20230907-01-opened-form-verb.js
+++ b/lib/model/migrations/20230907-01-opened-form-verb.js
@@ -1,0 +1,18 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = (db) => db.raw(`
+UPDATE roles SET verbs = REPLACE(verbs ::TEXT, 'form', 'open_form')::JSONB
+WHERE system IN ('app-user', 'formview', 'formfill', 'pub-link')`);
+
+const down = (db) => db.raw(`
+UPDATE roles SET verbs = REPLACE(verbs ::TEXT, 'open_form', 'form')::JSONB
+WHERE system IN ('app-user', 'formview', 'formfill', 'pub-link')`);
+
+module.exports = { up, down };

--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -20,17 +20,21 @@ with recursive implied(id) as (
   (select unnest(ARRAY[ parent, species ]) from actees
     join implied on implied.id=actees.id))`;
 
-const can = (actor, verb, actee) => ({ oneFirst }) => {
+const _verbClause = (verbs) => sql.join(Array.from(verbs).map(v => sql`verbs ? ${v}`), sql` or `);
+
+const can = (actor, verbs, actee) => ({ oneFirst }) => {
   const acteeId = actee.acteeId || actee;
+
+  const verbsSet = new Set(typeof verbs === 'string' ? [verbs] : verbs);
 
   if (actor.acteeId === acteeId) {
     // special privileges actors always get on themselves.
-    if ((verb === 'user.read') || (verb === 'user.update'))
+    if ((verbsSet.has('user.read')) || (verbsSet.has('user.update')))
       return resolve(true);
 
     // all actors except app users can always log themselves out.
     // (public links cannot reach this route.)
-    if ((verb === 'session.end') && (actor.type !== 'field_key'))
+    if ((verbsSet.has('session.end')) && (actor.type !== 'field_key'))
       return resolve(true);
   }
 
@@ -38,7 +42,7 @@ const can = (actor, verb, actee) => ({ oneFirst }) => {
 ${_impliedActees(acteeId)}
 select count(*) from assignments
 inner join implied on implied.id=assignments."acteeId"
-inner join (select id from roles where verbs ? ${verb}) as role on role.id=assignments."roleId"
+inner join (select id from roles where ${_verbClause(verbsSet)}) as role on role.id=assignments."roleId"
 where "actorId"=${actor.id}
 limit 1`)
     .then((count) => count > 0);
@@ -47,6 +51,10 @@ limit 1`)
 const canAssignRole = (actor, role, actee) => ({ Auth }) =>
   Auth.verbsOn(actor.id, actee).then((hasArray) => {
     const has = new Set(hasArray);
+    // `open_form` is subset of `form` so if someone has grant access on `form`
+    // they should be able do it on `open_form` as well
+    if (has.has('form.list')) has.add('open_form.list');
+    if (has.has('form.read')) has.add('open_form.read');
     for (const required of role.verbs) if (!has.has(required)) return false;
     return true;
   });

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -547,7 +547,7 @@ inner join
   on filtered.id=forms."projectId"`}
 where ${equals(options.condition)} and forms."deletedAt" is ${deleted ? sql`not` : sql``} null
 ${(actorId == null) ? sql`` : sql`and (form_defs."publishedAt" is not null or filtered."showDraft" = 1)`}
-${(actorId == null) ? sql`` : sql`and (state not in ('closing', 'closed') or filtered."showNonOpen" = 1)`}
+${(actorId == null) ? sql`` : sql`and (state != 'closed' or filtered."showNonOpen" = 1)`}
 order by coalesce(form_defs.name, "xmlFormId") asc`);
 
 const _getWithoutXml = extender(Form, Form.Def)(Form.Extended, Actor.into('createdBy'))(_getSql);

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -452,7 +452,7 @@ inner join
     inner join projects on projects.id=forms."projectId"
     inner join
       (select "acteeId" from assignments
-        inner join (select id from roles where verbs ? 'form.read') as role
+        inner join (select id from roles where verbs ? 'form.read' or verbs ? 'open_form.read') as role
           on role.id=assignments."roleId"
         where "actorId"=${auth.actor.map((actor) => actor.id).orElse(-1)}) as assignment
       on assignment."acteeId" in ('*', 'form', projects."acteeId", forms."acteeId")
@@ -531,14 +531,14 @@ ${extend|| sql`
     on form_defs.id = dd."formDefId"`}
 ${(actorId == null) ? sql`` : sql`
 inner join
-  (select id, max(assignment."showDraft") as "showDraft" from projects
+  (select id, max(assignment."showDraft") as "showDraft", max(assignment."showNonOpen") as "showNonOpen" from projects
     inner join
-      (select "acteeId", 0 as "showDraft" from assignments
-        inner join (select id from roles where verbs ? 'form.read') as role
+      (select "acteeId", 0 as "showDraft", case when verbs ? 'form.read' then 1 else 0 end as "showNonOpen" from assignments
+        inner join (select id, verbs from roles where verbs ? 'form.read' or verbs ? 'open_form.read') as role
           on role.id=assignments."roleId"
         where "actorId"=${actorId}
       union all
-      select "acteeId", 1 as "showDraft" from assignments
+      select "acteeId", 1 as "showDraft", 1 as "showNonOpen" from assignments
         inner join (select id from roles where verbs ? 'form.update') as role
           on role.id=assignments."roleId"
         where "actorId"=${actorId}) as assignment
@@ -547,6 +547,7 @@ inner join
   on filtered.id=forms."projectId"`}
 where ${equals(options.condition)} and forms."deletedAt" is ${deleted ? sql`not` : sql``} null
 ${(actorId == null) ? sql`` : sql`and (form_defs."publishedAt" is not null or filtered."showDraft" = 1)`}
+${(actorId == null) ? sql`` : sql`and (state not in ('closing', 'closed') or filtered."showNonOpen" = 1)`}
 order by coalesce(form_defs.name, "xmlFormId") asc`);
 
 const _getWithoutXml = extender(Form, Form.Def)(Form.Extended, Actor.into('createdBy'))(_getSql);
@@ -554,8 +555,8 @@ const _getWithXml = extender(Form, Form.Def, Form.Xml)(Form.Extended, Actor.into
 const _get = (exec, options, xml, version, deleted, actorId) =>
   ((xml === true) ? _getWithXml : _getWithoutXml)(exec, options, version, deleted, actorId);
 
-const getByProjectId = (projectId, xml, version, options = QueryOptions.none, deleted = false) => ({ all }) =>
-  _get(all, options.withCondition({ projectId }), xml, version, deleted);
+const getByProjectId = (auth, projectId, xml, version, options = QueryOptions.none, deleted = false) => ({ all }) =>
+  _get(all, options.withCondition({ projectId }), xml, version, deleted, auth.actor.map((actor) => actor.id).orElse(-1));
 const getByProjectAndXmlFormId = (projectId, xmlFormId, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ projectId, xmlFormId }), xml, version, deleted);
 const getByProjectAndNumericId = (projectId, id, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -36,7 +36,7 @@ del.audit = (project) => (log) => log('project.delete', project);
 ////////////////////////////////////////////////////////////////////////////////
 // MANAGED ENCRYPTION
 
-const setManagedEncryption = (project, passphrase, hint) => ({ Forms, Keys, Projects }) => {
+const setManagedEncryption = (project, passphrase, hint, auth) => ({ Forms, Keys, Projects }) => {
   if (project.keyId != null)
     return reject(Problem.user.alreadyActive({ feature: 'managed encryption' }));
   if (isBlank(passphrase))
@@ -53,7 +53,7 @@ const setManagedEncryption = (project, passphrase, hint) => ({ Forms, Keys, Proj
   return generateManagedKey(passphrase)
     .then((keys) => Forms.lockDefs() // lock!
       .then(() => Promise.all([
-        Forms.getByProjectId(project.id, true),
+        Forms.getByProjectId(auth, project.id, true),
         Keys.create(new Key({
           public: stripPemEnvelope(Buffer.from(keys.pubkey, 'base64')),
           private: keys,
@@ -112,7 +112,7 @@ inner join
         where "actorId"=${actorId}) as assignment
       on assignment."acteeId" in ('*', 'project', projects."acteeId")
     group by id
-    having array_agg(distinct verb) @> array['project.read', 'form.list']
+    having array_agg(distinct verb) @> array['project.read', 'form.list'] or array_agg(distinct verb) @> array['project.read', 'open_form.list']
   ) as filtered
 on filtered.id=projects.id
 `}

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -29,6 +29,10 @@ const excelMimeTypes = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 };
 
+const canReadForm = (auth, form) => (form.state === 'open'
+  ? auth.canOrReject(['open_form.read', 'form.read'], form)
+  : auth.canOrReject('form.read', form));
+
 const streamAttachment = async (container, attachment, response) => {
   const { Blobs, Datasets, Entities } = container;
 
@@ -59,8 +63,8 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/forms', endpoint(({ Forms, Projects }, { auth, params, query, queryOptions }) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
-      .then((project) => auth.canOrReject('form.list', project))
-      .then((project) => Forms.getByProjectId(project.id, false, undefined, queryOptions, isTrue(query.deleted)))));
+      .then((project) => auth.canOrReject(['form.list', 'open_form.list'], project))
+      .then((project) => Forms.getByProjectId(auth, project.id, false, undefined, queryOptions, isTrue(query.deleted)))));
 
   // non-REST openrosa endpoint for project-specialized formlist.
   service.get('/projects/:projectId/formList', endpoint.openRosa(({ Forms, Projects, env }, { auth, params, originalUrl, queryOptions }) =>
@@ -251,14 +255,14 @@ module.exports = (service, endpoint) => {
     // get just the XML of the form; used for downloading forms from collect.
     service.get(`${base}.xml`, endpoint(({ Forms }, { params, auth }) =>
       getInstance(Forms, params, true)
-        .then((form) => auth.canOrReject('form.read', form))
+        .then((form) => canReadForm(auth, form))
         .then((form) => xml(form.xml))));
 
     // we could move this up a scope to save a couple instantiations, but really it's
     // not that expensive and it reads more easily here.
     const getXls = (extension) => endpoint(({ Blobs, Forms }, { params, auth }) =>
       getInstance(Forms, params)
-        .then((form) => auth.canOrReject('form.read', form))
+        .then((form) => canReadForm(auth, form))
         .then((form) => ((form.def.xlsBlobId == null)
           ? reject(Problem.user.notFound())
           : Blobs.getById(form.def.xlsBlobId)
@@ -270,19 +274,19 @@ module.exports = (service, endpoint) => {
 
     service.get(`${base}`, endpoint(({ Forms }, { auth, params, queryOptions }) =>
       getInstance(Forms, params, false, queryOptions)
-        .then((form) => auth.canOrReject('form.read', form))));
+        .then((form) => canReadForm(auth, form))));
 
     // returns form fields, optionally sanitizing names to match odata.
     service.get(`${base}/fields`, endpoint(({ Forms }, { params, query, auth }) =>
       getInstance(Forms, params)
-        .then((form) => auth.canOrReject('form.read', form))
+        .then((form) => canReadForm(auth, form))
         .then((form) => Forms.getFields(form.def.id)
           .then(isTrue(query.odata) ? sanitizeFieldsForOdata : identity))));
 
     // non-REST openrosa endpoint for formlist manifest document.
     service.get(`${base}/manifest`, endpoint.openRosa(({ FormAttachments, Forms, env }, { auth, params, originalUrl }) =>
       getInstance(Forms, params)
-        .then((form) => auth.canOrReject('form.read', form))
+        .then((form) => canReadForm(auth, form))
         .then((form) => FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id)
           .then((attachments) =>
             formManifest({ attachments, basePath: path.resolve(originalUrl, '..'), domain: env.domain })))));
@@ -294,13 +298,13 @@ module.exports = (service, endpoint) => {
     // their metadata; they may only update their binary contents.
     service.get(`${base}/attachments`, endpoint(({ FormAttachments, Forms }, { params, auth }) =>
       getInstance(Forms, params)
-        .then((form) => auth.canOrReject('form.read', form))
+        .then((form) => canReadForm(auth, form))
         .then((form) => FormAttachments.getAllByFormDefId(form.def.id))));
 
     service.get(`${base}/attachments/:name`, endpoint((container, { params, auth }, request, response) => {
       const { FormAttachments, Forms } = container;
       return getInstance(Forms, params)
-        .then((form) => auth.canOrReject('form.read', form))
+        .then((form) => canReadForm(auth, form))
         .then((form) => FormAttachments.getByFormDefIdAndName(form.def.id, params.name)
           .then(getOrNotFound)
           .then(attachment => streamAttachment(container, attachment, response)));
@@ -348,7 +352,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/forms/:id/versions', endpoint(({ Forms }, { auth, params, queryOptions }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id)
       .then(getOrNotFound)
-      .then((form) => auth.canOrReject('form.read', form))
+      .then((form) => canReadForm(auth, form))
       .then((form) => Forms.getVersions(form.id, queryOptions))));
 
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -29,9 +29,9 @@ const excelMimeTypes = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 };
 
-const canReadForm = (auth, form) => (form.state === 'open'
-  ? auth.canOrReject(['open_form.read', 'form.read'], form)
-  : auth.canOrReject('form.read', form));
+const canReadForm = (auth, form) => (form.state === 'closed'
+  ? auth.canOrReject('form.read', form)
+  : auth.canOrReject(['open_form.read', 'form.read'], form));
 
 const streamAttachment = async (container, attachment, response) => {
   const { Blobs, Datasets, Entities } = container;

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -62,7 +62,7 @@ module.exports = (service, endpoint) => {
     Projects.getById(params.id)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.update', project))
-      .then((project) => Projects.setManagedEncryption(project, body.passphrase, body.hint)
+      .then((project) => Projects.setManagedEncryption(project, body.passphrase, body.hint, auth)
         .then(() => Submissions.clearDraftSubmissionsForProject(project.id))
         .then(() => Forms.clearUnneededDrafts(null, project))) // remove obsolete unencrypted draft form defs
       .then(success)));
@@ -73,7 +73,7 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.update', project))
       .then((project) => Promise.all([
-        Forms.getByProjectId(project.id),
+        Forms.getByProjectId(auth, project.id),
         Assignments.getForFormsByProjectId(project.id, QueryOptions.extended),
         Roles.getAll()
       ])

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const { testService } = require('../setup');
+const { testService, withClosedForm } = require('../setup');
 const testData = require('../../data/xml');
 const authenticateUser = require('../../util/authenticate-user');
 
@@ -250,5 +250,41 @@ describe('api: /key/:key', () => {
             .send(testData.instances.simple.one)
             .set('Content-Type', 'application/xml')
             .expect(200))))));
+
+  it('should not be able access closed forms and its sub-resources', testService(withClosedForm(async (service) => {
+    const asAlice = await service.login('alice');
+
+    const fk = await asAlice.post('/v1/projects/1/app-users')
+      .send({ displayName: 'fktest' })
+      .then(({ body }) => body);
+
+    await asAlice.post(`/v1/projects/1/forms/withAttachments/assignments/app-user/${fk.id}`)
+      .expect(200);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms?publish=true`)
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments`)
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/simple2.xls`)
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments.xml`)
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments/versions`)
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments/fields`)
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments/manifest`)
+      .set('X-OpenRosa-Version', '1.0')
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments/attachments/goodone.csv`)
+      .expect(403);
+  })));
 });
 

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -261,7 +261,7 @@ describe('api: /key/:key', () => {
     await asAlice.post(`/v1/projects/1/forms/withAttachments/assignments/app-user/${fk.id}`)
       .expect(200);
 
-    await service.get(`/v1/key/${fk.token}/projects/1/forms?publish=true`)
+    await service.get(`/v1/key/${fk.token}/projects/1/forms`)
       .expect(403);
 
     await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments`)
@@ -281,6 +281,9 @@ describe('api: /key/:key', () => {
 
     await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments/manifest`)
       .set('X-OpenRosa-Version', '1.0')
+      .expect(403);
+
+    await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments/attachments`)
       .expect(403);
 
     await service.get(`/v1/key/${fk.token}/projects/1/forms/withAttachments/attachments/goodone.csv`)

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -233,7 +233,7 @@ describe('api: /key/:key', () => {
       .send({ displayName: 'linktest' })
       .then(({ body }) => body);
 
-    await service.get(`/v1/key/${link.token}/projects/1/forms?publish=true`)
+    await service.get(`/v1/key/${link.token}/projects/1/forms`)
       .expect(403);
 
     await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments`)
@@ -253,6 +253,9 @@ describe('api: /key/:key', () => {
 
     await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments/manifest`)
       .set('X-OpenRosa-Version', '1.0')
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments/attachments`)
       .expect(403);
 
     await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments/attachments/goodone.csv`)

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const { testService } = require('../setup');
+const { testService, withClosedForm } = require('../setup');
 const testData = require('../../data/xml');
 const authenticateUser = require('../../util/authenticate-user');
 
@@ -225,6 +225,39 @@ describe('api: /key/:key', () => {
           .send(testData.instances.withrepeat.one)
           .set('Content-Type', 'application/xml')
           .expect(403)))));
+
+  it('should not be able access closed forms and its sub-resources', testService(withClosedForm(async (service) => {
+    const asAlice = await service.login('alice');
+
+    const link = await asAlice.post('/v1/projects/1/forms/withAttachments/public-links')
+      .send({ displayName: 'linktest' })
+      .then(({ body }) => body);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms?publish=true`)
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments`)
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/simple2.xls`)
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments.xml`)
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments/versions`)
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments/fields`)
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments/manifest`)
+      .set('X-OpenRosa-Version', '1.0')
+      .expect(403);
+
+    await service.get(`/v1/key/${link.token}/projects/1/forms/withAttachments/attachments/goodone.csv`)
+      .expect(403);
+  })));
 });
 
 


### PR DESCRIPTION
Closes [sec#2](https://github.com/getodk/security/issues/2)

**Impact:**

Following endpoints were accessible for "App User", "Data Collector" and "Public link" when Form was closed, after this change they return 403:

- /v1/projects/1/forms/:name
- /v1/projects/1/forms/:name.xls
- /v1/projects/1/forms/:name.xml
- /v1/projects/1/forms/:name/versions
- /v1/projects/1/forms/:name/fields
- /v1/projects/1/forms/:name/manifest
- /v1/projects/1/forms/:name/attachments
- /v1/projects/1/forms/:name/attachments/:name.csv

#### What has been done to verify that this works as intended?

Integration tests + Manual testing

#### Why is this the best possible solution? Were any other approaches considered?

Discussed the solution over Slack

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced