### PR TITLE
Fix jsonb concatenation in down migration

### DIFF
--- a/lib/model/migrations/20190917-01-cleanup-app-user-role.js
+++ b/lib/model/migrations/20190917-01-cleanup-app-user-role.js
@@ -14,7 +14,7 @@ const up = async (db) => {
 
 const down = async (db) => {
   await db.raw("update roles set system = 'app_user' where system = 'app-user';");
-  await db.raw("update roles set verbs = verbs + 'form.list' where system = 'app_user';");
+  await db.raw(`update roles set verbs = verbs || '["form.list"]'::jsonb where system = 'app_user';`);
 };
 
 module.exports = { up, down };


### PR DESCRIPTION
While working on #1090, I took a look at how previous migrations had updated verbs. I noticed the use of the `+` operator in one migration, but later I realized that that's not actually a valid operator for the `verbs` column, which is `jsonb`. We use the `||` operator in other migrations, so I went ahead and replaced the `+` with `||`. Clearly, the `+` wasn't actually causing any issues: we must never have needed to run the down migration. But it was a little confusing when I was trying to find prior related work and came across the operator.

#### What has been done to verify that this works as intended?

I didn't do anything to verify the change, since it seems clear that we've never needed to run the down migration. I just wanted to make the code a little clearer and more consistent with other migrations.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced