### PR TITLE
Improve flow of SSO account creation email

### DIFF
--- a/lib/formats/mail.js
+++ b/lib/formats/mail.js
@@ -33,7 +33,7 @@ const messages = {
   accountCreatedWithPassword: message('ODK Central account created', '<html>Hello!<p>An account has been provisioned for you on an ODK Central server.</p><p>If this message is unexpected, simply ignore it. Your account was created with an assigned password. Please use that password to <a href="{{{domain}}}">sign in</a>.</p><p>If you have not been given the password, or you cannot remember it, you can reset it at any time at this link:</p><p><a href="{{{domain}}}/#/reset-password">{{{domain}}}/#/reset-password</a></p></html>'),
 
   // Notifies a user that an account has been created for login exclusively with OIDC.
-  accountCreatedForOidc: message('ODK Central account created', '<html>Hello!<p>An account has been provisioned for you on an ODK Central data collection server.</p><p>If this message is unexpected, simply ignore it. Please go to <a href="{{{domain}}}">{{{domain}}}</a> to sign in.</p></html>'),
+  accountCreatedForOidc: message('ODK Central account created', '<html>Hello!<p>An account has been provisioned for you on an ODK Central data collection server.</p><p>If this message is unexpected, simply ignore it. Otherwise, please go to <a href="{{{domain}}}">{{{domain}}}</a> to sign in.</p></html>'),
 
   // Notifies a user that their account's email has been changed
   accountEmailChanged: message('ODK Central account email changed', '<html>Hello!<p><p>We are emailing because you have an ODK Central account, and somebody has just changed the email address associated with the account from this one you are reading right now ({{oldEmail}}) to a new address ({{newEmail}}).</p><p>If this was you, please feel free to ignore this email. Otherwise, please contact your local ODK system administrator immediately.</p></html>'),


### PR DESCRIPTION
Adds "Otherwise" to more closely match other similar emails.

#### What has been done to verify that this works as intended?
Only visual verification.

#### Why is this the best possible solution? Were any other approaches considered?
I considered moving the "please sign in" up to the first paragraph but I decided to match the structure of other existing emails instead.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced