### PR TITLE
Check entity actions in submission against those permitted by form def

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -15,7 +15,7 @@
 
 const Option = require('../util/option');
 const Problem = require('../util/problem');
-const { traverseXml, findOne, and, root, node, hasAttr, tree, attr } = require('../util/xml');
+const { traverseXml, findOne, root, node, attr, stripNamespacesFromPath } = require('../util/xml');
 
 const validateDatasetName = (name) => {
   // Regex explanation:
@@ -61,21 +61,36 @@ const getDataset = (xml) => {
   const metaNode = findOne(root('html'), node('head'), node('model'), node('instance'), node(), node('meta'));
   return traverseXml(xml, [
     findOne(root('html'), node('head'), node('model'))(attr('entities-version')),
-    metaNode(findOne(root(), node('entity'))(tree())),
-    metaNode(findOne(root(), and(node('entity'), hasAttr('dataset')))(attr('dataset')))
-  ]).then(([ version, entityTag, datasetName ]) => {
-    if (entityTag.isEmpty() && datasetName.isEmpty())
+    metaNode(findOne(root(), node('entity'))(attr()))
+  ]).then(([ version, entityAttrs ]) => {
+    if (entityAttrs.isEmpty())
       return Option.none();
+
     if (version.isEmpty())
       throw Problem.user.invalidEntityForm({ reason: 'Entities specification version is missing.' });
     else if (!(version.get().startsWith('2022.1.') || version.get().startsWith('2023.1.')))
       throw Problem.user.invalidEntityForm({ reason: `Entities specification version [${version.get()}] is not supported.` });
+
+    const strippedAttrs = Object.create(null);
+    for (const [name, value] of Object.entries(entityAttrs.get()))
+      strippedAttrs[stripNamespacesFromPath(name)] = value;
+
     // check that dataset name is valid
-    if (datasetName.isEmpty())
+    const datasetName = strippedAttrs.dataset;
+    if (datasetName == null)
       throw Problem.user.invalidEntityForm({ reason: 'Dataset name is missing.' });
-    if (!validateDatasetName(datasetName.get()))
+    if (!validateDatasetName(datasetName))
       throw Problem.user.invalidEntityForm({ reason: 'Invalid dataset name.' });
-    return Option.of(datasetName.get().trim());
+
+    // Entity actions permitted by the form def
+    const actions = [];
+    const { create, update } = strippedAttrs;
+    if (create != null) actions.push('create');
+    if (update != null) actions.push('update');
+    if (actions.length === 0)
+      throw Problem.user.invalidEntityForm({ reason: 'The form must specify at least one entity action, for example, create or update.' });
+
+    return Option.of({ name: datasetName.trim(), actions });
   });
 };
 

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 //
 // This is an extension of schema.js where we define *datasest-specific* functions
-// for dealing with the XForms XML schema. When a form us uploaded to Central,
+// for dealing with the XForms XML schema. When a form is uploaded to Central,
 // we check the XML for an <entity> block, which will contain information
 // about datasets and mappings from form fields to
 // dataset properties.
@@ -17,6 +17,14 @@ const Option = require('../util/option');
 const Problem = require('../util/problem');
 const { traverseXml, findOne, root, node, attr, stripNamespacesFromPath } = require('../util/xml');
 
+/*
+Validates a dataset name:
+
+  - valid xml identifier
+  - does not contain `.`
+  - `__` prefix reserved
+  - case insensitive?
+*/
 const validateDatasetName = (name) => {
   // Regex explanation:
   // Check for a match with a valid string
@@ -26,10 +34,9 @@ const validateDatasetName = (name) => {
   // If there's a match, return true (valid)!
   // Note that '.' is not in the valid character set.
   // Non-letter unicode characters also not currently allowed
-  const match = /^(?!__)[\p{L}:_][\p{L}:\d_-]*$/u.exec(name.trim());
+  const match = /^(?!__)[\p{L}:_][\p{L}:\d_-]*$/u.exec(name);
   return (match !== null);
 };
-
 
 const validatePropertyName = (name) => {
   // Regex explanation
@@ -46,22 +53,24 @@ const validatePropertyName = (name) => {
   return (match !== null);
 };
 
-// Here we are looking for dataset-registrating information within the <entity> tag.
-// We mainly need the dataset name, but we also do a bit of validation:
-//   1. namespace validation:
-//       e.g. xmlns:entities="http://www.opendatakit.org/xforms/entities
-//   2. dataset name validation:
-//       - valid xml identifier
-//       - does not contain `.`
-//       - `__` prefix reserved
-//       - case insensitive?
-//
-// Like with getFormFields in schema.js, we assume the form is otherwise valid.
-const getDataset = (xml) => {
-  const metaNode = findOne(root('html'), node('head'), node('model'), node('instance'), node(), node('meta'));
-  return traverseXml(xml, [
+/*
+getDataset() parses form XML for dataset-related information on the <entity>
+tag:
+
+  - The dataset name
+  - The entity actions permitted by the form def
+
+getDataset() also does some validation, including of:
+
+  - The version of the entities spec
+  - The dataset name
+
+Like with getFormFields() in schema.js, we assume the form is otherwise valid.
+*/
+const getDataset = (xml) =>
+  traverseXml(xml, [
     findOne(root('html'), node('head'), node('model'))(attr('entities-version')),
-    metaNode(findOne(root(), node('entity'))(attr()))
+    findOne(root('html'), node('head'), node('model'), node('instance'), node(), node('meta'), node('entity'))(attr())
   ]).then(([ version, entityAttrs ]) => {
     if (entityAttrs.isEmpty())
       return Option.none();
@@ -76,7 +85,7 @@ const getDataset = (xml) => {
       strippedAttrs[stripNamespacesFromPath(name)] = value;
 
     // check that dataset name is valid
-    const datasetName = strippedAttrs.dataset;
+    const datasetName = strippedAttrs.dataset?.trim();
     if (datasetName == null)
       throw Problem.user.invalidEntityForm({ reason: 'Dataset name is missing.' });
     if (!validateDatasetName(datasetName))
@@ -90,8 +99,7 @@ const getDataset = (xml) => {
     if (actions.length === 0)
       throw Problem.user.invalidEntityForm({ reason: 'The form must specify at least one entity action, for example, create or update.' });
 
-    return Option.of({ name: datasetName.trim(), actions });
+    return Option.of({ name: datasetName, actions });
   });
-};
 
 module.exports = { getDataset, validateDatasetName, validatePropertyName };

--- a/lib/model/migrations/20231208-01-dataset-form-def-actions.js
+++ b/lib/model/migrations/20231208-01-dataset-form-def-actions.js
@@ -1,0 +1,20 @@
+// Copyright 2023 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw('ALTER TABLE dataset_form_defs ADD COLUMN actions jsonb');
+  // eslint-disable-next-line quotes
+  await db.raw(`UPDATE dataset_form_defs SET actions = '["create"]'`);
+  await db.raw('ALTER TABLE dataset_form_defs ALTER COLUMN actions SET NOT NULL');
+};
+
+const down = (db) =>
+  db.raw('ALTER TABLE dataset_form_defs DROP COLUMN actions');
+
+module.exports = { up, down };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -20,7 +20,7 @@ const { sanitizeOdataIdentifier } = require('../../util/util');
 ////////////////////////////////////////////////////////////////////////////
 // DATASET CREATE AND UPDATE
 
-const _insertDatasetDef = (dataset, acteeId) => sql`
+const _insertDatasetDef = (dataset, acteeId, actions) => sql`
   WITH ds_ins AS (
     INSERT INTO datasets (id, name, "projectId", "createdAt", "acteeId")
     VALUES (nextval(pg_get_serial_sequence('datasets', 'id')), ${dataset.name}, ${dataset.projectId}, clock_timestamp(), ${acteeId})
@@ -35,7 +35,7 @@ const _insertDatasetDef = (dataset, acteeId) => sql`
   ),
   ds_defs AS (
     INSERT INTO dataset_form_defs
-    SELECT ds.id, ${dataset.aux.formDefId} FROM ds
+    SELECT ds.id, ${dataset.aux.formDefId}, ${JSON.stringify(actions)} FROM ds
     ON CONFLICT ON CONSTRAINT dataset_form_defs_datasetid_formdefid_unique 
     DO NOTHING
   )
@@ -69,25 +69,27 @@ insert_property_fields AS (
 // should be moved to util.js or we already have similar func somewhere?
 const isNilOrEmpty = either(isNil, isEmpty);
 
-const _createOrMerge = (dataset, fields, acteeId) => sql`
-${_insertDatasetDef(dataset, acteeId)}
+const _createOrMerge = (dataset, acteeId, actions, fields) => sql`
+${_insertDatasetDef(dataset, acteeId, actions)}
 ${isNilOrEmpty(fields) ? sql`` : _insertProperties(fields)}
 SELECT "action", "id" FROM ds
 `;
 
-// Takes the dataset name and field->property mappings defined in a form
-// and creates or updates the named dataset.
+// Takes information about the dataset parsed from the form XML, as well as
+// field->property mappings defined in a form, then creates or updates the named
+// dataset.
 // Arguments:
-// * dataset name
+// * information about the dataset parsed from the form XML
 // * form (a Form frame or object containing projectId, formDefId, and schemaId)
 // * array of field objects and property names that were parsed from the form xml
-const createOrMerge = (name, form, fields) => async ({ one, Actees, Datasets, Projects }) => {
+const createOrMerge = (parsedDataset, form, fields) => async ({ one, Actees, Datasets, Projects }) => {
   const { projectId } = form;
   const { id: formDefId, schemaId } = form.def;
 
   // Provision acteeId if necessary.
   // Need to check for existing dataset, and if not found, need to also
   // fetch the project since the dataset will be an actee child of the project.
+  const { name } = parsedDataset;
   const existingDataset = await Datasets.get(projectId, name, false);
   const acteeId = existingDataset.isDefined()
     ? existingDataset.get().acteeId
@@ -107,7 +109,7 @@ const createOrMerge = (name, form, fields) => async ({ one, Actees, Datasets, Pr
 
   // Insert or update: update dataset, dataset properties, and links to fields and current form
   // result contains action (created or updated) and the id of the dataset.
-  const result = await one(_createOrMerge(partial, dsPropertyFields, acteeId))
+  const result = await one(_createOrMerge(partial, acteeId, parsedDataset.actions, dsPropertyFields))
     .catch(error => {
       if (error.constraint === 'ds_property_fields_dspropertyid_formdefid_unique') {
         throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single property.' });

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -148,6 +148,14 @@ resolveConflict.audit = (entity, dataset) => (log) => log('entity.update.resolve
 /////////////////////////////////////////////////////////////////////////
 // Processing submission events to create and update entities
 
+const _getFormDefActions = async (oneFirst, datasetId, submissionDefId) => oneFirst(sql`
+SELECT dataset_form_defs.actions
+FROM submission_defs
+JOIN dataset_form_defs ON
+  dataset_form_defs."datasetId" = ${datasetId} AND
+  dataset_form_defs."formDefId" = submission_defs."formDefId"
+WHERE submission_defs.id = ${submissionDefId}`);
+
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
   // an approval event, then don't create an entity
@@ -236,7 +244,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 // Entrypoint to where submissions (a specific version) become entities
-const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms }) => {
+const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms, oneFirst }) => {
   const { submissionId, submissionDefId } = event.details;
 
   const form = await Forms.getByActeeId(event.acteeId);
@@ -278,6 +286,16 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
   }
   const dataset = (await Datasets.get(form.get().projectId, entityData.system.dataset, true))
     .orThrow(Problem.user.datasetNotFound({ datasetName: entityData.system.dataset }));
+
+  // Check that the form permits the entity action(s) specified in the
+  // submission.
+  const permittedActions = await _getFormDefActions(oneFirst, dataset.id, submissionDefId);
+  for (const action of ['create', 'update']) {
+    const submissionAction = entityData.system[action];
+    if ((submissionAction === '1' || submissionAction === 'true') &&
+      !permittedActions.includes(action))
+      throw Problem.user.entityActionNotAllowed({ action, permitted: permittedActions });
+  }
 
   // Try update before create (if both are specified)
   if (entityData.system.update === '1' || entityData.system.update === 'true')

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -148,13 +148,10 @@ resolveConflict.audit = (entity, dataset) => (log) => log('entity.update.resolve
 /////////////////////////////////////////////////////////////////////////
 // Processing submission events to create and update entities
 
-const _getFormDefActions = async (oneFirst, datasetId, submissionDefId) => oneFirst(sql`
-SELECT dataset_form_defs.actions
-FROM submission_defs
-JOIN dataset_form_defs ON
-  dataset_form_defs."datasetId" = ${datasetId} AND
-  dataset_form_defs."formDefId" = submission_defs."formDefId"
-WHERE submission_defs.id = ${submissionDefId}`);
+const _getFormDefActions = (oneFirst, datasetId, formDefId) => oneFirst(sql`
+SELECT actions
+FROM dataset_form_defs
+WHERE "datasetId" = ${datasetId} AND "formDefId" = ${formDefId}`);
 
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
@@ -289,12 +286,12 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
 
   // Check that the form permits the entity action(s) specified in the
   // submission.
-  const permittedActions = await _getFormDefActions(oneFirst, dataset.id, submissionDefId);
+  const permittedActions = await _getFormDefActions(oneFirst, dataset.id, submissionDef.formDefId);
   for (const action of ['create', 'update']) {
     const submissionAction = entityData.system[action];
     if ((submissionAction === '1' || submissionAction === 'true') &&
       !permittedActions.includes(action))
-      throw Problem.user.entityActionNotAllowed({ action, permitted: permittedActions });
+      throw Problem.user.entityActionNotPermitted({ action, permitted: permittedActions });
   }
 
   // Try update before create (if both are specified)

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -114,7 +114,7 @@ const createNew = (partial, project, publish = false) => async ({ run, Actees, D
   defData.keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form XML for fields and entity/dataset definitions
-  const [fields, datasetName] = await Promise.all([
+  const [fields, parsedDataset] = await Promise.all([
     getFormFields(partial.xml),
     (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml)) // Don't parse dataset schema if Form has encryption key
   ]);
@@ -163,8 +163,8 @@ const createNew = (partial, project, publish = false) => async ({ run, Actees, D
   ]);
 
   // Update datasets and properties if defined
-  if (datasetName.isDefined()) {
-    await Datasets.createOrMerge(datasetName.get(), savedForm, fields);
+  if (parsedDataset.isDefined()) {
+    await Datasets.createOrMerge(parsedDataset.get(), savedForm, fields);
 
     if (publish) {
       await Datasets.publishIfExists(savedForm.def.id, savedForm.def.publishedAt.toISOString());
@@ -242,7 +242,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form fields and dataset/entity definition from form XML
-  const [fields, datasetName] = await Promise.all([
+  const [fields, parsedDataset] = await Promise.all([
     getFormFields(partial.xml),
     (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml))
   ]);
@@ -299,8 +299,8 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   ]);
 
   // Update datasets and properties if defined
-  if (datasetName.isDefined()) {
-    await Datasets.createOrMerge(datasetName.get(), new Form(form, { def: savedDef }), fieldsForInsert);
+  if (parsedDataset.isDefined()) {
+    await Datasets.createOrMerge(parsedDataset.get(), new Form(form, { def: savedDef }), fieldsForInsert);
     if (publish) {
       await Datasets.publishIfExists(savedDef.id, savedDef.publishedAt.toISOString());
     }

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -136,8 +136,8 @@ const problems = {
     // TODO: should have details but not sure what yet.
     insufficientRights: problem(403.1, () => 'The authentication you provided does not have rights to perform that action.'),
 
-    entityActionNotAllowed: problem(403.2, ({ action, permitted }) =>
-      `The submission attempts an entity ${action}, but the form does not permit that action. The form permits the following actions: ${permitted.join(',')}.`),
+    entityActionNotPermitted: problem(403.2, ({ action, permitted }) =>
+      `The submission attempts an entity ${action}, but the form does not permit that action. The form permits the following actions: ${permitted.join(', ')}.`),
 
     // no detail information as the problem should be self-evident by REST conventions.
     notFound: problem(404.1, () => 'Could not find the resource you were looking for.'),

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -136,6 +136,9 @@ const problems = {
     // TODO: should have details but not sure what yet.
     insufficientRights: problem(403.1, () => 'The authentication you provided does not have rights to perform that action.'),
 
+    entityActionNotAllowed: problem(403.2, ({ action, permitted }) =>
+      `The submission attempts an entity ${action}, but the form does not permit that action. The form permits the following actions: ${permitted.join(',')}.`),
+
     // no detail information as the problem should be self-evident by REST conventions.
     notFound: problem(404.1, () => 'Could not find the resource you were looking for.'),
 

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -603,23 +603,23 @@ module.exports = {
                   <entities:label>Alice (88)</entities:label>
                 </entities:entity>
                 <orx:instanceName>one</orx:instanceName>
-                </meta>
-                <name>Alice</name>
-                <age>88</age>
-                <hometown>Chicago</hometown>
-                </data>`,
+              </meta>
+              <name>Alice</name>
+              <age>88</age>
+              <hometown>Chicago</hometown>
+            </data>`,
       two: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="1.0">
               <meta>
                 <instanceID>two</instanceID>
                 <entities:entity dataset="people" id="uuid:12345678-1234-4123-8234-123456789aaa" create="1">
-                <entities:label>Jane (30)</entities:label>
+                  <entities:label>Jane (30)</entities:label>
                 </entities:entity>
                 <orx:instanceName>two</orx:instanceName>
-            </meta>
-            <name>Jane</name>
-            <age>30</age>
-            <hometown>Boston</hometown>
-          </data>`,
+              </meta>
+              <name>Jane</name>
+              <age>30</age>
+              <hometown>Boston</hometown>
+            </data>`,
       three: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="simpleEntity" version="1.0">
           <meta>
             <instanceID>three</instanceID>

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -12,15 +12,15 @@ describe('parsing dataset from entity block', () => {
       res.should.equal(Option.none())));
 
   describe('versioning', () => {
-    it('should check for any version that starts with 2022.1.', () =>
+    it('should validate any version that starts with 2022.1.', () =>
       getDataset(testData.forms.simpleEntity
-        .replace('2022.1.0', '2022.1.123')).then((res) =>
-        res.get().should.eql('people')));
+        .replace('2022.1.0', '2022.1.123'))
+        .should.be.fulfilled());
 
-    it('should check for any version that starts with 2023.1.', () =>
+    it('should validate any version that starts with 2023.1.', () =>
       getDataset(testData.forms.updateEntity
-        .replace('2023.1.0', '2023.1.123')).then((res) =>
-        res.get().should.eql('people')));
+        .replace('2023.1.0', '2023.1.123'))
+        .should.be.fulfilled());
 
     it('should reject probable future version', () =>
       getDataset(testData.forms.simpleEntity
@@ -53,7 +53,7 @@ describe('parsing dataset from entity block', () => {
                 <name/>
                 <age/>
                 <meta>
-                  <entities:entity dataset="foo">
+                  <entities:entity dataset="foo" create="">
                     <entities:label/>
                   </entities:entity>
                 </meta>
@@ -63,7 +63,7 @@ describe('parsing dataset from entity block', () => {
         </h:head>
       </h:html>`;
       return getDataset(xml).then((res) =>
-        res.get().should.eql('foo'));
+        res.get().name.should.eql('foo'));
     });
 
     it('should retrieve the name of a dataset with namespace prefix on dataset attribute ', () => {
@@ -77,7 +77,7 @@ describe('parsing dataset from entity block', () => {
                 <name/>
                 <age/>
                 <meta>
-                  <entity entities:dataset="foo">
+                  <entity entities:dataset="foo" create="">
                     <label/>
                   </entity>
                 </meta>
@@ -87,7 +87,7 @@ describe('parsing dataset from entity block', () => {
         </h:head>
       </h:html>`;
       return getDataset(xml).then((res) =>
-        res.get().should.eql('foo'));
+        res.get().name.should.eql('foo'));
     });
 
     it('should find dataset name even if other fields are in meta block before entity block', () => {
@@ -104,7 +104,7 @@ describe('parsing dataset from entity block', () => {
                           <meta>
                               <instanceID/>
                               <instanceName/>
-                              <entity dataset="bar">
+                              <entity dataset="bar" create="">
                                 <label/>
                               </entity>
                           </meta>
@@ -115,7 +115,7 @@ describe('parsing dataset from entity block', () => {
           </h:head>
       </h:html>`;
       return getDataset(xml).then((res) =>
-        res.get().should.eql('bar'));
+        res.get().name.should.eql('bar'));
     });
 
     it('should return rejected promise if dataset name is missing', () => {
@@ -129,7 +129,7 @@ describe('parsing dataset from entity block', () => {
                 <name/>
                 <age/>
                 <meta>
-                  <entity>
+                  <entity create="">
                     <label/>
                   <entity>
                 </meta>
@@ -138,8 +138,11 @@ describe('parsing dataset from entity block', () => {
           </model>
         </h:head>
       </h:html>`;
-      // Problem.user.invalidEntityForm
-      return getDataset(xml).should.be.rejectedWith(Problem, { problemCode: 400.25 });
+      return getDataset(xml).should.be.rejectedWith(Problem, {
+        // Problem.user.invalidEntityForm
+        problemCode: 400.25,
+        message: 'The entity definition within the form is invalid. Dataset name is missing.'
+      });
     });
 
     it('should return rejected promise if dataset name is invalid', () => {
@@ -153,7 +156,7 @@ describe('parsing dataset from entity block', () => {
                 <name/>
                 <age/>
                 <meta>
-                  <entity dataset="bad.name">
+                  <entity dataset="bad.name" create="">
                     <label/>
                   </entity>
                 </meta>
@@ -162,40 +165,71 @@ describe('parsing dataset from entity block', () => {
           </model>
         </h:head>
       </h:html>`;
-      // Problem.user.invalidEntityForm
-      return getDataset(xml).should.be.rejectedWith(Problem, { problemCode: 400.25 });
+      return getDataset(xml).should.be.rejectedWith(Problem, {
+        // Problem.user.invalidEntityForm
+        problemCode: 400.25,
+        message: 'The entity definition within the form is invalid. Invalid dataset name.'
+      });
+    });
+
+    it('should return rejected promise for <entities:entity> if dataset name is missing', () => {
+      const xml = `
+      <?xml version="1.0"?>
+      <h:html xmlns:entities="http://www.opendatakit.org/xforms">
+        <h:head>
+          <model entities:entities-version="2022.1.0">
+            <instance>
+              <data id="NoName">
+                <name/>
+                <age/>
+                <meta>
+                  <entities:entity create="">
+                    <label/>
+                  <entities:entity>
+                </meta>
+              </data>
+            </instance>
+          </model>
+        </h:head>
+      </h:html>`;
+      return getDataset(xml).should.be.rejectedWith(Problem, {
+        problemCode: 400.25,
+        message: 'The entity definition within the form is invalid. Dataset name is missing.'
+      });
     });
   });
 
-  it('should tolerate this weird edge case', () => {
-    // This is a weird case where the code looking for the <entity> block at all
-    // fails to find it. But since it also contains no dataset name, it treats
-    // this form as a valid non-entity-related form.
-    const xml = `
-    <?xml version="1.0"?>
-    <h:html xmlns:entities="http://www.opendatakit.org/xforms">
-        <h:head>
-            <h:title>Foo Registration 2</h:title>
-            <model odk:xforms-version="1.0.0">
-                <instance>
-                    <data id="bar_registration" version="1234">
-                        <bbb/>
-                        <ccc/>
-                        <meta>
-                            <instanceID/>
-                            <instanceName/>
-                            <entities:entity>
-                              <entities:label/>
-                            </entities:entity>
-                        </meta>
-                    </data>
-                </instance>
-                <bind nodeset="/data/bbb" type="string" entities:save_to="b"/>
-              </model>
-        </h:head>
-    </h:html>`;
-    return getDataset(xml).then((res) =>
-      res.should.equal(Option.none()));
+  describe('parsing entity actions', () => {
+    it('should return create for a create form', async () => {
+      const result = await getDataset(testData.forms.simpleEntity);
+      result.get().actions.should.eql(['create']);
+    });
+
+    it('should return update for an update form', async () => {
+      const result = await getDataset(testData.forms.updateEntity);
+      result.get().actions.should.eql(['update']);
+    });
+
+    it('should return create and update for a form that can do both', async () => {
+      const result = await getDataset(testData.forms.updateEntity
+        .replace('update=""', 'create="" update=""'));
+      result.get().actions.should.eql(['create', 'update']);
+    });
+
+    it('should strip namespaces from action attributes', async () => {
+      const result = await getDataset(testData.forms.updateEntity
+        .replace('update=""', 'entities:create="" entities:update=""'));
+      result.get().actions.should.eql(['create', 'update']);
+    });
+
+    it('should reject for an entity form without an action', () => {
+      const promise = getDataset(testData.forms.simpleEntity
+        .replace('create=""', ''));
+      return promise.should.be.rejectedWith(Problem, {
+        problemCode: 400.25,
+        message: 'The entity definition within the form is invalid. The form must specify at least one entity action, for example, create or update.'
+      });
+    });
   });
 
   it('should extract entity properties from form field bindings', () =>
@@ -282,12 +316,12 @@ describe('dataset name validation', () => {
   it('should have name be case sensitive', () =>
     getDataset(testData.forms.simpleEntity
       .replace('people', 'PeopleWithACapitalP')).then((res) =>
-      res.get().should.eql('PeopleWithACapitalP')));
+      res.get().name.should.eql('PeopleWithACapitalP')));
 
   it('should strip whitespace from name', () =>
     getDataset(testData.forms.simpleEntity
       .replace('people', '   people ')).then((res) =>
-      res.get().should.eql('people')));
+      res.get().name.should.eql('people')));
 
   it('should reject names with .', () => {
     validateDatasetName('this.that').should.equal(false);

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -185,7 +185,7 @@ describe('parsing dataset from entity block', () => {
                 <meta>
                   <entities:entity create="">
                     <label/>
-                  <entities:entity>
+                  </entities:entity>
                 </meta>
               </data>
             </instance>
@@ -323,20 +323,26 @@ describe('dataset name validation', () => {
       .replace('people', '   people ')).then((res) =>
       res.get().name.should.eql('people')));
 
-  it('should reject names with .', () => {
-    validateDatasetName('this.that').should.equal(false);
-  });
-
   it('should reject empty name', () => {
     validateDatasetName('').should.equal(false);
   });
 
-  it('should reject blank string name', () => {
-    validateDatasetName('   ').should.equal(false);
+  it('should reject name that is all whitespace', () => {
+    const name = '   ';
+    validateDatasetName(name).should.equal(false);
+    const xml = testData.forms.simpleEntity.replace('people', name);
+    return getDataset(xml).should.be.rejectedWith(Problem, {
+      problemCode: 400.25,
+      message: 'The entity definition within the form is invalid. Invalid dataset name.'
+    });
   });
 
-  it('should reject name with whitepsace', () => {
+  it('should reject name with internal whitespace', () => {
     validateDatasetName('white space').should.equal(false);
+  });
+
+  it('should reject names with .', () => {
+    validateDatasetName('this.that').should.equal(false);
   });
 
   it('should reject names starting with disallowed characters', () => {
@@ -403,7 +409,7 @@ describe('property name validation', () => {
   });
 
   it('should allow name with unicode letters', () => {
-    validateDatasetName('bébés').should.equal(true);
+    validatePropertyName('bébés').should.equal(true);
   });
 
   // REJECT
@@ -458,6 +464,6 @@ describe('property name validation', () => {
   });
 
   it('should reject name with unicode', () => {
-    validateDatasetName('unicode÷divide').should.equal(false);
+    validatePropertyName('unicode÷divide').should.equal(false);
   });
 });


### PR DESCRIPTION
Closes getodk/central#518.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

The permitted actions from the form def are persisted on the `dataset_form_defs` record. It seems like a good idea to persist the actions rather than parsing the form XML each time a submission is processed for entities. `dataset_form_defs` also seems like the right table to store the actions. In the future, a form def will be able to take actions on multiple datasets, and in theory, it could take different actions on the different datasets. So conceptually, the permitted actions aren't per form def: they're per form def + dataset.

Note also that a single form may have different versions/defs that permit different actions. When a submission is processed, the form version specified in the submission will be used.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

All existing forms that make changes to entities will permit entity creation and only entity creation.

One edge case that was tolerated before now results in an error. See test/unit/data/dataset.js for details about that change. I think it's likely good that we no longer tolerate that edge case.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

No API responses have changed (other than some Problems). Maybe one day we'll want to return the list of permitted actions over the API.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced