### PR TITLE
Refactoring entity tests and adding new entity update tests

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -157,6 +157,9 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities }) => {
+  if (!(event.action === 'submission.create')) // only update on submission.create
+    return null;
+
   // Get client version of entity
   const clientEntity = await Entity.fromParseEntityData(entityData); // validation happens here
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -13,6 +13,7 @@ const { equals, extender, unjoiner, page, markDeleted } = require('../../util/db
 const { map, mergeRight } = require('ramda');
 const { blankStringToNull, construct } = require('../../util/util');
 const { QueryOptions } = require('../../util/db');
+const { getOrNotFound } = require('../../util/promise');
 const { odataFilter } = require('../../data/odata-filter');
 const { odataToColumnMap, parseSubmissionXml } = require('../../data/entity');
 const { isTrue } = require('../../util/http');
@@ -160,7 +161,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   const clientEntity = await Entity.fromParseEntityData(entityData); // validation happens here
 
   // Get version of entity on the server
-  const serverEntity = await Entities.getById(dataset.id, clientEntity.uuid).then(o => o.get());
+  const serverEntity = await Entities.getById(dataset.id, clientEntity.uuid).then(getOrNotFound);
 
   // merge data
   const mergedData = mergeRight(serverEntity.aux.currentVersion.data, clientEntity.def.data);

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -174,7 +174,7 @@ describe('extracting and validating entities', () => {
     });
   });
 
-  describe('exctact entity from API request: extractEntity', () => {
+  describe('extract entity from API request: extractEntity', () => {
     // Used to compare entity structure when Object.create(null) used.
     beforeEach(() => {
       should.config.checkProtoEql = false;


### PR DESCRIPTION
Closes the following issues:
* https://github.com/getodk/central-backend/issues/1009
* https://github.com/getodk/central/issues/510 
    * except for offshoot issue: https://github.com/getodk/central/issues/520)

In particular:

**commit 1**
- updated entity-parsing unit tests 

**commit 2**
- moved extra tests of streaming CSVs of entities from `worker/entity` test to `api/datasets` test (multi form and updated entities in particular)
- removed redundant checks and tests from `worker/entity` test file
- added entity update tests to relevant sections of `api/entities` API test file
	* returning current version and data of updated entity
	* audit log events for an entity

**commit 3**
- added tests of entity processing errors flagged by worker

**commit 4**
- added tests about when submissions about entity updates do or do not get processed including tests for comments:
    - submisssion.update/approval should never update entity https://github.com/getodk/central-backend/pull/1005#discussion_r1341794108
    - update should be processed even if approval required for creation https://github.com/getodk/central-backend/pull/1005#discussion_r1341833278

**commit 5**
- tests of basic update logic (can update label and data) 
    * does not test or even consider conflicts
    * has some issues (skipped tests) where setting a field to blank doesn't work. waiting for https://github.com/getodk/central-backend/pull/1020 first to not get in the way (or maybe that PR can directly address this issue)

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

it's mostly all tests!

#### Why is this the best possible solution? Were any other approaches considered?

Some of the tests got refactored. I moved tests that started in worker/entity but weren't really about the worker into other files, e.g. csv streaming of entities, which was one of the first tests about entities to exist. 

Many tests about entity updates have an API endpoint that is most relevant, and it seems reasonable to move tests/parts of tests to those places.

I added one special section to the end of `integration/api/entities` for capturing update logic. There are some special sections at the bottom of `integration/api/datasets` specifically for dataset scenarios.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

More reliable entity update behavior 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced