### PR TITLE
Added ability to build odk-docs via dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ If you want to use OpenID Connect instead of username/password for authenticatio
 
 Instead of `make dev`, run both `make dev-oidc` and `make fake-oidc-server`.
 
+### API documentation
+
+We use OpenAPI specification for API documentation. It is located at `docs/api.yaml`. 
+
+You can run `make api-docs` to preview the document.
+
 ## Guidelines
 
 If you're starting work on an issue ticket, please leave a comment saying so. If you run into trouble or have to stop working on a ticket, please leave a comment as well. As you write code, the usual guidelines apply; please ensure you are following existing conventions:

--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,8 @@ rm-docker-postgres: stop-docker-postgres
 .PHONY: check-file-headers
 check-file-headers:
 	git ls-files | node lib/bin/check-file-headers.js
+
+.PHONY: api-docs
+api-docs:
+	(test "$(docker images -q odk-docs)" || docker build --file odk-docs.dockerfile -t odk-docs .) && \
+	docker run --rm -it -v ./docs/api.yaml:/docs/docs/_static/api-spec/central.yaml -p 8000:8000 odk-docs

--- a/odk-docs.dockerfile
+++ b/odk-docs.dockerfile
@@ -1,0 +1,15 @@
+FROM sphinxdoc/sphinx
+
+RUN apt-get update && apt-get install -y libenchant-2-2 git
+
+WORKDIR /docs
+
+RUN git clone https://github.com/getodk/docs.git .
+
+RUN sed -i 's/sphinx-autobuild.*/& --host 0.0.0.0/' Makefile
+
+RUN pip3 install -r requirements.txt
+
+EXPOSE 8000
+
+ENTRYPOINT ["/bin/sh", "-c" , "(git pull --autostash) && make autobuild"]


### PR DESCRIPTION
To help us preview API docs without need to setup getodk/docs repo.

You should be able to see ODK docs by running `make api-docs`

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced