### PR TITLE
Clarify that OData operator for "not equals" is ne, not neq

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -7745,7 +7745,7 @@ paths:
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
-          are available to reference. The operators `lt`, `le`, `eq`, `neq`, `ge`,
+          are available to reference. The operators `lt`, `le`, `eq`, `ne`, `ge`,
           `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`,
           `year`, `month`, `day`, `hour`, `minute`, `second`.
         schema:
@@ -7859,7 +7859,7 @@ paths:
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
-          are available to reference. The operators `lt`, `le`, `eq`, `neq`, `ge`,
+          are available to reference. The operators `lt`, `le`, `eq`, `ne`, `ge`,
           `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`,
           `year`, `month`, `day`, `hour`, `minute`, `second`.
         schema:
@@ -7970,7 +7970,7 @@ paths:
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
-          are available to reference. The operators `lt`, `le`, `eq`, `neq`, `ge`,
+          are available to reference. The operators `lt`, `le`, `eq`, `ne`, `ge`,
           `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`,
           `year`, `month`, `day`, `hour`, `minute`, `second`.
         schema:
@@ -8050,7 +8050,7 @@ paths:
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
-          are available to reference. The operators `lt`, `le`, `eq`, `neq`, `ge`,
+          are available to reference. The operators `lt`, `le`, `eq`, `ne`, `ge`,
           `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`,
           `year`, `month`, `day`, `hour`, `minute`, `second`.
         schema:
@@ -12189,7 +12189,7 @@ paths:
         in: query
         description: If provided, will filter responses to those matching the query.
           Only [certain fields](/central-api-odata-endpoints/#data-document)
-          are available to reference. The operators `lt`, `le`, `eq`, `neq`, `ge`,
+          are available to reference. The operators `lt`, `le`, `eq`, `ne`, `ge`,
           `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`,
           `year`, `month`, `day`, `hour`, `minute`, `second`.
         schema:
@@ -12658,7 +12658,7 @@ paths:
         in: query
         description: If provided, will filter responses to those matching the query.
           Only [certain fields](/central-api-odata-endpoints/#data-document)
-          are available to reference. The operators `lt`, `le`, `eq`, `neq`, `ge`,
+          are available to reference. The operators `lt`, `le`, `eq`, `ne`, `ge`,
           `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`,
           `year`, `month`, `day`, `hour`, `minute`, `second`.
         schema:
@@ -13107,7 +13107,7 @@ paths:
         in: query
         description: If provided, will filter responses to those matching the query.
           Only [certain fields](/central-api-odata-endpoints/#data-document)
-          are available to reference. The operators `lt`, `le`, `eq`, `neq`, `ge`,
+          are available to reference. The operators `lt`, `le`, `eq`, `ne`, `ge`,
           `gt`, `not`, `and`, and `or` are supported, and the built-in functions `now`,
           `year`, `month`, `day`, `hour`, `minute`, `second`.
         schema:

--- a/test/unit/data/odata-filter.js
+++ b/test/unit/data/odata-filter.js
@@ -18,6 +18,7 @@ const odataFilter = (exp) => _odataFilter(exp, odataToColumnMap);
 describe('OData filter query transformer', () => {
   it('should transform binary expressions', () => {
     odataFilter('3 eq 5').should.eql(sql`(${'3'} is not distinct from ${'5'})`);
+    odataFilter('3 ne 5').should.eql(sql`(${'3'} is distinct from ${'5'})`);
     odataFilter('2 lt 3 and 5 gt 4').should.eql(sql`((${'2'} < ${'3'}) and (${'5'} > ${'4'}))`);
     odataFilter('3 eq __system/submitterId').should.eql(sql`(${'3'} is not distinct from ${sql.identifier([ 'submissions', 'submitterId' ])})`);
     odataFilter('2 eq $root/Submissions/__system/submitterId').should.eql(sql`(${'2'} is not distinct from ${sql.identifier([ 'submissions', 'submitterId' ])})`);


### PR DESCRIPTION
For getodk/central#503, I'm currently planning to use the OData "not equals" operator in the `$filter` query parameter, something like `__system/conflict ne null`. While looking into that, I noticed that the API docs say that `neq` is the OData operator. However, the operator is actually `ne`: https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_NotEquals. I updated a test to confirm that.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced