### PR TITLE
Capture label in dataReceived for new entities

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -59,9 +59,10 @@ const createNew = (dataset, partial, subDef, sourceId, userAgentIn) => ({ one, c
   }
 
   const json = JSON.stringify(partial.def.data);
+  const dataReceived = JSON.stringify(partial.def.dataReceived);
 
   return one(sql`
-with def as (${_defInsert(nextval, true, creatorId, userAgent, partial.def.label, json, 1, json, sourceId)}),
+with def as (${_defInsert(nextval, true, creatorId, userAgent, partial.def.label, json, 1, dataReceived, sourceId)}),
 ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ${dataset.id}, ${partial.uuid}, def."createdAt", ${creatorId} from def
   returning entities.*)

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -233,6 +233,11 @@ describe('Entities API', () => {
             age: '88',
             first_name: 'Alice'
           });
+          person.currentVersion.should.have.property('dataReceived').which.is.eql({
+            age: '88',
+            first_name: 'Alice',
+            label: 'Alice (88)'
+          });
         });
     }));
 
@@ -274,6 +279,11 @@ describe('Entities API', () => {
           person.currentVersion.should.have.property('data').which.is.eql({
             age: '85',
             first_name: 'Alicia'
+          });
+          person.currentVersion.should.have.property('dataReceived').which.is.eql({
+            age: '85',
+            first_name: 'Alicia',
+            label: 'Alicia (85)'
           });
         });
     }));
@@ -1126,6 +1136,11 @@ describe('Entities API', () => {
           person.currentVersion.should.have.property('data').which.is.eql({
             first_name: 'Johnny',
             age: '22'
+          });
+          person.currentVersion.should.have.property('dataReceived').which.is.eql({
+            first_name: 'Johnny',
+            age: '22',
+            label: 'Johnny Doe'
           });
         });
     }));


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/539

Easy fix, `dataReceived` was available, just not getting used and passed to DB when creating a new entity.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added some tests

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced