### PR TITLE
Usage metrics for 2023.5 about entity updates from submissions and conflicts

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/forms/odk-analytics/submissions",
         "formId": "odk-analytics",
-        "version": "v2023.4.0_1"
+        "version": "v2023.5.0_1"
       }
     }
   },

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -165,7 +165,21 @@ const metricsTemplate = {
         "num_entity_updates": {
           "recent": 0,
           "total": 0
-        }
+        },
+        "num_entity_updates_sub": {
+          total: 0,
+          recent: 0
+        },
+        "num_entity_updates_api": {
+          total: 0,
+          recent: 0
+        },
+        "num_entities_updated": {
+          total: 0,
+          recent: 0
+        },
+        "num_entity_conflicts": 0,
+        "num_entity_conflicts_resolved": 0
       }]
     }
   ]

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -604,7 +604,14 @@ const projectMetrics = () => (({ Analytics }) => Promise.all([
       num_followup_forms: row.num_followup_forms,
       num_entities: { total: row.num_entities_total, recent: row.num_entities_recent },
       num_failed_entities: { total: row.num_failed_entities_total, recent: row.num_failed_entities_recent },
-      num_entity_updates: { total: row.num_entity_updates_total, recent: row.num_entity_updates_recent }
+      num_entity_updates: { total: row.num_entity_updates_total, recent: row.num_entity_updates_recent },
+
+      // 2023.5 metrics
+      num_entity_updates_sub: { total: row.num_entity_updates_sub_total, recent: row.num_entity_updates_sub_recent },
+      num_entity_updates_api: { total: row.num_entity_updates_api_total, recent: row.num_entity_updates_api_recent },
+      num_entities_updated: { total: row.num_entities_updated_total, recent: row.num_entities_updated_recent },
+      num_entity_conflicts: row.num_entity_conflicts,
+      num_entity_conflicts_resolved: row.num_entity_conflicts_resolved,
     });
   }
 

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -399,12 +399,20 @@ const getDatasets = () => ({ all }) => all(sql`
 SELECT 
   ds.id, ds."projectId", COUNT(DISTINCT p.id) num_properties, COUNT(DISTINCT e.id) num_entities_total,
   COUNT(DISTINCT CASE WHEN e."createdAt" >= current_date - cast(${DAY_RANGE} as int) THEN e.id END) num_entities_recent,
+  COUNT(DISTINCT CASE WHEN e."updatedAt" IS NOT NULL THEN e.id END) num_entities_updated_total,
+  COUNT(DISTINCT CASE WHEN e."updatedAt" >= current_date - cast(${DAY_RANGE} as int) THEN e.id END) num_entities_updated_recent,
   COUNT(DISTINCT fd."formId") num_creation_forms,
   COUNT(DISTINCT CASE WHEN f."currentDefId" IS NOT NULL THEN fa."formId" END) num_followup_forms,
   MAX(COALESCE(errors.total, 0)) num_failed_entities_total,
   MAX(COALESCE(errors.recent, 0)) num_failed_entities_recent,
   MAX(COALESCE(updates.total, 0)) num_entity_updates_total,
-  MAX(COALESCE(updates.recent, 0)) num_entity_updates_recent
+  MAX(COALESCE(updates.recent, 0)) num_entity_updates_recent,
+  MAX(COALESCE(updates.update_sub_total, 0)) num_entity_updates_sub_total,
+  MAX(COALESCE(updates.update_sub_recent, 0)) num_entity_updates_sub_recent,
+  MAX(COALESCE(updates.update_api_total, 0)) num_entity_updates_api_total,
+  MAX(COALESCE(updates.update_api_recent, 0)) num_entity_updates_api_recent,
+  MAX(COALESCE(conflict_stats.conflicts, 0)) num_entity_conflicts,
+  MAX(COALESCE(conflict_stats.resolved, 0)) num_entity_conflicts_resolved
 FROM datasets ds
   LEFT JOIN ds_properties p ON p."datasetId" = ds.id AND p."publishedAt" IS NOT NULL
   LEFT JOIN entities e ON e."datasetId" = ds.id
@@ -430,12 +438,27 @@ FROM datasets ds
     SELECT
       COUNT (1) total,
       SUM (CASE WHEN a."loggedAt" >= current_date - cast(${DAY_RANGE} as int) THEN 1 ELSE 0 END) recent,
+      SUM (CASE WHEN a."details"->'submissionDefId' IS NOT NULL THEN 1 ELSE 0 END) update_sub_total,
+      SUM (CASE WHEN a."details"->'submissionDefId' IS NOT NULL AND a."loggedAt" >= current_date - cast(${DAY_RANGE} as int)
+        THEN 1 ELSE 0 END) update_sub_recent,
+      SUM (CASE WHEN a."details"->'submissionDefId' IS NULL THEN 1 ELSE 0 END) update_api_total,
+      SUM (CASE WHEN a."details"->'submissionDefId' IS NULL AND a."loggedAt" >= current_date - cast(${DAY_RANGE} as int)
+        THEN 1 ELSE 0 END) update_api_recent,
       e."datasetId"
     FROM audits a
       JOIN entities e on CAST((a.details ->> 'entityId'::TEXT) AS integer) = e.id
     WHERE a."action" = 'entity.update.version'
     GROUP BY e."datasetId"
   ) as updates ON ds.id = updates."datasetId"
+  LEFT JOIN (
+    SELECT COUNT (1) conflicts,
+    SUM (CASE WHEN e."conflict" IS NULL THEN 1 ELSE 0 END) resolved,
+    e."datasetId"
+    FROM entities e
+    WHERE e.id IN
+      (SELECT DISTINCT "entityId" FROM entity_defs WHERE "conflictingProperties" IS NOT NULL)
+    GROUP BY e."datasetId"
+  ) AS conflict_stats ON ds.id = conflict_stats."datasetId"
 WHERE ds."publishedAt" IS NOT NULL
 GROUP BY ds.id, ds."projectId"
 `);


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/498

Adds

* `num_entity_updates_sub` (total and recent) entity updates via submission
* `num_entity_updates_api` (total and recent) entity updates via api
    * the two above sum together to get the previous metric `num_entity_updates`
 * `num_entities_updated` (total and recent) counts the _entities_ updated rather than the update _events_
     * can be used to figure out what fraction of all entities ever get updated, and then with the update frequencies, how many updates each has on average 
 * `num_entity_conflicts` entities that have ever had a conflict
     * how common are conflicts in general? 
 * `num_entity_conflicts_resolved` entities that have ever had a conflict that are currently resolved
     * do people use entities with conflicts without resolving them? 


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

tests, trying it on a test analytics server


#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced