### PR TITLE
Disallow entity creation via API for unpublished datasets

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -88,7 +88,7 @@ const createOrMerge = (name, form, fields) => async ({ one, Actees, Datasets, Pr
   // Provision acteeId if necessary.
   // Need to check for existing dataset, and if not found, need to also
   // fetch the project since the dataset will be an actee child of the project.
-  const existingDataset = await Datasets.get(projectId, name);
+  const existingDataset = await Datasets.get(projectId, name, false);
   const acteeId = existingDataset.isDefined()
     ? existingDataset.get().acteeId
     : await Projects.getById(projectId).then((o) => o.get())
@@ -189,7 +189,7 @@ publishIfExists.audit.withResult = true;
 ////////////////////////////////////////////////////////////////////////////
 // DATASET GETTERS
 
-const _get = extender(Dataset)(Dataset.Extended)((fields, extend, options, publishedOnly = false, actorId) => sql`
+const _get = extender(Dataset)(Dataset.Extended)((fields, extend, options, publishedOnly, actorId) => sql`
   SELECT ${fields} FROM datasets
   ${extend|| sql`
   LEFT JOIN (
@@ -224,7 +224,7 @@ const getList = (projectId, options = QueryOptions.none) => ({ all }) =>
   _get(all, options.withCondition({ projectId }), true);
 
 // Get a dataset by it's project id and name. Commonly used in a resource.
-const get = (projectId, name, publishedOnly = false, extended = false) => ({ maybeOne }) => {
+const get = (projectId, name, publishedOnly, extended = false) => ({ maybeOne }) => {
   const options = extended ? QueryOptions.extended : QueryOptions.none;
   return _get(maybeOne, options.withCondition({ projectId, name }), publishedOnly);
 };

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -79,7 +79,7 @@ module.exports = (service, endpoint) => {
 
   service.post('/projects/:id/datasets/:name/entities', endpoint(async ({ Datasets, Entities }, { auth, body, params, userAgent }) => {
 
-    const dataset = await Datasets.get(params.id, params.name).then(getOrNotFound);
+    const dataset = await Datasets.get(params.id, params.name, true).then(getOrNotFound);
 
     await auth.canOrReject('entity.create', dataset);
 
@@ -96,7 +96,7 @@ module.exports = (service, endpoint) => {
 
   service.patch('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { auth, body, params, query, userAgent, headers }) => {
 
-    const dataset = await Datasets.get(params.id, params.name).then(getOrNotFound);
+    const dataset = await Datasets.get(params.id, params.name, true).then(getOrNotFound);
 
     await auth.canOrReject('entity.update', dataset);
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -715,6 +715,25 @@ describe('Entities API', () => {
         });
     }));
 
+    it('should reject creating new entity if dataset not yet published', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.simpleEntity)
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/datasets/people')
+        .expect(404);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-111111111aaa',
+          label: 'Johnny Doe',
+          data: {}
+        })
+        .expect(404);
+    }));
+
     it('should create an Entity', testDataset(async (service) => {
       const asAlice = await service.login('alice');
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/483

Follows suggestions from that PR:
1. Noticed that `Datasets.get()` was getting all datasets including unpublished ones so entities could in some cases be created via API before dataset was published and available (only if they had no data properties, though). 
2. Checked usage of `Datasets.get()` throughout code
3. Made 3rd param `publishedOnly` non-optional and set to false in the only place it matters: when uploading multiple forms that contribute to a dataset and none are published yet. 
    - I looked into this case a little more and saw how with this flag set incorrectly (set to only find published datasets), we'd get an extra actee id in the database but it didn't show up in any tests. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Test and inspecting and agreeing with the comments in the original issue.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Can't make entities before their entity lists.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

no

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced