### PR TITLE
Makefile: depend on node_version for oidc targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ node_modules: package.json
 	touch node_modules
 
 .PHONY: test-oidc-integration
-test-oidc-integration: node_modules
+test-oidc-integration: node_version
 	TEST_AUTH=oidc NODE_CONFIG_ENV=oidc-integration-test make test-integration
 
 .PHONY: test-oidc-e2e
-test-oidc-e2e: node_modules
+test-oidc-e2e: node_version
 	cd oidc-dev && \
 	docker compose down && \
 	docker compose build && \


### PR DESCRIPTION
Brings test-oidc-* targets in line with other test-* targets.