### PR TITLE
WIP: http: strip etags from error responses

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -87,6 +87,13 @@ module.exports = (container) => {
   // first, translate routing fallthroughs to 404:
   service.use((request, response, next) => { next(Problem.user.notFound()); });
 
+  // strip inappropriate headers from error responses
+  service.use((error, request, response, next) => {
+    if (response.headersSent) next(error); // too late to do anything
+    response.removeHeader('etag');
+    next(error);
+  });
+
   // apply the Sentry error hook.
   service.use(container.Sentry.Handlers.errorHandler());
 

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -90,7 +90,7 @@ module.exports = (container) => {
   // strip inappropriate headers from error responses
   service.use((error, request, response, next) => {
     if (response.headersSent) next(error); // too late to do anything
-    response.removeHeader('etag');
+    response.removeHeader('ETag');
     next(error);
   });
 

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -90,7 +90,14 @@ module.exports = (container) => {
   // strip inappropriate headers from error responses
   service.use((error, request, response, next) => {
     if (response.headersSent) next(error); // too late to do anything
-    response.removeHeader('ETag');
+    switch (process.env.STRIP_ERR_ETAGS) {
+      case 'yes': response.removeHeader('ETag'); break;
+      case 'no': /* do nothing */ break;
+      default:
+        /* eslint-ignore-next-line no-console */
+        console.log('Please set STRIP_ERR_ETAGS env var to yes or no test this.');
+        process.exit(1);
+    }
     next(error);
   });
 

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -16,6 +16,8 @@ const { Dataset } = require('../model/frames');
 const Problem = require('../util/problem');
 const { QueryOptions } = require('../util/db');
 
+let first = true;
+
 module.exports = (service, endpoint) => {
   service.get('/projects/:id/datasets', endpoint(({ Projects, Datasets }, { auth, params, queryOptions }) =>
     Projects.getById(params.id, queryOptions)
@@ -67,6 +69,10 @@ module.exports = (service, endpoint) => {
       const extension = 'csv';
       response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
       response.append('Content-Type', 'text/csv');
+      if (first) {
+        first = false;
+        throw new Error('i was first');
+      }
       return streamEntityCsv(entities, properties);
     };
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -622,7 +622,7 @@ describe('datasets and entities', () => {
 
       }));
 
-      it('should return 304 content not changed if ETag matches', testService(async (service, container) => {
+      it.only('should return 304 content not changed if ETag matches', testService(async (service, container) => {
         const asAlice = await service.login('alice');
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
@@ -640,6 +640,11 @@ describe('datasets and entities', () => {
           .expect(200);
 
         await exhaust(container);
+
+        const errResult = await asAlice.get('/v1/projects/1/datasets/people/entities.csv')
+          .expect(500);
+        const errEtag = errResult.get('ETag');
+        errEtag.should.match(/W\/".*"/); // express sets weak etags on everything
 
         const result = await asAlice.get('/v1/projects/1/datasets/people/entities.csv')
           .expect(200);


### PR DESCRIPTION
This PR currently demonstrates that strong ETags are set on error responses, and that if these are stripped, express still sets weak ETags on those responses.

Setting strong ETags which correspond with OK responses on error responses with non-matching content is not useful, and may cause caching issues.

Adding a test for this without making invasive changes to production code seems tricky.

Running the test locally:

* `STRIP_ERR_ETAGS=yes make test-integration`
* `STRIP_ERR_ETAGS=no  make test-integration`