### PR TITLE
Fix count of pending submissions involving edits

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -455,7 +455,8 @@ LEFT JOIN (
   entity_defs ed 
   JOIN entity_def_sources es ON es.id = ed."sourceId"
   JOIN entities e ON e.id =  ed."entityId" AND e."datasetId" = ${datasetId}
-) ON es."submissionDefId" = sd.id
+  JOIN submission_defs source_sub_defs ON es."submissionDefId" = source_sub_defs.id
+) ON source_sub_defs."submissionId" = s.id
 LEFT JOIN (
   SELECT DISTINCT ON ((details->'submissionDefId')::INTEGER) * FROM audits
   WHERE action = 'entity.error'


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/561

Submission edits were getting counted/including in pending submissions because their specific `submissionDef` didn't create any entity defs. I modified the pending submission query to look for any existing entity def with the same submission, not just the same submission def. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

no

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced