### PR TITLE
Make name/label entity prop validation case-insensitive

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -36,12 +36,12 @@ const validatePropertyName = (name) => {
   // (similar to above dataset name check with some slight differences)
   // Check for a match with a valid string
   //   (?!__) is negative lookahead to check string does not start with double underscore __
-  //   (?!name$)(?!label$) negative lookahead for "name" and "label" specifically
+  //   (?!name$)(?!label$) negative lookahead for "name" and "label" specifically, insensitive to case
   //   [\p{L}_] valid start character of unicode letter or _ (no :)
   //   [\p{L}\d\\._-]* more characters from valid starting character set, digits, hyphens, and '.'
   // If there's a match, return true (valid)!
   // Non-letter unicode characters also not currently allowed
-  const match = /^(?!__)(?!name$)(?!label$)[\p{L}_][\p{L}\d._-]*$/u.exec(name);
+  const match = /^(?!__)(?!name$)(?!label$)[\p{L}_][\p{L}\d._-]*$/u.exec(name.toLowerCase());
 
   return (match !== null);
 };

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -310,6 +310,12 @@ describe('property name validation', () => {
     validatePropertyName('label').should.equal(false);
   });
 
+  it('should reject name or label in case-insensitive way', () => {
+    validatePropertyName('Name').should.equal(false);
+    validatePropertyName('NaMe').should.equal(false);
+    validatePropertyName('LABEL').should.equal(false);
+  });
+
   it('should reject name with whitespace at the ends', () => {
     validatePropertyName(' bad_whitespace ').should.equal(false);
   });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/482

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

This wont make the property name lowercase but it will temporarily lowercase it before doing the regex validation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced