### PR TITLE
Generate entity UUID if one is not provided in API request

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -43,6 +43,10 @@ info:
     - OData Data Document for requests of Submissions and Entities now allow use of `$orderby`.
     - ETag headers on all Blobs.
 
+    **Changed**:
+
+    - The [Entity Create](/central-api-entity-management/#creating-an-entity) endpoint will now generate a UUID if the `uuid` parameter is not provided.
+
 
     ## ODK Central v2023.5
 
@@ -10068,7 +10072,11 @@ paths:
       - Entity Management
       summary: Creating an Entity
       description: |-
-        Creates an Entity in the Dataset. Request body takes the JSON representation of the Entity. It should have `uuid` and `label` property in addition to the user-defined properties of the Dataset in `data` property.
+        Creates an Entity in the Dataset. The request body takes a JSON representation of the Entity, which has the following properties:
+
+          1. A `data` object containing values for the user-defined Dataset properties. (Not all properties have to have values.)
+          2. A `label` property, which cannot be blank or an empty string. (This is used as a human-readable label in Forms that consume Entities.)
+          3. An optional `uuid` property. If the `uuid` is not specified, Central will generate a UUID for an Entity with the provided data and label.
         
         Value type of all properties is `string`.
 

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -14,6 +14,7 @@
 const csv = require('csv-stringify');
 const { clone, path, mergeLeft } = require('ramda');
 const { Transform } = require('stream');
+const uuid = require('uuid').v4;
 const { PartialPipe } = require('../util/stream');
 const Problem = require('../util/problem');
 const { submissionXmlToFieldStream } = require('./submission');
@@ -112,7 +113,7 @@ const extractEntity = (body, propertyNames, existingEntity) => {
     if (body.uuid && typeof body.uuid !== 'string')
       throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'string' });
 
-    entity.system.uuid = normalizeUuid(body.uuid);
+    entity.system.uuid = (body.uuid) ? normalizeUuid(body.uuid) : uuid();
   }
 
   if (body.label != null)


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/574

Simple change to generate a UUID for an entity of one is not provided. This is currently for the single entity create via API case, but will apply to the bulk create, too.

For entities created with submissions, the parsing path is different so a UUID (generated by the client) is still required. 

For entity API updates, the UUID is specified in the URL, not in the request body, so nothing needs to change. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Short and simple!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

Yes, this needs documentation changes. I intend to make those changes in this PR! 

#### Before submitting this PR, please make sure you have:

- [x] run `make test-full` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced