### PR TITLE
Upgrade postgres to 14.10 in dev container setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ lint: node_version
 
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres
-	docker start odk-postgres14 || (docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.10 && sleep 5 && node lib/bin/create-docker-databases.js)
+	docker start odk-postgres14 || (docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.10-alpine && sleep 5 && node lib/bin/create-docker-databases.js)
 
 .PHONY: stop-docker-postgres
 stop-docker-postgres:

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ lint: node_version
 
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres
-	docker start odk-postgres14 || (docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.6 && sleep 5 && node lib/bin/create-docker-databases.js)
+	docker start odk-postgres14 || (docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.10 && sleep 5 && node lib/bin/create-docker-databases.js)
 
 .PHONY: stop-docker-postgres
 stop-docker-postgres:


### PR DESCRIPTION
Follow on to https://github.com/getodk/central-backend/pull/1052

I wanted the changes that affect production to go on staging as quickly as possible so left this behind. At the time I was having trouble running the make task because I already had a postgres server running on my machine. The make task would start the container but then would fail when trying to create the `jubilant` role because it already existed in my local db.

I've also switched to the alpine image. I don't think we need any particular utilities to be available and this saves ~40mb in download.

#### What has been done to verify that this works as intended?
Discarded my existing container and image, ran the make task, verified I could use the db with Central and that the postgres version was 14.10.

#### Why is this the best possible solution? Were any other approaches considered?
This is not really a complete solution because it won't upgrade an existing container. It seems like a reasonable first step but I think we should give some more thought to what we want this task to do:
- If the goal is to quickly spin up a clean database, then this is probably fine. Folks who use it will periodically throw away their existing containers and images and create new ones which will have the latest postgres version. 
- If the goal is to have a stable local database for development, I think we should use a named volume and make it so containers can be upgraded

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
No

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced