### PR TITLE
added test-fast in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,14 @@ debug: base
 .PHONY: test
 test: lint
 	BCRYPT=no npx mocha --recursive --exit
+
 .PHONY: test-full
 test-full: lint
 	npx mocha --recursive --exit
+
+.PHONY: test-fast
+test-fast: node_version
+	BCRYPT=no npx mocha --recursive --exit --fgrep @slow --invert
 
 .PHONY: test-integration
 test-integration: node_version


### PR DESCRIPTION
Added a rule in Makefile to skip @slow test, this is helpful for me during development because most of the time I'm not changing the code which is tested by slow tests like encryption

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced