### PR TITLE
Add ETag header to all blobs

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -4550,6 +4550,8 @@ paths:
       description: If a Draft Form was created with an Excel file (`.xls` or `.xlsx`),
         you can get that file back by adding `.xls` or `.xlsx` as appropriate to the
         Draft Form resource path.
+
+        This endpoint supports `ETag`, which can be used to avoid downloading the same content more than once. When an API consumer calls this endpoint, it returns a value in `ETag` header, you can pass this value in the header `If-None-Match` of subsequent requests. If the file has not been changed since the previous request, you will receive `304 Not Modified` response otherwise you'll get the latest file.
       operationId: Retrieving Draft Form XLS(X)
       parameters:
       - name: projectId
@@ -4569,6 +4571,11 @@ paths:
       responses:
         200:
           description: OK
+          headers:
+            ETag:
+              schema:
+                type: string
+                description: content version identifier
           content:
             application/xml:
               example: |
@@ -4662,6 +4669,8 @@ paths:
         (attachment with a filename or Dataset name) and `Content-Type` (based on
         the type supplied at upload time or `text/csv` in the case of a linked Dataset)
         will be given.
+
+        This endpoint supports `ETag`, which can be used to avoid downloading the same content more than once. When an API consumer calls this endpoint, it returns a value in `ETag` header, you can pass this value in the header `If-None-Match` of subsequent requests. If the file has not been changed since the previous request, you will receive `304 Not Modified` response otherwise you'll get the latest file.
       operationId: Downloading a Draft Form Attachment
       parameters:
       - name: projectId
@@ -4692,6 +4701,10 @@ paths:
             Content-Disposition:
               schema:
                 type: string
+            ETag:
+              schema:
+                type: string
+                description: content version identifier
           content:
             '{the MIME type of the attachment file itself or text/csv for a Dataset}':
               example: |
@@ -5363,6 +5376,8 @@ paths:
       description: If a Form Version was created with an Excel file (`.xls` or `.xlsx`),
         you can get that file back by adding `.xls` or `.xlsx` as appropriate to the
         Form Version resource path.
+
+        This endpoint supports `ETag` header, which can be used to avoid downloading the same content more than once. When an API consumer calls this endpoint, the endpoint returns a value in `ETag` header. If you pass that value in the `If-None-Match` header of a subsequent request, then if the file has not been changed since the previous request, you will receive `304 Not Modified` response; otherwise you'll get the latest file.
       operationId: Retrieving Form Version XLS(X)
       parameters:
       - name: projectId
@@ -5390,6 +5405,10 @@ paths:
       responses:
         200:
           description: OK
+            ETag:
+              schema:
+                type: string
+                description: content version identifier
           content:
             application/xml:
               example: |
@@ -7866,6 +7885,8 @@ paths:
       summary: Downloading an Attachment
       description: The `Content-Type` and `Content-Disposition` will be set appropriately
         based on the file itself when requesting an attachment file download.
+
+        This endpoint supports `ETag`, which can be used to avoid downloading the same content more than once. When an API consumer calls this endpoint, it returns a value in `ETag` header, you can pass this value in the header `If-None-Match` of subsequent requests. If the file has not been changed since the previous request, you will receive `304 Not Modified` response otherwise you'll get the latest file.
       operationId: Downloading an Attachment
       parameters:
       - name: projectId
@@ -7903,6 +7924,10 @@ paths:
             Content-Disposition:
               schema:
                 type: string
+            ETag:
+              schema:
+                type: string
+                description: content version identifier
           content:
             '{the MIME type of the attachment file itself}':
               example: |
@@ -8414,6 +8439,8 @@ paths:
       description: It is important to note that this endpoint returns whatever is
         _currently_ uploaded against the _particular version_ of the _Submission_.
         It will not track overwritten attachments.
+
+        This endpoint supports `ETag`, which can be used to avoid downloading the same content more than once. When an API consumer calls this endpoint, it returns a value in `ETag` header, you can pass this value in the header `If-None-Match` of subsequent requests. If the file has not been changed since the previous request, you will receive `304 Not Modified` response otherwise you'll get the latest file.
       operationId: Downloading a Version's Attachment
       parameters:
       - name: projectId
@@ -8459,6 +8486,10 @@ paths:
             Content-Disposition:
               schema:
                 type: string
+            ETag:
+              schema:
+                type: string
+                description: content version identifier
           content:
             '{the MIME type of the attachment file itself}':
               example: |

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -12,7 +12,7 @@ const { identity } = require('ramda');
 const { Blob, Form } = require('../model/frames');
 const { ensureDef } = require('../model/frame');
 const { QueryOptions } = require('../util/db');
-const { isTrue, xml, binary, contentDisposition, withEtag } = require('../util/http');
+const { isTrue, xml, blobResponse, contentDisposition, withEtag } = require('../util/http');
 const Problem = require('../util/problem');
 const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
 const { getOrNotFound, reject, resolve, rejectIf } = require('../util/promise');
@@ -40,7 +40,7 @@ const streamAttachment = async (container, attachment, response) => {
     return reject(Problem.user.notFound());
   } else if (attachment.blobId != null) {
     const blob = await Blobs.getById(attachment.blobId).then(getOrNotFound);
-    return withEtag(`${blob.md5}`, () => binary(blob.contentType, attachment.name, blob.content));
+    return blobResponse(attachment.name, blob);
   } else {
     const dataset = await Datasets.getById(attachment.datasetId, true).then(getOrNotFound);
     const properties = await Datasets.getProperties(attachment.datasetId);
@@ -268,7 +268,7 @@ module.exports = (service, endpoint) => {
           : Blobs.getById(form.def.xlsBlobId)
             .then(getOrNotFound)
             .then(rejectIf(((blob) => blob.contentType !== excelMimeTypes[extension]), noargs(Problem.user.notFound)))
-            .then((blob) => binary(blob.contentType, `${form.xmlFormId}.${extension}`, blob.content)))));
+            .then((blob) => blobResponse(`${form.xmlFormId}.${extension}`, blob)))));
     service.get(`${base}.xls`, getXls('xls'));
     service.get(`${base}.xlsx`, getXls('xlsx'));
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -15,7 +15,7 @@ const { ensureDef } = require('../model/frame');
 const { createdMessage } = require('../formats/openrosa');
 const { getOrNotFound, getOrReject, rejectIf, reject } = require('../util/promise');
 const { QueryOptions } = require('../util/db');
-const { success, xml, isFalse, contentDisposition, binary, redirect, url } = require('../util/http');
+const { success, xml, isFalse, contentDisposition, blobResponse, redirect, url } = require('../util/http');
 const Problem = require('../util/problem');
 const { streamBriefcaseCsvs } = require('../data/briefcase');
 const { streamAttachments } = require('../data/attachments');
@@ -411,7 +411,7 @@ module.exports = (service, endpoint) => {
       getOrRedirect(Forms, Submissions, context)
         .then(([ form, submission ]) => SubmissionAttachments.getCurrentBlobByIds(form.id, submission.id, context.params.name, draft))
         .then(getOrNotFound)
-        .then((blob) => binary(blob.contentType, context.params.name, blob.content))));
+        .then((blob) => blobResponse(context.params.name, blob))));
 
     // TODO: wow audit-logging this is expensive.
     service.post(
@@ -498,7 +498,7 @@ module.exports = (service, endpoint) => {
             .then(getOrNotFound),
           Submissions.verifyVersion(form.id, params.rootId, params.instanceId, draft)
         ]))
-        .then(([ blob ]) => binary(blob.contentType, params.name, blob.content))));
+        .then(([ blob ]) => blobResponse(params.name, blob))));
 
     ////////////////////////////////////////////////////////////////////////////////
     // Diffs between all versions of a submission

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -157,10 +157,15 @@ const withEtag = (serverEtag, fn) => (request, response) => {
   return fn();
 };
 
+const blobResponse = (filename, blob) => withEtag(
+  blob.md5,
+  () => binary(blob.contentType, filename, blob.content),
+);
+
 module.exports = {
   isTrue, isFalse, urlPathname,
   serialize,
-  success, contentType, xml, atom, json, contentDisposition, binary, redirect,
+  success, contentType, xml, atom, json, contentDisposition, blobResponse, redirect,
   urlWithQueryParams, url,
   withEtag
 };

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -772,25 +772,6 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
               text.should.equal(testData.forms.simple);
             }))));
 
-      it('should return standard body if incorrect ETag provided', testService((service) =>
-        service.login('alice', (asAlice) =>
-          asAlice.get('/v1/projects/1/forms/simple.xml')
-            .set('If-None-Match', 'a-random-string')
-            .expect(200)
-            .then(({ text }) => {
-              text.should.equal(testData.forms.simple);
-            }))));
-
-      it('should return 304 if correct ETag provided', testService((service) =>
-        service.login('alice', async (asAlice) => {
-          const res = await asAlice.get('/v1/projects/1/forms/simple.xml').expect(200);
-          const etag = res.get('ETag');
-
-          return asAlice.get('/v1/projects/1/forms/simple.xml')
-            .set('If-None-Match', etag)
-            .expect(304);
-        })));
-
       it('should get the correct form given duplicates across projects', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects')

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -772,6 +772,25 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
               text.should.equal(testData.forms.simple);
             }))));
 
+      it('should return standard body if incorrect ETag provided', testService((service) =>
+        service.login('alice', (asAlice) =>
+          asAlice.get('/v1/projects/1/forms/simple.xml')
+            .set('If-None-Match', 'a-random-string')
+            .expect(200)
+            .then(({ text }) => {
+              text.should.equal(testData.forms.simple);
+            }))));
+
+      it('should return 304 if correct ETag provided', testService((service) =>
+        service.login('alice', async (asAlice) => {
+          const res = await asAlice.get('/v1/projects/1/forms/simple.xml').expect(200);
+          const etag = res.get('ETag');
+
+          return asAlice.get('/v1/projects/1/forms/simple.xml')
+            .set('If-None-Match', etag)
+            .expect(304);
+        })));
+
       it('should get the correct form given duplicates across projects', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects')

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -474,6 +474,7 @@ describe('api: /submission', () => {
                 .then(({ headers, body }) => {
                   headers['content-type'].should.equal('image/jpeg');
                   headers['content-disposition'].should.equal('attachment; filename="here_is_file2.jpg"; filename*=UTF-8\'\'here_is_file2.jpg');
+                  headers.etag.should.equal('"25bdb03b7942881c279788575997efba"');
                   body.toString('utf8').should.equal('this is test file two');
                 })))))));
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -474,7 +474,6 @@ describe('api: /submission', () => {
                 .then(({ headers, body }) => {
                   headers['content-type'].should.equal('image/jpeg');
                   headers['content-disposition'].should.equal('attachment; filename="here_is_file2.jpg"; filename*=UTF-8\'\'here_is_file2.jpg');
-                  headers.etag.should.equal('"25bdb03b7942881c279788575997efba"');
                   body.toString('utf8').should.equal('this is test file two');
                 })))))));
 


### PR DESCRIPTION
### Benefits

* improved server performance in situations where a client re-accesses the same data multiple times
* near-zero implementation cost, as blob hashes have already been fetched from db
* centralises code for serving blobs, which will simplify implementation of:
  * support for external storage options
  * streaming blob data from db (not currently scheduled AFAIK)
  
### Costs

* additional tests
* additional documentation