### PR TITLE
eslint: relax enforcement of string quotes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
     "padded-blocks": "off",
     "prefer-object-spread": "off",
     "prefer-template": "off",
+    "quotes": [ "error", "single", { "allowTemplateLiterals": true, "avoidEscape": true } ],
     "space-infix-ops": "off",
     "spaced-comment": "off"
   }

--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -30,7 +30,7 @@ if (oidc.isEnabled()) {
 
   program.command('user-set-password')
     .action(() => {
-      throw new Error(`You cannot set a user's password when OpenID Connect (OIDC) is enabled.`); // eslint-disable-line quotes
+      throw new Error(`You cannot set a user's password when OpenID Connect (OIDC) is enabled.`);
     });
 } else {
   // gets a password interactively if not supplied in cli args.

--- a/lib/model/migrations/20231002-01-add-conflict-details.js
+++ b/lib/model/migrations/20231002-01-add-conflict-details.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const up = async (db) => {
-  await db.raw(`CREATE TYPE "conflictType" AS ENUM ('soft', 'hard')`); // eslint-disable-line quotes
+  await db.raw(`CREATE TYPE "conflictType" AS ENUM ('soft', 'hard')`);
 
   await db.raw('ALTER TABLE entities ADD COLUMN conflict "conflictType" NULL');
 
@@ -25,7 +25,6 @@ const up = async (db) => {
   `);
 
   // Sets the value for "dataReceived" and "baseVersion" for existing row
-  // eslint-disable-next-line quotes
   await db.raw(`UPDATE entity_defs SET "dataReceived" = data || jsonb_build_object('label', "label"), "baseVersion" = CASE WHEN version > 1 THEN version - 1 ELSE NULL END`);
 
 };

--- a/lib/model/migrations/20231208-01-dataset-form-def-actions.js
+++ b/lib/model/migrations/20231208-01-dataset-form-def-actions.js
@@ -9,7 +9,6 @@
 
 const up = async (db) => {
   await db.raw('ALTER TABLE dataset_form_defs ADD COLUMN actions jsonb');
-  // eslint-disable-next-line quotes
   await db.raw(`UPDATE dataset_form_defs SET actions = '["create"]'`);
   await db.raw('ALTER TABLE dataset_form_defs ALTER COLUMN actions SET NOT NULL');
 };

--- a/lib/resources/oidc.js
+++ b/lib/resources/oidc.js
@@ -145,7 +145,6 @@ module.exports = (service, endpoint) => {
 
       const { email, email_verified } = userinfo;
       if (!email) {
-        // eslint-disable-next-line quotes
         container.Sentry.captureException(new Error(`Required claim not provided in UserInfo Response: 'email'`));
         return errorToFrontend(req, res, 'email-claim-not-provided');
       }

--- a/oidc-dev/playwright-tests/src/oidc-login.spec.js
+++ b/oidc-dev/playwright-tests/src/oidc-login.spec.js
@@ -46,8 +46,8 @@ test.describe('happy', () => {
 test.describe('redirected errors', () => {
   [
     [ 'user unknown by central',                'bob',     'auth-ok-user-not-found' ],   // eslint-disable-line no-multi-spaces
-    [ `no 'email' claim provided`,              'dave',    'email-claim-not-provided' ], // eslint-disable-line no-multi-spaces, quotes
-    [ `claim 'email_verified' has value false`, 'charlie', 'email-not-verified' ],       // eslint-disable-line no-multi-spaces, quotes
+    [ `no 'email' claim provided`,              'dave',    'email-claim-not-provided' ], // eslint-disable-line no-multi-spaces
+    [ `claim 'email_verified' has value false`, 'charlie', 'email-not-verified' ],       // eslint-disable-line no-multi-spaces
   ].forEach(([ description, username, expectedError ]) => {
     test(`successful authN, but ${description}`, async ({ browserName, page }, testInfo) => {
       // given

--- a/test/integration/task/task.js
+++ b/test/integration/task/task.js
@@ -31,7 +31,6 @@ describe('task: runner', () => {
   });
 
   it('should print success object to stdout', () => runScript(success)
-    // eslint-disable-next-line quotes
     .then(([ , stdout ]) => stdout.should.equal(`'{"test":"result"}'\n`)));
 
   it('should print failure details to stderr and exit nonzero', () => runScript(failure)

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -171,7 +171,6 @@ describe('util/crypto', () => {
       const instanceId = 'uuid:99b303d9-6494-477b-a30d-d8aae8867335';
       const encAesKey = Buffer.from('iyEB1LAlvVE8uaW0HuhLhzwcLceIukqfgusDNdDEE2FFxVtUtSI3FiOuNxhgI/Zbgnaabh/vqeZ3yLXwv0f66pAbN0n8kM9f84VJR18fdUp6doOz7o8IQD7gc3ZfbRXweab/NxnahfYa9ij0Kax1LTKS05Oodk2MewkzwfBhdbf/CfiBP1HSskDio40jdW5f04GkqZsFCPUluF2DfMnwYCo0wdwf2m8o+lSNR+vrFeEYG7LtGE4X90pVrQnJHwFWHGjSwJpg/USn5skBioDKUCv/Dva9xJ+JXUz+QSg6LOuP+SDxsrmf36WKrnE8kWfN4oaBdmIwFSStkLH9foNXUw==', 'base64');
       const ciphertext = Buffer.from('kMhJdk0mZOqvlxndUO3v4+UPvfYoc+bbkPmF3QmhoP7lP/QjHbzqw/IfZxQ54D328eCc4V6jtbrjeAXV+m1cWsCGGLW5KwTAxBjPBXzsZrUeY0RISVJ1g9BJoXfSRAjYMrFYOM907BFUIYYxMqpVWGy1lo8ljqY+Sgq1VphkQk/TQGgOVYFALHDLOYnLKuLHvwBLQQwK3lje8CwNlf/b2rY9qfGC4P1emoiP+YzkLp8eH6x/HfMvRIFoZEaom1i5s3SU4WVwe2Tno4jKD69ojMlQN6VKB7DK4xaRSs2C7zfDm63n1WCyyOAj8mASIFhb3sc3hD56HTJFUV/TH3UVlzP7oPm/Mm7nEcU3+HdSSwm3I1qFYhsXfVRym41IlbC4Twf660/kUZrugA7Zqd5K9Un3lOVTzYowaF+m5OIOO56wff3zPBxeOVjANDKR7V6/', 'base64');
-      // eslint-disable-next-line quotes
       const plaintext = `<?xml version='1.0' ?><data id="encrypted" version="working3" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa"><meta><instanceID>uuid:99b303d9-6494-477b-a30d-d8aae8867335</instanceID></meta><name>bob</name><age>30</age><file>1561432532482.jpg</file></data>`;
 
       it('should successfully decrypt data syncronously @slow', () => {


### PR DESCRIPTION
Keeps the expectation of single quotes for strings, but makes enforcement less strict when:

* a single quote is included inside the string
* template literals (`backticks`) are used when not strictly required

This allows removing all existing inline exceptions for `quotes` rule, except where JSON(?) is directly included in `lib/data/analytics.js`.