### PR TITLE
Remove submissionCreate from entity audit events

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -13436,7 +13436,7 @@ components:
             source:
               type: object
               description: The source of the Entity version, such as a Submission or an API request. This property is experimental and may change in the future.
-              example: {event: {}, submissionCreate: {}, submission: {}}
+              example: {event: {}, submission: {}}
             baseDiff:
               type: array
               description: List of properties that are different between this version and its base version. Includes the label if it differs between the two versions.

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -365,7 +365,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
   const relevantBaseVersions = new Set();
 
   for (const def of defs) {
-    const { sourceEvent, submissionCreate, submission } = auditMap.get(def.id);
+    const { sourceEvent, submission } = auditMap.get(def.id);
 
     const v = mergeLeft(def.forApi(),
       {
@@ -373,7 +373,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
         resolved: false,
         baseDiff: [],
         serverDiff: [],
-        source: { event: sourceEvent, submissionCreate, submission },
+        source: { event: sourceEvent, submission },
         lastGoodVersion: false
       });
 

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -365,7 +365,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
   const relevantBaseVersions = new Set();
 
   for (const def of defs) {
-    const { sourceEvent, submission } = auditMap.get(def.id);
+    const { source = {} } = auditMap.get(def.id);
 
     const v = mergeLeft(def.forApi(),
       {
@@ -373,7 +373,7 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
         resolved: false,
         baseDiff: [],
         serverDiff: [],
-        source: { event: sourceEvent, submission },
+        source,
         lastGoodVersion: false
       });
 

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -192,30 +192,29 @@ const getByEntityId = (entityId, options) => ({ all }) => {
         .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
         .map(a => a.forApi());
 
-      // if entity event is based on a submission, get the rest of the details from the submission create
-      // event even if submission is deleted.
-      // otherwise, leave submission and don't include in audit details.
-      let submission;
-      const createEvent = audit.aux.submissionCreateEvent.orNull();
-      if (createEvent) {
+      // If the entity event is based on a submission, get submission details from the submission create event,
+      // which should always exist, even if the entity has been deleted.
+      const submission = audit.aux.submissionCreateEvent.map((createEvent) => {
         const baseSubmission = {
           instanceId: createEvent.details.instanceId,
           createdAt: createEvent.loggedAt,
           submitter: audit.aux.submissionCreateEventActor.get().forApi()
         };
 
+        // If the submission has not been deleted, return full submission details, not just what
+        // was in the submission create event details.
         const fullSubmission = audit.aux.submission
           .map(s => s.withAux('submitter', audit.aux.submissionActor.orNull()))
           .map(s => s.withAux('currentVersion', audit.aux.currentVersion.map(v => v.withAux('submitter', audit.aux.currentSubmissionActor.orNull()))))
           .map(s => s.forApi())
           .map(s => mergeLeft(s, { xmlFormId: audit.aux.form.map(f => f.xmlFormId).orNull() }));
 
-        submission = mergeLeft(baseSubmission, fullSubmission.orElse(undefined));
-      }
+        return mergeLeft(baseSubmission, fullSubmission.orElse(undefined));
+      });
 
       const details = mergeLeft(audit.details, {
         sourceEvent: sourceEvent.orElse(undefined),
-        submission
+        submission: submission.orElse(undefined)
       });
 
       return new Audit({ ...audit, details }, { actor: audit.aux.actor });

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -201,7 +201,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
         const baseSubmission = {
           instanceId: createEvent.details.instanceId,
           createdAt: createEvent.loggedAt,
-          actor: audit.aux.submissionCreateEventActor.get().forApi()
+          submitter: audit.aux.submissionCreateEventActor.get().forApi()
         };
 
         const fullSubmission = audit.aux.submission

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -192,20 +192,30 @@ const getByEntityId = (entityId, options) => ({ all }) => {
         .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
         .map(a => a.forApi());
 
-      const submissionCreate = audit.aux.submissionCreateEvent
-        .map(a => a.withAux('actor', audit.aux.submissionCreateEventActor.orNull()))
-        .map(a => a.forApi());
+      // if entity event is based on a submission, get the rest of the details from the submission create
+      // event even if submission is deleted.
+      // otherwise, leave submission and don't include in audit details.
+      let submission;
+      const createEvent = audit.aux.submissionCreateEvent.orNull();
+      if (createEvent) {
+        const baseSubmission = {
+          instanceId: createEvent.details.instanceId,
+          createdAt: createEvent.loggedAt,
+          actor: audit.aux.submissionCreateEventActor.get().forApi()
+        };
 
-      const submission = audit.aux.submission
-        .map(s => s.withAux('submitter', audit.aux.submissionActor.orNull()))
-        .map(s => s.withAux('currentVersion', audit.aux.currentVersion.map(v => v.withAux('submitter', audit.aux.currentSubmissionActor.orNull()))))
-        .map(s => s.forApi())
-        .map(s => mergeLeft(s, { xmlFormId: audit.aux.form.map(f => f.xmlFormId).orNull() }));
+        const fullSubmission = audit.aux.submission
+          .map(s => s.withAux('submitter', audit.aux.submissionActor.orNull()))
+          .map(s => s.withAux('currentVersion', audit.aux.currentVersion.map(v => v.withAux('submitter', audit.aux.currentSubmissionActor.orNull()))))
+          .map(s => s.forApi())
+          .map(s => mergeLeft(s, { xmlFormId: audit.aux.form.map(f => f.xmlFormId).orNull() }));
+
+        submission = mergeLeft(baseSubmission, fullSubmission.orElse(undefined));
+      }
 
       const details = mergeLeft(audit.details, {
         sourceEvent: sourceEvent.orElse(undefined),
-        submissionCreate: submissionCreate.orElse(undefined),
-        submission: submission.orElse(undefined)
+        submission
       });
 
       return new Audit({ ...audit, details }, { actor: audit.aux.actor });

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -208,14 +208,13 @@ const getByEntityId = (entityId, options) => ({ all }) => {
           .map(s => s.withAux('currentVersion', audit.aux.currentVersion.map(v => v.withAux('submitter', audit.aux.currentSubmissionActor.orNull()))))
           .map(s => s.forApi())
           .map(s => mergeLeft(s, { xmlFormId: audit.aux.form.map(f => f.xmlFormId).orNull() }));
-
         return mergeLeft(baseSubmission, fullSubmission.orElse(undefined));
-      });
+      })
+        .orElse(undefined);
 
-      const details = mergeLeft(audit.details, {
-        sourceEvent: sourceEvent.orElse(undefined),
-        submission: submission.orElse(undefined)
-      });
+      const details = mergeLeft(audit.details, sourceEvent
+        .map(event => ({ source: { event, submission } }))
+        .orElse(undefined));
 
       return new Audit({ ...audit, details }, { actor: audit.aux.actor });
     }));

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -3825,10 +3825,10 @@ describe('datasets and entities', () => {
             logs[0].action.should.be.eql('entity.create');
             logs[0].actor.displayName.should.be.eql('Alice');
 
-            logs[0].details.submission.should.be.a.Submission();
-            logs[0].details.submission.xmlFormId.should.be.eql('simpleEntity');
-            logs[0].details.submission.currentVersion.instanceName.should.be.eql('one');
-            logs[0].details.submission.currentVersion.submitter.displayName.should.be.eql('Alice');
+            logs[0].details.source.submission.should.be.a.Submission();
+            logs[0].details.source.submission.xmlFormId.should.be.eql('simpleEntity');
+            logs[0].details.source.submission.currentVersion.instanceName.should.be.eql('one');
+            logs[0].details.source.submission.currentVersion.submitter.displayName.should.be.eql('Alice');
           });
 
 
@@ -4159,8 +4159,8 @@ describe('datasets and entities', () => {
           .then(({ body: logs }) => {
             const updateDetails = logs.filter(log => log.action === 'entity.update.version').map(log => log.details);
             updateDetails.length.should.equal(4);
-            updateDetails.filter(d => d.sourceEvent.action === 'submission.create').length.should.equal(4);
-            updateDetails.map(d => d.submission.instanceId).should.eql([
+            updateDetails.filter(d => d.source.event.action === 'submission.create').length.should.equal(4);
+            updateDetails.map(d => d.source.submission.instanceId).should.eql([
               'six', 'five', 'four', 'three'
             ]);
           });
@@ -4170,9 +4170,9 @@ describe('datasets and entities', () => {
           .expect(200)
           .then(({ body: logs }) => {
             logs[0].action.should.equal('entity.create');
-            logs[0].details.submission.xmlFormId.should.equal('simpleEntity');
-            logs[0].details.submission.instanceId.should.equal('two');
-            logs[0].details.sourceEvent.action.should.equal('submission.create');
+            logs[0].details.source.submission.xmlFormId.should.equal('simpleEntity');
+            logs[0].details.source.submission.instanceId.should.equal('two');
+            logs[0].details.source.event.action.should.equal('submission.create');
           });
 
         // only one entity def should have a source with a non-null parent id
@@ -4486,7 +4486,7 @@ describe('datasets and entities', () => {
         // Observe that the entity's audit says it was updated by the new edited submission
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .then(({ body: logs }) => {
-            logs[0].details.submission.instanceId.should.equal('one2');
+            logs[0].details.source.submission.instanceId.should.equal('one2');
           });
 
         // Observe that the submission's audit log makes sense

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -841,14 +841,14 @@ describe('Entities API', () => {
           logs[0].details.entity.uuid.should.be.eql('12345678-1234-4123-8234-123456789abc');
           logs[0].actor.displayName.should.be.eql('Bob');
 
-          logs[0].details.submission.should.be.a.Submission();
-          logs[0].details.submission.xmlFormId.should.be.eql('updateEntity');
-          logs[0].details.submission.currentVersion.instanceName.should.be.eql('one');
-          logs[0].details.submission.currentVersion.submitter.displayName.should.be.eql('Bob');
-          logs[0].details.sourceEvent.should.be.an.Audit();
-          logs[0].details.sourceEvent.actor.displayName.should.be.eql('Bob');
-          logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
-          logs[0].details.sourceEvent.action.should.be.eql('submission.create');
+          logs[0].details.source.submission.should.be.a.Submission();
+          logs[0].details.source.submission.xmlFormId.should.be.eql('updateEntity');
+          logs[0].details.source.submission.currentVersion.instanceName.should.be.eql('one');
+          logs[0].details.source.submission.currentVersion.submitter.displayName.should.be.eql('Bob');
+          logs[0].details.source.event.should.be.an.Audit();
+          logs[0].details.source.event.actor.displayName.should.be.eql('Bob');
+          logs[0].details.source.event.loggedAt.should.be.isoDate();
+          logs[0].details.source.event.action.should.be.eql('submission.create');
 
           logs[1].should.be.an.Audit();
           logs[1].action.should.be.eql('entity.update.version');
@@ -859,15 +859,15 @@ describe('Entities API', () => {
           logs[2].action.should.be.eql('entity.create');
           logs[2].actor.displayName.should.be.eql('Alice');
 
-          logs[2].details.sourceEvent.should.be.an.Audit();
-          logs[2].details.sourceEvent.actor.displayName.should.be.eql('Alice');
-          logs[2].details.sourceEvent.loggedAt.should.be.isoDate();
-          logs[2].details.sourceEvent.action.should.be.eql('submission.update');
+          logs[2].details.source.event.should.be.an.Audit();
+          logs[2].details.source.event.actor.displayName.should.be.eql('Alice');
+          logs[2].details.source.event.loggedAt.should.be.isoDate();
+          logs[2].details.source.event.action.should.be.eql('submission.update');
 
-          logs[2].details.submission.should.be.a.Submission();
-          logs[2].details.submission.xmlFormId.should.be.eql('simpleEntity');
-          logs[2].details.submission.currentVersion.instanceName.should.be.eql('one');
-          logs[2].details.submission.currentVersion.submitter.displayName.should.be.eql('Alice');
+          logs[2].details.source.submission.should.be.a.Submission();
+          logs[2].details.source.submission.xmlFormId.should.be.eql('simpleEntity');
+          logs[2].details.source.submission.currentVersion.instanceName.should.be.eql('one');
+          logs[2].details.source.submission.currentVersion.submitter.displayName.should.be.eql('Alice');
         });
     }));
 
@@ -917,9 +917,9 @@ describe('Entities API', () => {
           logs[0].action.should.be.eql('entity.create');
           logs[0].actor.displayName.should.be.eql('Alice');
 
-          logs[0].details.submission.should.be.a.Submission();
-          logs[0].details.submission.xmlFormId.should.be.eql('simpleEntity');
-          logs[0].details.submission.currentVersion.instanceName.should.be.eql('new instance name');
+          logs[0].details.source.submission.should.be.a.Submission();
+          logs[0].details.source.submission.xmlFormId.should.be.eql('simpleEntity');
+          logs[0].details.source.submission.currentVersion.instanceName.should.be.eql('new instance name');
         });
     }));
 
@@ -942,8 +942,7 @@ describe('Entities API', () => {
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .expect(200)
           .then(({ body: logs }) => {
-            logs[0].details.should.not.have.property('submission');
-            logs[0].details.should.not.have.property('sourceEvent');
+            logs[0].details.should.not.have.property('source');
           });
 
         await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?force=true')
@@ -953,8 +952,7 @@ describe('Entities API', () => {
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .expect(200)
           .then(({ body: logs }) => {
-            logs[0].details.should.not.have.property('submission');
-            logs[0].details.should.not.have.property('sourceEvent');
+            logs[0].details.should.not.have.property('source');
           });
       }));
 
@@ -965,14 +963,14 @@ describe('Entities API', () => {
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .expect(200)
           .then(({ body: logs }) => {
-            logs[0].details.submission.should.be.a.Submission();
-            logs[0].details.submission.instanceId.should.be.eql('one');
-            logs[0].details.submission.xmlFormId.should.be.eql('simpleEntity');
-            logs[0].details.submission.currentVersion.instanceName.should.be.eql('one');
+            logs[0].details.source.submission.should.be.a.Submission();
+            logs[0].details.source.submission.instanceId.should.be.eql('one');
+            logs[0].details.source.submission.xmlFormId.should.be.eql('simpleEntity');
+            logs[0].details.source.submission.currentVersion.instanceName.should.be.eql('one');
 
-            logs[0].details.sourceEvent.should.be.an.Audit();
-            logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
-            logs[0].details.sourceEvent.action.should.be.eql('submission.update');
+            logs[0].details.source.event.should.be.an.Audit();
+            logs[0].details.source.event.actor.displayName.should.be.eql('Alice');
+            logs[0].details.source.event.action.should.be.eql('submission.update');
           });
       }));
 
@@ -993,14 +991,14 @@ describe('Entities API', () => {
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .expect(200)
           .then(({ body: logs }) => {
-            logs[0].details.submission.should.be.a.Submission();
-            logs[0].details.submission.instanceId.should.be.eql('one');
-            logs[0].details.submission.xmlFormId.should.be.eql('simpleEntity');
-            logs[0].details.submission.currentVersion.instanceName.should.be.eql('one');
+            logs[0].details.source.submission.should.be.a.Submission();
+            logs[0].details.source.submission.instanceId.should.be.eql('one');
+            logs[0].details.source.submission.xmlFormId.should.be.eql('simpleEntity');
+            logs[0].details.source.submission.currentVersion.instanceName.should.be.eql('one');
 
-            logs[0].details.sourceEvent.should.be.an.Audit();
-            logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
-            logs[0].details.sourceEvent.action.should.be.eql('submission.create');
+            logs[0].details.source.event.should.be.an.Audit();
+            logs[0].details.source.event.actor.displayName.should.be.eql('Alice');
+            logs[0].details.source.event.action.should.be.eql('submission.create');
           });
       }));
 
@@ -1018,14 +1016,14 @@ describe('Entities API', () => {
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .expect(200)
           .then(({ body: logs }) => {
-            logs[0].details.submission.should.be.a.Submission();
-            logs[0].details.submission.instanceId.should.be.eql('one');
-            logs[0].details.submission.xmlFormId.should.be.eql('updateEntity');
-            logs[0].details.submission.currentVersion.instanceName.should.be.eql('one');
+            logs[0].details.source.submission.should.be.a.Submission();
+            logs[0].details.source.submission.instanceId.should.be.eql('one');
+            logs[0].details.source.submission.xmlFormId.should.be.eql('updateEntity');
+            logs[0].details.source.submission.currentVersion.instanceName.should.be.eql('one');
 
-            logs[0].details.sourceEvent.should.be.an.Audit();
-            logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
-            logs[0].details.sourceEvent.action.should.be.eql('submission.create');
+            logs[0].details.source.event.should.be.an.Audit();
+            logs[0].details.source.event.actor.displayName.should.be.eql('Alice');
+            logs[0].details.source.event.action.should.be.eql('submission.create');
           });
       }));
 
@@ -1044,16 +1042,16 @@ describe('Entities API', () => {
             logs[0].action.should.be.eql('entity.create');
             logs[0].actor.displayName.should.be.eql('Alice');
 
-            logs[0].details.sourceEvent.should.be.an.Audit();
-            logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
-            logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
+            logs[0].details.source.event.should.be.an.Audit();
+            logs[0].details.source.event.actor.displayName.should.be.eql('Alice');
+            logs[0].details.source.event.loggedAt.should.be.isoDate();
 
-            logs[0].details.submission.instanceId.should.be.eql('one');
-            logs[0].details.submission.submitter.displayName.should.be.eql('Alice');
-            logs[0].details.submission.createdAt.should.be.isoDate();
+            logs[0].details.source.submission.instanceId.should.be.eql('one');
+            logs[0].details.source.submission.submitter.displayName.should.be.eql('Alice');
+            logs[0].details.source.submission.createdAt.should.be.isoDate();
 
             // submission is only a stub so it shouldn't have currentVersion
-            logs[0].details.submission.should.not.have.property('currentVersion');
+            logs[0].details.source.submission.should.not.have.property('currentVersion');
           });
       }));
 
@@ -1070,17 +1068,17 @@ describe('Entities API', () => {
             logs[0].action.should.be.eql('entity.create');
             logs[0].actor.displayName.should.be.eql('Alice');
 
-            logs[0].details.sourceEvent.should.be.an.Audit();
-            logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
-            logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
+            logs[0].details.source.event.should.be.an.Audit();
+            logs[0].details.source.event.actor.displayName.should.be.eql('Alice');
+            logs[0].details.source.event.loggedAt.should.be.isoDate();
 
-            logs[0].details.submission.instanceId.should.be.eql('one');
-            logs[0].details.submission.submitter.displayName.should.be.eql('Alice');
-            logs[0].details.submission.createdAt.should.be.isoDate();
+            logs[0].details.source.submission.instanceId.should.be.eql('one');
+            logs[0].details.source.submission.submitter.displayName.should.be.eql('Alice');
+            logs[0].details.source.submission.createdAt.should.be.isoDate();
 
             // submission is only a stub so it doesn't have things like instanceName or currentVersion
-            logs[0].details.submission.should.not.have.property('instanceName');
-            logs[0].details.submission.should.not.have.property('currentVersion');
+            logs[0].details.source.submission.should.not.have.property('instanceName');
+            logs[0].details.source.submission.should.not.have.property('currentVersion');
           });
       }));
 
@@ -1169,15 +1167,15 @@ describe('Entities API', () => {
           logs[0].action.should.be.eql('entity.create');
           logs[0].actor.displayName.should.be.eql('Alice');
 
-          logs[0].details.sourceEvent.should.be.an.Audit();
-          logs[0].details.sourceEvent.actor.displayName.should.be.eql('Alice');
-          logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
-          logs[0].details.sourceEvent.notes.should.be.eql('create entity'); // this confirms that it's the second approval
+          logs[0].details.source.event.should.be.an.Audit();
+          logs[0].details.source.event.actor.displayName.should.be.eql('Alice');
+          logs[0].details.source.event.loggedAt.should.be.isoDate();
+          logs[0].details.source.event.notes.should.be.eql('create entity'); // this confirms that it's the second approval
 
-          logs[0].details.submission.should.be.a.Submission();
-          logs[0].details.submission.xmlFormId.should.be.eql('simpleEntity');
-          logs[0].details.submission.currentVersion.instanceName.should.be.eql('one');
-          logs[0].details.submission.currentVersion.submitter.displayName.should.be.eql('Alice');
+          logs[0].details.source.submission.should.be.a.Submission();
+          logs[0].details.source.submission.xmlFormId.should.be.eql('simpleEntity');
+          logs[0].details.source.submission.currentVersion.instanceName.should.be.eql('one');
+          logs[0].details.source.submission.currentVersion.submitter.displayName.should.be.eql('Alice');
         });
 
     }));

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -1049,7 +1049,7 @@ describe('Entities API', () => {
             logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
 
             logs[0].details.submission.instanceId.should.be.eql('one');
-            logs[0].details.submission.actor.displayName.should.be.eql('Alice');
+            logs[0].details.submission.submitter.displayName.should.be.eql('Alice');
             logs[0].details.submission.createdAt.should.be.isoDate();
 
             // submission is only a stub so it doesn't have things like instanceName or currentVersion
@@ -1076,7 +1076,7 @@ describe('Entities API', () => {
             logs[0].details.sourceEvent.loggedAt.should.be.isoDate();
 
             logs[0].details.submission.instanceId.should.be.eql('one');
-            logs[0].details.submission.actor.displayName.should.be.eql('Alice');
+            logs[0].details.submission.submitter.displayName.should.be.eql('Alice');
             logs[0].details.submission.createdAt.should.be.isoDate();
 
             // submission is only a stub so it doesn't have things like instanceName or currentVersion

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -1052,8 +1052,7 @@ describe('Entities API', () => {
             logs[0].details.submission.submitter.displayName.should.be.eql('Alice');
             logs[0].details.submission.createdAt.should.be.isoDate();
 
-            // submission is only a stub so it doesn't have things like instanceName or currentVersion
-            logs[0].details.submission.should.not.have.property('instanceName');
+            // submission is only a stub so it shouldn't have currentVersion
             logs[0].details.submission.should.not.have.property('currentVersion');
           });
       }));

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -637,7 +637,7 @@ describe('database migrations from 20230512: adding entity_def_sources table', f
     audits[0].details.entityDefId.should.equal(newDef.id);
   }));
 
-  it('should migrate the submissionDefId source of an entity to new table with event links', testServiceFullTrx(async (service, container) => {
+  it.skip('should migrate the submissionDefId source of an entity to new table with event links', testServiceFullTrx(async (service, container) => {
     await upToMigration('20230512-03-add-entity-source.js', false); // actually this is the previous migration
     await populateUsers(container);
     await populateForms(container);

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -954,7 +954,7 @@ describe('worker: entity', () => {
         .expect(200)
         .then(({ body: logs }) => {
           logs[0].action.should.be.eql('entity.update.version');
-          logs[0].details.sourceEvent.action.should.be.eql('submission.create');
+          logs[0].details.source.event.action.should.be.eql('submission.create');
         });
     }));
 


### PR DESCRIPTION
Closes #1036

It used to be that entity events that were triggered by a Submission (e.g. entity create OR update) would return these objects in the `details`: 
- `sourceEvent` (the actual event that caused the entity update, whether it was a submission approval, or submission creation, etc.)
- `submission` (the Submission object, but only if a Submission was part of the event AND the Submission was not deleted)
- a `submissionCreate` object for the Submission (if a Submission was part of the event) that had enough historical information including the creation time and instance ID to describe the Submission even if it was deleted. 

Now, entity audits (accessed via `/projects/.../datasets/.../entities/[uuid]/audits`) have `details.source`. This looks like
* `source: { submission, event }` (for events like create and update that were triggered by a submission)
* `source: {}` (empty source object for events triggered through the API)

This now matches the structure of `source` returned for Entity Versions. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

We've been discussing this for a while. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

There's a small documentation change included in this PR showing that an `entityVersion` source no longer contains `submissionCreate`. But we don't document the details of specific audit events, so the main change in this PR doesn't need a docs change.

It is super important for us making changes on frontend, though, so I'm trying to document it here 😅

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced