### PR TITLE
Bulk entity creation via API

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -40,12 +40,15 @@ info:
 
     **Added**:
 
+    - Bulk Entity Creation!
+      * The existing [Entity Create](/central-api-entity-management/#creating-entities) endpoint now also accepts a list of Entities to append to a Dataset.
+      * The `uuid` property is no longer required and Central will generate a UUID for each new Entity if needed.
     - OData Data Document for requests of Submissions and Entities now allow use of `$orderby`.
     - ETag headers on all Blobs.
 
     **Changed**:
 
-    - The [Entity Create](/central-api-entity-management/#creating-an-entity) endpoint will now generate a UUID if the `uuid` parameter is not provided.
+    - The [Entity Create](/central-api-entity-management/#creating-entities) endpoint will now generate a UUID if the `uuid` parameter is not provided.
 
 
     ## ODK Central v2023.5
@@ -96,7 +99,7 @@ info:
       * New endpoint [GET /projects/:id/datasets/:name/entities/:uuid/versions](/central-api-entity-management/#listing-versions) for listing the versions of an Entity.
       * New endpoint [GET /projects/:id/datasets/:name/entities/:uuid/diffs](/central-api-entity-management/#getting-changes-between-versions) for getting the changes between versions of an Entity.
       * New endpoint [GET /projects/:id/datasets/:name/entities/:uuid/audits](/central-api-entity-management/#entity-audit-log) for getting the server audit logs about a specific Entity.
-      * New endpoint [POST /projects/:id/datasets/:name/entities](/central-api-entity-management/#creating-an-entity) for creating an Entity from JSON.
+      * New endpoint [POST /projects/:id/datasets/:name/entities](/central-api-entity-management/#creating-entities) for creating an Entity from JSON.
       * New endpoint [PATCH /projects/:id/datasets/:name/entities/:uuid](/central-api-entity-management/#updating-an-entity) for updating the data or label of an Entity.
       * New endpoint [DELETE /projects/:id/datasets/:name/entities/:uuid](/central-api-entity-management/#deleting-an-entity) for soft-deleting an Entity.
 
@@ -10070,14 +10073,28 @@ paths:
     post:
       tags:
       - Entity Management
-      summary: Creating an Entity
+      summary: Creating Entities
       description: |-
-        Creates an Entity in the Dataset. The request body takes a JSON representation of the Entity, which has the following properties:
+        Creates one or more Entities in the Dataset.
+        
+        For creating a single Entity, the request body takes a JSON representation of the Entity, which has the following properties:
 
           1. A `data` object containing values for the user-defined Dataset properties. (Not all properties have to have values.)
           2. A `label` property, which cannot be blank or an empty string. (This is used as a human-readable label in Forms that consume Entities.)
           3. An optional `uuid` property. If the `uuid` is not specified, Central will generate a UUID for an Entity with the provided data and label.
-        
+      
+        `
+          {
+            "label": "John Doe",
+            "data": {
+              "firstName": "John",
+              "age": "22"
+            }
+          }
+        `
+
+        For creating multiple Entities in bulk, the request body takes a property `entities` containing a list of Entities as described above, as well as an optional `source` property. 
+
         Value type of all properties is `string`.
 
         You can provide header `X-Action-Notes` to store the metadata about the request. The metadata can retrieved using [Entity Audit Log](/central-api-entity-management/#entity-audit-log)
@@ -10100,23 +10117,27 @@ paths:
       requestBody:
         content:
           '*/*':
-            schema:              
-              type: object
-              properties:
-                uuid:
-                  type: string
-                  description: The `uuid` of the Entity that uniquely identifies the Entity.
-                label:
-                  type: string
-                  description: Label of the Entity
-                data:
-                  $ref: '#/components/schemas/DataExample'
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/EntityCreateSingle'
+                - $ref: '#/components/schemas/EntityCreateBulk'
             example:
-              uuid: 54a405a0-53ce-4748-9788-d23a30cc3afa
-              label: John Doe (88)
-              data:
-                firstName: John
-                age: '88'
+              entities:
+                -
+                  uuid: 54a405a0-53ce-4748-9788-d23a30cc3afa
+                  label: John Doe (22)
+                  data:
+                    firstName: John
+                    age: '22'
+                -
+                  uuid: 0c3a7922-b611-42ca-a961-944e09fa9aa2
+                  label: Amy Jane (38)
+                  data:
+                    firstName: Amy
+                    age: '38'
+              source:
+                name: my_dataset.csv
+                size: 100
       responses:
         200:
           description: OK
@@ -13580,6 +13601,29 @@ components:
                 type: string
               circumference_cm:
                 type: string
+    EntityCreateSingle:
+      type: object
+      properties:
+        uuid:
+          type: string
+          description: (Optional) The `uuid` of the Entity that uniquely identifies the Entity.
+        label:
+          type: string
+          description: Label of the Entity
+        data:
+          $ref: '#/components/schemas/DataExample'
+    EntityCreateBulk:
+      type: object
+      properties:
+        entities:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityCreateSingle'
+          description: A list of Entities
+        source:
+          type: object
+          items: {}
+          description: An object describing the source of this bulk create action with `name` and `size`.
     DataExample:
       type: object
       properties:

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -10077,7 +10077,7 @@ paths:
       description: |-
         Creates one or more Entities in the Dataset.
         
-        For creating a single Entity, the request body takes a JSON representation of the Entity, which has the following properties:
+        For creating **a single Entity**, the request body takes a JSON representation of the Entity, which has the following properties:
 
           1. A `data` object containing values for the user-defined Dataset properties. (Not all properties have to have values.)
           2. A `label` property, which cannot be blank or an empty string. (This is used as a human-readable label in Forms that consume Entities.)
@@ -10093,9 +10093,15 @@ paths:
           }
         `
 
-        For creating multiple Entities in bulk, the request body takes a property `entities` containing a list of Entities as described above, as well as an optional `source` property. 
+        The value type of all properties is `string`.
 
-        Value type of all properties is `string`.
+        For creating **multiple Entities** in bulk, the request body takes an array `entities` containing a list of Entity objects as described above. The bulk entity version also takes a `source` property with a required `name` field and optional `size`, for example to capture the filename and size of a bulk upload source.
+
+        `
+          {
+            "entities": [...], "source": {"name": "file.csv", "size": 100}
+          }
+        `
 
         You can provide header `X-Action-Notes` to store the metadata about the request. The metadata can retrieved using [Entity Audit Log](/central-api-entity-management/#entity-audit-log)
       operationId: Creating an Entity
@@ -13568,6 +13574,18 @@ components:
           type: string
           description: The name of the property that is changed.
           example: name
+    EntityBulkSource:
+      type: object
+      properties:
+        name:
+          type: string
+          description: A name to identify the bulk source, filename or API run
+          example: myfile.csv
+        size:
+          type: number
+          description: Optional, meant to indicate filesize (in MB)
+          example: 100
+      description: An object describing the source of this bulk create action.
     EntityOdata:
       type: object
       properties:
@@ -13621,9 +13639,7 @@ components:
             $ref: '#/components/schemas/EntityCreateSingle'
           description: A list of Entities
         source:
-          type: object
-          items: {}
-          description: An object describing the source of this bulk create action with `name` and `size`.
+          $ref: '#/components/schemas/EntityBulkSource'
     DataExample:
       type: object
       properties:

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -19,7 +19,7 @@ const { PartialPipe } = require('../util/stream');
 const Problem = require('../util/problem');
 const { submissionXmlToFieldStream } = require('./submission');
 const { nextUrlFor, getServiceRoot, jsonDataFooter, extractPaging } = require('../util/odata');
-const { sanitizeOdataIdentifier } = require('../util/util');
+const { sanitizeOdataIdentifier, blankStringToNull } = require('../util/util');
 
 const odataToColumnMap = new Map([
   ['__system/createdAt', 'entities.createdAt'],
@@ -140,6 +140,28 @@ const extractEntity = (body, propertyNames, existingEntity) => {
     }
 
   return entity;
+};
+
+// Input: object representing source (file name and size), sent via API
+// Also handles userAgent string
+// Returns validated and sanitized source object
+const extractBulkSource = (source, count, userAgent) => {
+  if (!source)
+    throw Problem.user.missingParameter({ field: 'source' });
+
+  const { name, size } = source;
+
+  if (!name)
+    throw Problem.user.missingParameter({ field: 'source.name' });
+
+  if (typeof name !== 'string')
+    throw Problem.user.invalidDataTypeOfParameter({ field: 'name', value: typeof name, expected: 'string' });
+
+  if (size != null && typeof size !== 'number')
+    throw Problem.user.invalidDataTypeOfParameter({ field: 'size', value: typeof size, expected: 'number' });
+
+
+  return { name, ...(size) && { size }, count, userAgent: blankStringToNull(userAgent) };
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -429,6 +451,7 @@ module.exports = {
   normalizeUuid,
   extractLabelFromSubmission,
   extractBaseVersionFromSubmission,
+  extractBulkSource,
   streamEntityCsv, streamEntityCsvAttachment,
   streamEntityOdata, odataToColumnMap,
   extractSelectedProperties, selectFields,

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -36,7 +36,7 @@ const actionCondition = (action) => {
     // The backup action was logged by a backup script that has been removed.
     // Even though the script has been removed, the audit log entries it logged
     // have not, so we should continue to exclude those.
-    return sql`action not in ('entity.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete', 'submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup', 'analytics')`;
+    return sql`action not in ('entity.create', 'entity.bulk.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete', 'submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'backup', 'analytics')`;
   else if (action === 'user')
     return sql`action in ('user.create', 'user.update', 'user.delete', 'user.assignment.create', 'user.assignment.delete', 'user.session.create')`;
   else if (action === 'field_key')
@@ -52,7 +52,7 @@ const actionCondition = (action) => {
   else if (action === 'dataset')
     return sql`action in ('dataset.create', 'dataset.update')`;
   else if (action === 'entity')
-    return sql`action in ('entity.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete')`;
+    return sql`action in ('entity.create', 'entity.bulk.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete')`;
 
   return sql`action=${action}`;
 };
@@ -136,7 +136,7 @@ const _getByEntityId = (fields, options, entityId) => sql`
 SELECT ${fields} FROM entity_defs
 
   LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
-  LEFT JOIN audits ON ((audits.details->'entityDefId')::INTEGER = entity_defs.id OR (audits.details->'sourceId')::INTEGER = entity_def_sources.id)
+  INNER JOIN audits ON ((audits.details->'entityDefId')::INTEGER = entity_defs.id OR (audits.details->'sourceId')::INTEGER = entity_def_sources.id)
 
   LEFT JOIN actors ON actors.id=audits."actorId"
 

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -133,11 +133,12 @@ const getBySubmissionId = (submissionId, options) => ({ all }) => _getBySubmissi
 
 
 const _getByEntityId = (fields, options, entityId) => sql`
-SELECT ${fields} FROM audits
-  LEFT JOIN actors ON actors.id=audits."actorId"
+SELECT ${fields} FROM entity_defs
 
-  LEFT JOIN entity_defs ON (audits.details->'entityDefId')::INTEGER = entity_defs.id
   LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
+  LEFT JOIN audits ON ((audits.details->'entityDefId')::INTEGER = entity_defs.id OR (audits.details->'sourceId')::INTEGER = entity_def_sources.id)
+
+  LEFT JOIN actors ON actors.id=audits."actorId"
 
   LEFT JOIN audits triggering_event ON entity_def_sources."auditId" = triggering_event.id
   LEFT JOIN actors triggering_event_actor ON triggering_event_actor.id = triggering_event."actorId"
@@ -167,15 +168,14 @@ SELECT ${fields} FROM audits
 
   -- if some other kind of target object defined, add subquery here
   -- ...
-
-  WHERE (audits.details->>'entityId')::INTEGER = ${entityId}
+  WHERE entity_defs."entityId" = ${entityId}
   ORDER BY audits."loggedAt" DESC, audits.id DESC
   ${page(options)}`;
 
 const getByEntityId = (entityId, options) => ({ all }) => {
 
   const _unjoiner = unjoiner(
-    Audit, Actor,
+    Audit, Actor, Entity.Def.Source,
     Option.of(Audit.alias('triggering_event', 'triggeringEvent')), Option.of(Actor.alias('triggering_event_actor', 'triggeringEventActor')),
     Option.of(Audit.alias('submission_create_event', 'submissionCreateEvent')), Option.of(Actor.alias('submission_create_event_actor', 'submissionCreateEventActor')),
     Option.of(Submission), Option.of(Submission.Def.alias('current_submission_def', 'currentVersion')),
@@ -187,6 +187,8 @@ const getByEntityId = (entityId, options) => ({ all }) => {
   return all(_getByEntityId(_unjoiner.fields, options, entityId))
     .then(map(_unjoiner))
     .then(map(audit => {
+
+      const entitySourceDetails = audit.aux.source.details;
 
       const sourceEvent = audit.aux.triggeringEvent
         .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
@@ -214,7 +216,8 @@ const getByEntityId = (entityId, options) => ({ all }) => {
 
       const details = mergeLeft(audit.details, sourceEvent
         .map(event => ({ source: { event, submission } }))
-        .orElse({ source: {} })); // Add default empty source to all other entity audit events
+        .orElse({ source: entitySourceDetails ?? {} })); // Add details from entity def source, or add default empty source to all other entity audit events
+
 
       return new Audit({ ...audit, details }, { actor: audit.aux.actor });
     }));

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -188,7 +188,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
     .then(map(_unjoiner))
     .then(map(audit => {
 
-      const entitySourceDetails = audit.aux.source.details;
+      const entitySourceDetails = audit.aux.source.forApi();
 
       const sourceEvent = audit.aux.triggeringEvent
         .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
@@ -214,9 +214,11 @@ const getByEntityId = (entityId, options) => ({ all }) => {
       })
         .orElse(undefined);
 
+      // Note: The source added to each audit event represents the source of the
+      // corresponding entity _version_, rather than the source of the event.
       const details = mergeLeft(audit.details, sourceEvent
         .map(event => ({ source: { event, submission } }))
-        .orElse({ source: entitySourceDetails ?? {} })); // Add details from entity def source, or add default empty source to all other entity audit events
+        .orElse({ source: entitySourceDetails }));
 
 
       return new Audit({ ...audit, details }, { actor: audit.aux.actor });

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -24,7 +24,6 @@ const { reject, runSequentially } = require('../../util/promise');
 // ENTITY DEF SOURCES
 
 const createSource = (details = null, subDefId = null, eventId = null) => ({ one }) => {
-  // TODO: what should the type of the source be? allow type to be `bulk`?
   const type = (subDefId) ? 'submission' : 'api';
   return one(sql`insert into entity_def_sources ("type", "submissionDefId", "auditId", "details")
   values (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)})

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -125,7 +125,7 @@ const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, c
 };
 
 createMany.audit = (dataset, entities, sourceId) => (log) =>
-  log('entity.bulk.create', dataset, { sourceId, count: entities.length });
+  log('entity.bulk.create', dataset, { sourceId });
 createMany.audit.withResult = false;
 
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -17,7 +17,7 @@ const { odataFilter, odataOrderBy } = require('../../data/odata-filter');
 const { odataToColumnMap, parseSubmissionXml, getDiffProp, ConflictType } = require('../../data/entity');
 const { isTrue } = require('../../util/http');
 const Problem = require('../../util/problem');
-const { runSequentially } = require('../../util/promise');
+const { reject, runSequentially } = require('../../util/promise');
 
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -87,7 +87,7 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
 };
 createNew.audit.withResult = true;
 
-const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, context }) => {
+const _createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, context }) => {
   const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
   const userAgent = blankStringToNull(userAgentIn);
 
@@ -111,17 +111,23 @@ const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, c
     '1'
   ], sql`,`)} )`), sql`,`);
 
-  await all(sql`
+  const defs = await all(sql`
   INSERT INTO entity_defs ("entityId", "label", "data", "dataReceived",
     "sourceId", "creatorId", "userAgent", "root", "current", "createdAt", "version")
   VALUES ${defInsert}
   RETURNING *
   `);
+
+  return defs;
 };
 
-// TODO: figure out audit log for bulk append/create
-createMany.audit = (dataset) => (log) =>
-  log('entity.bulk.create', dataset, { foo: 'bar' });
+const createMany = (dataset, entities, sourceId, userAgentIn) => (container) =>
+  container.db.transaction((trxn) =>
+    container.with({ db: trxn }).Entities._createMany(dataset, entities, sourceId, userAgentIn))
+    .catch((err) => reject(err));
+
+createMany.audit = (dataset, entities, sourceId) => (log) =>
+  log('entity.bulk.create', dataset, { sourceId, count: entities.length });
 createMany.audit.withResult = false;
 
 
@@ -529,7 +535,7 @@ del.audit = (entity, dataset) => (log) => log('entity.delete', entity.with({ act
 module.exports = {
   createNew, _processSubmissionEvent,
   createSource,
-  createMany,
+  createMany, _createMany,
   _createEntity, _updateEntity,
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -111,14 +111,12 @@ const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, c
     '1'
   ], sql`,`)} )`), sql`,`);
 
-  const newDefs = await all(sql`
+  await all(sql`
   INSERT INTO entity_defs ("entityId", "label", "data", "dataReceived",
     "sourceId", "creatorId", "userAgent", "root", "current", "createdAt", "version")
   VALUES ${defInsert}
   RETURNING *
   `);
-
-  return newDefs.length;
 };
 
 // TODO: figure out audit log for bulk append/create

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -17,7 +17,7 @@ const { odataFilter, odataOrderBy } = require('../../data/odata-filter');
 const { odataToColumnMap, parseSubmissionXml, getDiffProp, ConflictType } = require('../../data/entity');
 const { isTrue } = require('../../util/http');
 const Problem = require('../../util/problem');
-const { reject, runSequentially } = require('../../util/promise');
+const { runSequentially } = require('../../util/promise');
 
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -86,7 +86,7 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
 };
 createNew.audit.withResult = true;
 
-const _createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, context }) => {
+const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, context }) => {
   const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
   const userAgent = blankStringToNull(userAgentIn);
 
@@ -119,11 +119,6 @@ const _createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, 
 
   return defs;
 };
-
-const createMany = (dataset, entities, sourceId, userAgentIn) => (container) =>
-  container.db.transaction((trxn) =>
-    container.with({ db: trxn }).Entities._createMany(dataset, entities, sourceId, userAgentIn))
-    .catch((err) => reject(err));
 
 createMany.audit = (dataset, entities, sourceId) => (log) =>
   log('entity.bulk.create', dataset, { sourceId, count: entities.length });
@@ -534,7 +529,7 @@ del.audit = (entity, dataset) => (log) => log('entity.delete', entity.with({ act
 module.exports = {
   createNew, _processSubmissionEvent,
   createSource,
-  createMany, _createMany,
+  createMany,
   _createEntity, _updateEntity,
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -86,6 +86,10 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
 };
 createNew.audit.withResult = true;
 
+// createMany() inserts many entities and entity defs in bulk two main queries.
+// it could be used in places of createNew() but createNew uses a single query so it may be faster
+// in single entity situations (eg. processing submissions to make entities)
+// Note: if the entity schema changes, createMany and createNew would both need to change.
 const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, context }) => {
   const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
   const userAgent = blankStringToNull(userAgentIn);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -24,6 +24,7 @@ const { runSequentially } = require('../../util/promise');
 // ENTITY DEF SOURCES
 
 const createSource = (details = null, subDefId = null, eventId = null) => ({ one }) => {
+  // TODO: what should the type of the source be? allow type to be `bulk`?
   const type = (subDefId) ? 'submission' : 'api';
   return one(sql`insert into entity_def_sources ("type", "submissionDefId", "auditId", "details")
   values (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)})
@@ -85,6 +86,45 @@ createNew.audit = (newEntity, dataset, partial, subDef) => (log) => {
     });
 };
 createNew.audit.withResult = true;
+
+const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, context }) => {
+  const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
+  const userAgent = blankStringToNull(userAgentIn);
+
+  const entityInsert = sql.join(entities.map(e => sql`(${sql.join([dataset.id, e.uuid, creatorId, sql`clock_timestamp()`], sql`,`)} )`), sql`,`);
+  const newEntities = await all(sql`
+  INSERT INTO entities ("datasetId", "uuid", "creatorId", "createdAt")
+  VALUES ${entityInsert}
+  RETURNING id`);
+
+  const defInsert = sql.join(entities.map((e, i) => sql`(${sql.join([
+    newEntities[i].id,
+    e.def.label,
+    JSON.stringify(e.def.data),
+    JSON.stringify(e.def.dataReceived),
+    sourceId,
+    creatorId,
+    userAgent,
+    'true',
+    'true',
+    sql`clock_timestamp()`,
+    '1'
+  ], sql`,`)} )`), sql`,`);
+
+  const newDefs = await all(sql`
+  INSERT INTO entity_defs ("entityId", "label", "data", "dataReceived",
+    "sourceId", "creatorId", "userAgent", "root", "current", "createdAt", "version")
+  VALUES ${defInsert}
+  RETURNING *
+  `);
+
+  return newDefs.length;
+};
+
+// TODO: figure out audit log for bulk append/create
+createMany.audit = (dataset) => (log) =>
+  log('entity.bulk.create', dataset, { foo: 'bar' });
+createMany.audit.withResult = false;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -491,6 +531,7 @@ del.audit = (entity, dataset) => (log) => log('entity.delete', entity.with({ act
 module.exports = {
   createNew, _processSubmissionEvent,
   createSource,
+  createMany,
   _createEntity, _updateEntity,
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -13,7 +13,6 @@ const { Entity } = require('../model/frames');
 const Problem = require('../util/problem');
 const { diffEntityData, getWithConflictDetails } = require('../data/entity');
 const { QueryOptions } = require('../util/db');
-const { json } = require('../util/http');
 
 module.exports = (service, endpoint) => {
 
@@ -103,8 +102,8 @@ module.exports = (service, endpoint) => {
       // TODO: maybe validate source fields
       const sourceId = await Entities.createSource({ ...source, userAgent });
       const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
-      const numEntities = await Entities.createMany(dataset, partials, sourceId, userAgent);
-      return json({ numEntities });
+      await Entities.createMany(dataset, partials, sourceId, userAgent);
+      return success();
     }
 
   }));

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -11,7 +11,7 @@ const { getOrNotFound, reject } = require('../util/promise');
 const { isTrue, success } = require('../util/http');
 const { Entity } = require('../model/frames');
 const Problem = require('../util/problem');
-const { diffEntityData, getWithConflictDetails } = require('../data/entity');
+const { diffEntityData, extractBulkSource, getWithConflictDetails } = require('../data/entity');
 const { QueryOptions } = require('../util/db');
 
 module.exports = (service, endpoint) => {
@@ -107,8 +107,7 @@ module.exports = (service, endpoint) => {
 
       const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
 
-      // TODO: maybe validate source fields
-      const sourceId = await Entities.createSource({ ...source, userAgent });
+      const sourceId = await Entities.createSource(extractBulkSource(source, partials.length, userAgent));
 
       await Entities.createMany(dataset, partials, sourceId, userAgent);
       return success();

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -79,21 +79,34 @@ module.exports = (service, endpoint) => {
 
   }));
 
+  // Create a single entity or bulk create multiple entities.
+  // In either case, this appends new entities to a dataset.
   service.post('/projects/:id/datasets/:name/entities', endpoint(async ({ Datasets, Entities }, { auth, body, params, userAgent }) => {
-
     const dataset = await Datasets.get(params.id, params.name, true).then(getOrNotFound);
 
     await auth.canOrReject('entity.create', dataset);
 
     const properties = await Datasets.getProperties(dataset.id);
 
-    const partial = await Entity.fromJson(body, properties, dataset);
+    // Destructure list of new entities and source if bulk operation
+    const { entities, source } = body;
 
-    const sourceId = await Entities.createSource();
-    const entity = await Entities.createNew(dataset, partial, null, sourceId, userAgent);
+    if (!entities) {
+      // not a bulk operation
+      const partial = await Entity.fromJson(body, properties, dataset);
+      const sourceId = await Entities.createSource();
+      const entity = await Entities.createNew(dataset, partial, null, sourceId, userAgent);
+      // Entities.createNew doesn't return enough information for a full response so re-fetch.
+      return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
+    } else {
+      // bulk operation
+      // TODO: maybe validate source fields
+      const sourceId = await Entities.createSource({ ...source, userAgent });
+      const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
+      const numEntities = await Entities.createMany(dataset, partials, sourceId, userAgent);
+      return json({ numEntities });
+    }
 
-    // Entities.createNew doesn't return enough information for a full response so re-fetch.
-    return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
   }));
 
   service.patch('/projects/:id/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { auth, body, params, query, userAgent }) => {
@@ -149,27 +162,5 @@ module.exports = (service, endpoint) => {
 
     return success();
 
-  }));
-
-  // bulk operations
-  // TODO: not fully committed to this upload path.. maybe upload, import, append? fit with future actions?
-  service.post('/projects/:id/datasets/:name/entities/upload', endpoint(async ({ Datasets, Entities }, { auth, body, params, userAgent }) => {
-
-    const dataset = await Datasets.get(params.id, params.name, true).then(getOrNotFound);
-
-    await auth.canOrReject('entity.create', dataset);
-
-    const properties = await Datasets.getProperties(dataset.id);
-
-    // TODO: think more about what source metadata comes we want and how to specify something about bulk/shared source
-    const sourceId = await Entities.createSource({ type: 'bulk', filename: body.source.filename });
-
-    // Parse the array of entity data
-    const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
-
-    const numEntities = await Entities.createMany(dataset, partials, sourceId, userAgent);
-
-    // TODO: what kind of response
-    return json({ numEntities });
   }));
 };

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -99,9 +99,17 @@ module.exports = (service, endpoint) => {
       return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
     } else {
       // bulk operation
+      if (!Array.isArray(body.entities))
+        return reject(Problem.user.unexpectedAttributes({ expected: ['entities: [...]'], actual: ['not an array'] }));
+
+      if (!body.entities.length)
+        return reject(Problem.user.unexpectedAttributes({ expected: ['entities: [...]'], actual: ['empty array'] }));
+
+      const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
+
       // TODO: maybe validate source fields
       const sourceId = await Entities.createSource({ ...source, userAgent });
-      const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
+
       await Entities.createMany(dataset, partials, sourceId, userAgent);
       return success();
     }

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -13,6 +13,7 @@ const { Entity } = require('../model/frames');
 const Problem = require('../util/problem');
 const { diffEntityData, getWithConflictDetails } = require('../data/entity');
 const { QueryOptions } = require('../util/db');
+const { json } = require('../util/http');
 
 module.exports = (service, endpoint) => {
 
@@ -148,5 +149,27 @@ module.exports = (service, endpoint) => {
 
     return success();
 
+  }));
+
+  // bulk operations
+  // TODO: not fully committed to this upload path.. maybe upload, import, append? fit with future actions?
+  service.post('/projects/:id/datasets/:name/entities/upload', endpoint(async ({ Datasets, Entities }, { auth, body, params, userAgent }) => {
+
+    const dataset = await Datasets.get(params.id, params.name, true).then(getOrNotFound);
+
+    await auth.canOrReject('entity.create', dataset);
+
+    const properties = await Datasets.getProperties(dataset.id);
+
+    // TODO: think more about what source metadata comes we want and how to specify something about bulk/shared source
+    const sourceId = await Entities.createSource({ type: 'bulk', filename: body.source.filename });
+
+    // Parse the array of entity data
+    const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
+
+    const numEntities = await Entities.createMany(dataset, partials, sourceId, userAgent);
+
+    // TODO: what kind of response
+    return json({ numEntities });
   }));
 };

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -613,6 +613,23 @@ describe('/audits', () => {
         .then(({ body }) => {
           body.success.should.be.true();
         });
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          source: {
+            name: 'people.csv',
+            size: 100,
+          },
+          entities: [
+            {
+              label: 'Johnny Doe',
+              data: {
+                first_name: 'Johnny',
+                age: '22'
+              }
+            }
+          ]
+        })
+        .expect(200);
 
       await asAlice.get('/v1/audits?action=nonverbose')
         .expect(200)

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2116,7 +2116,7 @@ describe('Entities API', () => {
           },
           entities: [
             {
-              uuid: '12345678-1234-4123-8234-111111111aaa', // TODO: don't require UUIDs
+              uuid: '12345678-1234-4123-8234-111111111aaa',
               label: 'Johnny Doe',
               data: {
                 first_name: 'Johnny',
@@ -2149,6 +2149,52 @@ describe('Entities API', () => {
         .then(({ body }) => {
           body[0].action.should.equal('entity.bulk.create');
           body[0].details.count.should.equal(2);
+        });
+    }));
+
+
+    it('should generate uuids for entities when no uuid is provided', testDataset(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.get('/v1/projects/1/datasets/people/entities')
+        .then(({ body }) => {
+          body.length.should.equal(0);
+        });
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          source: {
+            name: 'people.csv',
+            size: 100,
+          },
+          entities: [
+            {
+              uuid: '12345678-1234-4123-8234-111111111aaa',
+              label: 'Johnny Doe',
+              data: {
+                first_name: 'Johnny',
+                age: '22'
+              }
+            },
+            {
+              label: 'Alice',
+              data: {
+                first_name: 'Alice',
+                age: '44'
+              }
+            },
+          ]
+        })
+        .expect(200)
+        .then(({ body }) => {
+          body.success.should.be.true();
+        });
+
+      // Used provided UUID and generated other UUID
+      await asAlice.get('/v1/projects/1/datasets/people/entities')
+        .then(({ body }) => {
+          body[0].uuid.should.equal('12345678-1234-4123-8234-111111111aaa');
+          body[1].uuid.should.be.a.uuid();
         });
     }));
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2089,7 +2089,7 @@ describe('Entities API', () => {
     // - should reject if the user cannot write
     // - should reject creating new entity if dataset not yet published
 
-    it('should reject malformed json', testDataset(async (service) => {
+    it('should reject malformed entity object json', testDataset(async (service) => {
       const asAlice = await service.login('alice');
 
       await asAlice.post('/v1/projects/1/datasets/people/entities')
@@ -2098,6 +2098,18 @@ describe('Entities API', () => {
         .then(({ body }) => {
           body.code.should.equal(400.31);
           body.message.should.equal('Expected parameters: (label, uuid, data). Got (broken).');
+        });
+    }));
+
+    it('should reject malformed contents of entity array', testDataset(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ entities: ['1', '2', '3'] })
+        .expect(400)
+        .then(({ body }) => {
+          body.code.should.equal(400.31);
+          body.message.should.equal('Expected parameters: (label, uuid, data). Got (0).');
         });
     }));
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2082,57 +2082,32 @@ describe('Entities API', () => {
   });
 
   // Bulk API operations
-  describe.only('POST /datasets/:name/entities/upload', () => {
-    it('should return notfound if the dataset does not exist', testDataset(async (service) => {
+  describe('POST /datasets/:name/entities', () => {
+    // Tests that one would expect to find here are found above because this is additional
+    // functionality of an existing endpoint:
+    // - should return notfound if the dataset does not exist
+    // - should reject if the user cannot write
+    // - should reject creating new entity if dataset not yet published
+
+    it('should reject malformed json', testDataset(async (service) => {
       const asAlice = await service.login('alice');
 
-      await asAlice.post('/v1/projects/1/datasets/nonexistent/entities/upload')
-        .expect(404);
-    }));
-
-    it('should reject if the user cannot write', testDataset(async (service) => {
-      const asChelsea = await service.login('chelsea');
-
-      await asChelsea.post('/v1/projects/1/datasets/people/entities/upload')
-        .expect(403);
-    }));
-
-    it.skip('should reject malformed json', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities/upload')
-        .send({ broken: 'json' })
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send([{ broken: 'json' }])
         .expect(400)
         .then(({ body }) => {
           body.code.should.equal(400.31);
         });
     }));
 
-    it('should reject creating new entity if dataset not yet published', testService(async (service) => {
+    it('should create two Entities', testDataset(async (service) => {
       const asAlice = await service.login('alice');
 
-      await asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.simpleEntity)
-        .expect(200);
-
-      await asAlice.get('/v1/projects/1/datasets/people')
-        .expect(404);
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities/upload')
-        .send({
-          fix: 'this'
-        })
-        .expect(404);
-    }));
-
-    it('should create an Entity', testDataset(async (service) => {
-      const asAlice = await service.login('alice');
-
-      await asAlice.post('/v1/projects/1/datasets/people/entities/upload')
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
         .send({
           source: {
-            filename: 'people.csv',
-            filesize: 100,
+            name: 'people.csv',
+            size: 100,
           },
           entities: [
             {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/573

Uses POSTing to existing `/v1/projects/1/datasets/people/entities` endpoint so it can handle
* single entities with just `{uuid, label, data}`
* multiple entities with `{entities: [{}, {}], source: {name, size}}`

For the source object,
* `source` is required
* `name` within source is required (not sure if it should be but it will help with displaying on the front end...)
* `size` (meant to represent file size) 

I was thinking about how to handle the bulk SQL insert and decided it was easiest to think/build two separate queries, one for the `entities` table and another for the `entity_defs` table. Elsewhere the code, we have complex queries for inserting a single entity's data into both tables at once, but it didn't seem reasonable to try to do that with multiple entities. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, trying it out.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Documentation is included in this PR!!

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced