### PR TITLE
Auto-link form that creates and consumes dataset on publish

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -319,7 +319,7 @@ createVersion.audit.withResult = true;
 
 // TODO: we need to make more explicit what .def actually represents throughout.
 // for now, enforce an extra check here just in case.
-const publish = (form) => async ({ Forms, Datasets }) => {
+const publish = (form) => async ({ Forms, Datasets, FormAttachments }) => {
   if (form.draftDefId !== form.def.id) throw Problem.internal.unknown();
 
   // Try to push the form to Enketo if it hasn't been pushed already. If doing
@@ -329,15 +329,27 @@ const publish = (form) => async ({ Forms, Datasets }) => {
     : {};
 
   const publishedAt = (new Date()).toISOString();
-  return Promise.all([
+  await Promise.all([
     Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null, ...enketoIds }),
     Forms._updateDef(form.def, { draftToken: null, enketoId: null, publishedAt }),
-    Datasets.publishIfExists(form.def.id, publishedAt)
   ])
     .catch(Problem.translate(
       Problem.user.uniquenessViolation,
       () => Problem.user.versionUniquenessViolation({ xmlFormId: form.xmlFormId, version: form.def.version })
     ));
+
+  const ds = await Datasets.publishIfExists(form.def.id, publishedAt);
+  // this check is for issue c#554. we will hopefully come back to this flow and improve it later.
+  // ds contains a list of objects about what happened with the dataset
+  // like if the dataset was published and which properties were published.
+  // if it's empty, there is no dataset to work with.
+  if (!ds || ds.length > 0) {
+    const dataset = await Datasets.getById(ds[0].id).then(o => o.get());
+    const attachment = await FormAttachments.getByFormDefIdAndName(form.def.id, `${dataset.name}.csv`);
+    if (attachment.isDefined() && attachment.get().blobId == null && attachment.get().datasetId == null) {
+      await FormAttachments.update(form, attachment.get(), null, dataset.id);
+    }
+  }
 };
 publish.audit = (form) => (log) => log('form.update.publish', form,
   { oldDefId: form.currentDefId, newDefId: form.draftDefId });

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -343,7 +343,7 @@ const publish = (form) => async ({ Forms, Datasets, FormAttachments }) => {
   // ds contains a list of objects about what happened with the dataset
   // like if the dataset was published and which properties were published.
   // if it's empty, there is no dataset to work with.
-  if (!ds || ds.length > 0) {
+  if (ds.length > 0) {
     const dataset = await Datasets.getById(ds[0].id).then(o => o.get());
     const attachment = await FormAttachments.getByFormDefIdAndName(form.def.id, `${dataset.name}.csv`);
     if (attachment.isDefined() && attachment.get().blobId == null && attachment.get().datasetId == null) {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1583,6 +1583,7 @@ describe('datasets and entities', () => {
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.true();
               body[0].datasetExists.should.be.false();
+              body[0].updatedAt.should.not.be.null();
             });
         }));
 
@@ -1650,6 +1651,7 @@ describe('datasets and entities', () => {
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.false();
               body[0].datasetExists.should.be.true();
+              body[0].should.not.have.property('updatedAt'); // linked to dataset when created, never updated
             });
 
           await asAlice.post('/v1/projects/1/forms/updateEntity/draft/publish')
@@ -1661,6 +1663,7 @@ describe('datasets and entities', () => {
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.false();
               body[0].datasetExists.should.be.true();
+              body[0].should.not.have.property('updatedAt'); // linked to dataset when created, never updated
             });
         }));
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/554

There are multiple code paths for publishing forms (which is related to https://github.com/getodk/central-backend/issues/755). This only adds this auto linking feature when you have a draft of a form and publish it in a separate API call, because that is the main flow available to Central. The immediately POST a new form and publish is many a dev tool for testing and I didn't want to worry about adding this auto-linking code in both places.


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

Used @lognaturel's [create or update form](https://staging.getodk.cloud/#/projects/11/forms/participant_create_update)

See note about making new dataset
<img width="1501" alt="Screenshot 2023-12-06 at 12 07 04 PM" src="https://github.com/getodk/central-backend/assets/76205/4c15641b-df9b-4b4c-a175-6f1fc7654f7d">

See that nothing is attached
<img width="1501" alt="Screenshot 2023-12-06 at 12 07 07 PM" src="https://github.com/getodk/central-backend/assets/76205/73e40905-b18e-46ef-b1a4-eeccb2ecdc20">

See that form uses and updates dataset after being published for the first time
<img width="1501" alt="Screenshot 2023-12-06 at 12 07 21 PM" src="https://github.com/getodk/central-backend/assets/76205/360782cd-a674-4ac8-abe0-47384cbc83a1">

Form works
<img width="1501" alt="Screenshot 2023-12-06 at 12 09 51 PM" src="https://github.com/getodk/central-backend/assets/76205/3efca09a-8261-4d26-8ca8-33926a2eaad2">

Entity create/update appears correctly
<img width="1501" alt="Screenshot 2023-12-06 at 12 09 36 PM" src="https://github.com/getodk/central-backend/assets/76205/1a6ca917-5c6a-428c-a07b-a93cfc259c9e">



#### Why is this the best possible solution? Were any other approaches considered?

I think it solves a confusing scenario that people are likely to run into. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

See above, will hopefully help avoid confusion.

Regression risk is that things could get linked without anyone seeing that explicit link. And then on a form detail page, it doesn't clearly show the attachments of a published form. 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Yeah it could be mentioned in the docs.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced