### PR TITLE
GitHub Actions: set job timeouts

### DIFF
--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -1,4 +1,5 @@
 name: OIDC e2e tests
+timeout-minutes: 2
 
 on: push
 

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -1,10 +1,10 @@
 name: OIDC e2e tests
-timeout-minutes: 2
 
 on: push
 
 jobs:
   oidc-e2e-test:
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   oidc-e2e-test:
-    timeout-minutes: 2
+    timeout-minutes: 6
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   oidc-integration-test:
-    timeout-minutes: 2
+    timeout-minutes: 6
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -1,4 +1,5 @@
 name: OIDC integration tests
+timeout-minutes: 2
 
 on: push
 

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -1,10 +1,10 @@
 name: OIDC integration tests
-timeout-minutes: 2
 
 on: push
 
 jobs:
   oidc-integration-test:
+    timeout-minutes: 2
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   soak-test:
-    timeout-minutes: 2
+    timeout-minutes: 15
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -1,10 +1,10 @@
 name: Soak Test
-timeout-minutes: 2
 
 on: push
 
 jobs:
   soak-test:
+    timeout-minutes: 2
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -1,4 +1,5 @@
 name: Soak Test
+timeout-minutes: 2
 
 on: push
 

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   standard-tests:
-    timeout-minutes: 2
+    timeout-minutes: 20
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -1,10 +1,10 @@
 name: Full Standard Test Suite
-timeout-minutes: 2
 
 on: push
 
 jobs:
   standard-tests:
+    timeout-minutes: 2
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -1,4 +1,5 @@
 name: Full Standard Test Suite
+timeout-minutes: 2
 
 on: push
 


### PR DESCRIPTION
Without these, a runaway job can continue for the default job timeout of **[6 hours](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)**.

I've set the timeouts as approximately double the time I've seen for recent ✅ green builds.