### PR TITLE
Run multiple worker loops

### DIFF
--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -59,7 +59,7 @@ const server = service.listen(config.get('default.server.port'), () => {
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// START WORKER
+// START WORKERS
 
 const { workerQueue } = require('../worker/worker');
 workerQueue(container).loops(4);

--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -61,8 +61,8 @@ const server = service.listen(config.get('default.server.port'), () => {
 ////////////////////////////////////////////////////////////////////////////////
 // START WORKER
 
-const { worker } = require('../worker/worker');
-worker(container);
+const { workerQueue } = require('../worker/worker');
+workerQueue(container).loops(4);
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -11,7 +11,7 @@ const { min } = Math;
 const { inspect } = require('util');
 const { head } = require('ramda');
 const { sql } = require('slonik');
-const { timebound, resolve, runSequentially } = require('../util/promise');
+const { timebound, runSequentially } = require('../util/promise');
 const defaultJobMap = require('./jobs').jobs;
 
 // TODO: domain catch/restart? << investigated and seems unlikely.
@@ -58,10 +58,9 @@ const workerQueue = (container, jobMap = defaultJobMap) => {
       .then(() => { process.stdout.write(`[${(new Date()).toISOString()}] finish processing event ${logname}\n`); })
       .catch((err) => {
         report(err);
-        return run(sql`update audits set claimed=null, failures=${event.failures + 1}, "lastFailure"=clock_timestamp() where id=${event.id}`)
-          .then(() => resolve());
+        return run(sql`update audits set claimed=null, failures=${event.failures + 1}, "lastFailure"=clock_timestamp() where id=${event.id}`);
       })
-      .then(done, done);
+      .finally(done);
 
     return true;
   };

--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -13,6 +13,7 @@ const { head } = require('ramda');
 const { sql } = require('slonik');
 const { timebound, runSequentially } = require('../util/promise');
 const defaultJobMap = require('./jobs').jobs;
+const { noop } = require('../util/util');
 
 // TODO: domain catch/restart? << investigated and seems unlikely.
 
@@ -40,8 +41,8 @@ const workerQueue = (container, jobMap = defaultJobMap) => {
 
   // given an event, attempts to run the appropriate jobs for the event,
   // returning `true` immediately if there is a job to run and `false` if not.
-  // if there is a job, the function will call the `done` callback once all jobs
-  // have been run, or once there has been an error. the function works hard on
+  // if there is a job, runJobs() will call the `done` callback once all jobs
+  // have been run, or once there has been an error. runJobs() works hard on
   // error handling, and will attempt to unclaim the event if a failure occurs.
   const runJobs = (event, done) => {
     if (event == null) return false;
@@ -58,7 +59,8 @@ const workerQueue = (container, jobMap = defaultJobMap) => {
       .then(() => { process.stdout.write(`[${(new Date()).toISOString()}] finish processing event ${logname}\n`); })
       .catch((err) => {
         report(err);
-        return run(sql`update audits set claimed=null, failures=${event.failures + 1}, "lastFailure"=clock_timestamp() where id=${event.id}`);
+        return run(sql`update audits set claimed=null, failures=${event.failures + 1}, "lastFailure"=clock_timestamp() where id=${event.id}`)
+          .catch(noop);
       })
       .finally(done);
 
@@ -81,7 +83,7 @@ update audits set claimed=clock_timestamp() from q where audits.id=q.id returnin
     .then(head);
 
   // main loop. kicks off a check and attempts to process the result of the check.
-  // if there was something to do, takes a break while that happens; the runner will
+  // if there was something to do, takes a break while that happens; runJobs() will
   // call back into the scheduler when it's done.
   // if there was nothing to do, immediately schedules a subsequent check at a capped
   // exponential backoff rate.

--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -16,25 +16,34 @@ const defaultJobMap = require('./jobs').jobs;
 
 // TODO: domain catch/restart? << investigated and seems unlikely.
 
-// we'd love to report to sentry, but it's much more important that we don't fail
-// in our error handling code. so we will do anything to pass this and move on.
-const reporter = (Sentry) => (err) => {
-  /* eslint-disable */ // i don't like anything it suggests here.
-  try { Sentry.captureException(err); }
-  catch (ierr) {
-    try { process.stderr.write(inspect(err) + '\n'); process.stderr.write(inspect(ierr) + '\n'); }
-    catch (_) { /* too scared to try anything at this point */ }
-  }
-  /* eslint-enable */
-};
+// tiny struct thing to just store worker last report status below.
+const stati = { idle: Symbol('idle'), check: Symbol('check'), run: Symbol('run') };
+class Status {
+  constructor() { this.set(stati.idle); }
+  set(status) { this.status = status; this.at = (new Date()).getTime(); }
+}
 
-// given an event, attempts to run the appropriate jobs for the event and then
-// calls the reschedule callback to continue the worker loop. works hard on error
-// handling, and will attempt to unclaim the event if a failure occurs.
-const runner = (container, jobMap) => {
-  const { run } = container;
-  const report = reporter(container.Sentry);
-  return (event, reschedule) => {
+const workerQueue = (container, jobMap = defaultJobMap) => {
+  const { Sentry, all, run } = container;
+
+  // we'd love to report to sentry, but it's much more important that we don't fail
+  // in our error handling code. so we will do anything to pass this and move on.
+  const report = (err) => {
+    /* eslint-disable */ // i don't like anything it suggests here.
+    try { Sentry.captureException(err); }
+    catch (ierr) {
+      try { process.stderr.write(inspect(err) + '\n'); process.stderr.write(inspect(ierr) + '\n'); }
+      catch (_) { /* too scared to try anything at this point */ }
+    }
+    /* eslint-enable */
+  };
+
+  // given an event, attempts to run the appropriate jobs for the event,
+  // returning `true` immediately if there is a job to run and `false` if not.
+  // if there is a job, the function will call the `done` callback once all jobs
+  // have been run, or once there has been an error. the function works hard on
+  // error handling, and will attempt to unclaim the event if a failure occurs.
+  const runJobs = (event, done) => {
     if (event == null) return false;
     const jobs = jobMap[event.action];
     if (jobs == null) return false;
@@ -42,6 +51,7 @@ const runner = (container, jobMap) => {
     const loggedAt = (event.loggedAt == null) ? '--' : event.loggedAt.toISOString();
     const logname = `${event.action}::${loggedAt}::${event.acteeId}`;
     process.stdout.write(`[${(new Date()).toISOString()}] start processing event ${logname} (${jobs.length} jobs)\n`);
+
     // run sequentially because a job can start a child transaction and then other jobs can't execute queries via parent transaction.
     container.transacting((tc) => timebound(runSequentially(jobs.map((f) => () => f(tc, event))))
       .then(() => tc.run(sql`update audits set processed=clock_timestamp() where id=${event.id}`)))
@@ -51,15 +61,14 @@ const runner = (container, jobMap) => {
         return run(sql`update audits set claimed=null, failures=${event.failures + 1}, "lastFailure"=clock_timestamp() where id=${event.id}`)
           .then(() => resolve());
       })
-      .then(reschedule, reschedule);
+      .then(done, done);
 
     return true;
   };
-};
 
-// using a CTE, attempts to atomically grab an available queue event for processing.
-// does some work to avoid problematic events. returns (Audit?)
-const checker = ({ all }) => () => all(sql`
+  // using a CTE, attempts to atomically grab an available queue event for processing.
+  // does some work to avoid problematic events. returns (Audit?)
+  const check = () => all(sql`
 with q as
   (select id from audits
     where processed is null
@@ -70,78 +79,79 @@ with q as
     limit 1
     for update skip locked)
 update audits set claimed=clock_timestamp() from q where audits.id=q.id returning *`)
-  .then(head);
+    .then(head);
 
-// tiny struct thing to just store worker last report status below.
-const stati = { idle: Symbol('idle'), check: Symbol('check'), run: Symbol('run') };
-class Status {
-  constructor() { this.set(stati.idle); }
-  set(status) { this.status = status; this.at = (new Date()).getTime(); }
-}
+  // main loop. kicks off a check and attempts to process the result of the check.
+  // if there was something to do, takes a break while that happens; the runner will
+  // call back into the scheduler when it's done.
+  // if there was nothing to do, immediately schedules a subsequent check at a capped
+  // exponential backoff rate.
+  const loop = (defaultDelay = 3000) => {
+    let enable = true; // we allow the caller to abort for testing.
+    const status = new Status();
+    const withStatus = (x, chain) => { status.set(x); return chain; };
 
-// main loop. kicks off a check and attempts to process the result of the check.
-// if there was something to do, takes a break while that happens; the runner will
-// call back into the scheduler when it's done.
-// if there was nothing to do, immediately schedules a subsequent check at a capped
-// exponential backoff rate.
-const worker = (container, jobMap = defaultJobMap, defaultDelay = 3000) => {
-  let enable = true; // we allow the caller to abort for testing.
-  const check = checker(container);
-  const run = runner(container, jobMap);
-  const status = new Status();
-  const withStatus = (x, chain) => { status.set(x); return chain; };
-  const report = reporter(container.Sentry);
-
-  // this is the main loop, which should already try to hermetically catch its own
-  // failures and restart itself.
-  const now = (delay = defaultDelay) => {
-    if (!enable) return;
-    const wait = () => { waitFor(min(delay * 2, 25000)); }; // eslint-disable-line no-use-before-define
-    try {
-      withStatus(stati.check, check())
-        .then((event) => withStatus(stati.run, run(event, now)))
-        .then((running) => { if (!running) withStatus(stati.idle, wait()); })
-        .catch((err) => {
-          report(err);
-          process.stderr.write(`!! unexpected worker loop error: ${inspect(err)}\n`);
-          wait();
-        });
-    } catch (ex) {
-      report(ex);
-      process.stderr.write(`!! unexpected worker invocation error: ${inspect(ex)}\n`);
-      wait();
-    }
-  };
-  const waitFor = (amount) => { setTimeout(() => { now(amount); }, amount); }; // awkward..?
-  now();
-
-  // this is the watchdog timer, which ensures that the worker has reported back
-  // in a reasonable time for what it claims to be doing. if not, it starts a new
-  // check immediately. there is some theoretical chance if the worker was secretly
-  // fine we'll end up with extras, but it seems unlikely.
-  const woof = (which) => {
-    process.stderr.write(`!! unexpected worker loss in ${which} (${status.at})\n`);
+    // this is the main loop, which should already try to hermetically catch its own
+    // failures and restart itself.
+    const now = (delay = defaultDelay) => {
+      if (!enable) return;
+      const wait = () => { waitFor(min(delay * 2, 25000)); }; // eslint-disable-line no-use-before-define
+      try {
+        withStatus(stati.check, check())
+          .then((event) => withStatus(stati.run, runJobs(event, now)))
+          .then((running) => { if (!running) withStatus(stati.idle, wait()); })
+          .catch((err) => {
+            report(err);
+            process.stderr.write(`!! unexpected worker loop error: ${inspect(err)}\n`);
+            wait();
+          });
+      } catch (ex) {
+        report(ex);
+        process.stderr.write(`!! unexpected worker invocation error: ${inspect(ex)}\n`);
+        wait();
+      }
+    };
+    const waitFor = (amount) => { setTimeout(() => { now(amount); }, amount); }; // awkward..?
     now();
+
+    // this is the watchdog timer, which ensures that the worker has reported back
+    // in a reasonable time for what it claims to be doing. if not, it starts a new
+    // check immediately. there is some theoretical chance if the worker was secretly
+    // fine we'll end up with extras, but it seems unlikely.
+    const woof = (which) => {
+      process.stderr.write(`!! unexpected worker loss in ${which} (${status.at})\n`);
+      now();
+    };
+    const watchdog = setInterval(() => {
+      const delta = (new Date()).getTime() - status.at;
+      if ((delta > 120000) && (status.status === stati.idle)) woof('idle');
+      else if ((delta > 120000) && (status.status === stati.check)) woof('check');
+      else if ((delta > 720000) && (status.status === stati.run)) woof('run');
+    }, 60000);
+
+    return () => { enable = false; clearInterval(watchdog); };
   };
-  const watchdog = setInterval(() => {
-    const delta = (new Date()).getTime() - status.at;
-    if ((delta > 120000) && (status.status === stati.idle)) woof('idle');
-    else if ((delta > 120000) && (status.status === stati.check)) woof('check');
-    else if ((delta > 720000) && (status.status === stati.run)) woof('run');
-  }, 60000);
 
-  return () => { enable = false; clearInterval(watchdog); };
+  const loops = (count) => {
+    for (let i = 0; i < count; i += 1) loop();
+  };
+
+  // for testing: chews through the event queue serially until there is nothing left to process.
+  const exhaust = async () => {
+    const runWait = (event) => new Promise((done) => {
+      if (!runJobs(event, () => { done(true); })) done(false);
+    });
+    while (await check().then(runWait)); // eslint-disable-line no-await-in-loop
+  };
+
+  return {
+    loop, loops,
+    // for testing
+    exhaust, run: runJobs, check
+  };
 };
 
-// for testing: chews through the event queue serially until there is nothing left to process.
-const exhaust = async (container, jobMap = defaultJobMap) => {
-  const check = checker(container);
-  const run = runner(container, jobMap);
-  const runWait = (event) => new Promise((done) => {
-    if (!run(event, () => { done(true); })) done(false);
-  });
-  while (await check().then(runWait)); // eslint-disable-line no-await-in-loop
-};
+const exhaust = (container) => workerQueue(container).exhaust();
 
-module.exports = { runner, checker, worker, exhaust };
+module.exports = { workerQueue, exhaust };
 

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -5,7 +5,7 @@ const { createReadStream, readFileSync } = require('fs');
 
 const { promisify } = require('util');
 const testData = require('../../data/xml');
-const { runner, exhaust } = require(appRoot + '/lib/worker/worker');
+const { exhaust, workerQueue } = require(appRoot + '/lib/worker/worker');
 
 const geoForm = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <h:head>
@@ -305,7 +305,7 @@ describe('analytics task queries', function () {
         let event = (await container.Audits.getLatestByAction('submission.attachment.update')).get();
         // eslint-disable-next-line prefer-promise-reject-errors
         const jobMap = { 'submission.attachment.update': [ () => Promise.reject({ uh: 'oh' }) ] };
-        await promisify(runner(container, jobMap))(event);
+        await promisify(workerQueue(container, jobMap).run)(event);
 
         // should still be 0 because the failure count is only at 1, needs to be at 5 to count
         event = (await container.Audits.getLatestByAction('submission.attachment.update')).get();
@@ -377,7 +377,7 @@ describe('analytics task queries', function () {
       // eslint-disable-next-line prefer-promise-reject-errors
       const jobMap = { 'submission.attachment.update': [ () => Promise.reject({ uh: 'oh' }) ] };
       const eventOne = (await container.Audits.getLatestByAction('submission.attachment.update')).get();
-      await promisify(runner(container, jobMap))(eventOne);
+      await promisify(workerQueue(container, jobMap).run)(eventOne);
 
       // making this look like it failed 5 times
       await asAlice.post('/v1/projects/1/submission')

--- a/test/integration/worker/worker.js
+++ b/test/integration/worker/worker.js
@@ -4,7 +4,7 @@ const { promisify } = require('util');
 const { DateTime, Duration } = require('luxon');
 const { sql } = require('slonik');
 const { testContainerFullTrx, testContainer } = require('../setup');
-const { runner, checker, worker } = require(appRoot + '/lib/worker/worker');
+const { workerQueue } = require(appRoot + '/lib/worker/worker');
 const { Audit } = require(appRoot + '/lib/model/frames');
 const { insert } = require(appRoot + '/lib/util/db');
 
@@ -16,7 +16,7 @@ describe('worker', () => {
     it('should return false and do nothing if no event is given', () => {
       let called = false;
       const reschedule = () => { called = true; };
-      runner({})(null, reschedule).should.equal(false);
+      workerQueue({}).run(null, reschedule).should.equal(false);
       called.should.equal(false);
     });
 
@@ -24,14 +24,16 @@ describe('worker', () => {
       let called = false;
       const reschedule = () => { called = true; };
       const event = { action: 'test.event' };
-      runner({}, { other: [ () => Promise.resolve(42) ] })(event, reschedule).should.equal(false);
+      const queue = workerQueue({}, { other: [ () => Promise.resolve(42) ] });
+      queue.run(event, reschedule).should.equal(false);
       called.should.equal(false);
     });
 
     it('should return true if a job is matched', (done) => {
       const jobMap = { 'test.event': [] };
       const container = { transacting() { return Promise.resolve(); } };
-      runner(container, jobMap)({ action: 'test.event' }, done).should.equal(true);
+      const queue = workerQueue(container, jobMap);
+      queue.run({ action: 'test.event' }, done).should.equal(true);
     });
 
     it('should pass the container and event details to the job', testContainerFullTrx(async (container) => {
@@ -48,7 +50,7 @@ describe('worker', () => {
         return Promise.resolve();
       } ] };
 
-      await promisify(runner(sentineledContainer, jobMap))(event);
+      await promisify(workerQueue(sentineledContainer, jobMap).run)(event);
       checked.should.equal(true);
     }));
 
@@ -62,7 +64,7 @@ describe('worker', () => {
       ] };
 
       const event = { id: -1, action: 'test.event' };
-      await promisify(runner(container, jobMap))(event);
+      await promisify(workerQueue(container, jobMap).run)(event);
       count.should.equal(2);
     }));
 
@@ -73,7 +75,7 @@ describe('worker', () => {
       const event = (await Audits.getLatestByAction('submission.attachment.create')).get();
 
       const jobMap = { 'submission.attachment.create': [ () => Promise.resolve() ] };
-      await promisify(runner(container, jobMap))(event);
+      await promisify(workerQueue(container, jobMap).run)(event);
       const after = (await Audits.getLatestByAction('submission.attachment.create')).get();
       after.processed.should.be.a.recentDate();
     }));
@@ -86,7 +88,7 @@ describe('worker', () => {
       const event = { id: -1, action: 'test.event', failures: 0 };
       // eslint-disable-next-line prefer-promise-reject-errors
       const jobMap = { 'test.event': [ () => Promise.reject({ uh: 'oh' }) ] };
-      await promisify(runner(hijackedContainer, jobMap))(event);
+      await promisify(workerQueue(hijackedContainer, jobMap).run)(event);
       captured.should.eql({ uh: 'oh' });
     }));
 
@@ -100,7 +102,7 @@ describe('worker', () => {
       const event = { id: -1, action: 'test.event', failures: 0 };
       // eslint-disable-next-line prefer-promise-reject-errors
       const jobMap = { 'test.event': [ () => Promise.reject({ uh: 'oh' }) ] };
-      await promisify(runner(hijackedContainer, jobMap))(event);
+      await promisify(workerQueue(hijackedContainer, jobMap).run)(event);
       // not hanging is the test here.
     }));
 
@@ -115,7 +117,7 @@ describe('worker', () => {
 
       // eslint-disable-next-line prefer-promise-reject-errors
       const jobMap = { 'submission.attachment.update': [ () => Promise.reject({ uh: 'oh' }) ] };
-      await promisify(runner(container, jobMap))(event);
+      await promisify(workerQueue(container, jobMap).run)(event);
       const after = (await Audits.getLatestByAction('submission.attachment.update')).get();
       should.not.exist(after.claimed);
       should.not.exist(after.processed);
@@ -133,7 +135,7 @@ describe('worker', () => {
         ({ Audits: AuditQuery }) => AuditQuery.log(alice.actor, 'dummy.event', alice.actor),
         // eslint-disable-next-line prefer-promise-reject-errors
         () => Promise.reject({ uh: 'oh' }) ] };
-      await promisify(runner(container, jobMap))(event);
+      await promisify(workerQueue(container, jobMap).run)(event);
 
       const dummyEvent = (await Audits.getLatestByAction('dummy.event'));
       dummyEvent.isDefined().should.be.false();
@@ -143,7 +145,6 @@ describe('worker', () => {
       should.not.exist(after.processed);
       after.failures.should.equal(1);
       after.lastFailure.should.be.a.recentDate();
-
     }));
   });
 
@@ -151,7 +152,7 @@ describe('worker', () => {
   // the only event that is not automarked as processed upon initial audit logging.
   describe('checker', () => {
     it('should return null if there are no unprocessed events', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'test.event', alice.actor);
@@ -159,7 +160,7 @@ describe('worker', () => {
     }));
 
     it('should mark the event as claimed', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -170,7 +171,7 @@ describe('worker', () => {
     }));
 
     it('should not mark any other events as claimed', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -187,7 +188,7 @@ describe('worker', () => {
     }));
 
     it('should return the oldest eligible event', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor, { is: 'oldest' });
@@ -198,7 +199,7 @@ describe('worker', () => {
     }));
 
     it('should not return a recently failed event', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Users, run } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await run(insert(new Audit({
@@ -212,7 +213,7 @@ describe('worker', () => {
     }));
 
     it('should retry a previously failed event after some time', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Users, run } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await run(insert(new Audit({
@@ -227,7 +228,7 @@ describe('worker', () => {
     }));
 
     it('should not return a repeatedly failed event', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Users, run } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await run(insert(new Audit({
@@ -241,7 +242,7 @@ describe('worker', () => {
     }));
 
     it('should claim a stale/hung event', testContainer(async (container) => {
-      const check = checker(container);
+      const { check } = workerQueue(container);
       const { Users, run } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await run(insert(new Audit({
@@ -255,7 +256,7 @@ describe('worker', () => {
     }));
   });
 
-  describe('worker', () => {
+  describe('loop', () => {
     const millis = (x) => new Promise((done) => { setTimeout(done, x); });
 
     it('should run a full loop right away', testContainerFullTrx(async (container) => {
@@ -265,7 +266,7 @@ describe('worker', () => {
 
       let ran;
       const jobMap = { 'submission.attachment.update': [ () => { ran = true; return Promise.resolve(); } ] };
-      const cancel = worker(container, jobMap);
+      const cancel = workerQueue(container, jobMap).loop();
 
       // eslint-disable-next-line no-await-in-loop
       while ((await Audits.getLatestByAction('submission.attachment.update')).get().processed == null)
@@ -284,7 +285,7 @@ describe('worker', () => {
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
 
       const jobMap = { 'submission.attachment.update': [ () => Promise.resolve() ] };
-      const cancel = worker(container, jobMap);
+      const cancel = workerQueue(container, jobMap).loop();
 
       // eslint-disable-next-line no-await-in-loop
       while ((await container.oneFirst(sql`
@@ -302,7 +303,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
 
       const jobMap = { 'submission.attachment.update': [ () => Promise.resolve() ] };
-      const cancel = worker(container, jobMap, 50);
+      const cancel = workerQueue(container, jobMap).loop(50);
 
       // eslint-disable-next-line no-await-in-loop
       while ((await container.oneFirst(sql`
@@ -338,7 +339,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
         }
       };
       const jobMap = { 'submission.attachment.update': [ () => Promise.resolve() ] };
-      const cancel = worker(hijacked, jobMap, 10);
+      const cancel = workerQueue(hijacked, jobMap).loop(10);
 
       // eslint-disable-next-line no-await-in-loop
       while ((await Audits.getLatestByAction('submission.attachment.update')).get().processed == null)
@@ -368,7 +369,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
         }
       };
       const jobMap = { 'submission.attachment.update': [ () => Promise.resolve() ] };
-      const cancel = worker(hijacked, jobMap, 10);
+      const cancel = workerQueue(hijacked, jobMap).loop(10);
 
       // eslint-disable-next-line no-await-in-loop
       while ((await Audits.getLatestByAction('submission.attachment.update')).get().processed == null)
@@ -401,7 +402,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
         checks.should.equal(1);
         throw new Error('oh no!');
       } ] };
-      const cancel = worker(hijacked, jobMap);
+      const cancel = workerQueue(hijacked, jobMap).loop();
 
       // eslint-disable-next-line no-await-in-loop
       while ((await Audits.getLatestByAction('submission.attachment.update')).get().lastFailure == null)


### PR DESCRIPTION
Closes #533. Instead of running a single worker loop, Backend will now run 4. I didn't change the timing of how a worker waits between work.

#### What has been done to verify that this works as intended?

Existing tests continue to pass, but tests usually run workers manually (via `exhaust()`). When they do run a loop, it's at most one loop. I think it's hard to really test multiple loops and that the best thing to do is just to get the PR merged before regression testing begins. If we run into performance or other issues during regression testing, we can address them then.

#### Why is this the best possible solution? Were any other approaches considered?

I probably could have called the existing `worker()` function multiple times, but I noticed that each invocation of `worker()` would create functions to `check`, `run`, and `report`. Instead, I created a new function named `workerQueue()` that will create all worker-related functions at once. That reduces the number of duplicate functions and I think is a little easier to understand.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We already have concurrent workers in place because of our use of `pm2`, so I'm hoping we won't run into any issues.

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced