### PR TITLE
Add relevantToConflict field in the GET /versions response

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -10454,7 +10454,7 @@ paths:
                   conflictingProperties: null
                   baseDiff: []
                   serverDiff: []
-                  source: "// same as Audit.details - It is fluid; can be changed later on."
+                  source: "// Similar to Audit.details. This property is experimental and may change in the future."
                   data:
                     firstName: John
                     age: '88'
@@ -10483,7 +10483,7 @@ paths:
                   conflictingProperties: null
                   baseDiff: []
                   serverDiff: []
-                  source: "// same as Audit.details - It is fluid; can be changed later on."
+                  source: "// Similar to Audit.details. This property is experimental and may change in the future."
                   data:
                     firstName: John
                     age: '88'
@@ -13317,7 +13317,7 @@ components:
           example: 2
         baseVersion:
           type: number
-          description: The version number of the base Entity, which was used to make an update.
+          description: The version number of the version that was the "base version" of this version. The base version is the version that was shown to the data collector when they made their update.
           example: 1
     EntitySummary:
       allOf: 
@@ -13382,15 +13382,15 @@ components:
           properties:
             source:
               type: object
-              description: The source of the Entity version, like Submission or API request
+              description: The source of the Entity version, such as a Submission or an API request. This property is experimental and may change in the future.
               example: {event: {}, submissionCreate: {}, submission: {}}
             baseDiff:
               type: array
-              description: List of properties that are different between this version and base version
+              description: List of properties that are different between this version and its base version. Includes the label if it differs between the two versions.
               example: ['name', 'age']
             serverDiff:
               type: array
-              description: List of properties that are different between this version and the last version on the server
+              description: List of properties that are different between this version and the previous version on the server. Includes the label if it differs between the two versions.
               example: ['name', 'age']
             conflict:
               type: string
@@ -13404,11 +13404,11 @@ components:
               example: false
             lastGoodVersion:
               type: boolean
-              description: Is this version the last good known version?
+              description: Indicates whether this version is the last known good version. Currently, the last known good version is defined as the version immediately prior to the first unresolved conflict. If there is no conflict, or if all conflicts are resolved, then the current version is the last known good version. This property is experimental, as the definition of the last known good version may change in the future.
               example: false
             relevantToConflict:
               type: boolean
-              description: Is this version relevant for the conflict resolution?
+              description: Indicates whether this version includes information relevant to resolving a conflict. If so, it will be shown to the user during conflict resolution. This property is experimental, as we may redefine conflict relevance in the future.
               example: false
     ExtendedEntityVersionFull:
       allOf: 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -9961,6 +9961,9 @@ paths:
                   createdAt: '2018-03-21T12:45:02.312Z'
                   creatorId: 1
                   userAgent: Enketo/3.0.4
+                  version: 1
+                  baseVersion: null
+                  conflictingProperties: null
             application/json; extended:
               schema:
                 type: array
@@ -9987,6 +9990,8 @@ paths:
                   createdAt: '2018-03-21T12:45:02.312Z'
                   creatorId: 1
                   userAgent: Enketo/3.0.4
+                  version: 1
+                  baseVersion: null
                   conflictingProperties: null
                   creator:
                     createdAt: '2018-04-18T23:19:14.802Z'
@@ -10068,7 +10073,13 @@ paths:
                   creatorId: 1
                   userAgent: Enketo/3.0.4
                   conflictingProperties: null
+                  version: 1
+                  baseVersion: null
                   data:
+                    firstName: John
+                    age: '88'
+                  dataReceived:
+                    label: John (88)
                     firstName: John
                     age: '88'
         403:
@@ -10129,9 +10140,15 @@ paths:
                   creatorId: 1
                   userAgent: Enketo/3.0.4
                   conflictingProperties: null
+                  version: 1
+                  baseVersion: null
                   data:
                     firstName: John
                     age: '88'
+                  dataReceived:
+                    firstName: John
+                    age: '88'
+                    label: John (88)
             application/json; extended:
               schema:
                 type: array
@@ -10158,9 +10175,15 @@ paths:
                   creatorId: 1
                   userAgent: Enketo/3.0.4
                   conflictingProperties: null
+                  version: 1
+                  baseVersion: null
                   data:
                     firstName: John
                     age: '88'
+                  dataReceived:
+                    firstName: John
+                    age: '88'
+                    label: John (88)
                   creator:
                     createdAt: '2018-04-18T23:19:14.802Z'
                     displayName: My Display Name
@@ -10337,9 +10360,15 @@ paths:
                   creatorId: 1
                   userAgent: Enketo/3.0.4
                   conflictingProperties: null
+                  version: 1
+                  baseVersion: null
                   data:
                     firstName: John
                     age: '88'
+                  dataReceived:
+                    firstName: John
+                    age: '88'
+                    label: John (88)
         403:
           description: Forbidden
           content:
@@ -10409,33 +10438,59 @@ paths:
                 type: array
                 description: Standard Response
                 items:
-                  $ref: '#/components/schemas/EntityVersion'
+                  $ref: '#/components/schemas/EntityVersionFull'
               example:
                 - label: John (88)
                   current: true
                   createdAt: '2018-03-21T12:45:02.312Z'
                   creatorId: 1
                   userAgent: Enketo/3.0.4
+                  version: 1
+                  baseVersion: null
+                  conflict: null
+                  resolved: false
+                  lastGoodVersion: true
+                  relevantToConflict: false
                   conflictingProperties: null
+                  baseDiff: []
+                  serverDiff: []
+                  source: "// same as Audit.details - It is fluid; can be changed later on."
                   data:
                     firstName: John
                     age: '88'
+                  dataReceived:
+                    firstName: John
+                    age: '88'
+                    label: John (88)
             application/json; extended:
               schema:
                 type: array
                 description: Extended Response
                 items:
-                  $ref: '#/components/schemas/ExtendedEntityVersion'
+                  $ref: '#/components/schemas/ExtendedEntityVersionFull'
               example:
                 - label: John (88)
                   current: true
                   createdAt: '2018-03-21T12:45:02.312Z'
                   creatorId: 1
                   userAgent: Enketo/3.0.4
+                  version: 1
+                  baseVersion: null
+                  conflict: null
+                  resolved: false
+                  lastGoodVersion: true
+                  relevantToConflict: false
                   conflictingProperties: null
+                  baseDiff: []
+                  serverDiff: []
+                  source: "// same as Audit.details - It is fluid; can be changed later on."
                   data:
                     firstName: John
                     age: '88'
+                  dataReceived:
+                    firstName: John
+                    age: '88'
+                    label: John (88)
                   creator:
                     createdAt: '2018-04-18T23:19:14.802Z'
                     displayName: My Display Name
@@ -13256,6 +13311,14 @@ components:
           description: list of properties updated offline simultaneously.
           items:
             type: string
+        version:
+          type: number
+          description: The version number of the Entity. Each update increments this number.
+          example: 2
+        baseVersion:
+          type: number
+          description: The version number of the base Entity, which was used to make an update.
+          example: 1
     EntitySummary:
       allOf: 
         - $ref: '#/components/schemas/EntitySummaryFields'
@@ -13302,12 +13365,57 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/DataExample'
+            dataReceived:
+              $ref: '#/components/schemas/DataReceivedExample'
+    
     ExtendedEntityVersion:
       allOf: 
         - $ref: '#/components/schemas/EntityVersion'
         - type: object
           properties:
-            reator:
+            creator:
+              $ref: '#/components/schemas/Actor'
+    EntityVersionFull:
+      allOf: 
+        - $ref: '#/components/schemas/EntityVersion'
+        - type: object
+          properties:
+            source:
+              type: object
+              description: The source of the Entity version, like Submission or API request
+              example: {event: {}, submissionCreate: {}, submission: {}}
+            baseDiff:
+              type: array
+              description: List of properties that are different between this version and base version
+              example: ['name', 'age']
+            serverDiff:
+              type: array
+              description: List of properties that are different between this version and the last version on the server
+              example: ['name', 'age']
+            conflict:
+              type: string
+              description: Type of the conflict if this version causes a conflict; otherwise `null`
+              enum:
+                - soft
+                - hard
+            resolved:
+              type: boolean
+              description: Is the conflict resolved? Note that this is also false for the version which didn't cause a conflict
+              example: false
+            lastGoodVersion:
+              type: boolean
+              description: Is this version the last good known version?
+              example: false
+            relevantToConflict:
+              type: boolean
+              description: Is this version relevant for the conflict resolution?
+              example: false
+    ExtendedEntityVersionFull:
+      allOf: 
+        - $ref: '#/components/schemas/EntityVersionFull'
+        - type: object
+          properties:
+            creator:
               $ref: '#/components/schemas/Actor'
     EntityDiffValue:
       type: array
@@ -13370,6 +13478,14 @@ components:
         age:
           type: string
           example: '88'    
+    DataReceivedExample:
+      allOf: 
+        - $ref: '#/components/schemas/DataExample'
+        - type: object
+          properties:
+            label:
+              type: string
+              example: John (88)
     Form:
       required:
       - createdAt

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -390,7 +390,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
       if (conflict) {
         v.conflict = v.conflictingProperties && v.conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
 
-        v.resolved = lastResolveEvent && lastResolveEvent.details.entityDefId >= def.id;
+        v.resolved = !!lastResolveEvent && lastResolveEvent.details.entityDefId >= def.id;
 
         if (!v.resolved && lastGoodVersion === 0) {
           lastGoodVersion = v.version - 1;
@@ -407,16 +407,17 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
     result.push(v);
   }
 
-  // We return all the versions after last good version and the base versions of those.
-  if (relevantToConflict) {
-    return lastGoodVersion > 0 ? result.filter(v => v.version >= lastGoodVersion || relevantBaseVersions.has(v.version)) : [];
+  // Set relevantToConflict (Resolution) flag
+  // It is relevant if versions comes after last good version or it is the base versions of one of those.
+  for (const v of result) {
+    v.relevantToConflict = lastGoodVersion > 0 && (v.version >= lastGoodVersion || relevantBaseVersions.has(v.version));
   }
 
   if (lastGoodVersion === 0) {
     result[result.length - 1].lastGoodVersion = true;
   }
 
-  return result;
+  return relevantToConflict ? result.filter(v => v.relevantToConflict) : result;
 };
 
 module.exports = {

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -81,7 +81,7 @@ Entity.Def.Metadata = class extends Entity.Def {
 
   // we don't want `data` to be selected from database, hence return in forApi()
   static get fields() {
-    return super.fields.filter(f => f !== 'data');
+    return super.fields.filter(f => f !== 'data' && f !== 'dataReceived');
   }
 };
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -18,8 +18,28 @@ should.Assertion.add('isoDate', function() {
 });
 
 should.Assertion.add('nullOrIsoDate', function() {
-  this.params = { operator: 'to be an ISO date string' };
+  this.params = { operator: 'to be null or an ISO date string' };
   if (this.obj != null) this.obj.should.be.an.isoDate();
+});
+
+should.Assertion.add('nullOrString', function() {
+  this.params = { operator: 'to be null or string' };
+  if (this.obj != null) this.obj.should.be.String();
+});
+
+should.Assertion.add('nullOrNumber', function() {
+  this.params = { operator: 'to be null or number' };
+  if (this.obj != null) this.obj.should.be.Number();
+});
+
+should.Assertion.add('nullOrArray', function() {
+  this.params = { operator: 'to be null or array' };
+  if (this.obj != null) this.obj.should.be.Array();
+});
+
+should.Assertion.add('nullOrObject', function() {
+  this.params = { operator: 'to be null or object' };
+  if (this.obj != null) this.obj.should.be.Object();
 });
 
 should.Assertion.add('recentIsoDate', function() {
@@ -362,9 +382,9 @@ should.Assertion.add('EntityDef', function assertEntityDef() {
   this.obj.should.have.property('current').which.is.a.Boolean();
   this.obj.should.have.property('createdAt').which.is.a.isoDate();
   this.obj.should.have.property('creatorId').which.is.a.Number();
-  this.obj.should.have.property('version');
-  this.obj.should.have.property('baseVersion');
-  this.obj.should.have.property('conflictingProperties');
+  this.obj.should.have.property('version').which.is.a.Number();
+  this.obj.should.have.property('baseVersion').which.is.nullOrNumber();
+  this.obj.should.have.property('conflictingProperties').which.is.nullOrArray();
   if (this.obj.userAgent !== null) this.obj.userAgent.should.be.a.String();
 });
 
@@ -379,15 +399,15 @@ should.Assertion.add('EntityDefFull', function assertEntityDefFull() {
   this.params = { operator: 'to be an Entity Def (version) including Conflict related fields' };
 
   this.obj.should.be.an.EntityDef();
-  this.obj.should.have.property('data');
-  this.obj.should.have.property('dataReceived');
-  this.obj.should.have.property('source');
-  this.obj.should.have.property('baseDiff');
-  this.obj.should.have.property('serverDiff');
-  this.obj.should.have.property('conflict');
-  this.obj.should.have.property('resolved');
-  this.obj.should.have.property('lastGoodVersion');
-  this.obj.should.have.property('relevantToConflict');
+  this.obj.should.have.property('data').which.is.nullOrObject();
+  this.obj.should.have.property('dataReceived').which.is.nullOrObject();
+  this.obj.should.have.property('source').which.is.nullOrObject();
+  this.obj.should.have.property('baseDiff').which.is.nullOrArray();
+  this.obj.should.have.property('serverDiff').which.is.nullOrArray();
+  this.obj.should.have.property('conflict').which.is.nullOrString();
+  this.obj.should.have.property('resolved').which.is.Boolean();
+  this.obj.should.have.property('lastGoodVersion').which.is.Boolean();
+  this.obj.should.have.property('relevantToConflict').which.is.Boolean();
 });
 
 should.Assertion.add('SourceType', function Source() {

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -362,6 +362,9 @@ should.Assertion.add('EntityDef', function assertEntityDef() {
   this.obj.should.have.property('current').which.is.a.Boolean();
   this.obj.should.have.property('createdAt').which.is.a.isoDate();
   this.obj.should.have.property('creatorId').which.is.a.Number();
+  this.obj.should.have.property('version');
+  this.obj.should.have.property('baseVersion');
+  this.obj.should.have.property('conflictingProperties');
   if (this.obj.userAgent !== null) this.obj.userAgent.should.be.a.String();
 });
 
@@ -370,6 +373,21 @@ should.Assertion.add('ExtendedEntityDef', function assertEntity() {
 
   this.obj.should.be.an.EntityDef();
   this.obj.should.have.property('creator').which.is.an.Actor();
+});
+
+should.Assertion.add('EntityDefFull', function assertEntityDefFull() {
+  this.params = { operator: 'to be an Entity Def (version) including Conflict related fields' };
+
+  this.obj.should.be.an.EntityDef();
+  this.obj.should.have.property('data');
+  this.obj.should.have.property('dataReceived');
+  this.obj.should.have.property('source');
+  this.obj.should.have.property('baseDiff');
+  this.obj.should.have.property('serverDiff');
+  this.obj.should.have.property('conflict');
+  this.obj.should.have.property('resolved');
+  this.obj.should.have.property('lastGoodVersion');
+  this.obj.should.have.property('relevantToConflict');
 });
 
 should.Assertion.add('SourceType', function Source() {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -467,8 +467,7 @@ describe('Entities API', () => {
         .expect(200)
         .then(({ body: versions }) => {
           versions.forEach(v => {
-            v.should.be.an.EntityDef();
-            v.should.have.property('data');
+            v.should.be.an.EntityDefFull();
           });
 
           versions[1].data.should.be.eql({ age: '12', first_name: 'John' });
@@ -491,7 +490,7 @@ describe('Entities API', () => {
         .then(({ body: versions }) => {
           versions.forEach(v => {
             v.should.be.an.ExtendedEntityDef();
-            v.should.have.property('data');
+            v.should.be.an.EntityDefFull();
           });
 
           versions[0].creator.displayName.should.be.eql('Alice');
@@ -546,9 +545,10 @@ describe('Entities API', () => {
         .expect(200)
         .then(({ body: versions }) => {
           versions.forEach(v => {
-            v.should.be.an.EntityDef();
-            v.should.have.property('data');
+            v.should.be.an.EntityDefFull();
           });
+
+          versions.filter(v => v.relevantToConflict).map(v => v.version).should.eql([1, 2, 3, 4]);
 
           const thirdVersion = versions[2];
           thirdVersion.conflict.should.be.eql('soft');
@@ -606,6 +606,19 @@ describe('Entities API', () => {
             versions[1].lastGoodVersion.should.be.true();
             versions[2].conflictingProperties.should.be.eql(['age']);
           });
+      }));
+
+      it('should correctly set relevantToConflict field', testEntities(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await createConflictOnV2(asAlice, container);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/versions')
+          .expect(200)
+          .then(({ body: versions }) => {
+            versions.filter(v => v.relevantToConflict).map(v => v.version).should.eql([2, 3, 4]);
+          });
+
       }));
 
       it('should return empty array when all conflicts are resolved', testEntities(async (service, container) => {

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -113,6 +113,7 @@ describe('Entities API', () => {
             p.should.be.an.Entity();
             p.should.have.property('currentVersion').which.is.an.EntityDef();
             p.currentVersion.should.not.have.property('data');
+            p.currentVersion.should.not.have.property('dataReceived');
           });
         });
     }));


### PR DESCRIPTION
### Changes:

- Added `relevantToConflict` field in GET /versions response; this should help in creation of conflict summary table on Entity feed page
- Return the fields that are stored in `entity_defs` table for all Entity related endpoints, except `data` and `dataReceived`
- Updated assertions and API docs to reflect the changes

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced