### PR TITLE
Trigger entity update on submission edit

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -171,7 +171,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, maybeOne }) => {
-  if (!(event.action === 'submission.create')) // only update on submission.create
+  if (!(event.action === 'submission.create' || event.action === 'submission.update.version'))
     return null;
 
   // Get client version of entity

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -691,6 +691,15 @@ module.exports = {
             <label>Alicia - 85</label>
           </entity>
         </meta>
+      </data>`,
+      three: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="updateEntity" version="1.0">
+        <meta>
+          <instanceID>three</instanceID>
+          <orx:instanceName>three</orx:instanceName>
+          <entity dataset="people" id="12345678-1234-4123-8234-123456789abc" baseVersion="1" update="1">
+          </entity>
+        </meta>
+        <age>55</age>
       </data>`
     },
     groupRepeat: {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1986,7 +1986,6 @@ describe('datasets and entities', () => {
             .then(() => asAlice.get('/v1/projects/1/forms/multiPropertyEntity/draft/dataset-diff')
               .expect(200)
               .then(({ body }) => {
-                //console.log(body);
                 body.should.be.eql([
                   {
                     name: 'foo',
@@ -3323,6 +3322,149 @@ describe('datasets and entities', () => {
         entityErrors.length.should.be.eql(1);
         entityErrors[0].details.errorMessage.should.match(/Required parameter label missing/);
 
+      }));
+
+      it('should do something reasonable with pending submissions when they contain entity updates', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        // can use update form to make dataset populate via api
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.updateEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ approvalRequired: true })
+          .expect(200);
+
+        // populate one entity
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({
+            uuid: '12345678-1234-4123-8234-123456789abc',
+            label: 'Johnny Doe',
+            data: { first_name: 'Johnny', age: '22' }
+          })
+          .expect(200);
+
+        // I also want one actual submission create that needs approval to run
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ approvalRequired: true })
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.two)
+          .expect(200);
+
+        // send update submissions!
+        // this is an update so it will be processed without needing to be approved.
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.three)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        // this will also process the create entity submission, but it wont make an entity
+        await exhaust(container);
+
+        // at this point, the main entity has been updated
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+          .expect(200)
+          .then(({ body: person }) => {
+            person.currentVersion.data.age.should.equal('55');
+            person.currentVersion.version.should.equal(2);
+          });
+
+        // the second entity has not yet been created because it needs submission approval
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789aaa')
+          .expect(404);
+
+        // send next two submission
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.three
+            .replace('<instanceID>three</instanceID>', '<instanceID>four</instanceID>')
+            .replace('<age>55</age>', '<age>66</age>'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        // send next submission
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.three
+            .replace('<instanceID>three</instanceID>', '<instanceID>five</instanceID>')
+            .replace('<age>55</age>', '<age>77</age>'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        // exhaust hasn't run yet so the one create submission and two update submissions count as pending
+        // central has no way to know if a submission is a create or update until it reads the submission
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ approvalRequired: false })
+          .expect(400)
+          .then(({ body }) => {
+            body.code.should.be.eql(400.29);
+            body.details.count.should.be.eql(3);
+          });
+
+        await asAlice.patch('/v1/projects/1/datasets/people?convert=true')
+          .send({ approvalRequired: false })
+          .expect(200)
+          .then(({ body }) => body.approvalRequired.should.be.false());
+
+        // send another submission
+        await asAlice.post('/v1/projects/1/forms/updateEntity/submissions')
+          .send(testData.instances.updateEntity.three
+            .replace('<instanceID>three</instanceID>', '<instanceID>six</instanceID>')
+            .replace('<age>55</age>', '<age>888</age>'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        // at this point, none of the new submissions have been processed
+        // the unprocessed audit log looks like this with the datset.update event between some submission events
+        const unprocessedAudits = await container.Audits.get(new QueryOptions({ condition: { processed: null } }));
+        unprocessedAudits.map(a => a.action).should.eql([
+          'submission.create',
+          'dataset.update',
+          'submission.create',
+          'submission.create'
+        ]);
+
+        await exhaust(container);
+
+        // main entity with many updates
+        // events should all look like submission.create events (vs. dataset update events)
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
+          .expect(200)
+          .then(({ body: logs }) => {
+            const updateDetails = logs.filter(log => log.action === 'entity.update.version').map(log => log.details);
+            updateDetails.length.should.equal(4);
+            updateDetails.filter(d => d.sourceEvent.action === 'submission.create').length.should.equal(4);
+            updateDetails.map(d => d.submission.instanceId).should.eql([
+              'six', 'five', 'four', 'three'
+            ]);
+          });
+
+        // other entity that was created
+        await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789aaa/audits')
+          .expect(200)
+          .then(({ body: logs }) => {
+            logs[0].action.should.equal('entity.create');
+            logs[0].details.submission.xmlFormId.should.equal('simpleEntity');
+            logs[0].details.submission.instanceId.should.equal('two');
+            logs[0].details.sourceEvent.action.should.equal('submission.create');
+          });
+
+        // only one entity def should have a source with a non-null parent id
+        // the submission that only created an entity
+        const defSourceParentIds = await container.all(sql`
+        select eds.details->'submission'->'instanceId' as "submissionInstanceId"
+        from entity_defs as ed
+        join entity_def_sources as eds on ed."sourceId" = eds.id
+        where eds.details->'parentEventId' is not null`);
+        defSourceParentIds.length.should.equal(1);
+        defSourceParentIds[0].submissionInstanceId.should.equal('two');
       }));
     });
   });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/517 by letting `submission.update.version` events also be used to update entities. 

All the scenarios listed in the issue are tested.

### processing pending submissions
I also tested what happens when some submissions that are meant to _update_ entities get picked up in the "pending submissions" when a dataset that requires approval for entity creation gets toggled to no longer require approval. Since we don't know ahead of time which submissions create vs. update entities, we can't really treat them differently here. 

However, entity updates should get processed right away (regardless of if approval is required) so this probably wont come up often. The main situation this comes up is if a entity update submission comes in, the worker hasn't come by to process it yet, and the user toggles the dataset flag in the time between submission and worker processing. Or if a submission comes in after they toggle the dataset, but the worker still hasn't run yet.

Within this flow, it could also happen that dataset update event gets queued after the submission events, then the worker processes the individual submissions, and by the time it gets to the bulk processing event, there is nothing left to process.

There's a lot going on but ultimately none of it seems like a problem.

Also because of how entity updates get processed, there is no link from the update event back to the parent bulk processing `dataset.update` event.

### frontend changes 

I don't actually think anything needs to change here on the front end.

This shows two updates, one which came from a `submission.update.version` event and one from a `submission.create` event.  We just show the submission and don't mention the specific kind of submission event for an entity update. 
<img width="750" alt="Screenshot 2023-11-15 at 3 50 47 PM" src="https://github.com/getodk/central-backend/assets/76205/242e1e15-2ed5-4a4a-80c7-a2eebff19fb4">

Here's the submission feed
<img width="751" alt="Screenshot 2023-11-15 at 3 55 35 PM" src="https://github.com/getodk/central-backend/assets/76205/84ddb462-54fe-4561-8b56-199f8085b1be">

I made a [conditional update form](https://staging.getodk.cloud/#/projects/49/forms/tree_conditional_update) on staging that works locally and will work once this PR is merged. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

This PR is mostly tests. 

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced