### PR TITLE
fixes c#480: set required engine version to major level (18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "18.17.0"
+    "node": "18"
   },
   "volta": {
     "node": "18.17.0"


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/480

Reverted back engine requirement to major version i.e. 18 instead of patch level

Verified on test env

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced