### PR TITLE
Exclude deleted entities from extended metadata about entity list

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -195,6 +195,7 @@ const _get = extender(Dataset)(Dataset.Extended)((fields, extend, options, publi
   LEFT JOIN (
     SELECT "datasetId", COUNT(1) "entities", MAX(COALESCE("updatedAt", "createdAt")) "lastEntity", COUNT(1) FILTER (WHERE conflict IS NOT NULL) "conflicts"
     FROM entities e
+    WHERE "deletedAt" IS NULL
     GROUP BY "datasetId"
   ) stats on stats."datasetId" = datasets.id`}
   ${(actorId == null) ? sql`` : sql`


### PR DESCRIPTION
This PR relates to getodk/central#560 and I think is a major part of the issue there. It looks like we weren't excluding deleted entities from extended metadata about the entity list.

You can see this by looking at the example in the issue: https://staging.getodk.cloud/#/projects/62/entity-lists/trees/entities. There, the count of entities is sometimes off by 1. And there is 1 deleted entity: https://staging.getodk.cloud/v1/projects/62/datasets/trees/entities?deleted=true

#### What has been done to verify that this works as intended?

New test.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced