### PR TITLE
API-docs container: use env variable for spec path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ check-file-headers:
 .PHONY: api-docs
 api-docs:
 	(test "$(docker images -q odk-docs)" || docker build --file odk-docs.dockerfile -t odk-docs .) && \
-	docker run --rm -it -v ./docs/api.yaml:/docs/docs/_static/api-spec/central.yaml -p 8000:8000 odk-docs
+	docker run --rm -it -v ./docs:/docs/docs/_static/central-spec -p 8000:8000 odk-docs

--- a/odk-docs.dockerfile
+++ b/odk-docs.dockerfile
@@ -10,6 +10,8 @@ RUN sed -i 's/sphinx-autobuild.*/& --host 0.0.0.0/' Makefile
 
 RUN pip3 install -r requirements.txt
 
+ENV  API_SPEC_PATH "/docs/docs/_static/central-spec/api.yaml"
+
 EXPOSE 8000
 
-ENTRYPOINT ["/bin/sh", "-c" , "(git pull --autostash) && make autobuild"]
+ENTRYPOINT ["/bin/sh", "-c" , "(pip3 install -r requirements.txt) && (git pull --autostash) && make autobuild"]


### PR DESCRIPTION
API-docs container: use env variable for spec path, this fixes issue where git is unable to operate on mounted file.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced