### PR TITLE
Return 404 if accessing unpublished dataset aka entity list

### DIFF
--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -621,6 +621,15 @@ describe('datasets and entities', () => {
 
       }));
 
+      it('should reject if dataset is not published', testService((service) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1/datasets/people')
+              .expect(404)))));
+
       it('should not return duplicate linkedForms', testService(async (service) => {
         const asAlice = await service.login('alice');
 


### PR DESCRIPTION
Backend part of https://github.com/getodk/central/issues/467

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested it with frontend and added a specific test.

#### Why is this the best possible solution? Were any other approaches considered?

When getting metadata about a dataset/entity list, it doesn't even seem to include the `publishedAt` timestamp, so it makes sense to only return published datasets at the `/datasets/:name` url and return 404 resource not found otherwise.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Limits access to unpublished datasets but makes some parts of frontend more consistent.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Writing this out in the API would be a good idea. Tagging https://github.com/getodk/central-backend/issues/949

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced