### PR TITLE
Update systeminformation dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9446,9 +9446,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.17.12",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.17.12.tgz",
-      "integrity": "sha512-I3pfMW2vue53u+X08BNxaJieaHkRoMMKjWetY9lbYJeWFaeWPO6P4FkNc4XOCX8F9vbQ0HqQ25RJoz3U/B7liw==",
+      "version": "5.21.8",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.8.tgz",
+      "integrity": "sha512-Xf1KDMUTQHLOT9Z7MjpSpsbaICOHcm4OZ9c9qqpkCoXuxq5MoyDrgu5GIQYpoiralXNPrqxDz3ND8MdllpXeQA==",
       "optional": true,
       "os": [
         "darwin",
@@ -17428,9 +17428,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "systeminformation": {
-      "version": "5.17.12",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.17.12.tgz",
-      "integrity": "sha512-I3pfMW2vue53u+X08BNxaJieaHkRoMMKjWetY9lbYJeWFaeWPO6P4FkNc4XOCX8F9vbQ0HqQ25RJoz3U/B7liw==",
+      "version": "5.21.8",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.8.tgz",
+      "integrity": "sha512-Xf1KDMUTQHLOT9Z7MjpSpsbaICOHcm4OZ9c9qqpkCoXuxq5MoyDrgu5GIQYpoiralXNPrqxDz3ND8MdllpXeQA==",
       "optional": true
     },
     "tar": {


### PR DESCRIPTION
I updated the `systeminformation` package by running `npm audit fix`. `systeminformation` is a subdependency of `pm2`:

```
$ npm ls systeminformation
odk-central@0.1.0
└─┬ pm2@5.3.0
  └─┬ pm2-sysmonit@1.2.8
    └── systeminformation@5.21.8
```

#### What has been done to verify that this works as intended?

Just running tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Given that the package is a subdependency within the allowed semver range, I'm hopeful that any risk of regression is low.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced