### PR TITLE
Change pyxform-http port because macOS uses port 5000 for ControlCenter

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,7 @@
     },
     "xlsform": {
       "host": "localhost",
-      "port": 5000
+      "port": 5001
     },
     "enketo": {
       "url": "http://localhost:8005/-",


### PR DESCRIPTION
I updated pyxform-http's port to 5000 to match Central's docs because of https://github.com/getodk/central-backend/issues/1000.

But that broke running pyxform-http on macOS because port 5000 is used by [ControlCenter](https://nono.ma/port-5000-used-by-control-center-in-macos-ventura-controlce).

So, I'll be reverting the pyxform-http change, but I think we should also make this change here. I say think because I have no idea the implications for this change in Central.