### PR TITLE
package-lock: loosen engines.node in line with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "tmp": "~0.2"
       },
       "engines": {
-        "node": "18.17.0"
+        "node": "18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
Every time I run `make node_modules`, this change is made.  

Ref 73157108a43052f9d1f50b09ae980275d3b7b4be