### PR TITLE
ci: upgrade upload-articact action to v4

### DIFF
--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     - run: make test-oidc-e2e
     - name: Archive playwright screenshots
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Playwright Screenshots
         path: oidc-dev/playwright-results/**/*.png


### PR DESCRIPTION
Extension to 401afdd4599d5931a0b2e3271c1ba8f711411cd5.

Fixes:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
