### PR TITLE
Fix to analytics saving extra property in wrong place

### DIFF
--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -631,8 +631,10 @@ const previewMetrics = () => (({ Analytics }) => Promise.all([
   metrics.system.num_questions_biggest_form = bigForm;
   for (const [key, value] of Object.entries(admins))
     metrics.system.num_admins[key] = value;
-  for (const [key, value] of Object.entries(audits))
-    metrics.system.num_audit_log_entries[key] = value;
+
+  metrics.system.num_audit_log_entries.recent = audits.recent;
+  metrics.system.num_audit_log_entries.total = audits.total;
+
   metrics.projects = projMetrics;
 
   metrics.system.uses_external_db = Analytics.databaseExternal(config.get('default.database.host'));


### PR DESCRIPTION
Matt noticed that the analytics preview was returning more subproperties than `recent` and `total` because of how i'd combined a SQL query and pulled the response back out.

```
"num_audit_log_entries":{"recent":1440,"total":3337,"any_failure":0,"failed5":0,"unprocessed":0}
```

now should be
```
"num_audit_log_entries":{"recent":1440,"total":3337}
```

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced