### PR TITLE
Update backfill migration to also set label in dataReceived column

### DIFF
--- a/lib/model/migrations/20231002-01-add-conflict-details.js
+++ b/lib/model/migrations/20231002-01-add-conflict-details.js
@@ -25,7 +25,8 @@ const up = async (db) => {
   `);
 
   // Sets the value for "dataReceived" and "baseVersion" for existing row
-  await db.raw('UPDATE entity_defs SET "dataReceived" = data, "baseVersion" = CASE WHEN version > 1 THEN version - 1 ELSE NULL END');
+  // eslint-disable-next-line quotes
+  await db.raw(`UPDATE entity_defs SET "dataReceived" = data || jsonb_build_object('label', "label"), "baseVersion" = CASE WHEN version > 1 THEN version - 1 ELSE NULL END`);
 
 };
 

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -892,8 +892,8 @@ describe.skip('database migration: 20231002-01-add-conflict-details.js', functio
 
     // Create two entity defs
     await container.run(sql`
-      INSERT INTO entity_defs ("entityId", "createdAt", "creatorId", "current", "label", "data")
-      VALUES (${newEntity.id}, now(), 5, true, 'some label', '{"foo": "bar"}')`);
+      INSERT INTO entity_defs ("entityId", "createdAt", "creatorId", "current", "label", "data", "version")
+      VALUES (${newEntity.id}, now(), 5, false, 'some label', '{"foo": "bar"}', 1)`);
 
     await container.run(sql`
       INSERT INTO entity_defs ("entityId", "createdAt", "creatorId", "current", "label", "data", "version")


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/540

I debated between adding a new migration that would fill in this data, or changing the old migration file. I decided to change the old migration file, the one that added `baseVersion` and that introduced the column `dataReceived`, to also populate the label field in `dataReceived`. 

I was nervous about getting that change right so I wrote a test, but I've committed the code with the test skipped. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

A test.

#### Why is this the best possible solution? Were any other approaches considered?

I think this is tidier. The change is simple, it'll mean fewer migrations have to run on upgrade. The only downside is some of our test data may not have the label populated. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

no 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

no

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced