### PR TITLE
Tests of reprocessing submissions that yielded entity.error earlier

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -456,9 +456,14 @@ LEFT JOIN (
   JOIN entity_def_sources es ON es.id = ed."sourceId"
   JOIN entities e ON e.id =  ed."entityId" AND e."datasetId" = ${datasetId}
 ) ON es."submissionDefId" = sd.id
+LEFT JOIN (
+  SELECT DISTINCT ON ((details->'submissionId')::INTEGER) * FROM audits
+  WHERE action = 'entity.error'
+) errors ON (errors.details->'submissionId')::INTEGER = s.id
 WHERE sd.current AND dfd."datasetId" = ${datasetId}
 AND (s."reviewState" IS NULL OR s."reviewState" = 'edited' OR s."reviewState" = 'hasIssues')
 AND ed.id IS NULL
+AND errors.action IS NULL
 `;
 
 const countUnprocessedSubmissions = (datasetId) => ({ oneFirst }) => oneFirst(_unprocessedSubmissions(datasetId, sql`COUNT(1)`));

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -457,9 +457,9 @@ LEFT JOIN (
   JOIN entities e ON e.id =  ed."entityId" AND e."datasetId" = ${datasetId}
 ) ON es."submissionDefId" = sd.id
 LEFT JOIN (
-  SELECT DISTINCT ON ((details->'submissionId')::INTEGER) * FROM audits
+  SELECT DISTINCT ON ((details->'submissionDefId')::INTEGER) * FROM audits
   WHERE action = 'entity.error'
-) errors ON (errors.details->'submissionId')::INTEGER = s.id
+) errors ON (errors.details->'submissionDefId')::INTEGER = sd.id
 WHERE sd.current AND dfd."datasetId" = ${datasetId}
 AND (s."reviewState" IS NULL OR s."reviewState" = 'edited' OR s."reviewState" = 'hasIssues')
 AND ed.id IS NULL


### PR DESCRIPTION
Related to https://github.com/getodk/central/issues/547

The main code change here is that in the list of submissions to reprocess when toggling the dataset `approvalRequired` flag, submissions that were already processed for some reason and led to an entity processing `entity.error` are now filtered out and not reprocessed.

Two main scenarios: 
1. A submission failed to create an entity, and then the status was changed so there was a new `submission.update` event. Because the first attempt created an error, this will no longer be re-processed.
2. A submission failed to update an entity, and then something with the dataset changed (maybe a non-existent entity came into existence) but that submission wont be reprocessed in the "reprocess all unprocessed submissions" flow. (It was awkward it got caught up in this process anyway, but we don't have a good way of knowing ahead of time if a submission is about creating or updating so we have to re-examine it.)
    * In this entity update case, if you _edit_ the submission, that can re-trigger the desired entity update.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced