### PR TITLE
Features/entities/relevant to conflict flag

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -355,8 +355,6 @@ const ConflictType = {
   HARD: 'hard' // discrepancy in version number and one/more properties updated simultaneously
 };
 const getWithConflictDetails = (defs, audits, relevantToConflict) => {
-  const defMap = new Map(defs.map(d => [d.version, d]));
-
   const result = [];
 
   const lastResolveEvent = audits.findLast(a => a.action === 'entity.update.resolve');
@@ -364,8 +362,6 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
   const auditMap = new Map(audits
     .filter(a => a.action === 'entity.create' || a.action === 'entity.update.version')
     .map(a => [a.details.entityDefId, a.details]));
-
-  const versionMap = new Map();
 
   let lastGoodVersion = 0; // Entity Version is never 0
 
@@ -387,23 +383,20 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
     if (v.version > 1) { // v.root is false here - can use either
       const conflict = v.version !== (v.baseVersion + 1);
 
-      v.baseDiff = getDiffProp(v.dataReceived, defMap.get(v.baseVersion).data);
-      if ('label' in v.dataReceived && v.dataReceived.label !== defMap.get(v.baseVersion).label) v.baseDiff.push('label');
+      v.baseDiff = getDiffProp(v.dataReceived, defs[v.baseVersion - 1].data);
+      if ('label' in v.dataReceived && v.dataReceived.label !== defs[v.baseVersion - 1].label) v.baseDiff.push('label');
 
-      v.serverDiff = getDiffProp(v.dataReceived, defMap.get(v.version - 1).data);
-      if ('label' in v.dataReceived && v.dataReceived.label !== defMap.get(v.version - 1).label) v.serverDiff.push('label');
+      v.serverDiff = getDiffProp(v.dataReceived, defs[v.version - 2].data);
+      if ('label' in v.dataReceived && v.dataReceived.label !== defs[v.version - 2].label) v.serverDiff.push('label');
 
       if (conflict) {
         v.conflict = v.conflictingProperties && v.conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
 
         v.resolved = lastResolveEvent && lastResolveEvent.details.entityDefId >= def.id;
 
-        // lastGoodVersion is the baseVersion of first unresolved conflict
         if (!v.resolved && lastGoodVersion === 0) {
-          lastGoodVersion = v.baseVersion;
-
-          // baseVersion will be always in versionMap; if not then something terrible has happened - 500 error is fine
-          versionMap.get(v.baseVersion).lastGoodVersion = true;
+          lastGoodVersion = v.version - 1;
+          result[v.version - 2].lastGoodVersion = true;
         }
       }
 
@@ -412,8 +405,6 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
         relevantBaseVersions.add(v.baseVersion);
       }
     }
-
-    versionMap.set(v.version, v);
 
     result.push(v);
   }

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -361,7 +361,9 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
 
   const lastResolveEvent = audits.findLast(a => a.action === 'entity.update.resolve');
 
-  const auditMap = new Map(audits.map(a => [a.details.entityDefId, a.details]));
+  const auditMap = new Map(audits
+    .filter(a => a.action === 'entity.create' || a.action === 'entity.update.version')
+    .map(a => [a.details.entityDefId, a.details]));
 
   const versionMap = new Map();
 
@@ -418,7 +420,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
 
   // We return all the versions after last good version and the base versions of those.
   if (relevantToConflict) {
-    return result.filter(v => lastGoodVersion > 0 && (v.version >= lastGoodVersion || relevantBaseVersions.has(v.version)));
+    return lastGoodVersion > 0 ? result.filter(v => v.version >= lastGoodVersion || relevantBaseVersions.has(v.version)) : [];
   }
 
   return result;

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -376,7 +376,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
         resolved: false,
         baseDiff: [],
         serverDiff: [],
-        source: { sourceEvent, submissionCreate, submission },
+        source: { event: sourceEvent, submissionCreate, submission },
         lastGoodVersion: false
       });
 
@@ -412,6 +412,10 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
   // We return all the versions after last good version and the base versions of those.
   if (relevantToConflict) {
     return lastGoodVersion > 0 ? result.filter(v => v.version >= lastGoodVersion || relevantBaseVersions.has(v.version)) : [];
+  }
+
+  if (lastGoodVersion === 0) {
+    result[result.length - 1].lastGoodVersion = true;
   }
 
   return result;

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -354,20 +354,32 @@ const ConflictType = {
   SOFT: 'soft', // discrepancy in version number but no overlaping properties
   HARD: 'hard' // discrepancy in version number and one/more properties updated simultaneously
 };
-const getWithConflictDetails = (defs) => {
+const getWithConflictDetails = (defs, audits, relevantToConflict) => {
   const defMap = new Map(defs.map(d => [d.version, d]));
 
   const result = [];
 
+  const lastResolveEvent = audits.findLast(a => a.action === 'entity.update.resolve');
+
+  const auditMap = new Map(audits.map(a => [a.details.entityDefId, a.details]));
+
+  const versionMap = new Map();
+
+  let lastGoodVersion = 0; // Entity Version is never 0
+
+  const relevantBaseVersions = new Set();
+
   for (const def of defs) {
-    const v = mergeLeft(def,
+    const { sourceEvent, submissionCreate, submission } = auditMap.get(def.id);
+
+    const v = mergeLeft(def.forApi(),
       {
         conflict: null,
         resolved: false,
         baseDiff: [],
         serverDiff: [],
-        conflictingProp: [],
-        source: {} // TODO
+        source: { sourceEvent, submissionCreate, submission },
+        lastGoodVersion: false
       });
 
     if (v.version > 1) { // v.root is false here - can use either
@@ -380,13 +392,35 @@ const getWithConflictDetails = (defs) => {
       if ('label' in v.dataReceived && v.dataReceived.label !== defMap.get(v.version - 1).label) v.serverDiff.push('label');
 
       if (conflict) {
-        v.conflict = v.conflictingProp && v.conflictingProp.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
+        v.conflict = v.conflictingProperties && v.conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
 
-        v.resolve = false; // TOOD
+        v.resolved = lastResolveEvent && lastResolveEvent.details.entityDefId >= def.id;
+
+        // lastGoodVersion is the baseVersion of first unresolved conflict
+        if (!v.resolved && lastGoodVersion === 0) {
+          lastGoodVersion = v.baseVersion;
+
+          // baseVersion will be always in versionMap; if not then something terrible has happened - 500 error is fine
+          versionMap.get(v.baseVersion).lastGoodVersion = true;
+        }
+      }
+
+      // We have some unresolved conflicts
+      if (lastGoodVersion > 0) {
+        relevantBaseVersions.add(v.baseVersion);
       }
     }
+
+    versionMap.set(v.version, v);
+
     result.push(v);
   }
+
+  // We return all the versions after last good version and the base versions of those.
+  if (relevantToConflict) {
+    return result.filter(v => lastGoodVersion > 0 && (v.version >= lastGoodVersion || relevantBaseVersions.has(v.version)));
+  }
+
   return result;
 };
 

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -36,7 +36,7 @@ module.exports = (service, endpoint) => {
     return withEtag(entity.aux.currentVersion.version, () => entity);
   }));
 
-  service.get('/projects/:projectId/datasets/:name/entities/:uuid/versions', endpoint(async ({ Datasets, Entities, Audits }, { params, auth, queryOptions }) => {
+  service.get('/projects/:projectId/datasets/:name/entities/:uuid/versions', endpoint(async ({ Datasets, Entities, Audits }, { params, auth, queryOptions, query }) => {
 
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
 
@@ -47,9 +47,9 @@ module.exports = (service, endpoint) => {
     // it means there's no entity with the provided UUID
     if (defs.length === 0) return reject(Problem.user.notFound());
 
-    const audits = Audits.getByEntityId(defs[0].id, queryOptions);
+    const audits = await Audits.getByEntityId(defs[0].entityId, queryOptions);
 
-    return getWithConflictDetails(defs.map(d => d.forApi()), audits);
+    return getWithConflictDetails(defs, audits, isTrue(query.relevantToConflict));
   }));
 
   service.get('/projects/:projectId/datasets/:name/entities/:uuid/diffs', endpoint(async ({ Datasets, Entities }, { params, auth, queryOptions }) => {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -590,7 +590,7 @@ describe('Entities API', () => {
             // Doesn't return first version
             versions.some(v => v.version === 1).should.be.false();
 
-            versions[0].lastGoodVersion.should.be.true();
+            versions[1].lastGoodVersion.should.be.true();
             versions[2].conflictingProperties.should.be.eql(['age']);
           });
       }));
@@ -632,7 +632,7 @@ describe('Entities API', () => {
             // Doesn't return old versions
             versions.some(v => v.version < 3).should.be.false();
 
-            versions[0].lastGoodVersion.should.be.true();
+            versions[1].lastGoodVersion.should.be.true();
             versions[2].conflictingProperties.should.be.eql(['label']);
           });
       }));

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -2,6 +2,7 @@ const should = require('should');
 const appRoot = require('app-root-path');
 const assert = require('assert');
 const { ConflictType } = require('../../../lib/data/entity');
+const { Entity } = require('../../../lib/model/frames');
 const { parseSubmissionXml, extractEntity, validateEntity, extractSelectedProperties, selectFields, diffEntityData, getDiffProp, getWithConflictDetails } = require(appRoot + '/lib/data/entity');
 const { fieldsFor } = require(appRoot + '/test/util/schema');
 const testData = require(appRoot + '/test/data/xml');
@@ -682,12 +683,14 @@ describe('extracting and validating entities', () => {
 
     it('should fill in correct information for SOFT conflict', () => {
       const defs = [
-        { version: 1, label: 'John', data: { name: 'John', age: '88' }, dataReceived: { name: 'John', age: '88' }, conflictingProp: null, baseVersion: null },
-        { version: 2, label: 'Jane', data: { name: 'Jane', age: '88' }, dataReceived: { name: 'Jane' }, conflictingProp: [], baseVersion: 1 },
-        { version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProp: [], baseVersion: 1 }
+        new Entity.Def({ id: 0, version: 1, label: 'John', data: { name: 'John', age: '88' }, dataReceived: { name: 'John', age: '88' }, conflictingProp: null, baseVersion: null }),
+        new Entity.Def({ id: 0, version: 2, label: 'Jane', data: { name: 'Jane', age: '88' }, dataReceived: { name: 'Jane' }, conflictingProp: [], baseVersion: 1 }),
+        new Entity.Def({ id: 0, version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProp: [], baseVersion: 1 })
       ];
 
-      const result = getWithConflictDetails(defs);
+      const audits = [{ details: { entityDefId: 0 } }];
+
+      const result = getWithConflictDetails(defs, audits, false);
 
       result[2].conflict.should.be.eql(ConflictType.SOFT);
       result[2].baseDiff.should.be.eql(['age']);
@@ -696,12 +699,14 @@ describe('extracting and validating entities', () => {
 
     it('should fill in correct information for HARD conflict', () => {
       const defs = [
-        { version: 1, label: 'John', data: { name: 'John', age: '88' }, dataReceived: { name: 'John', age: '88' }, conflictingProp: null, baseVersion: null },
-        { version: 2, label: 'Jane', data: { name: 'Jane', age: '77' }, dataReceived: { age: '77' }, conflictingProp: [], baseVersion: 1 },
-        { version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProp: ['age'], baseVersion: 1 }
+        new Entity.Def({ id: 0, version: 1, label: 'John', data: { name: 'John', age: '88' }, dataReceived: { name: 'John', age: '88' }, conflictingProperties: null, baseVersion: null }),
+        new Entity.Def({ id: 0, version: 2, label: 'Jane', data: { name: 'Jane', age: '77' }, dataReceived: { age: '77' }, conflictingProperties: [], baseVersion: 1 }),
+        new Entity.Def({ id: 0, version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProperties: ['age'], baseVersion: 1 })
       ];
 
-      const result = getWithConflictDetails(defs);
+      const audits = [{ details: { entityDefId: 0 } }];
+
+      const result = getWithConflictDetails(defs, audits, false);
 
       result[2].conflict.should.be.eql(ConflictType.HARD);
       result[2].baseDiff.should.be.eql(['age']);

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -688,7 +688,7 @@ describe('extracting and validating entities', () => {
         new Entity.Def({ id: 0, version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProp: [], baseVersion: 1 })
       ];
 
-      const audits = [{ details: { entityDefId: 0 } }];
+      const audits = [{ action: 'entity.create', details: { entityDefId: 0 } }];
 
       const result = getWithConflictDetails(defs, audits, false);
 
@@ -704,7 +704,7 @@ describe('extracting and validating entities', () => {
         new Entity.Def({ id: 0, version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProperties: ['age'], baseVersion: 1 })
       ];
 
-      const audits = [{ details: { entityDefId: 0 } }];
+      const audits = [{ action: 'entity.create', details: { entityDefId: 0 } }];
 
       const result = getWithConflictDetails(defs, audits, false);
 

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -684,7 +684,7 @@ describe('extracting and validating entities', () => {
     it('should fill in correct information for SOFT conflict', () => {
       const defs = [
         new Entity.Def({ id: 0, version: 1, label: 'John', data: { name: 'John', age: '88' }, dataReceived: { name: 'John', age: '88' }, conflictingProp: null, baseVersion: null }),
-        new Entity.Def({ id: 0, version: 2, label: 'Jane', data: { name: 'Jane', age: '88' }, dataReceived: { name: 'Jane' }, conflictingProp: [], baseVersion: 1 }),
+        new Entity.Def({ id: 0, version: 2, label: 'Jane', data: { name: 'Jane', age: '88' }, dataReceived: { label: 'Jane', name: 'Jane' }, conflictingProp: [], baseVersion: 1 }),
         new Entity.Def({ id: 0, version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProp: [], baseVersion: 1 })
       ];
 
@@ -700,7 +700,7 @@ describe('extracting and validating entities', () => {
     it('should fill in correct information for HARD conflict', () => {
       const defs = [
         new Entity.Def({ id: 0, version: 1, label: 'John', data: { name: 'John', age: '88' }, dataReceived: { name: 'John', age: '88' }, conflictingProperties: null, baseVersion: null }),
-        new Entity.Def({ id: 0, version: 2, label: 'Jane', data: { name: 'Jane', age: '77' }, dataReceived: { age: '77' }, conflictingProperties: [], baseVersion: 1 }),
+        new Entity.Def({ id: 0, version: 2, label: 'Jane', data: { name: 'Jane', age: '77' }, dataReceived: { label: 'Jane', name: 'Jane', age: '77' }, conflictingProperties: [], baseVersion: 1 }),
         new Entity.Def({ id: 0, version: 3, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProperties: ['age'], baseVersion: 1 })
       ];
 
@@ -711,6 +711,22 @@ describe('extracting and validating entities', () => {
       result[2].conflict.should.be.eql(ConflictType.HARD);
       result[2].baseDiff.should.be.eql(['age']);
       result[2].serverDiff.should.be.eql(['age']);
+    });
+
+    it('should return only relevant versions', () => {
+      const defs = [
+        new Entity.Def({ id: 0, version: 1, label: 'John', data: { name: 'John', age: '88' }, dataReceived: { name: 'John', age: '88' }, conflictingProp: null, baseVersion: null }),
+        new Entity.Def({ id: 0, version: 2, label: 'Robert', data: { name: 'Robert', age: '20' }, dataReceived: { label: 'Robert', name: 'Robert', age: '20' }, conflictingProp: null, baseVersion: 1 }),
+        new Entity.Def({ id: 0, version: 3, label: 'Jane', data: { name: 'Jane', age: '20' }, dataReceived: { label: 'Jane', name: 'Jane' }, conflictingProp: [], baseVersion: 2 }),
+        new Entity.Def({ id: 0, version: 4, label: 'Jane', data: { name: 'Jane', age: '99' }, dataReceived: { age: '99' }, conflictingProp: [], baseVersion: 2 }),
+        new Entity.Def({ id: 0, version: 5, label: 'Jane', data: { name: 'Jane', age: '10' }, dataReceived: { age: '10' }, conflictingProp: [], baseVersion: 3 }),
+      ];
+
+      const audits = [{ action: 'entity.create', details: { entityDefId: 0 } }];
+
+      const result = getWithConflictDetails(defs, audits, true);
+
+      result.map(v => v.version).should.eql([2, 3, 4, 5]);
     });
   });
 });


### PR DESCRIPTION
Part of getodk/central#504

#### What has been done to verify that this works as intended?

Added tests

#### Why is this the best possible solution? Were any other approaches considered?

The name of querystring parameter could be shorter but we came to consensus on `relevantToConflict` in Slack

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Yes

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced