### PR TITLE
Request Enketo IDs during request when form is created or published

### DIFF
--- a/lib/external/enketo.js
+++ b/lib/external/enketo.js
@@ -7,11 +7,6 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-// here we support previewing forms (and hopefully other things in the future)
-// by providing a very thin wrapper around node http requests to Enketo. given
-// an OpenRosa endpoint to access a form's xml and its media, Enketo should
-// return a preview url, which we then pass untouched to the client.
-
 const http = require('http');
 const https = require('https');
 const { posix } = require('path');
@@ -21,14 +16,10 @@ const { url } = require('../util/http');
 const { isBlank } = require('../util/util');
 const Problem = require('../util/problem');
 
-const mock = {
-  create: () => Promise.reject(Problem.internal.enketoNotConfigured()),
-  createOnceToken: () => Promise.reject(Problem.internal.enketoNotConfigured()),
-  edit: () => Promise.reject(Problem.internal.enketoNotConfigured())
-};
-
-const enketo = (hostname, pathname, port, protocol, apiKey) => {
-  const _enketo = (apiPath, responseField, token, postData) => new Promise((resolve, reject) => {
+// Returns a very thin wrapper around Node HTTP requests for sending requests to
+// Enketo. The methods of the object can be used to send requests to Enketo.
+const _init = (hostname, pathname, port, protocol, apiKey) => {
+  const enketoRequest = (apiPath, token, postData) => new Promise((resolve, reject) => {
     const path = posix.join(pathname, apiPath);
     const auth = `${apiKey}:`;
     const headers = {
@@ -51,7 +42,7 @@ const enketo = (hostname, pathname, port, protocol, apiKey) => {
           return reject(Problem.user.enketoEditRateLimit());
         if ((res.statusCode !== 200) && (res.statusCode !== 201))
           return reject(Problem.internal.enketoUnexpectedResponse('wrong status code'));
-        resolve(body[responseField]);
+        resolve(body);
       });
     });
 
@@ -61,21 +52,29 @@ const enketo = (hostname, pathname, port, protocol, apiKey) => {
     req.end();
   });
 
-  const _create = (apiPath, responseField) => (openRosaUrl, xmlFormId, token) =>
-    _enketo(apiPath, responseField, token, querystring.stringify({ server_url: openRosaUrl, form_id: xmlFormId }))
-      .then((result) => {
-        const match = /\/([:a-z0-9]+)$/i.exec(result);
-        if (match == null) throw Problem.internal.enketoUnexpectedResponse(`Could not parse token from enketo response url: ${result}`);
-        return match[1];
-      });
+  // openRosaUrl is the OpenRosa endpoint for Enketo to use to access the form's
+  // XML and attachments.
+  const create = async (openRosaUrl, xmlFormId, token) => {
+    const body = await enketoRequest('/api/v2/survey/all', token, querystring.stringify({
+      server_url: openRosaUrl,
+      form_id: xmlFormId
+    }));
 
-  const _edit = (apiPath, responseField) => (openRosaUrl, domain, form, logicalId, submissionDef, attachments, token) => {
+    // Parse enketoOnceId from single_once_url.
+    const match = /\/([:a-z0-9]+)$/i.exec(body.single_once_url);
+    if (match == null) throw Problem.internal.enketoUnexpectedResponse(`Could not parse token from single_once_url: ${body.single_once_url}`);
+    const enketoOnceId = match[1];
+
+    return { enketoId: body.enketo_id, enketoOnceId };
+  };
+
+  const edit = (openRosaUrl, domain, form, logicalId, submissionDef, attachments, token) => {
     const attsMap = {};
     for (const att of attachments)
       if (att.blobId != null)
         attsMap[url`instance_attachments[${att.name}]`] = domain + url`/v1/projects/${form.projectId}/forms/${form.xmlFormId}/submissions/${logicalId}/versions/${submissionDef.instanceId}/attachments/${att.name}`;
 
-    return _enketo(apiPath, responseField, token, querystring.stringify({
+    return enketoRequest('api/v2/instance', token, querystring.stringify({
       server_url: openRosaUrl,
       form_id: form.xmlFormId,
       instance: submissionDef.xml,
@@ -83,7 +82,7 @@ const enketo = (hostname, pathname, port, protocol, apiKey) => {
       ...attsMap,
       return_url: domain + url`/#/projects/${form.projectId}/forms/${form.xmlFormId}/submissions/${logicalId}`
     }))
-      .then((enketoUrlStr) => {
+      .then(({ edit_url: enketoUrlStr }) => {
         // need to override proto/host/port with our own.
         const enketoUrl = new URL(enketoUrlStr);
         const ownUrl = new URL(domain);
@@ -94,16 +93,16 @@ const enketo = (hostname, pathname, port, protocol, apiKey) => {
       });
   };
 
-  return {
-    create: _create('api/v2/survey', 'url'),
-    createOnceToken: _create('api/v2/survey/single/once', 'single_once_url'),
-    edit: _edit('api/v2/instance', 'edit_url')
-  };
+  return { create, edit };
 };
 
+const mock = {
+  create: () => Promise.reject(Problem.internal.enketoNotConfigured()),
+  edit: () => Promise.reject(Problem.internal.enketoNotConfigured())
+};
 
-// sorts through config and returns an object containing stubs or real functions for Enketo integration.
-// (okay, right now it's just one function)
+// sorts through config and returns an object containing either stubs or real
+// functions for Enketo integration.
 const init = (config) => {
   if (config == null) return mock;
   if (isBlank(config.url) || isBlank(config.apiKey)) return mock;
@@ -115,7 +114,7 @@ const init = (config) => {
     else throw ex;
   }
   const { hostname, pathname, port, protocol } = parsedUrl;
-  return enketo(hostname, pathname, port, protocol, config.apiKey);
+  return _init(hostname, pathname, port, protocol, config.apiKey);
 };
 
 module.exports = { init };

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -76,14 +76,18 @@ class Form extends Frame.define(
       .then((partial) => partial.with({ key: Option.of(key) }));
   }
 
+  _enketoIdForApi() {
+    if (this.def == null) return null;
+    if (this.def.id === this.draftDefId) return this.def.enketoId;
+    if (this.def.id === this.currentDefId) return this.enketoId;
+    return null;
+  }
+
   forApi() {
-    /* eslint-disable indent */
-    const enketoId =
-      (this.def.id === this.draftDefId) ? this.def.enketoId
-      : (this.def.id === this.currentDefId) ? this.enketoId
+    const enketoId = this._enketoIdForApi();
+    const enketoOnceId = this.def != null && this.def.id === this.currentDefId
+      ? this.enketoOnceId
       : null;
-    const enketoOnceId = (this.def.id === this.currentDefId) ? this.enketoOnceId : null;
-    /* eslint-enable indent */
 
     // Include deletedAt in response only if it is not null (most likely on resources about soft-deleted forms)
     // and also include the numeric form id (used to restore)

--- a/lib/model/query/assignments.js
+++ b/lib/model/query/assignments.js
@@ -64,7 +64,7 @@ select ${fields} from assignments
   where ${equals(options.condition)}`);
 const getByActeeId = (acteeId, options = QueryOptions.none) => ({ all }) =>
   _get(all, options.withCondition({ 'assignments.acteeId': acteeId }));
-const getByActeeAndRoleId = (acteeId, roleId, options) => ({ all }) =>
+const getByActeeAndRoleId = (acteeId, roleId, options = QueryOptions.none) => ({ all }) =>
   _get(all, options.withCondition({ 'assignments.acteeId': acteeId, roleId }));
 
 const _getForForms = extender(Assignment, Assignment.FormSummary)(Actor)((fields, extend, options) => sql`

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -94,7 +94,8 @@ const get = (options = QueryOptions.none) => ({ all }) =>
 
     // TODO: better if we don't have to loop over all this data twice.
     return rows.map((row) => {
-      const form = row.aux.form.map((f) => f.withAux('def', row.aux.def));
+      const form = row.aux.form.map((f) =>
+        row.aux.def.map((def) => f.withAux('def', def)).orElse(f));
       const actees = [ row.aux.acteeActor, form, row.aux.project, row.aux.dataset, row.aux.actee ];
       return new Audit(row, { actor: row.aux.actor, actee: Option.firstDefined(actees) });
     });

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -58,34 +58,56 @@ const pushDraftToEnketo = ({ projectId, xmlFormId, def, draftToken = def?.draftT
   return (await timeboundEnketo(enketo.create(path, xmlFormId), bound)).enketoId;
 };
 
+// Pushes a form that is published or about to be published to Enketo. Accepts
+// either a Form or a Form-like object. Also accepts an optional bound on the
+// amount of time for the request to Enketo to complete (in seconds). If a bound
+// is specified, and the request to Enketo times out or results in an error,
+// then an empty object is returned.
+const pushFormToEnketo = ({ projectId, xmlFormId, acteeId }, bound = undefined) => async ({ Actors, Assignments, Sessions, enketo, env }) => {
+  // Generate a single use actor that grants Enketo access just to this form for
+  // just long enough for it to pull the information it needs.
+  const expiresAt = new Date();
+  expiresAt.setMinutes(expiresAt.getMinutes() + 15);
+  const actor = await Actors.create(new Actor({
+    type: 'singleUse',
+    expiresAt,
+    displayName: `Enketo sync token for ${acteeId}`
+  }));
+  await Assignments.grantSystem(actor, 'formview', acteeId);
+  const { token } = await Sessions.create(actor, expiresAt);
+
+  const path = `${env.domain}/v1/projects/${projectId}`;
+  return timeboundEnketo(enketo.create(path, xmlFormId, token), bound);
+};
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING NEW FORMS
 
-const _createNew = (form, def, project, publish) => ({ oneFirst, Actees, Forms }) =>
-  Actees.provision('form', project)
-    .then((actee) => oneFirst(sql`
+const _createNew = (form, def, project, publish) => ({ oneFirst, Forms }) =>
+  oneFirst(sql`
 with sch as
   (insert into form_schemas (id)
     values (default)
     returning *),
 def as
-  (insert into form_defs ("formId", "schemaId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "createdAt", "publishedAt")
-  select nextval(pg_get_serial_sequence('forms', 'id')), sch.id, ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${(publish !== true) ? generateToken() : null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null}
+  (insert into form_defs ("formId", "schemaId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "enketoId", "createdAt", "publishedAt")
+  select nextval(pg_get_serial_sequence('forms', 'id')), sch.id, ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${def.draftToken || null}, ${def.enketoId || null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null}
     from sch
   returning *),
 form as
-  (insert into forms (id, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "createdAt")
-  select def."formId", ${form.xmlFormId}, ${form.state || 'open'}, ${project.id}, def.id, ${actee.id}, def."createdAt" from def
+  (insert into forms (id, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "enketoId", "enketoOnceId", "createdAt")
+  select def."formId", ${form.xmlFormId}, ${form.state || 'open'}, ${project.id}, def.id, ${form.acteeId}, ${form.enketoId || null}, ${form.enketoOnceId || null}, def."createdAt" from def
   returning forms.*)
-select id from form`))
+select id from form`)
     .then(() => Forms.getByProjectAndXmlFormId(project.id, form.xmlFormId, false,
       (publish === true) ? undefined : Form.DraftVersion))
     .then((option) => option.get());
 
-const createNew = (partial, project, publish = false) => async ({ run, Datasets, FormAttachments, Forms, Keys }) => {
+const createNew = (partial, project, publish = false) => async ({ run, Actees, Datasets, FormAttachments, Forms, Keys }) => {
   // Check encryption keys before proceeding
-  const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
+  const defData = {};
+  defData.keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form XML for fields and entity/dataset definitions
   const [fields, datasetName] = await Promise.all([
@@ -100,8 +122,32 @@ const createNew = (partial, project, publish = false) => async ({ run, Datasets,
   await Forms.checkDeletedForms(partial.xmlFormId, project.id);
   await Forms.rejectIfWarnings();
 
+  const formData = {};
+  formData.acteeId = (await Actees.provision('form', project)).id;
+
+  // We will try to push to Enketo. If doing so fails or is too slow, then the
+  // worker will try again later.
+  if (publish !== true) {
+    defData.draftToken = generateToken();
+    defData.enketoId = await Forms.pushDraftToEnketo(
+      { projectId: project.id, xmlFormId: partial.xmlFormId, draftToken: defData.draftToken },
+      0.5
+    );
+  } else {
+    const enketoIds = await Forms.pushFormToEnketo(
+      { projectId: project.id, xmlFormId: partial.xmlFormId, acteeId: formData.acteeId },
+      0.5
+    );
+    Object.assign(formData, enketoIds);
+  }
+
   // Save form
-  const savedForm = await Forms._createNew(partial, partial.def.with({ keyId }), project, publish);
+  const savedForm = await Forms._createNew(
+    partial.with(formData),
+    partial.def.with(defData),
+    project,
+    publish
+  );
 
   // Prepare the form fields
   const ids = { formId: savedForm.id, schemaId: savedForm.def.schemaId };
@@ -269,12 +315,18 @@ createVersion.audit.withResult = true;
 
 // TODO: we need to make more explicit what .def actually represents throughout.
 // for now, enforce an extra check here just in case.
-const publish = (form) => ({ Forms, Datasets }) => {
+const publish = (form) => async ({ Forms, Datasets }) => {
   if (form.draftDefId !== form.def.id) throw Problem.internal.unknown();
+
+  // Try to push the form to Enketo if it hasn't been pushed already. If doing
+  // so fails or is too slow, then the worker will try again later.
+  const enketoIds = form.enketoId == null || form.enketoOnceId == null
+    ? await Forms.pushFormToEnketo(form, 0.5)
+    : {};
 
   const publishedAt = (new Date()).toISOString();
   return Promise.all([
-    Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null }),
+    Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null, ...enketoIds }),
     Forms._updateDef(form.def, { draftToken: null, enketoId: null, publishedAt }),
     Datasets.publishIfExists(form.def.id, publishedAt)
   ])
@@ -728,7 +780,7 @@ const _newSchema = () => ({ one }) =>
     .then((s) => s.id);
 
 module.exports = {
-  fromXls, pushDraftToEnketo, _createNew, createNew, _createNewDef, createVersion,
+  fromXls, pushDraftToEnketo, pushFormToEnketo, _createNew, createNew, _createNewDef, createVersion,
   publish, clearDraft,
   _update, update, _updateDef, del, restore, purge,
   clearUnneededDrafts,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -41,6 +41,24 @@ const fromXls = (stream, contentType, formIdFallback, ignoreWarnings) => ({ Blob
         .then(([ partial, xlsBlobId ]) => partial.withAux('xls', { xlsBlobId, itemsets }));
     });
 
+
+////////////////////////////////////////////////////////////////////////////////
+// PUSHING TO ENKETO
+
+const timeboundEnketo = (request, bound) =>
+  (bound != null ? timebound(request, bound).catch(() => ({})) : request);
+
+// Accepts either a Form or an object with a top-level draftToken property. Also
+// accepts an optional bound on the amount of time for the request to Enketo to
+// complete (in seconds). If a bound is specified, and the request to Enketo
+// times out or results in an error, then a nullish value is returned.
+const pushDraftToEnketo = ({ projectId, xmlFormId, def, draftToken = def?.draftToken }, bound = undefined) => async ({ enketo, env }) => {
+  const encodedFormId = encodeURIComponent(xmlFormId);
+  const path = `${env.domain}/v1/test/${draftToken}/projects/${projectId}/forms/${encodedFormId}/draft`;
+  return (await timeboundEnketo(enketo.create(path, xmlFormId), bound)).enketoId;
+};
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING NEW FORMS
 
@@ -120,7 +138,7 @@ createNew.audit.withResult = true;
 // Inserts a new form def into the database for createVersion() below, setting
 // fields on the def according to whether the def will be the current def or the
 // draft def.
-const _createNewDef = (partial, form, publish, data) => async ({ one, enketo, env }) => {
+const _createNewDef = (partial, form, publish, data) => async ({ one, Forms }) => {
   const insertWith = (moreData) => one(insert(partial.def.with({
     formId: form.id,
     xlsBlobId: partial.xls.xlsBlobId,
@@ -135,14 +153,12 @@ const _createNewDef = (partial, form, publish, data) => async ({ one, enketo, en
   // generate a draft token and enketoId.
   if (form.def.id == null || form.def.id !== form.draftDefId) {
     const draftToken = generateToken();
-
     // Try to push the draft to Enketo. If doing so fails or is too slow, then
     // the worker will try again later.
-    const encodedId = encodeURIComponent(form.xmlFormId);
-    const path = `/v1/test/${draftToken}/projects/${form.projectId}/forms/${encodedId}/draft`;
-    const request = enketo.create(`${env.domain}${path}`, form.xmlFormId);
-    const enketoId = await timebound(request, 0.5).catch(() => null);
-
+    const enketoId = await Forms.pushDraftToEnketo(
+      { projectId: form.projectId, xmlFormId: form.xmlFormId, draftToken },
+      0.5
+    );
     return insertWith({ draftToken, enketoId });
   }
 
@@ -712,7 +728,7 @@ const _newSchema = () => ({ one }) =>
     .then((s) => s.id);
 
 module.exports = {
-  fromXls, _createNew, createNew, _createNewDef, createVersion,
+  fromXls, pushDraftToEnketo, _createNew, createNew, _createNewDef, createVersion,
   publish, clearDraft,
   _update, update, _updateDef, del, restore, purge,
   clearUnneededDrafts,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -45,17 +45,21 @@ const fromXls = (stream, contentType, formIdFallback, ignoreWarnings) => ({ Blob
 ////////////////////////////////////////////////////////////////////////////////
 // PUSHING TO ENKETO
 
+// Time-bounds a request from enketo.create(). If the request times out or
+// results in an error, then an empty object is returned.
 const timeboundEnketo = (request, bound) =>
   (bound != null ? timebound(request, bound).catch(() => ({})) : request);
 
 // Accepts either a Form or an object with a top-level draftToken property. Also
 // accepts an optional bound on the amount of time for the request to Enketo to
 // complete (in seconds). If a bound is specified, and the request to Enketo
-// times out or results in an error, then a nullish value is returned.
+// times out or results in an error, then `null` is returned.
 const pushDraftToEnketo = ({ projectId, xmlFormId, def, draftToken = def?.draftToken }, bound = undefined) => async ({ enketo, env }) => {
   const encodedFormId = encodeURIComponent(xmlFormId);
   const path = `${env.domain}/v1/test/${draftToken}/projects/${projectId}/forms/${encodedFormId}/draft`;
-  return (await timeboundEnketo(enketo.create(path, xmlFormId), bound)).enketoId;
+  const { enketoId } = await timeboundEnketo(enketo.create(path, xmlFormId), bound);
+  // Return `null` if enketoId is `undefined`.
+  return enketoId ?? null;
 };
 
 // Pushes a form that is published or about to be published to Enketo. Accepts

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -9,7 +9,7 @@
 
 const { Actor, Form } = require('../model/frames');
 
-const pushDraftToEnketo = ({ Forms, enketo, env }, event) =>
+const pushDraftToEnketo = ({ Forms }, event) =>
   Forms.getByActeeIdForUpdate(event.acteeId, undefined, Form.DraftVersion)
     .then((maybeForm) => maybeForm.map((form) => {
       // if there was no draft or this form isn't the draft anymore just bail.
@@ -23,8 +23,7 @@ const pushDraftToEnketo = ({ Forms, enketo, env }, event) =>
       // and wrong. still want to log a fail but bail early.
       if (form.def.draftToken == null) throw new Error('Could not find a draft token!');
 
-      const path = `${env.domain}/v1/test/${form.def.draftToken}/projects/${form.projectId}/forms/${encodeURIComponent(form.xmlFormId)}/draft`;
-      return enketo.create(path, form.xmlFormId)
+      return Forms.pushDraftToEnketo(form)
         .then((enketoId) => Forms._updateDef(form.def, new Form.Def({ enketoId })));
     }).orNull());
 

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -45,9 +45,7 @@ const pushFormToEnketo = ({ Actors, Assignments, Forms, Sessions, enketo, env },
         .then((actor) => Assignments.grantSystem(actor, 'formview', form)
           .then(() => Sessions.create(actor, expiresAt)))
         .then(({ token }) => enketo.create(path, form.xmlFormId, token)
-          .then((enketoId) => enketo.createOnceToken(path, form.xmlFormId, token)
-            .then((enketoOnceId) =>
-              Forms.update(form, new Form({ enketoId, enketoOnceId })))));
+          .then((enketoIds) => Forms.update(form, new Form(enketoIds))));
     }).orNull());
 
 const create = pushDraftToEnketo;

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -7,7 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { Actor, Form } = require('../model/frames');
+const { Form } = require('../model/frames');
 
 const pushDraftToEnketo = ({ Forms }, event) =>
   Forms.getByActeeIdForUpdate(event.acteeId, undefined, Form.DraftVersion)
@@ -27,24 +27,15 @@ const pushDraftToEnketo = ({ Forms }, event) =>
         .then((enketoId) => Forms._updateDef(form.def, new Form.Def({ enketoId })));
     }).orNull());
 
-const pushFormToEnketo = ({ Actors, Assignments, Forms, Sessions, enketo, env }, event) =>
+const pushFormToEnketo = ({ Forms }, event) =>
   Forms.getByActeeIdForUpdate(event.acteeId)
     .then((maybeForm) => maybeForm.map((form) => {
       // if this form already has both enketo ids then we have no work to do here.
       // if the form is updated enketo will see the difference and update.
       if ((form.enketoId != null) && (form.enketoOnceId != null)) return;
 
-      // generate a single use actor that grants enketo access just to this
-      // form for just long enough for it to pull the information it needs.
-      const path = `${env.domain}/v1/projects/${form.projectId}`;
-      const expiresAt = new Date();
-      expiresAt.setMinutes(expiresAt.getMinutes() + 15);
-      const displayName = `Enketo sync token for ${form.acteeId}`;
-      return Actors.create(new Actor({ type: 'singleUse', expiresAt, displayName }))
-        .then((actor) => Assignments.grantSystem(actor, 'formview', form)
-          .then(() => Sessions.create(actor, expiresAt)))
-        .then(({ token }) => enketo.create(path, form.xmlFormId, token)
-          .then((enketoIds) => Forms.update(form, new Form(enketoIds))));
+      return Forms.pushFormToEnketo(form)
+        .then((enketoIds) => Forms.update(form, new Form(enketoIds)));
     }).orNull());
 
 const create = pushDraftToEnketo;

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -6,6 +6,9 @@ const { testService } = require('../setup');
 const testData = require('../../data/xml');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
+const assertAuditActions = (audits, expected) => {
+  audits.map(a => a.action).should.deepEqual(expected);
+};
 const submitThree = (asAlice) =>
   asAlice.post('/v1/projects/1/forms/simple/submissions')
     .send(testData.instances.simple.one)
@@ -45,7 +48,7 @@ describe('/audits', () => {
               Users.getByEmail('david@getodk.org').then((o) => o.get())
             ]))
             .then(([ audits, project, alice, david ]) => {
-              assertAuditActions(audits, [ // eslint-disable-line no-use-before-define
+              assertAuditActions(audits, [
                 'user.create',
                 'project.update',
                 'project.create',
@@ -105,7 +108,7 @@ describe('/audits', () => {
               Users.getByEmail('david@getodk.org').then((o) => o.get())
             ]))
             .then(([ audits, [ project, form ], alice, david ]) => {
-              assertAuditActions(audits, [ // eslint-disable-line no-use-before-define
+              assertAuditActions(audits, [
                 'user.create',
                 'form.update.publish',
                 'form.create',
@@ -157,6 +160,25 @@ describe('/audits', () => {
               audits[4].actee.should.eql(plain(alice.actor.forApi()));
               audits[4].loggedAt.should.be.a.recentIsoDate();
             })))));
+
+    it('should return Enketo IDs for form', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .send(testData.forms.simple2)
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+      const { body: audits } = await asAlice.get('/v1/audits')
+        .set('X-Extended-Metadata', true)
+        .expect(200);
+      assertAuditActions(audits, [
+        'form.update.publish',
+        'form.create',
+        'user.session.create'
+      ]);
+      const form = audits[0].actee;
+      form.enketoId.should.equal('::abcdefgh');
+      form.enketoOnceId.should.equal('::::abcdefgh');
+    }));
 
     it('should not expand actor if there is no actor', testService((service, { run }) =>
       run(sql`insert into audits (action, "loggedAt") values ('analytics', now())`)
@@ -234,7 +256,7 @@ describe('/audits', () => {
           .then(() => asAlice.get('/v1/audits?action=user')
             .expect(200)
             .then(({ body }) => {
-              assertAuditActions(body, [ // eslint-disable-line no-use-before-define
+              assertAuditActions(body, [
                 'user.delete',
                 'user.assignment.delete',
                 'user.assignment.create',
@@ -732,7 +754,3 @@ describe('/audits', () => {
     });
   });
 });
-
-function assertAuditActions(audits, expected) {
-  audits.map(a => a.action).should.deepEqual(expected);
-}

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -101,10 +101,10 @@ describe('api: /projects/:id/forms (drafts)', () => {
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         await asAlice.post('/v1/projects/1/forms/simple/draft/publish?version=two')
           .expect(200);
-        global.enketo.callCount.should.equal(1);
+        global.enketo.callCount.should.equal(2);
         global.enketo.enketoId = '::ijklmnop';
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
-        global.enketo.callCount.should.equal(2);
+        global.enketo.callCount.should.equal(3);
         global.enketo.receivedUrl.startsWith(env.domain).should.be.true();
         const match = global.enketo.receivedUrl.match(/\/v1\/test\/([a-z0-9$!]{64})\/projects\/1\/forms\/simple\/draft$/i);
         should.exist(match);
@@ -158,13 +158,12 @@ describe('api: /projects/:id/forms (drafts)', () => {
         global.enketo.callCount.should.equal(1);
       }));
 
-      it('should manage draft/published enketo tokens separately', testService((service, container) =>
+      it('should manage draft/published enketo tokens separately', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms?publish=true')
             .set('Content-Type', 'application/xml')
             .send(testData.forms.simple2)
             .expect(200)
-            .then(() => exhaust(container))
             .then(() => {
               global.enketo.enketoId = '::ijklmnop';
               return asAlice.post('/v1/projects/1/forms/simple2/draft')
@@ -898,13 +897,12 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 body.lastSubmission.should.be.a.recentIsoDate();
               })))));
 
-      it('should return the correct enketoId with extended draft', testService((service, container) =>
+      it('should return the correct enketoId with extended draft', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms?publish=true')
             .set('Content-Type', 'application/xml')
             .send(testData.forms.simple2)
             .expect(200)
-            .then(() => exhaust(container))
             .then(() => {
               global.enketo.enketoId = '::ijklmnop';
               return asAlice.post('/v1/projects/1/forms/simple2/draft')
@@ -1143,6 +1141,151 @@ describe('api: /projects/:id/forms (drafts)', () => {
                   { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false }
                 ]);
               })))));
+
+      it('should request Enketo IDs when publishing for first time', testService(async (service, { env }) => {
+        const asAlice = await service.login('alice');
+
+        // Create a draft form.
+        global.enketo.state = 'error';
+        const { body: draft } = await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        global.enketo.callCount.should.equal(1);
+        should.not.exist(draft.enketoId);
+        should.not.exist(draft.enketoOnceId);
+
+        // Publish.
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
+          .expect(200);
+        global.enketo.callCount.should.equal(2);
+        global.enketo.receivedUrl.should.equal(`${env.domain}/v1/projects/1`);
+        const { body: form } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        form.enketoId.should.equal('::abcdefgh');
+        form.enketoOnceId.should.equal('::::abcdefgh');
+      }));
+
+      it('should return with success even if request to Enketo fails', testService(async (service) => {
+        const asAlice = await service.login('alice');
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        global.enketo.state = 'error';
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
+          .expect(200);
+        const { body: form } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        should.not.exist(form.enketoId);
+        should.not.exist(form.enketoOnceId);
+      }));
+
+      it('should stop waiting for Enketo after 0.5 seconds @slow', testService(async (service) => {
+        const asAlice = await service.login('alice');
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        global.enketo.wait = (f) => { setTimeout(f, 501); };
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
+          .expect(200);
+        const { body: form } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        should.not.exist(form.enketoId);
+        should.not.exist(form.enketoOnceId);
+      }));
+
+      it('should request Enketo IDs when republishing if they are missing', testService(async (service, { env }) => {
+        const asAlice = await service.login('alice');
+
+        // First publish
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        global.enketo.state = 'error';
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
+          .expect(200);
+        const { body: v1 } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        should.not.exist(v1.enketoId);
+        should.not.exist(v1.enketoOnceId);
+
+        // Republish
+        await asAlice.post('/v1/projects/1/forms/simple2/draft').expect(200);
+        global.enketo.callCount.should.equal(3);
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish?version=new')
+          .expect(200);
+        global.enketo.callCount.should.equal(4);
+        global.enketo.receivedUrl.should.equal(`${env.domain}/v1/projects/1`);
+        const { body: v2 } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        v2.enketoId.should.equal('::abcdefgh');
+        v2.enketoOnceId.should.equal('::::abcdefgh');
+      }));
+
+      it('should not request Enketo IDs when republishing if they are present', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        // First publish
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
+          .expect(200);
+
+        // Republish
+        await asAlice.post('/v1/projects/1/forms/simple2/draft').expect(200);
+        global.enketo.callCount.should.equal(3);
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish?version=new')
+          .expect(200);
+        global.enketo.callCount.should.equal(3);
+        const { body: form } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        form.enketoId.should.equal('::abcdefgh');
+        form.enketoOnceId.should.equal('::::abcdefgh');
+      }));
+
+      it('should request Enketo IDs from worker if request from endpoint fails', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        // First request to Enketo, from endpoint
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        global.enketo.state = 'error';
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
+          .expect(200);
+        const { body: beforeWorker } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        should.not.exist(beforeWorker.enketoId);
+        should.not.exist(beforeWorker.enketoOnceId);
+
+        // Second request, from worker
+        await exhaust(container);
+        global.enketo.callCount.should.equal(3);
+        global.enketo.receivedUrl.should.equal(`${container.env.domain}/v1/projects/1`);
+        const { body: afterWorker } = await asAlice.get('/v1/projects/1/forms/simple2')
+          .expect(200);
+        afterWorker.enketoId.should.equal('::abcdefgh');
+        afterWorker.enketoOnceId.should.equal('::::abcdefgh');
+      }));
+
+      it('should not request Enketo IDs from worker if request from endpoint succeeds', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simple2)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
+          .expect(200);
+        global.enketo.callCount.should.equal(2);
+        await exhaust(container);
+        global.enketo.callCount.should.equal(2);
+      }));
 
       it('should log the action in the audit log', testService((service, { Forms }) =>
         service.login('alice', (asAlice) =>

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -84,7 +84,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
 
       it('should request an enketoId while setting a new draft', testService(async (service, { env }) => {
         const asAlice = await service.login('alice');
-        global.enketo.token = '::ijklmnop';
+        global.enketo.enketoId = '::ijklmnop';
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         global.enketo.callCount.should.equal(1);
         global.enketo.receivedUrl.startsWith(env.domain).should.be.true();
@@ -102,7 +102,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         await asAlice.post('/v1/projects/1/forms/simple/draft/publish?version=two')
           .expect(200);
         global.enketo.callCount.should.equal(1);
-        global.enketo.token = '::ijklmnop';
+        global.enketo.enketoId = '::ijklmnop';
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         global.enketo.callCount.should.equal(2);
         global.enketo.receivedUrl.startsWith(env.domain).should.be.true();
@@ -137,7 +137,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         global.enketo.state = 'error';
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         global.enketo.callCount.should.equal(1);
-        global.enketo.token = '::ijklmnop';
+        global.enketo.enketoId = '::ijklmnop';
         await exhaust(container);
         global.enketo.callCount.should.equal(2);
         global.enketo.receivedUrl.startsWith(container.env.domain).should.be.true();
@@ -166,7 +166,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
             .expect(200)
             .then(() => exhaust(container))
             .then(() => {
-              global.enketo.token = '::ijklmnop';
+              global.enketo.enketoId = '::ijklmnop';
               return asAlice.post('/v1/projects/1/forms/simple2/draft')
                 .expect(200)
                 .then(() => Promise.all([
@@ -906,7 +906,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
             .expect(200)
             .then(() => exhaust(container))
             .then(() => {
-              global.enketo.token = '::ijklmnop';
+              global.enketo.enketoId = '::ijklmnop';
               return asAlice.post('/v1/projects/1/forms/simple2/draft')
                 .expect(200)
                 .then(() => asAlice.get('/v1/projects/1/forms/simple2/draft')

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -1265,6 +1265,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(beforeWorker.enketoOnceId);
 
         // Second request, from worker
+        global.enketo.callCount.should.equal(2);
         await exhaust(container);
         global.enketo.callCount.should.equal(3);
         global.enketo.receivedUrl.should.equal(`${container.env.domain}/v1/projects/1`);

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -758,18 +758,16 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                 body.submissions.should.equal(0);
               })))));
 
-      it('should return the correct enketoId', testService((service, container) =>
+      it('should return the correct enketoId', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms?publish=true')
             .set('Content-Type', 'application/xml')
             .send(testData.forms.simple2)
             .expect(200)
-            .then(() => exhaust(container))
             .then(() => {
               global.enketo.enketoId = '::ijklmnop';
               return asAlice.post('/v1/projects/1/forms/simple2/draft')
                 .expect(200)
-                .then(() => exhaust(container))
                 .then(() => asAlice.get('/v1/projects/1/forms/simple2')
                   .set('X-Extended-Metadata', true)
                   .expect(200)

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -766,7 +766,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .expect(200)
             .then(() => exhaust(container))
             .then(() => {
-              global.enketo.token = '::ijklmnop';
+              global.enketo.enketoId = '::ijklmnop';
               return asAlice.post('/v1/projects/1/forms/simple2/draft')
                 .expect(200)
                 .then(() => exhaust(container))

--- a/test/integration/fixtures/02-forms.js
+++ b/test/integration/fixtures/02-forms.js
@@ -1,21 +1,22 @@
 const appRoot = require('app-root-path');
 const { Form } = require(appRoot + '/lib/model/frames');
-const { QueryOptions } = require(appRoot + '/lib/util/db');
 const { simple, withrepeat } = require('../../data/xml').forms;
 const forms = [ simple, withrepeat ];
 
-module.exports = async ({ Actors, Assignments, Forms, Projects, Roles }) => {
+module.exports = async ({ Assignments, Forms, Projects, Roles }) => {
   const project = (await Projects.getById(1)).get();
+  const { id: formview } = (await Roles.getBySystemName('formview')).get();
   /* eslint-disable no-await-in-loop */
   for (const xml of forms) {
     const partial = await Form.fromXml(xml);
+    // Create the form without Enketo IDs in order to maintain existing tests.
+    global.enketo.state = 'error';
     const { acteeId } = await Forms.createNew(partial, project, true);
 
-    // Delete the formview actor created by Forms.createNew() in order to
-    // maintain existing tests.
-    const { id: roleId } = (await Roles.getBySystemName('formview')).get();
-    const [{ actor }] = await Assignments.getByActeeAndRoleId(acteeId, roleId, QueryOptions.extended);
-    await Actors.del(actor);
+    // Delete the assignment of the formview actor created by Forms.createNew()
+    // in order to maintain existing tests.
+    const [{ actorId }] = await Assignments.getByActeeAndRoleId(acteeId, formview);
+    await Assignments.revokeByActorId(actorId);
   }
   /* eslint-enable no-await-in-loop */
 };

--- a/test/integration/fixtures/02-forms.js
+++ b/test/integration/fixtures/02-forms.js
@@ -1,13 +1,22 @@
-
 const appRoot = require('app-root-path');
-const { mapSequential } = require(appRoot + '/test/util/util');
 const { Form } = require(appRoot + '/lib/model/frames');
+const { QueryOptions } = require(appRoot + '/lib/util/db');
 const { simple, withrepeat } = require('../../data/xml').forms;
 const forms = [ simple, withrepeat ];
 
-module.exports = ({ Forms, Projects }) =>
-  Projects.getById(1)
-    .then((option) => option.get())
-    .then((project) => mapSequential(forms, (xml) =>
-      Form.fromXml(xml).then((partial) => Forms.createNew(partial, project, true))));
+module.exports = async ({ Actors, Assignments, Forms, Projects, Roles }) => {
+  const project = (await Projects.getById(1)).get();
+  /* eslint-disable no-await-in-loop */
+  for (const xml of forms) {
+    const partial = await Form.fromXml(xml);
+    const { acteeId } = await Forms.createNew(partial, project, true);
+
+    // Delete the formview actor created by Forms.createNew() in order to
+    // maintain existing tests.
+    const { id: roleId } = (await Roles.getBySystemName('formview')).get();
+    const [{ actor }] = await Assignments.getByActeeAndRoleId(acteeId, roleId, QueryOptions.extended);
+    await Actors.del(actor);
+  }
+  /* eslint-enable no-await-in-loop */
+};
 

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -41,7 +41,10 @@ const bcrypt = require(appRoot + '/lib/util/crypto').password(_bcrypt);
 
 // set up our enketo mock.
 const { reset: resetEnketo, ...enketo } = require(appRoot + '/test/util/enketo');
+// Initialize the mock before other setup that uses the mock, then reset the
+// mock after setup is complete and after each test.
 before(resetEnketo);
+after(resetEnketo);
 afterEach(resetEnketo);
 
 // set up odk analytics mock.
@@ -84,12 +87,7 @@ const initialize = async () => {
     await migrator.destroy();
   }
 
-  // When creating fixtures, create forms without Enketo IDs in order to
-  // maintain existing tests.
-  global.enketo.state = 'error';
-  return withDefaults({ db, bcrypt, context, enketo, env })
-    .transacting(populate)
-    .finally(resetEnketo);
+  return withDefaults({ db, bcrypt, context, enketo, env }).transacting(populate);
 };
 
 // eslint-disable-next-line func-names, space-before-function-paren

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -41,7 +41,8 @@ const bcrypt = require(appRoot + '/lib/util/crypto').password(_bcrypt);
 
 // set up our enketo mock.
 const { reset: resetEnketo, ...enketo } = require(appRoot + '/test/util/enketo');
-beforeEach(resetEnketo);
+before(resetEnketo);
+afterEach(resetEnketo);
 
 // set up odk analytics mock.
 const { ODKAnalytics } = require(appRoot + '/test/util/odk-analytics-mock');
@@ -83,7 +84,12 @@ const initialize = async () => {
     await migrator.destroy();
   }
 
-  return withDefaults({ db, bcrypt, context }).transacting(populate);
+  // When creating fixtures, create forms without Enketo IDs in order to
+  // maintain existing tests.
+  global.enketo.state = 'error';
+  return withDefaults({ db, bcrypt, context, enketo, env })
+    .transacting(populate)
+    .finally(resetEnketo);
 };
 
 // eslint-disable-next-line func-names, space-before-function-paren

--- a/test/integration/task/reap-sessions.js
+++ b/test/integration/task/reap-sessions.js
@@ -10,7 +10,9 @@ describe('task: reap-sessions', () => {
       .then((actor) => Promise.all([ 2000, 2001, 2002, 2003, 3000, 3001, 3002, 3003 ]
         .map((year) => Sessions.create(actor, new Date(`${year}-01-01`)))))
       .then(() => reapSessions())
-      .then(() => oneFirst(sql`select count(*) from sessions`))
+      .then(() => oneFirst(sql`
+SELECT count(*) FROM sessions
+JOIN actors ON actors.id = sessions."actorId" AND actors.type = 'actor'`))
       .then((count) => { count.should.equal(4); })));
 });
 

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -7,7 +7,8 @@ const Problem = require(appRoot + '/lib/util/problem');
 const { without } = require(appRoot + '/lib/util/util');
 
 const defaults = {
-  // Properties that each test can set to determine the behavior of the mock
+  // Properties that can be set to change the behavior of the mock. These
+  // properties are reset after each mock request.
 
   // If `state` is set to 'error', the mock will pretend that Enketo has
   // misbehaved and will return a rejected promise for the next call.
@@ -20,7 +21,8 @@ const defaults = {
   // Properties that the mock may update after being called. These properties
   // are how the mock communicates back to the test.
 
-  // The total number of times that the mock has been called during the test
+  // The number of times that the mock has been called during the test, that is,
+  // the number of requests that would be sent to Enketo
   callCount: 0,
   // The OpenRosa URL that was passed to the create() method
   receivedUrl: undefined,

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -14,18 +14,15 @@ const defaults = {
   state: undefined,
   // Controls the timing of the Enketo response.
   wait: call,
-  // The enketoId for the create() or createOnceToken() method to return. By
-  // default, it is ::abcdefgh for create() and ::::abcdefgh for
-  // createOnceToken().
-  token: undefined,
+  // The enketoId for the create() method to return (by default, ::abcdefgh).
+  enketoId: undefined,
 
   // Properties that the mock may update after being called. These properties
   // are how the mock communicates back to the test.
 
   // The total number of times that the mock has been called during the test
   callCount: 0,
-  // The OpenRosa URL that was passed to the create() or createOnceToken()
-  // method
+  // The OpenRosa URL that was passed to the create() method
   receivedUrl: undefined,
   // An object with a property for each argument passed to the edit() method
   editData: undefined
@@ -40,7 +37,7 @@ const reset = () => {
 };
 
 // Mocks a request to Enketo.
-const request = (f) => {
+const request = () => {
   global.enketo.callCount += 1;
   const options = { ...global.enketo };
   Object.assign(global.enketo, without(['callCount'], defaults));
@@ -53,25 +50,22 @@ const request = (f) => {
       else if (options.state === 'error')
         reject(Problem.internal.enketoUnexpectedResponse('wrong status code'));
       else
-        resolve(f(options));
+        resolve(options);
     });
   });
 };
 
-const _create = (prefix) => (openRosaUrl) =>
-  request(({ token = `${prefix}abcdefgh` }) => {
-    global.enketo.receivedUrl = openRosaUrl;
-    return token;
-  });
-
-const edit = (openRosaUrl, domain, form, logicalId, submissionDef, attachments, token) =>
-  request(() => {
-    global.enketo.editData = { openRosaUrl, domain, form, logicalId, submissionDef, attachments, token };
-    return 'https://enketo/edit/url';
-  });
-
-module.exports = {
-  create: _create('::'), createOnceToken: _create('::::'), edit,
-  reset
+const create = async (openRosaUrl) => {
+  const { enketoId = '::abcdefgh' } = await request();
+  global.enketo.receivedUrl = openRosaUrl;
+  return { enketoId, enketoOnceId: '::::abcdefgh' };
 };
+
+const edit = async (openRosaUrl, domain, form, logicalId, submissionDef, attachments, token) => {
+  await request();
+  global.enketo.editData = { openRosaUrl, domain, form, logicalId, submissionDef, attachments, token };
+  return 'https://enketo/edit/url';
+};
+
+module.exports = { create, edit, reset };
 


### PR DESCRIPTION
This PR addresses three cases related to getodk/central#385:

- When a form is created for the first time, request an `enketoId` for the draft.
- When a form is published for the first time, request an `enketoId` and `enketoOnceId` for the form.
- When a form is created for the first time and immediately published (via the `?publish=true` flag of the API, thereby skipping a draft), request an `enketoId` and `enketoOnceId` for the form.

These are the last cases to address, so this PR closes getodk/central#385.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I quickly searched the API docs for "Enketo", but I didn't see anything that needed to case.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced