### PR TITLE
Allow 2023.1 entity xform spec version (entity updates)

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -68,7 +68,7 @@ const getDataset = (xml) => {
       return Option.none();
     if (version.isEmpty())
       throw Problem.user.invalidEntityForm({ reason: 'Entities specification version is missing.' });
-    else if (!version.get().startsWith('2022.1.'))
+    else if (!(version.get().startsWith('2022.1.') || version.get().startsWith('2023.1.')))
       throw Problem.user.invalidEntityForm({ reason: `Entities specification version [${version.get()}] is not supported.` });
     // check that dataset name is valid
     if (datasetName.isEmpty())

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -396,7 +396,7 @@ module.exports = {
     updateEntity: `<?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
   <h:head>
-    <model entities:entities-version="2022.1.0">
+    <model entities:entities-version="2023.1.0">
       <instance>
         <data id="updateEntity" orx:version="1.0">
           <name/>

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -17,11 +17,16 @@ describe('parsing dataset from entity block', () => {
         .replace('2022.1.0', '2022.1.123')).then((res) =>
         res.get().should.eql('people')));
 
+    it('should check for any version that starts with 2023.1.', () =>
+      getDataset(testData.forms.updateEntity
+        .replace('2023.1.0', '2023.1.123')).then((res) =>
+        res.get().should.eql('people')));
+
     it('should reject probable future version', () =>
       getDataset(testData.forms.simpleEntity
-        .replace('2022.1.0', '2023.1.0'))
+        .replace('2022.1.0', '2024.1.0'))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
-          message: 'The entity definition within the form is invalid. Entities specification version [2023.1.0] is not supported.' }));
+          message: 'The entity definition within the form is invalid. Entities specification version [2024.1.0] is not supported.' }));
 
     it('should complain if version is wrong', () =>
       getDataset(testData.forms.simpleEntity


### PR DESCRIPTION
Makes Central support the latests version of the entities xform spec (v2023.1.0). This version is all about submissions that allow (online) entity updates. We wanted a way to alert users that if their form used the new entity update xform spec and they uploaded it into an old version of Central, it would let them know that it couldn't do the updating. 

The xform spec changes between versions was additive, adding the `update=true`, `baseVersion` so this is mostly allowing the new spec version, but it doesn't change how the forms are processed under the hood. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

Is it too simple? Is there a better "check if version is in acceptable list of versions" snippet of code?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Lets us try entity update forms converted with the latest pyxform! 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced