### PR TITLE
Fix sending usage metrics/analytics by using REST endpoint

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -28,7 +28,7 @@
     "external": {
       "sentry": {},
       "analytics": {
-        "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/submission",
+        "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/forms/odk-analytics/submissions",
         "formId": "odk-analytics",
         "version": "v2023.4.0_1"
       }

--- a/lib/bin/run-analytics.js
+++ b/lib/bin/run-analytics.js
@@ -15,7 +15,7 @@ const { run } = require('../task/task');
 const { runAnalytics } = require('../task/analytics');
 
 const { program } = require('commander');
-program.option('-f', 'Force analytics to be sent (if configured) even if not scheduled yet.');
+program.option('-f, --force', 'Force analytics to be sent (if configured) even if not scheduled yet.');
 program.parse();
 
 const options = program.opts();

--- a/lib/external/odk-analytics.js
+++ b/lib/external/odk-analytics.js
@@ -14,7 +14,6 @@
 
 const { request } = require('https');
 const { isBlank } = require('../util/util');
-const FormData = require('form-data');
 const Problem = require('../util/problem');
 const { pipeline } = require('stream');
 
@@ -24,30 +23,25 @@ const mock = {
 
 const odkAnalytics = (url) => {
   const _submit = (formXml) => new Promise((resolve, reject) => {
-    const formData = new FormData();
-    const fileBuffer = Buffer.from(formXml, 'utf-8');
-    formData.append('xml_submission_file', fileBuffer, 'submission.xml');
-
-    const formHeaders = formData.getHeaders();
-    formHeaders['X-OpenRosa-Version'] = '1.0';
-
     const options = {
       method: 'POST',
-      headers: formHeaders
+      headers: {
+        'Content-Type': 'text/xml'
+      }
     };
 
     const req = request(
       url,
       options,
       response => {
-        if (response.statusCode === 201)
+        if (response.statusCode === 200)
           resolve();
         else
           reject(Problem.internal.analyticsUnexpectedResponse());
       }
     );
 
-    pipeline(formData, req, (err) => { if (err != null) reject(err); });
+    pipeline(formXml, req, (err) => { if (err != null) reject(err); });
   });
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "express": "~4.18",
         "express-graceful-exit": "~0.5",
         "fast-myers-diff": "~3",
-        "form-data": "~4",
         "htmlparser2": "~3.9",
         "knex": "~0.21",
         "luxon": "~0.3",
@@ -1672,7 +1671,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -2318,6 +2318,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2713,6 +2714,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4044,6 +4046,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11581,7 +11584,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -12046,6 +12050,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -12351,7 +12356,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -13384,6 +13390,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "express": "~4.18",
     "express-graceful-exit": "~0.5",
     "fast-myers-diff": "~3",
-    "form-data": "~4",
     "htmlparser2": "~3.9",
     "knex": "~0.21",
     "luxon": "~0.3",


### PR DESCRIPTION
Closes #970 

I'm not really sure what was wrong -- pipeline + old FormData + an XML attachment in a buffer was just Not Working. Maybe something about not knowing the length of the request up front (even though I think we do have it) and that messing up streaming?

Anyway, this seems to work a lot better. 

Got rid of `form-data` package because I think I added it just for this purpose of sending analytics.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tried it.

#### Why is this the best possible solution? Were any other approaches considered?

I think it's pretty reasonable -- streaming the xml data directly in the request instead of shoving it into a file attachment, and using the REST API instead of the OpenRosa API. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Keeps analytics from breaking, but this just runs in a little cron job so it shouldn't have any impact on users.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

no

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced