### PR TITLE
Don't require label in entity update and allow other blank updates

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -40,6 +40,7 @@ const normalizeUuid = (id) => {
   return matches[2].toLowerCase();
 };
 
+// Input: object representing entity, parsed from submission XML
 const extractLabelFromSubmission = (entity) => {
   const { label, create, update } = entity.system;
   if ((create === '1' || create === 'true') && (!label || label.trim() === ''))
@@ -51,6 +52,7 @@ const extractLabelFromSubmission = (entity) => {
   return label;
 };
 
+// Input: object representing entity, parsed from submission XML
 const extractBaseVersionFromSubmission = (entity) => {
   const { baseVersion, update } = entity.system;
   if ((update === '1' || update === 'true')) {
@@ -77,8 +79,8 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
       entity.system.dataset = field.attrs.dataset;
       entity.system.id = field.attrs.id;
       entity.system.create = field.attrs.create;
-      entity.system.update = field.attrs.update; // TODO: add tests
-      entity.system.baseVersion = field.attrs.baseVersion; // TODO: add tests
+      entity.system.update = field.attrs.update;
+      entity.system.baseVersion = field.attrs.baseVersion;
     } else if (field.path.indexOf('/meta/entity') === 0)
       entity.system[field.name] = text;
     else if (field.propertyName != null)
@@ -118,7 +120,7 @@ const extractEntity = (body, propertyNames, existingEntity) => {
     if (typeof body.label !== 'string')
       throw Problem.user.invalidDataTypeOfParameter({ field: 'label', expected: 'string' });
     else if (body.label.trim() === '')
-      throw Problem.user.missingParameter({ field: 'label' });
+      throw Problem.user.unexpectedValue({ field: 'label', value: '(empty string)', reason: 'Label cannot be blank.' });
     else
       entity.system.label = body.label;
 

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -38,8 +38,25 @@ const odataToColumnMap = new Map([
 const validateEntity = (entity) => {
   const { label, id, update, baseVersion } = entity.system;
 
-  if (!label || label.trim() === '')
+  // Trying to describe this logic.
+  // if coming from a submission, create and/or update will hopefully be defined.
+  // if coming from json, create and update will not be available.
+  // in most cases, we need label to exist and not be blank...
+  // - creating an entity with a label
+  // - updating an entity's label
+  // but in one case, if its an update and label is not even specified,
+  // that is ok -- the label just wont be updated on the entity.
+  // TODO: do something different with validateEntity because it has too
+  // many special, subtle cases.
+  if (!(update === '1' || update === 'true') && (!label || label.trim() === ''))
     throw Problem.user.missingParameter({ field: 'label' });
+
+  // on update, it is okay for label to not be provided. but if it is,
+  // it cannot be an empty string.
+  if ((update === '1' || update === 'true') && (label != null && label.trim() === '')) {
+  //  console.log('deciding to throw missing label param', label);
+    throw Problem.user.missingParameter({ field: 'label' });
+  }
 
   if (!id || id.trim() === '')
     throw Problem.user.missingParameter({ field: 'uuid' });
@@ -78,7 +95,7 @@ const validateEntity = (entity) => {
 //    entity node attributes like dataset name.
 const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) => {
   const entity = { system: Object.create(null), data: Object.create(null) };
-  const stream = submissionXmlToFieldStream(entityFields, xml, true);
+  const stream = submissionXmlToFieldStream(entityFields, xml, true, true);
   stream.on('error', reject);
   stream.on('data', ({ field, text }) => {
     if (field.name === 'entity') {

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -30,9 +30,7 @@ const odataToColumnMap = new Map([
 ////////////////////////////////////////////////////////////////////////////
 // ENTITY PARSING
 
-const extractUuidFromSubmission = (entity) => {
-  const { id } = entity.system;
-
+const normalizeUuid = (id) => {
   if (!id || id.trim() === '')
     throw Problem.user.missingParameter({ field: 'uuid' });
 
@@ -61,8 +59,9 @@ const extractBaseVersionFromSubmission = (entity) => {
 
     if (!/^\d+$/.test(baseVersion))
       throw Problem.user.invalidDataTypeOfParameter({ field: 'baseVersion', expected: 'integer' });
+
+    return parseInt(entity.system.baseVersion, 10);
   }
-  return parseInt(entity.system.baseVersion, 10);
 };
 
 // This works similarly to processing submissions for export, but also note:
@@ -112,10 +111,7 @@ const extractEntity = (body, propertyNames, existingEntity) => {
     if (body.uuid && typeof body.uuid !== 'string')
       throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'string' });
 
-    const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
-    const matches = uuidPattern.exec(body.uuid);
-    if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'valid UUID' });
-    entity.system.uuid = matches[2].toLowerCase();
+    entity.system.uuid = normalizeUuid(body.uuid);
   }
 
   if (body.label != null)
@@ -421,7 +417,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
 module.exports = {
   parseSubmissionXml,
   extractEntity,
-  extractUuidFromSubmission,
+  normalizeUuid,
   extractLabelFromSubmission,
   extractBaseVersionFromSubmission,
   streamEntityCsv, streamEntityCsvAttachment,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -30,11 +30,47 @@ const odataToColumnMap = new Map([
 ////////////////////////////////////////////////////////////////////////////
 // ENTITY PARSING
 
+const extractUuidFromSubmission = (entity) => {
+  const { id } = entity.system;
+
+  if (!id || id.trim() === '')
+    throw Problem.user.missingParameter({ field: 'uuid' });
+
+  const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+  const matches = uuidPattern.exec(id);
+  if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'valid UUID' });
+  return matches[2].toLowerCase();
+};
+
+const extractLabelFromSubmission = (entity) => {
+  const { label, create, update } = entity.system;
+  if ((create === '1' || create === 'true') && (!label || label.trim() === ''))
+    throw Problem.user.missingParameter({ field: 'label' });
+
+  if ((update === '1' || update === 'true') && (!label || label.trim() === ''))
+    return null;
+
+  return label;
+};
+
+const extractBaseVersionFromSubmission = (entity) => {
+  const { baseVersion, update } = entity.system;
+  if ((update === '1' || update === 'true')) {
+    if (!baseVersion)
+      throw Problem.user.missingParameter({ field: 'baseVersion' });
+
+    if (!/^\d+$/.test(baseVersion))
+      throw Problem.user.invalidDataTypeOfParameter({ field: 'baseVersion', expected: 'integer' });
+  }
+  return parseInt(entity.system.baseVersion, 10);
+};
+
 // After collecting the entity data from the request body or submission,
 // we validate the data (properties must include label, and uuid)
 // and assemble a valid entity data object. System properties like dataset
 // label, uuid are in entity.system while the contents from the bound form
 // fields are in enttiy.data.
+// TODO: planning to phase this out
 const validateEntity = (entity) => {
   const { label, id, update, baseVersion } = entity.system;
 
@@ -439,6 +475,9 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
 module.exports = {
   parseSubmissionXml, validateEntity,
   extractEntity,
+  extractUuidFromSubmission,
+  extractLabelFromSubmission,
+  extractBaseVersionFromSubmission,
   streamEntityCsv, streamEntityCsvAttachment,
   streamEntityOdata, odataToColumnMap,
   extractSelectedProperties, selectFields,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -65,66 +65,6 @@ const extractBaseVersionFromSubmission = (entity) => {
   return parseInt(entity.system.baseVersion, 10);
 };
 
-// After collecting the entity data from the request body or submission,
-// we validate the data (properties must include label, and uuid)
-// and assemble a valid entity data object. System properties like dataset
-// label, uuid are in entity.system while the contents from the bound form
-// fields are in enttiy.data.
-// TODO: planning to phase this out
-const validateEntity = (entity) => {
-  const { label, id, update, baseVersion } = entity.system;
-
-  // Trying to describe this logic.
-  // if coming from a submission, create and/or update will hopefully be defined.
-  // if coming from json, create and update will not be available.
-  // in most cases, we need label to exist and not be blank...
-  // - creating an entity with a label
-  // - updating an entity's label
-  // but in one case, if its an update and label is not even specified,
-  // that is ok -- the label just wont be updated on the entity.
-  // TODO: do something different with validateEntity because it has too
-  // many special, subtle cases.
-  if (!(update === '1' || update === 'true') && (!label || label.trim() === ''))
-    throw Problem.user.missingParameter({ field: 'label' });
-
-  // on update, it is okay for label to not be provided. but if it is,
-  // it cannot be an empty string.
-  if ((update === '1' || update === 'true') && (label != null && label.trim() === '')) {
-  //  console.log('deciding to throw missing label param', label);
-    throw Problem.user.missingParameter({ field: 'label' });
-  }
-
-  if (!id || id.trim() === '')
-    throw Problem.user.missingParameter({ field: 'uuid' });
-
-  const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
-  const matches = uuidPattern.exec(id);
-
-  if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'valid UUID' });
-
-  const uuid = matches[2].toLowerCase();
-
-  const newEntity = { ...entity };
-  newEntity.system.uuid = uuid;
-
-  if ((update === '1' || update === 'true')) {
-    if (!baseVersion)
-      throw Problem.user.missingParameter({ field: 'baseVersion' });
-
-    if (!/^\d+$/.test(baseVersion))
-      throw Problem.user.invalidDataTypeOfParameter({ field: 'baseVersion', expected: 'integer' });
-
-    newEntity.system.baseVersion = parseInt(baseVersion, 10);
-  } else {
-    delete newEntity.system.baseVersion;
-  }
-
-  delete newEntity.system.id;
-  delete newEntity.system.create;
-  delete newEntity.system.update;
-  return newEntity;
-};
-
 // This works similarly to processing submissions for export, but also note:
 // 1. this is expecting the entityFields to be filled in with propertyName attributes
 // 2. the "meta/entity" structural field should be included to get necessary
@@ -164,20 +104,25 @@ const extractEntity = (body, propertyNames, existingEntity) => {
     throw Problem.user.unexpectedAttributes({ expected: bodyKeys, actual: Object.keys(body) });
 
   let entity;
+
   if (existingEntity) {
     entity = clone(existingEntity);
-    entity.system.id = entity.system.uuid;
-    delete entity.system.uuid;
   } else {
     entity = { system: Object.create(null), data: Object.create(null) };
     if (body.uuid && typeof body.uuid !== 'string')
       throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'string' });
-    entity.system.id = body.uuid;
+
+    const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+    const matches = uuidPattern.exec(body.uuid);
+    if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'valid UUID' });
+    entity.system.uuid = matches[2].toLowerCase();
   }
 
   if (body.label != null)
     if (typeof body.label !== 'string')
       throw Problem.user.invalidDataTypeOfParameter({ field: 'label', expected: 'string' });
+    else if (body.label.trim() === '')
+      throw Problem.user.missingParameter({ field: 'label' });
     else
       entity.system.label = body.label;
 
@@ -194,7 +139,7 @@ const extractEntity = (body, propertyNames, existingEntity) => {
         throw Problem.user.invalidEntity({ reason: `You specified the dataset property [${k}] which does not exist.` });
     }
 
-  return validateEntity(entity);
+  return entity;
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -473,7 +418,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
 };
 
 module.exports = {
-  parseSubmissionXml, validateEntity,
+  parseSubmissionXml,
   extractEntity,
   extractUuidFromSubmission,
   extractLabelFromSubmission,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -123,6 +123,8 @@ const extractEntity = (body, propertyNames, existingEntity) => {
       throw Problem.user.unexpectedValue({ field: 'label', value: '(empty string)', reason: 'Label cannot be blank.' });
     else
       entity.system.label = body.label;
+  else if (!existingEntity)
+    throw Problem.user.missingParameter({ field: 'label' });
 
   if (body.data == null && body.label == null)
     throw Problem.user.invalidEntity({ reason: 'No entity data or label provided.' });

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -21,19 +21,22 @@ const { union, last, pluck } = require('ramda');
 // field in the submission. does no processing at all to localize repeat groups,
 // etc. it's just a stream of found data values.
 //
-// !!! !!! WARNING WARNING:
-// right now this facility is used only by generateExpectedAttachments, which wants
+// the original place this facility is used is by generateExpectedAttachments, which wants
 // to navigate the schema stack ignoring gaps so it can just deal w binary fields.
+//
+// the second place this is used is by parseSubmissionXml for parsing entity data from
+// submissions. this scenario is similar to the one above in that we want to navigate to
+// specific entity-property fields and the SchemaStack allowEmptyNavigation is true.
+// includeStructuralAttrs and includeEmptyNodes are two flags specifically for reaching and
+// returning data needed for entities including the <entity> element with attributes
+// and empty elements like `<prop></prop>` meant to blank out certain entity properties.
+//
+// leaving this old comment here (the second use of this for entities didn't need to do this,
+// but the 3rd use might!) ---
+// !!! !!! WARNING WARNING:
 // if you are reading this thinking to use it elsewhere, you'll almost certainly
 // need to work out a sensible way to flag the SchemaStack allowEmptyNavigation boolean
 // to false for whatever you are doing.
-//
-// actually this is also used to parse entity data out of submissions, a scenario
-// in which we want to capture potentially empty nodes like <age></age> that might
-// mean the property should be set to blank. includeEmptyNodes allows that instead
-// of skipping over outputting empty nodes. i think this is different from what the
-// note above is talking about...
-// allowEmptyNavigation and includeStructuralAttrs are already true.
 const submissionXmlToFieldStream = (fields, xml, includeStructuralAttrs = false, includeEmptyNodes = false) => {
   const outStream = new Readable({ objectMode: true, read: noop });
 

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -27,7 +27,14 @@ const { union, last, pluck } = require('ramda');
 // if you are reading this thinking to use it elsewhere, you'll almost certainly
 // need to work out a sensible way to flag the SchemaStack allowEmptyNavigation boolean
 // to false for whatever you are doing.
-const submissionXmlToFieldStream = (fields, xml, includeStructuralAttrs = false) => {
+//
+// actually this is also used to parse entity data out of submissions, a scenario
+// in which we want to capture potentially empty nodes like <age></age> that might
+// mean the property should be set to blank. includeEmptyNodes allows that instead
+// of skipping over outputting empty nodes. i think this is different from what the
+// note above is talking about...
+// allowEmptyNavigation and includeStructuralAttrs are already true.
+const submissionXmlToFieldStream = (fields, xml, includeStructuralAttrs = false, includeEmptyNodes = false) => {
   const outStream = new Readable({ objectMode: true, read: noop });
 
   const stack = new SchemaStack(fields, true);
@@ -50,7 +57,7 @@ const submissionXmlToFieldStream = (fields, xml, includeStructuralAttrs = false)
     onclosetag: () => {
       const field = stack.pop();
 
-      if (textBuffer !== '') {
+      if (textBuffer !== '' || includeEmptyNodes) {
         if ((field != null) && !field.isStructural()) // don't output useless whitespace
           outStream.push({ field, text: textBuffer });
         textBuffer = '';

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -10,7 +10,7 @@
 /* eslint-disable no-multi-spaces */
 
 const { embedded, Frame, readable, table } = require('../frame');
-const { extractEntity, validateEntity } = require('../../data/entity');
+const { extractEntity, extractUuidFromSubmission, extractLabelFromSubmission, extractBaseVersionFromSubmission } = require('../../data/entity');
 
 // These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
@@ -26,12 +26,20 @@ class Entity extends Frame.define(
   get def() { return this.aux.def; }
 
   static fromParseEntityData(entityData) {
-    const validatedEntity = validateEntity(entityData);
-    const { uuid, label, dataset, baseVersion } = validatedEntity.system;
-    const { data } = validatedEntity;
-    const dataReceived = { ...data, label };
+    const { dataset } = entityData.system;
+    const { data } = entityData;
+    // validation for each field happens within each function
+    const uuid = extractUuidFromSubmission(entityData);
+    const label = extractLabelFromSubmission(entityData);
+    const baseVersion = extractBaseVersionFromSubmission(entityData);
+    const dataReceived = { ...data, ...(label && { label }) };
     return new Entity.Partial({ uuid }, {
-      def: new Entity.Def({ data, label, dataReceived, ...(baseVersion && { baseVersion }) }), // add baseVersion only if it's there
+      def: new Entity.Def({
+        data,
+        dataReceived,
+        ...(baseVersion && { baseVersion }), // add baseVersion only if it's there
+        ...(label && { label }) // add label only if it's there
+      }),
       dataset
     });
   }

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -10,7 +10,7 @@
 /* eslint-disable no-multi-spaces */
 
 const { embedded, Frame, readable, table } = require('../frame');
-const { extractEntity, extractUuidFromSubmission, extractLabelFromSubmission, extractBaseVersionFromSubmission } = require('../../data/entity');
+const { extractEntity, normalizeUuid, extractLabelFromSubmission, extractBaseVersionFromSubmission } = require('../../data/entity');
 
 // These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
@@ -29,7 +29,7 @@ class Entity extends Frame.define(
     const { dataset } = entityData.system;
     const { data } = entityData;
     // validation for each field happens within each function
-    const uuid = extractUuidFromSubmission(entityData);
+    const uuid = normalizeUuid(entityData.system.id);
     const label = extractLabelFromSubmission(entityData);
     const baseVersion = extractBaseVersionFromSubmission(entityData);
     const dataReceived = { ...data, ...(label && { label }) };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -207,7 +207,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 
   // merge data
   const mergedData = mergeRight(serverEntity.aux.currentVersion.data, clientEntity.def.data);
-  const mergedLabel = clientEntity.def.label || serverEntity.aux.currentVersion.label;
+  const mergedLabel = clientEntity.def.label ?? serverEntity.aux.currentVersion.label;
 
   // make some kind of source object
   const sourceDetails = {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -168,7 +168,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
     });
 };
 
-const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, one }) => {
+const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, maybeOne }) => {
   if (!(event.action === 'submission.create')) // only update on submission.create
     return null;
 
@@ -177,7 +177,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 
   // Get version of entity on the server
   const serverEntity = (await Entities.getById(dataset.id, clientEntity.uuid))
-    .orThrow(Problem.user.entityNotFound({ reason: `The entity with UUID (${clientEntity.uuid}) specified in the submission does not exist in the dataset (${dataset.name}).` }));
+    .orThrow(Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name }));
 
   let { conflict } = serverEntity;
   let conflictingProperties; // Maybe we don't need to persist this??? just compute at the read time
@@ -185,12 +185,10 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   if (clientEntity.def.baseVersion !== serverEntity.aux.currentVersion.version) {
 
     const condition = { datasetId: dataset.id, uuid: clientEntity.uuid, version: clientEntity.def.baseVersion };
-    let baseEntityVersion;
-    try {
-      baseEntityVersion = await _getDef(one, new QueryOptions({ condition })); // eslint-disable-line no-use-before-define
-    } catch (err) {
-      throw (Problem.user.entityNotFound({ reason: `Base version (${clientEntity.def.baseVersion}) does not exist for entity UUID (${clientEntity.uuid}) in dataset (${dataset.name}).` }));
-    }
+    // eslint-disable-next-line no-use-before-define
+    const baseEntityVersion = (await _getDef(maybeOne, new QueryOptions({ condition })))
+      .orThrow(Problem.user.entityVersionNotFound({ baseVersion: clientEntity.def.baseVersion, entityUuid: clientEntity.uuid, datasetName: dataset.name }));
+
     // we need to find what changed between baseVersion and lastVersion
     // it is not the data we received in lastVersion
     const serverVersionDiff = getDiffProp(serverEntity.aux.currentVersion.data, baseEntityVersion.data);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -177,7 +177,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 
   // Get version of entity on the server
   const serverEntity = (await Entities.getById(dataset.id, clientEntity.uuid))
-    .orThrow(Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name }));
+    .orThrow(Problem.user.entityNotFound({ reason: `The entity with UUID (${clientEntity.uuid}) specified in the submission does not exist in the dataset (${dataset.name}).` }));
 
   let { conflict } = serverEntity;
   let conflictingProperties; // Maybe we don't need to persist this??? just compute at the read time
@@ -185,8 +185,12 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   if (clientEntity.def.baseVersion !== serverEntity.aux.currentVersion.version) {
 
     const condition = { datasetId: dataset.id, uuid: clientEntity.uuid, version: clientEntity.def.baseVersion };
-    const baseEntityVersion = await _getDef(one, new QueryOptions({ condition })); // eslint-disable-line no-use-before-define
-
+    let baseEntityVersion;
+    try {
+      baseEntityVersion = await _getDef(one, new QueryOptions({ condition })); // eslint-disable-line no-use-before-define
+    } catch (err) {
+      throw (Problem.user.entityNotFound({ reason: `Base version (${clientEntity.def.baseVersion}) does not exist for entity UUID (${clientEntity.uuid}) in dataset (${dataset.name}).` }));
+    }
     // we need to find what changed between baseVersion and lastVersion
     // it is not the data we received in lastVersion
     const serverVersionDiff = getDiffProp(serverEntity.aux.currentVersion.data, baseEntityVersion.data);

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -158,7 +158,10 @@ const problems = {
     datasetNotFound: problem(404.7, ({ datasetName }) => `The dataset (${datasetName}) specified in the submission does not exist.`),
 
     // entity in submission does not exist
-    entityNotFound: problem(404.8, ({ reason }) => `Entity not found. ${reason}`),
+    entityNotFound: problem(404.8, ({ entityUuid, datasetName }) => `The entity with UUID (${entityUuid}) specified in the submission does not exist in the dataset (${datasetName}).`),
+
+    // entity in submission does not exist
+    entityVersionNotFound: problem(404.9, ({ baseVersion, entityUuid, datasetName }) => `Base version (${baseVersion}) does not exist for entity UUID (${entityUuid}) in dataset (${datasetName}).`),
 
     // { allowed: [ acceptable formats ], got }
     unacceptableFormat: problem(406.1, ({ allowed }) => `Requested format not acceptable; this resource allows: ${allowed.join()}.`),

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -158,7 +158,7 @@ const problems = {
     datasetNotFound: problem(404.7, ({ datasetName }) => `The dataset (${datasetName}) specified in the submission does not exist.`),
 
     // entity in submission does not exist
-    entityNotFound: problem(404.8, ({ entityUuid, datasetName }) => `The entity with UUID (${entityUuid}) specified in the submission does not exist in the dataset (${datasetName}).`),
+    entityNotFound: problem(404.8, ({ reason }) => `Entity not found. ${reason}`),
 
     // { allowed: [ acceptable formats ], got }
     unacceptableFormat: problem(406.1, ({ allowed }) => `Requested format not acceptable; this resource allows: ${allowed.join()}.`),

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -157,10 +157,10 @@ const problems = {
     // dataset in submission does not exist
     datasetNotFound: problem(404.7, ({ datasetName }) => `The dataset (${datasetName}) specified in the submission does not exist.`),
 
-    // entity in submission does not exist
+    // entity specified in submission does not exist
     entityNotFound: problem(404.8, ({ entityUuid, datasetName }) => `The entity with UUID (${entityUuid}) specified in the submission does not exist in the dataset (${datasetName}).`),
 
-    // entity in submission does not exist
+    // entity base version specified in submission does not exist
     entityVersionNotFound: problem(404.9, ({ baseVersion, entityUuid, datasetName }) => `Base version (${baseVersion}) does not exist for entity UUID (${entityUuid}) in dataset (${datasetName}).`),
 
     // { allowed: [ acceptable formats ], got }

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -1842,8 +1842,8 @@ describe('Entities API', () => {
           .then(({ body: logs }) => {
             logs[0].should.be.an.Audit();
             logs[0].action.should.be.eql('entity.error');
-            logs[0].details.problem.problemCode.should.equal(404.8);
-            logs[0].details.errorMessage.should.equal('Entity not found. Base version (2) does not exist for entity UUID (12345678-1234-4123-8234-123456789abc) in dataset (people).');
+            logs[0].details.problem.problemCode.should.equal(404.9);
+            logs[0].details.errorMessage.should.equal('Base version (2) does not exist for entity UUID (12345678-1234-4123-8234-123456789abc) in dataset (people).');
           });
       }));
     });

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -1732,7 +1732,7 @@ describe('Entities API', () => {
         });
     }));
 
-    it('should log error and not update if trying to set label to blank', testEntityUpdates(async (service, container) => {
+    it('should not update label if label is blank', testEntityUpdates(async (service, container) => {
       const asAlice = await service.login('alice');
 
       await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
@@ -1745,14 +1745,9 @@ describe('Entities API', () => {
       await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
         .expect(200)
         .then(({ body: person }) => {
-          should(person.currentVersion.baseVersion).be.null();
-        });
-
-      await asAlice.get('/v1/projects/1/forms/updateEntity/submissions/one/audits')
-        .expect(200)
-        .then(({ body: logs }) => {
-          logs[0].should.be.an.Audit();
-          logs[0].action.should.be.eql('entity.error');
+          person.currentVersion.dataReceived.should.eql({ age: '85', first_name: 'Alicia' });
+          person.currentVersion.data.should.eql({ age: '85', first_name: 'Alicia' });
+          person.currentVersion.label.should.equal('Johnny Doe');
         });
     }));
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -1107,6 +1107,22 @@ describe('Entities API', () => {
         });
     }));
 
+    it('should reject if uuid is not a valid uuid', testEntities(async (service) => {
+      // Use testEntities here vs. testDataset to prepopulate with 2 entities
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: 'bad_uuidv4',
+          label: 'Johnny Doe',
+          data: {
+            first_name: 'Johnny',
+            age: '22'
+          }
+        })
+        .expect(400);
+    }));
+
     it('should reject if uuid is not unique', testEntities(async (service) => {
       // Use testEntities here vs. testDataset to prepopulate with 2 entities
       const asAlice = await service.login('alice');

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -578,7 +578,7 @@ describe('worker: entity', () => {
         event.actorId.should.equal(5); // Alice
         event.details.submissionId.should.equal(subEvent.details.submissionId);
         event.details.problem.problemCode.should.equal(404.8);
-        event.details.errorMessage.should.equal('Entity not found. The entity with UUID (12345678-1234-4123-8234-123456789abc) specified in the submission does not exist in the dataset (people).');
+        event.details.errorMessage.should.equal('The entity with UUID (12345678-1234-4123-8234-123456789abc) specified in the submission does not exist in the dataset (people).');
       }));
 
       it('should fail for other constraint errors like dataset name does not exist', testService(async (service, container) => {

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -454,7 +454,6 @@ describe('worker: entity', () => {
   });
 
   describe('should catch problems updating entity', () => {
-    // TODO: these errors are getting logged as entity.error audit events
     describe('validation errors', () => {
       it('should fail because UUID is invalid', testService(async (service, container) => {
         const asAlice = await service.login('alice');
@@ -579,7 +578,7 @@ describe('worker: entity', () => {
         event.actorId.should.equal(5); // Alice
         event.details.submissionId.should.equal(subEvent.details.submissionId);
         event.details.problem.problemCode.should.equal(404.8);
-        event.details.errorMessage.should.equal('The entity with UUID (12345678-1234-4123-8234-123456789abc) specified in the submission does not exist in the dataset (people).');
+        event.details.errorMessage.should.equal('Entity not found. The entity with UUID (12345678-1234-4123-8234-123456789abc) specified in the submission does not exist in the dataset (people).');
       }));
 
       it('should fail for other constraint errors like dataset name does not exist', testService(async (service, container) => {

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -3,103 +3,11 @@ const appRoot = require('app-root-path');
 const assert = require('assert');
 const { ConflictType } = require('../../../lib/data/entity');
 const { Entity } = require('../../../lib/model/frames');
-const { parseSubmissionXml, extractEntity, validateEntity, extractSelectedProperties, selectFields, diffEntityData, getDiffProp, getWithConflictDetails } = require(appRoot + '/lib/data/entity');
+const { parseSubmissionXml, extractEntity, extractSelectedProperties, selectFields, diffEntityData, getDiffProp, getWithConflictDetails } = require(appRoot + '/lib/data/entity');
 const { fieldsFor } = require(appRoot + '/test/util/schema');
 const testData = require(appRoot + '/test/data/xml');
 
 describe('extracting and validating entities', () => {
-  describe('validateEntity', () => {
-    it('should throw errors on when label is missing', () => {
-      const entity = {
-        system: {
-          id: '12345678-1234-4123-8234-123456789abc',
-          dataset: 'foo',
-        },
-        data: {}
-      };
-      assert.throws(() => { validateEntity(entity); }, (err) => {
-        err.problemCode.should.equal(400.2);
-        err.message.should.equal('Required parameter label missing.');
-        return true;
-      });
-    });
-
-    it('should throw errors when id is missing', () => {
-      (() => validateEntity({
-        system: {
-          label: 'foo',
-          id: '  ',
-          dataset: 'foo',
-        },
-        data: {}
-      })).should.throw(/Required parameter uuid missing/);
-    });
-
-    it('should throw errors when id is not a valid uuid', () => {
-      (() => validateEntity({
-        system: {
-          label: 'foo',
-          id: 'uuid:12123123',
-          dataset: 'foo',
-        },
-        data: {}
-      })).should.throw(/Invalid input data type: expected \(uuid\) to be \(valid UUID\)/);
-    });
-
-    it('should remove create property from system', () => {
-      const entity = {
-        system: {
-          create: '1',
-          id: '12345678-1234-4123-8234-123456789abc',
-          label: 'foo',
-          dataset: 'foo',
-        },
-        data: {}
-      };
-      validateEntity(entity).system.should.not.have.property('create');
-    });
-
-    it('should id property with uuid and remove uuid: prefix from the value', () => {
-      const entity = {
-        system: {
-          id: '12345678-1234-4123-8234-123456789abc',
-          label: 'foo',
-          dataset: 'foo',
-        },
-        data: {}
-      };
-      const validatedEntity = validateEntity(entity);
-
-      validatedEntity.system.should.not.have.property('id');
-      validatedEntity.system.should.have.property('uuid', '12345678-1234-4123-8234-123456789abc');
-    });
-
-    it('should throw error when baseVersion for update is missing', () => {
-      (() => validateEntity({
-        system: {
-          id: '12345678-1234-4123-8234-123456789abc',
-          label: 'foo',
-          dataset: 'foo',
-          update: '1'
-        },
-        data: {}
-      })).should.throw(/Required parameter baseVersion missing/);
-    });
-
-    it('should throw error when baseVersion is not an integer', () => {
-      (() => validateEntity({
-        system: {
-          id: '12345678-1234-4123-8234-123456789abc',
-          label: 'foo',
-          dataset: 'foo',
-          update: '1',
-          baseVersion: 'a'
-        },
-        data: {}
-      })).should.throw('Invalid input data type: expected (baseVersion) to be (integer)');
-    });
-  });
-
   describe('extract entity from submission: parseSubmissionXml', () => {
     // Used to compare entity structure when Object.create(null) used.
     beforeEach(() => {


### PR DESCRIPTION
Closes [getodk/central#527](https://github.com/getodk/central/issues/527)  by allowing an entity update submission with no `<label>` tag specified. 

Specifying a blank `<label></label>` will be treated as ignoring the label (but only during an update).

Specifying an empty property `<age></age>` can now be used to set that property to blank.

The PR also adds a new Problem for not being able to find the base version of an entity, which should fix this one case of not seeing any error on frontend: https://github.com/getodk/central/issues/536 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

tests

should probably add tests for the new individual functions i added, but most of the cases are also tested through higher level tests.

#### Why is this the best possible solution? Were any other approaches considered?

This led me to refactor `validateEntity()`. It used to be that there was some validation spread out through the code (e.g. checking the dataset first to know if it existed) and then this one validation function. Awkwardly, that function took 4 different kinds of input (submissions vs. api crossed with create vs. update) and it also slightly modified the object it was checking to "help" prepare data to put into an Entity frame. It wasn't really helping! 

Now the different fields are validated when they are pulled out because they are only needed in certain cases, e.g. `baseVersion` is only relevant in an update from a submission, and `label` can or can't be blank depending on the context. (on an update from a submission, if it is blank, it will be ignored, but in other cases, it will throw an error.)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Better entity update behavior, clearer errors.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

I don't think so. 

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced