### PR TITLE
Use NODE_CONFIG_ENV to use test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ node_modules: package.json
 	npm install --legacy-peer-deps
 	touch node_modules
 
-.PHONY: test-oidc-integration
-test-oidc-integration: node_modules
-	TEST_AUTH=oidc NODE_CONFIG_ENV=oidc-integration-test make test-integration
-
 .PHONY: test-oidc-e2e
 test-oidc-e2e: node_modules
 	cd oidc-dev && \
@@ -60,22 +56,26 @@ debug: base
 
 .PHONY: test
 test: lint
-	NODE_CONFIG_ENV=test BCRYPT=no npx mocha --recursive --exit
+	NODE_CONFIG_ENV=test BCRYPT=no npm run test-all
 .PHONY: test-full
 test-full: lint
-	NODE_CONFIG_ENV=test npx mocha --recursive --exit
+	NODE_CONFIG_ENV=test npm run test-all
 
 .PHONY: test-integration
 test-integration: node_version
-	NODE_CONFIG_ENV=test BCRYPT=no npx mocha --recursive test/integration --exit
+	NODE_CONFIG_ENV=test BCRYPT=no npm run test-integration
+
+.PHONY: test-oidc-integration
+test-oidc-integration: node_modules
+	NODE_CONFIG_ENV=oidc-integration-test BCRYPT=no TEST_AUTH=oidc npm run test-integration
 
 .PHONY: test-unit
 test-unit: node_version
-	NODE_CONFIG_ENV=test npx mocha --recursive test/unit --exit
+	NODE_CONFIG_ENV=test npm run test-unit
 
 .PHONY: test-coverage
 test-coverage: node_version
-	NODE_CONFIG_ENV=test npx nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --exit --recursive test
+	NODE_CONFIG_ENV=test npx nyc -x "**/migrations/**" --reporter=lcov npm run test-all
 
 .PHONY: lint
 lint: node_version

--- a/Makefile
+++ b/Makefile
@@ -60,22 +60,22 @@ debug: base
 
 .PHONY: test
 test: lint
-	BCRYPT=no npx mocha --recursive --exit
+	NODE_CONFIG_ENV=test BCRYPT=no npx mocha --recursive --exit
 .PHONY: test-full
 test-full: lint
-	npx mocha --recursive --exit
+	NODE_CONFIG_ENV=test npx mocha --recursive --exit
 
 .PHONY: test-integration
 test-integration: node_version
-	BCRYPT=no npx mocha --recursive test/integration --exit
+	NODE_CONFIG_ENV=test BCRYPT=no npx mocha --recursive test/integration --exit
 
 .PHONY: test-unit
 test-unit: node_version
-	npx mocha --recursive test/unit --exit
+	NODE_CONFIG_ENV=test npx mocha --recursive test/unit --exit
 
 .PHONY: test-coverage
 test-coverage: node_version
-	npx nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --exit --recursive test
+	NODE_CONFIG_ENV=test npx nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --exit --recursive test
 
 .PHONY: lint
 lint: node_version

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ node_modules: package.json
 	npm install --legacy-peer-deps
 	touch node_modules
 
+.PHONY: test-oidc-integration
+test-oidc-integration: node_modules
+	NODE_CONFIG_ENV=oidc-integration-test BCRYPT=no TEST_AUTH=oidc npx mocha --recursive --exit ./test/integration
+
 .PHONY: test-oidc-e2e
 test-oidc-e2e: node_modules
 	cd oidc-dev && \
@@ -56,26 +60,22 @@ debug: base
 
 .PHONY: test
 test: lint
-	NODE_CONFIG_ENV=test BCRYPT=no npm run test-all
+	NODE_CONFIG_ENV=test BCRYPT=no npx mocha --recursive --exit
 .PHONY: test-full
 test-full: lint
-	NODE_CONFIG_ENV=test npm run test-all
+	NODE_CONFIG_ENV=test npx mocha --recursive --exit
 
 .PHONY: test-integration
 test-integration: node_version
-	NODE_CONFIG_ENV=test BCRYPT=no npm run test-integration
-
-.PHONY: test-oidc-integration
-test-oidc-integration: node_modules
-	NODE_CONFIG_ENV=oidc-integration-test BCRYPT=no TEST_AUTH=oidc npm run test-integration
+	NODE_CONFIG_ENV=test BCRYPT=no npx mocha --recursive test/integration --exit
 
 .PHONY: test-unit
 test-unit: node_version
-	NODE_CONFIG_ENV=test npm run test-unit
+	NODE_CONFIG_ENV=test npx mocha --recursive test/unit --exit
 
 .PHONY: test-coverage
 test-coverage: node_version
-	NODE_CONFIG_ENV=test npx nyc -x "**/migrations/**" --reporter=lcov npm run test-all
+	NODE_CONFIG_ENV=test npx nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --recursive --exit test
 
 .PHONY: lint
 lint: node_version

--- a/config/default.json
+++ b/config/default.json
@@ -33,19 +33,6 @@
         "version": "v2023.4.0_1"
       }
     }
-  },
-  "test": {
-    "database": {
-      "host": "localhost",
-      "user": "jubilant",
-      "password": "jubilant",
-      "database": "jubilant_test"
-    },
-    "email": {
-      "serviceAccount": "no-reply@getodk.org",
-      "transport": "json",
-      "transportOpts": { "newline": "unix" }
-    }
   }
 }
 

--- a/config/test.json
+++ b/config/test.json
@@ -10,13 +10,6 @@
       "serviceAccount": "no-reply@getodk.org",
       "transport": "json",
       "transportOpts": { "newline": "unix" }
-    },
-    "oidc": {
-      "enabled": true,
-      "issuerUrl": "http://localhost:9898",
-      "clientId": "odk-central-backend-dev",
-      "clientSecret": "super-top-secret"
     }
   }
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "tmp": "~0.2"
       },
       "engines": {
-        "node": "18.17.0"
+        "node": "18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "odk-central",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "test-all": "mocha --recursive --exit ./test",
+    "test-integration": "mocha --recursive --exit ./test/integration",
+    "test-unit": "mocha --recursive --exit ./test/unit"
+  },
   "engines": {
     "node": "18"
   },

--- a/package.json
+++ b/package.json
@@ -2,11 +2,6 @@
   "name": "odk-central",
   "version": "0.1.0",
   "private": true,
-  "scripts": {
-    "test-all": "mocha --recursive --exit ./test",
-    "test-integration": "mocha --recursive --exit ./test/integration",
-    "test-unit": "mocha --recursive --exit ./test/unit"
-  },
   "engines": {
     "node": "18"
   },

--- a/test/integration/other/db-stream.js
+++ b/test/integration/other/db-stream.js
@@ -10,7 +10,7 @@ describe('db.stream()', () => {
   let pool;
 
   beforeEach(() => {
-    pool = slonikPool(config.get('test.database'));
+    pool = slonikPool(config.get('default.database'));
     db = {};
     queryFuncs(pool, db);
   });

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -12,7 +12,7 @@ const populateForms = require('../fixtures/02-forms');
 const { getFormFields } = require('../../../lib/data/schema');
 
 
-const withTestDatabase = withDatabase(config.get('test.database'));
+const withTestDatabase = withDatabase(config.get('default.database'));
 const migrationsDir = appRoot + '/lib/model/migrations';
 const upToMigration = (toName, inclusive = true) => withTestDatabase(async (migrator) => {
   await migrator.raw('drop owned by current_user');

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -16,12 +16,12 @@ const { connect } = require(appRoot + '/lib/model/migrate');
 
 // slonik connection pool
 const { slonikPool } = require(appRoot + '/lib/external/slonik');
-const db = slonikPool(config.get('test.database'));
+const db = slonikPool(config.get('default.database'));
 
 // set up our mailer.
 const env = config.get('default.env');
 const { mailer } = require(appRoot + '/lib/external/mail');
-const mailConfig = config.get('test.email');
+const mailConfig = config.get('default.email');
 const mail = mailer(mergeRight(mailConfig, env));
 if (mailConfig.transport !== 'json')
   // eslint-disable-next-line no-console
@@ -71,7 +71,7 @@ const populate = (container, [ head, ...tail ] = fixtures) =>
 // this hook won't run if `test-unit` is called, as this directory is skipped
 // in that case.
 const initialize = async () => {
-  const migrator = connect(config.get('test.database'));
+  const migrator = connect(config.get('default.database'));
   const { log } = console;
   try {
     await migrator.raw('drop owned by current_user');


### PR DESCRIPTION
Demonstration of how code would change if using `NODE_CONFIG_ENV` to change `config` values.

More in-depth changes could be made if `mailer` and `slonikPool` were responsible for fetching their own config instead of having values injected.  The two different patterns for fetching config are both used throughout the codebase.