### PR TITLE
Updated statement to enable/disable DB connections

### DIFF
--- a/lib/task/db.js
+++ b/lib/task/db.js
@@ -42,7 +42,7 @@ const pgrestore = async (directory, namespace = 'default') => {
 
   // write the script that kicks everybody off the database (can't -c as it is multiple statements):
   const script = `
-    UPDATE pg_database SET datallowconn = 'false' WHERE datname = '${dbConfig.database}';
+    ALTER DATABASE ${dbConfig.database} ALLOW_CONNECTIONS FALSE;
     SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${dbConfig.database}';
   `;
   await tmp.withFile(async (tmpfile) => {
@@ -59,7 +59,7 @@ const pgrestore = async (directory, namespace = 'default') => {
   await task.promisify(exec)(invokeRestore, { env });
 
   // now we have to allow connections again:
-  const enableConnections = `UPDATE pg_database SET datallowconn = 'true' WHERE datname = '${dbConfig.database}';`;
+  const enableConnections = `ALTER DATABASE ${dbConfig.database} ALLOW_CONNECTIONS TRUE;`;
   return task.promisify(exec)(`psql -h ${dbConfig.host} -U ${dbConfig.user} -d template1 -c "${enableConnections}"`, { env });
 };
 


### PR DESCRIPTION
## Change:

Replace the statement to disable/enable connections. RDS doesn't allow to update `pg_database` catalog. Following links suggest right way to turnoff DB connection is to `ALTER DATABASE`:

https://stackoverflow.com/a/43888064/3633589
https://dba.stackexchange.com/questions/202685/postgresql-cannot-update-pg-database

#### What has been done to verify that this works as intended?

Verified on dev (AWS) and test (DO) instances

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced