### PR TITLE
Test that Enketo IDs are requested during request to create form

### DIFF
--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -1251,7 +1251,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
       it('should request Enketo IDs from worker if request from endpoint fails', testService(async (service, container) => {
         const asAlice = await service.login('alice');
 
-        // First request to Enketo, from endpoint
+        // First request to Enketo, from the endpoint
         await asAlice.post('/v1/projects/1/forms')
           .send(testData.forms.simple2)
           .set('Content-Type', 'application/xml')
@@ -1264,7 +1264,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(beforeWorker.enketoId);
         should.not.exist(beforeWorker.enketoOnceId);
 
-        // Second request, from worker
+        // Second request, from the worker
         global.enketo.callCount.should.equal(2);
         await exhaust(container);
         global.enketo.callCount.should.equal(3);

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -123,9 +123,9 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(body.enketoId);
       }));
 
-      it('should stop waiting for Enketo after 0.5 seconds @slow', testService(async (service) => {
+      it('should wait for Enketo only briefly @slow', testService(async (service) => {
         const asAlice = await service.login('alice');
-        global.enketo.wait = (f) => { setTimeout(f, 501); };
+        global.enketo.wait = (done) => { setTimeout(done, 600); };
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         const { body } = await asAlice.get('/v1/projects/1/forms/simple/draft')
           .expect(200);
@@ -1181,13 +1181,13 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(form.enketoOnceId);
       }));
 
-      it('should stop waiting for Enketo after 0.5 seconds @slow', testService(async (service) => {
+      it('should wait for Enketo only briefly @slow', testService(async (service) => {
         const asAlice = await service.login('alice');
         await asAlice.post('/v1/projects/1/forms')
           .send(testData.forms.simple2)
           .set('Content-Type', 'application/xml')
           .expect(200);
-        global.enketo.wait = (f) => { setTimeout(f, 501); };
+        global.enketo.wait = (done) => { setTimeout(done, 600); };
         await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
           .expect(200);
         const { body: form } = await asAlice.get('/v1/projects/1/forms/simple2')

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -24,6 +24,8 @@ const defaults = {
   // The number of times that the mock has been called during the test, that is,
   // the number of requests that would be sent to Enketo
   callCount: 0,
+  // An object with a property for each argument passed to the create() method
+  createData: undefined,
   // The OpenRosa URL that was passed to the create() method
   receivedUrl: undefined,
   // An object with a property for each argument passed to the edit() method
@@ -57,8 +59,9 @@ const request = () => {
   });
 };
 
-const create = async (openRosaUrl) => {
+const create = async (openRosaUrl, xmlFormId, token) => {
   const { enketoId = '::abcdefgh' } = await request();
+  global.enketo.createData = { openRosaUrl, xmlFormId, token };
   global.enketo.receivedUrl = openRosaUrl;
   return { enketoId, enketoOnceId: '::::abcdefgh' };
 };


### PR DESCRIPTION
Follow-up PR to #989, adding more tests. Only test/ is changed, not lib/.

#989 included tests of requests to publish an existing form. This PR also tests requests to create a form (either as a draft form or as an immediately published form).

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced