### PR TITLE
Return empty source object for all entity audit events

### DIFF
--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -214,7 +214,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
 
       const details = mergeLeft(audit.details, sourceEvent
         .map(event => ({ source: { event, submission } }))
-        .orElse(undefined));
+        .orElse({ source: {} })); // Add default empty source to all other entity audit events
 
       return new Audit({ ...audit, details }, { actor: audit.aux.actor });
     }));

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -854,6 +854,7 @@ describe('Entities API', () => {
           logs[1].action.should.be.eql('entity.update.version');
           logs[1].details.entity.uuid.should.be.eql('12345678-1234-4123-8234-123456789abc');
           logs[1].actor.displayName.should.be.eql('Bob');
+          logs[1].details.source.should.be.eql({});
 
           logs[2].should.be.an.Audit();
           logs[2].action.should.be.eql('entity.create');
@@ -942,7 +943,7 @@ describe('Entities API', () => {
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .expect(200)
           .then(({ body: logs }) => {
-            logs[0].details.should.not.have.property('source');
+            logs[0].details.source.should.eql({});
           });
 
         await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?force=true')
@@ -952,7 +953,7 @@ describe('Entities API', () => {
         await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/audits')
           .expect(200)
           .then(({ body: logs }) => {
-            logs[0].details.should.not.have.property('source');
+            logs[0].details.source.should.eql({});
           });
       }));
 


### PR DESCRIPTION
This was meant to be part of backend PR https://github.com/getodk/central-backend/pull/1072 but i forgot to push it!! 

Frontend PR https://github.com/getodk/central-frontend/pull/932 expects a source for every entity audit event, even API events, where the source is currently just `{}`.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced