### PR TITLE
Be able to pull entity version source details from def source table

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -365,7 +365,6 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
   const relevantBaseVersions = new Set();
 
   for (const def of defs) {
-    const { source = {} } = auditMap.get(def.id);
 
     const v = mergeLeft(def.forApi(),
       {
@@ -373,9 +372,15 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
         resolved: false,
         baseDiff: [],
         serverDiff: [],
-        source,
         lastGoodVersion: false
       });
+
+    // If there is a create or update audit event for this def, attach the source from the audit event
+    // because it will be as detailed as possible (full submission, event, etc.)
+    // Otherwise use the details found in the source table for this entity def.
+    const event = auditMap.get(def.id);
+    if (event)
+      v.source = event.source;
 
     if (v.version > 1) { // v.root is false here - can use either
       const conflict = v.version !== (v.baseVersion + 1);

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -93,12 +93,18 @@ Entity.Def.Metadata = class extends Entity.Def {
   }
 };
 
-Entity.Def.Source = Frame.define(
-  table('entity_def_sources', 'entityDefSource'),
+Entity.Def.Source = class extends Frame.define(
+  table('entity_def_sources', 'source'),
   'details', readable,
   'submissionDefId', 'auditId',
   embedded('submissionDef'),
   embedded('audit')
-);
+) {
+  forApi() {
+    return {
+      ...this.details || {},
+    };
+  }
+};
 
 module.exports = { Entity };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -399,9 +399,10 @@ const getAll = (datasetId, options = QueryOptions.none) => ({ all }) =>
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITY DEFS
 
-const _getDef = extender(Entity.Def)(Actor.into('creator'))((fields, extend, options) => sql`
+const _getDef = extender(Entity.Def, Entity.Def.Source)(Actor.into('creator'))((fields, extend, options) => sql`
   SELECT ${fields} FROM entities
   JOIN entity_defs ON entities.id = entity_defs."entityId"
+  LEFT JOIN entity_def_sources ON entity_defs."sourceId" = entity_def_sources."id"
   ${extend||sql`
     LEFT JOIN actors ON actors.id=entity_defs."creatorId"
   `}
@@ -411,7 +412,7 @@ const _getDef = extender(Entity.Def)(Actor.into('creator'))((fields, extend, opt
 
 const getAllDefs = (datasetId, uuid, options = QueryOptions.none) => ({ all }) =>
   _getDef(all, options.withCondition({ datasetId, uuid }))
-    .then(map((v) => new Entity.Def(v, { creator: v.aux.creator })));
+    .then(map((v) => new Entity.Def(v, { creator: v.aux.creator, source: v.aux.source })));
 
 // This will check for an entity related to any def of the same submission
 // as the one specified. Used when trying to reapprove an edited submission.


### PR DESCRIPTION
I came across this when I was trying to check entity sources created via bulk import. 

In the `/versions` endpoint, the source of each def was getting populated from the audits table, which in general is a good idea.
1. we already have audits around to determine some last conflict resolved event
2. the entity audits query does a bunch of work to fill out the most complete details about an event source, including full submission if it exists, backup submission details if it doesn't, and the corresponding event. 

But, we're about to have entity defs that don't have a single audit event (unless they do/will?) associated with their creation, because one event will likely be shared across multiple new entities. 

We have a way to directly look up an entity def's source, so I added that to the main entity def query. If there are no other source/event details to provide, it will fall back to the details directly in the source table. 


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

I thought getting an entity def source via audits was odd when we had it directly, but then i realized how much more detailed that way of doing things is so i left it in place and added this fallback to the more basic source details. I don't think it harms anything and we can come back to "what kind of events should exist for bulk actions". 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced