### PR TITLE
Improve error messages about datasets

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -101,7 +101,7 @@ const createOrMerge = (name, form, fields) => async ({ one, Actees, Datasets, Pr
   let dsPropertyFields = fields.filter((field) => (field.propertyName));
   // Step 2: Check for invalid property names
   if (dsPropertyFields.filter((field) => !validatePropertyName(field.propertyName)).length > 0)
-    throw Problem.user.invalidEntityForm({ reason: 'Invalid Dataset property.' });
+    throw Problem.user.invalidEntityForm({ reason: 'Invalid entity property name.' });
   // Step 3: Build Form Field frames to handle dataset property field insertion
   dsPropertyFields = dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId, formDefId }));
 
@@ -110,7 +110,7 @@ const createOrMerge = (name, form, fields) => async ({ one, Actees, Datasets, Pr
   const result = await one(_createOrMerge(partial, dsPropertyFields, acteeId))
     .catch(error => {
       if (error.constraint === 'ds_property_fields_dspropertyid_formdefid_unique') {
-        throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single Dataset Property.' });
+        throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single property.' });
       }
       throw error;
     });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -2119,7 +2119,7 @@ describe('datasets and entities', () => {
             .expect(400)
             .then(({ body }) => {
               body.code.should.equal(400.25);
-              body.details.reason.should.equal('Invalid Dataset property.');
+              body.details.reason.should.equal('Invalid entity property name.');
             }))));
 
       it('should return a Problem if the savetos reference invalid properties (extra whitespace)', testService((service) =>
@@ -2130,7 +2130,7 @@ describe('datasets and entities', () => {
             .expect(400)
             .then(({ body }) => {
               body.code.should.equal(400.25);
-              body.details.reason.should.equal('Invalid Dataset property.');
+              body.details.reason.should.equal('Invalid entity property name.');
             }))));
 
       it('should return the created form upon success', testService((service) =>
@@ -2190,7 +2190,7 @@ describe('datasets and entities', () => {
             .expect(400)
             .then(({ body }) => {
               body.code.should.be.eql(400.25);
-              body.message.should.be.eql('The entity definition within the form is invalid. Multiple Form Fields cannot be saved to a single Dataset Property.');
+              body.message.should.be.eql('The entity definition within the form is invalid. Multiple Form Fields cannot be saved to a single property.');
             }));
       }));
 
@@ -2377,7 +2377,7 @@ describe('datasets and entities', () => {
               .expect(400)
               .then(({ body }) => {
                 body.code.should.equal(400.25);
-                body.details.reason.should.equal('Invalid Dataset property.');
+                body.details.reason.should.equal('Invalid entity property name.');
               }));
         }));
       });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/487

This PR makes slight changes to the error messages coming from Backend about problems parsing form XML containing entity definitions.

<img width="589" alt="Screen Shot 2023-09-19 at 4 27 50 PM" src="https://github.com/getodk/central-backend/assets/76205/77c6ce0c-77bd-41b8-a63a-9840da1d8fc7">

There is a somewhat generic message for entity form parsing problems that says "The entity definition within the form is invalid" followed by a `reason` more specific to the problem, e.g. what we were seeing before with "Invalid Dataset property." Both parts get passed through to Frontend. I'm not sure localization makes the most sense here because the problem was with `reason` and we probably don't want to maintain translations for all possible reasons for this one case, especially since they are all within the same problem code. 

For this one case about "dataset property", it was easy to change it to "entity property", even within the world of still referring to datasets as datasets in the backend. 

For other cases, like problems that mention "invalid dataset name", the error message should actually stay as it is because this only happens for XML parsing (pyxform will catch other errors upstream) and in that case, the field is still called "dataset" within the XML. The other problems that still mention "dataset" are also like this -- they are about the value of "dataset" within XML. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, trying it.

#### Why is this the best possible solution? Were any other approaches considered?

See reasoning above

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Doesn't change much but hopefully makes this edge case a little less confusing.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced