### PR TITLE
endpoint: for pipes, only call next() on error

### DIFF
--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -200,7 +200,7 @@ const defaultResultWriter = (result, request, response, next) => {
     result.with(response).pipeline((err) => next?.(err));
   } else if (result.pipe != null) {
     result.on('error', streamErrorHandler(response));
-    pipeline(result, response, (err) => next?.(err));
+    pipeline(result, response, (err) => err && next?.(err));
   } else {
     response.send(serialize(result));
   }


### PR DESCRIPTION
Closes #1057

From express docs:

> If the current middleware function does not end the request-response cycle, it must call next() to pass control to the next middleware function.
> - https://expressjs.com/en/guide/using-middleware.html

`pipeline()` should be assumed to have ended the "request-response cycle" unless an error is passed to its callback function.
