### PR TITLE
Support updating AND creating entities from a single submission/form

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -41,14 +41,13 @@ const normalizeUuid = (id) => {
 };
 
 // Input: object representing entity, parsed from submission XML
-const extractLabelFromSubmission = (entity) => {
-  const { label, create, update } = entity.system;
-  if ((create === '1' || create === 'true') && (!label || label.trim() === ''))
-    throw Problem.user.missingParameter({ field: 'label' });
-
-  if ((update === '1' || update === 'true') && (!label || label.trim() === ''))
+const extractLabelFromSubmission = (entity, options = { create: true }) => {
+  const { create, update } = options;
+  const { label } = entity.system;
+  if (update && (!label || label.trim() === ''))
     return null;
-
+  if (create && (!label || label.trim() === ''))
+    throw Problem.user.missingParameter({ field: 'label' });
   return label;
 };
 

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -25,12 +25,12 @@ class Entity extends Frame.define(
 ) {
   get def() { return this.aux.def; }
 
-  static fromParseEntityData(entityData) {
+  static fromParseEntityData(entityData, options = { create: true, update: false }) {
     const { dataset } = entityData.system;
     const { data } = entityData;
     // validation for each field happens within each function
     const uuid = normalizeUuid(entityData.system.id);
-    const label = extractLabelFromSubmission(entityData);
+    const label = extractLabelFromSubmission(entityData, options);
     const baseVersion = extractBaseVersionFromSubmission(entityData);
     const dataReceived = { ...data, ...(label && { label }) };
     return new Entity.Partial({ uuid }, {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -278,13 +278,19 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
   const dataset = (await Datasets.get(form.get().projectId, entityData.system.dataset, true))
     .orThrow(Problem.user.datasetNotFound({ datasetName: entityData.system.dataset }));
 
-  // Create entity
-  if (entityData.system.create === '1' || entityData.system.create === 'true')
-    return Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
-
   // Or update entity
   if (entityData.system.update === '1' || entityData.system.update === 'true')
-    return Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event);
+    try {
+      await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event);
+    } catch (err) {
+      if ((err.problemCode === 404.8) && (entityData.system.create === '1' || entityData.system.create === 'true')) {
+        await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
+      } else {
+        throw (err);
+      }
+    }
+  else if (entityData.system.create === '1' || entityData.system.create === 'true')
+    return Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
 
   return null;
 };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -278,7 +278,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
   const dataset = (await Datasets.get(form.get().projectId, entityData.system.dataset, true))
     .orThrow(Problem.user.datasetNotFound({ datasetName: entityData.system.dataset }));
 
-  // Or update entity
+  // Try update before create (if both are specified)
   if (entityData.system.update === '1' || entityData.system.update === 'true')
     try {
       await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -154,7 +154,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
       (!dataset.approvalRequired && event.action === 'submission.update')) // don't process submission if approval is not required and submission metadata is updated
     return null;
 
-  const partial = await Entity.fromParseEntityData(entityData);
+  const partial = await Entity.fromParseEntityData(entityData, { create: true });
 
   const sourceDetails = { submission: { instanceId: submissionDef.instanceId }, parentEventId: parentEvent ? parentEvent.id : undefined };
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id);
@@ -175,7 +175,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
     return null;
 
   // Get client version of entity
-  const clientEntity = await Entity.fromParseEntityData(entityData); // validation happens here
+  const clientEntity = await Entity.fromParseEntityData(entityData, { update: true }); // validation happens here
 
   // Get version of entity on the server
   const serverEntity = (await Entities.getById(dataset.id, clientEntity.uuid, QueryOptions.forUpdate))

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2280,6 +2280,7 @@ describe('Entities API', () => {
           .expect(200)
           .then(({ body: logs }) => {
             logs[0].action.should.be.eql('entity.error');
+            logs[0].details.errorMessage.should.be.eql('Base version (99) does not exist for entity UUID (12345678-1234-4123-8234-123456789abc) in dataset (people).');
             logs[1].action.should.be.eql('submission.create');
           });
       }));

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2203,6 +2203,8 @@ describe('Entities API', () => {
           .expect(200)
           .then(({ body: logs }) => {
             logs[0].action.should.be.eql('entity.error');
+            logs[0].details.problem.problemCode.should.be.eql(400.2);
+            logs[0].details.errorMessage.should.be.eql('Required parameter label missing.')
             logs[1].action.should.be.eql('submission.create');
           });
       }));

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2155,5 +2155,139 @@ describe('Entities API', () => {
           });
       }));
     });
+
+    describe('create and update in a single submission', () => {
+      it('should create an entity if it does not yet exist', testEntityUpdates(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.one
+            .replace('update="1"', 'create="1" update="1"')
+            .replace('id="12345678-1234-4123-8234-123456789abc"', 'id="12345678-1234-4123-8234-123456789aaa"'))
+          .expect(200);
+
+        await exhaust(container);
+
+        await asAlice.get('/v1/projects/1/forms/updateEntity/submissions/one/audits')
+          .expect(200)
+          .then(({ body: logs }) => {
+            logs[0].action.should.be.eql('entity.create');
+            logs[1].action.should.be.eql('submission.create');
+          });
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789aaa')
+          .expect(200)
+          .then(({ body: person }) => {
+            person.currentVersion.data.should.eql({ age: '85', first_name: 'Alicia' });
+            person.currentVersion.label.should.equal('Alicia (85)');
+            person.currentVersion.version.should.equal(1);
+          });
+      }));
+
+      it('should have create error if failed to update non-existent entity but still had error with create (e.g blank label)', testEntityUpdates(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.one
+            .replace('update="1"', 'create="1" update="1"')
+            .replace('id="12345678-1234-4123-8234-123456789abc"', 'id="12345678-1234-4123-8234-123456789aaa"')
+            .replace('<label>Alicia (85)</label>', ''))
+          .expect(200);
+
+        await exhaust(container);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789aaa')
+          .expect(404);
+
+        await asAlice.get('/v1/projects/1/forms/updateEntity/submissions/one/audits')
+          .expect(200)
+          .then(({ body: logs }) => {
+            logs[0].action.should.be.eql('entity.error');
+            logs[1].action.should.be.eql('submission.create');
+          });
+      }));
+
+      it('should update an entity if it does exist', testEntityUpdates(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.one
+            .replace('update="1"', 'create="1" update="1"'))
+          .expect(200);
+
+        await exhaust(container);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+          .expect(200)
+          .then(({ body: person }) => {
+            person.currentVersion.data.should.eql({ age: '85', first_name: 'Alicia' });
+            person.currentVersion.label.should.equal('Alicia (85)');
+            person.currentVersion.version.should.equal(2);
+          });
+
+        await asAlice.get('/v1/projects/1/forms/updateEntity/submissions/one/audits')
+          .expect(200)
+          .then(({ body: logs }) => {
+            logs[0].action.should.be.eql('entity.update.version');
+            logs[1].action.should.be.eql('submission.create');
+          });
+      }));
+
+      it('should fail both update and create if uuid exists and base version is wrong', testEntityUpdates(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.one
+            .replace('update="1"', 'create="1" update="1"')
+            .replace('baseVersion="1"', 'baseVersion="99"'))
+          .expect(200);
+
+        await exhaust(container);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+          .expect(200)
+          .then(({ body: person }) => {
+            // Not updated
+            person.currentVersion.version.should.equal(1);
+            person.currentVersion.data.should.eql({ age: '22', first_name: 'Johnny' });
+            person.currentVersion.label.should.equal('Johnny Doe');
+          });
+
+        await asAlice.get('/v1/projects/1/forms/updateEntity/submissions/one/audits')
+          .expect(200)
+          .then(({ body: logs }) => {
+            logs[0].action.should.be.eql('entity.error');
+            logs[1].action.should.be.eql('submission.create');
+          });
+      }));
+
+      it('should fail both update and create on error like invalid uuid', testEntityUpdates(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.one
+            .replace('update="1"', 'create="1" update="1"')
+            .replace('id="12345678-1234-4123-8234-123456789abc"', 'id="not_a_valid_uuid"'))
+          .expect(200);
+
+        await exhaust(container);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+          .expect(200)
+          .then(({ body: person }) => {
+            // Not updated
+            person.currentVersion.version.should.equal(1);
+            person.currentVersion.data.should.eql({ age: '22', first_name: 'Johnny' });
+            person.currentVersion.label.should.equal('Johnny Doe');
+          });
+
+        await asAlice.get('/v1/projects/1/forms/updateEntity/submissions/one/audits')
+          .expect(200)
+          .then(({ body: logs }) => {
+            logs[0].action.should.be.eql('entity.error');
+            logs[1].action.should.be.eql('submission.create');
+          });
+      }));
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/514

A submission describing an entity can now set both `create` and `update` flags to true. The submission processing will try to update first, and if it can't find the entity with the specified uuid, it will try to create the entity.

If there is any error besides 404.8 (entityNotFound) when performing the update, it will log the error and stop before trying to create. For example, if the base version is wrong in the update+create, the error will be about not finding the correct base version.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Lots of tests.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced