### PR TITLE
Refactor Entities.createVersion

### DIFF
--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -47,7 +47,7 @@ class Entity extends Frame.define(
       });
     const { uuid, label } = entityData.system;
     const { data } = entityData;
-    return new Entity.Partial({ uuid, datasetId: dataset.id }, {
+    return new Entity.Partial({ uuid, datasetId: dataset.id, id: oldEntity?.id }, {
       def: new Entity.Def({ data, label }),
       dataset: dataset.name
     });

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -133,6 +133,12 @@ createVersion.audit.withResult = true;
 // Processing submission events to create and update entities
 
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
+  // If dataset requires approval on submission to create an entity and this event is not
+  // an approval event, then don't create an entity
+  if ((dataset.approvalRequired && event.details.reviewState !== 'approved') ||
+      (!dataset.approvalRequired && event.action === 'submission.update')) // don't process submission if approval is not required and submission metadata is updated
+    return null;
+
   const partial = await Entity.fromParseEntityData(entityData);
 
   const sourceDetails = { submission: { instanceId: submissionDef.instanceId }, parentEventId: parentEvent ? parentEvent.id : undefined };
@@ -150,13 +156,15 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities }) => {
+  // Get client version of entity
+  const clientEntity = await Entity.fromParseEntityData(entityData); // validation happens here
 
   // Get version of entity on the server
-  const serverEntity = await Entities.getById(dataset.id, entityData.system.id).then(o => o.get());
+  const serverEntity = await Entities.getById(dataset.id, clientEntity.uuid).then(o => o.get());
 
   // merge data
-  const mergedData = mergeRight(serverEntity.aux.currentVersion.data, entityData.data);
-  const mergedLabel = entityData.system.label || serverEntity.aux.currentVersion.label;
+  const mergedData = mergeRight(serverEntity.aux.currentVersion.data, clientEntity.def.data);
+  const mergedLabel = clientEntity.def.label || serverEntity.aux.currentVersion.label;
 
   // make some kind of source object
   const sourceDetails = {
@@ -173,8 +181,8 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   const entity = await Entities.createVersion(dataset, partial, submissionDef, serverEntity.aux.currentVersion.version + 1, sourceId);
   return Audits.log({ id: event.actorId }, 'entity.update.version', { acteeId: dataset.acteeId },
     {
-      entityId: entity.id, // Added in v2023.3 and backfilled
-      entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 and backfilled
+      entityId: entity.id,
+      entityDefId: entity.aux.currentVersion.id,
       entity: { uuid: entity.uuid, dataset: dataset.name },
       submissionId,
       submissionDefId
@@ -218,27 +226,18 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
 
   const entityData = await parseSubmissionXml(fields, submissionDef.xml);
 
-  // If dataset requires approval on submission to create an entity and this event is not
-  // an approval event, then don't create an entity
-  //
-  // We can't simply use submissionDefId to trace back to dataset and find out if approval
-  // is required because in future there can be multiple entities in a single submission.
-  // So we have to rely on dataset name from the xml to fetch the dataset.approvalRequired flag.
+  // We have to look up the dataset based on the name in the XML
   if (!entityData.system.dataset || entityData.system.dataset.trim() === '') {
     throw Problem.user.missingParameter({ field: 'dataset' });
   }
-
   const dataset = (await Datasets.get(form.get().projectId, entityData.system.dataset, true))
     .orThrow(Problem.user.datasetNotFound({ datasetName: entityData.system.dataset }));
 
-  if ((dataset.approvalRequired && event.details.reviewState !== 'approved') ||
-      (!dataset.approvalRequired && event.action === 'submission.update')) // don't process submission if approval is not required and submission metadata is updated
-    return null;
-
-  // If create is not true (either 1 or true) then we don't need to process further
+  // Create entity
   if (entityData.system.create === '1' || entityData.system.create === 'true')
     return Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
 
+  // Or update entity
   if (entityData.system.update === '1' || entityData.system.update === 'true')
     return Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event);
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -51,9 +51,9 @@ const createNew = (dataset, partial, subDef, sourceId, userAgentIn) => ({ one, c
   let userAgent;
 
   // Set creatorId and userAgent from submission def if it exists
-  if (subDef != null && subDef.id != null)
+  if (subDef != null) {
     ({ submitterId: creatorId, userAgent } = subDef);
-  else {
+  } else {
     creatorId = context.auth.actor.map((actor) => actor.id).orNull();
     userAgent = blankStringToNull(userAgentIn);
   }
@@ -94,9 +94,9 @@ const createVersion = (dataset, partial, subDef, version, sourceId, userAgentIn 
   let userAgent;
 
   // Set creatorId and userAgent from submission def if it exists
-  if (subDef != null && subDef.id != null)
+  if (subDef != null) {
     ({ submitterId: creatorId, userAgent } = subDef);
-  else {
+  } else {
     creatorId = context.auth.actor.map((actor) => actor.id).orNull();
     userAgent = blankStringToNull(userAgentIn);
   }

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -19,6 +19,18 @@ const { isTrue } = require('../../util/http');
 const Problem = require('../../util/problem');
 const { runSequentially } = require('../../util/promise');
 
+
+/////////////////////////////////////////////////////////////////////////////////
+// ENTITY DEF SOURCES
+
+const createSource = (details = null, subDefId = null, eventId = null) => ({ one }) => {
+  const type = (subDefId) ? 'submission' : 'api';
+  return one(sql`insert into entity_def_sources ("type", "submissionDefId", "auditId", "details")
+  values (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)})
+  returning id`)
+    .then((row) => row.id);
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 // ENTITY CREATE
 
@@ -37,15 +49,13 @@ const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 const createNew = (dataset, partial, subDef, sourceId, userAgentIn) => ({ one, context }) => {
   let creatorId;
   let userAgent;
-  let subDefId;
 
   // Set creatorId and userAgent from submission def if it exists
   if (subDef != null && subDef.id != null)
-    ({ id: subDefId, submitterId: creatorId, userAgent } = subDef);
+    ({ submitterId: creatorId, userAgent } = subDef);
   else {
     creatorId = context.auth.actor.map((actor) => actor.id).orNull();
     userAgent = blankStringToNull(userAgentIn);
-    subDefId = null;
   }
 
   const json = JSON.stringify(partial.def.data);
@@ -60,17 +70,13 @@ select ins.*, def.id as "entityDefId" from ins, def;`)
       new Entity(entityData, {
         currentVersion: new Entity.Def({
           id: entityDefId,
-          entityId: entityData.id,
-          submissionDefId: subDefId,
-          data: partial.def.data,
-          label: partial.def.label
+          entityId: entityData.id
         })
       }));
 };
 
-
 createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
-  if (!subDef)
+  if (!subDef) // entities created from submissions are logged elsewhere
     return log('entity.create', dataset, {
       entityId: newEntity.id, // Added in v2023.3 and backfilled
       entityDefId: newEntity.aux.currentVersion.id, // Added in v2023.3 and backfilled
@@ -80,20 +86,53 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
 createNew.audit.withResult = true;
 
 
-// Creates a source entry for entities created through audit events and submissions
-const createSource = (details = null, subDefId = null, eventId = null) => ({ one }) => {
-  const type = (subDefId) ? 'submission' : 'api';
-  return one(sql`insert into entity_def_sources ("type", "submissionDefId", "auditId", "details")
-  values (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)})
-  returning id`)
-    .then((row) => row.id);
+////////////////////////////////////////////////////////////////////////////////
+// ENTITY UPDATE
+
+const createVersion = (dataset, partial, subDef, version, sourceId, userAgentIn = null) => ({ context, one }) => {
+  let creatorId;
+  let userAgent;
+
+  // Set creatorId and userAgent from submission def if it exists
+  if (subDef != null && subDef.id != null)
+    ({ submitterId: creatorId, userAgent } = subDef);
+  else {
+    creatorId = context.auth.actor.map((actor) => actor.id).orNull();
+    userAgent = blankStringToNull(userAgentIn);
+  }
+
+  const json = JSON.stringify(partial.def.data);
+
+  const _unjoiner = unjoiner(Entity, Entity.Def.into('currentVersion'));
+
+  return one(sql`
+  with def as (${_defInsert(partial.id, false, creatorId, userAgent, partial.def.label, json, version, sourceId)}),
+  upd as (update entity_defs set current=false where entity_defs."entityId" = ${partial.id}),
+  entities as (update entities set "updatedAt"=clock_timestamp()
+    where "uuid"=${partial.uuid}
+    returning *)
+  select ${_unjoiner.fields} from def as entity_defs
+  join entities on entity_defs."entityId" = entities.id
+  `)
+    .then(_unjoiner);
 };
 
-//
-// Entity event processing
-//
+createVersion.audit = (updatedEntity, dataset, partial, subDef) => (log) => {
+  if (!subDef) // entities updated from submissions are logged elsewhere
+    return log('entity.update.version', dataset, {
+      entityId: updatedEntity.id,
+      entityDefId: updatedEntity.aux.currentVersion.id,
+      entity: { uuid: updatedEntity.uuid, dataset: dataset.name }
+    });
+};
+createVersion.audit.withResult = true;
 
-const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Entities, Audits }) => {
+
+
+/////////////////////////////////////////////////////////////////////////
+// Processing submission events to create and update entities
+
+const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   const partial = await Entity.fromParseEntityData(entityData);
 
   const sourceDetails = { submission: { instanceId: submissionDef.instanceId }, parentEventId: parentEvent ? parentEvent.id : undefined };
@@ -110,7 +149,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
     });
 };
 
-const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Entities }) => {
+const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities }) => {
 
   // Get version of entity on the server
   const serverEntity = await Entities.getById(dataset.id, entityData.system.id).then(o => o.get());
@@ -124,10 +163,22 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
     submission: { instanceId: submissionDef.instanceId }
   };
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id);
+  const partial = new Entity.Partial(serverEntity, {
+    def: new Entity.Def({
+      data: mergedData,
+      label: mergedLabel
+    })
+  });
 
-  // TODO: createVersion infers creator id from context.auth, shoving the submitter id in as another arg
-  // should be refactored
-  return Entities.createVersion(dataset, serverEntity, mergedData, mergedLabel, serverEntity.aux.currentVersion.version + 1, sourceId, null, submissionDef.submitterId);
+  const entity = await Entities.createVersion(dataset, partial, submissionDef, serverEntity.aux.currentVersion.version + 1, sourceId);
+  return Audits.log({ id: event.actorId }, 'entity.update.version', { acteeId: dataset.acteeId },
+    {
+      entityId: entity.id, // Added in v2023.3 and backfilled
+      entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 and backfilled
+      entity: { uuid: entity.uuid, dataset: dataset.name },
+      submissionId,
+      submissionDefId
+    });
 };
 
 // Entrypoint to where submissions (a specific version) become entities
@@ -219,39 +270,6 @@ const createEntitiesFromPendingSubmissions = (submissionEvents, parentEvent) => 
     () => processSubmissionEvent(event, parentEvent)(container)));
 
 
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// UPDATING ENTITIES
-
-const createVersion = (dataset, entity, data, label, version, sourceId, userAgentIn = null, submitterId = null) => ({ context, one }) => {
-  // dataset is passed in so the audit log can use its actee id
-  const creatorId = (context.auth ? context.auth.actor.map((actor) => actor.id).orNull() : submitterId);
-  const userAgent = blankStringToNull(userAgentIn);
-  const json = JSON.stringify(data);
-
-  const _unjoiner = unjoiner(Entity, Entity.Def.into('currentVersion'));
-
-  return one(sql`
-  with def as (${_defInsert(entity.id, false, creatorId, userAgent, label, json, version, sourceId)}),
-  upd as (update entity_defs set current=false where entity_defs."entityId" = ${entity.id}),
-  entities as (update entities set "updatedAt"=clock_timestamp()
-    where "uuid"=${entity.uuid}
-    returning *)
-  select ${_unjoiner.fields} from def as entity_defs
-  join entities on entity_defs."entityId" = entities.id
-  `)
-    .then(_unjoiner);
-};
-
-createVersion.audit = (newEntity, dataset, entity) => (log) =>
-  log('entity.update.version', dataset, {
-    entityId: entity.id,
-    entityDefId: newEntity.aux.currentVersion.id,
-    entity: { uuid: newEntity.uuid, dataset: dataset.name }
-  });
-createVersion.audit.withResult = true;
 
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -114,7 +114,7 @@ module.exports = (service, endpoint) => {
 
     const sourceId = await Entities.createSource();
 
-    return Entities.createVersion(dataset, entity, partial.def.data, partial.def.label, serverEntityVersion + 1, sourceId, userAgent);
+    return Entities.createVersion(dataset, partial, null, serverEntityVersion + 1, sourceId, userAgent);
   }));
 
   service.delete('/projects/:projectId/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { auth, params, queryOptions }) => {

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -845,6 +845,14 @@ describe('worker: entity', () => {
           person.currentVersion.version.should.equal(2);
         });
 
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
+        .expect(200)
+        .then(({ body: logs }) => {
+          logs[0].should.be.an.Audit();
+          logs[0].action.should.be.eql('entity.update.version');
+          logs[0].actor.displayName.should.be.eql('Alice');
+        });
+
       // update again
       await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
         .send(testData.instances.updateEntity.one


### PR DESCRIPTION
Addresses some clunkiness in https://github.com/getodk/central-backend/pull/1005 but I wanted to put it in a separate PR so the meaning of #1005 would be clearer.

There's a 2x2 square of situations and I tried to make the via submission vs. API cases more similar. 

[creating entities, updating entities] x [via submission, via API]

Via API:
* parse data from request
* entity def source is basic, practically empty
* creator is inferred from request auth
* audit logging happens through `createNew.audit` and `createVersion.audit`, which checks that submission def was not provided

Via submission:
* data parsed from submission
* entity def source is complex, based on submission, def, event, etc.
* creator is the submission's creator
* audit logging happens in a submission event processing method because different audit logging kicks in in case of a processing error

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced