### PR TITLE
Change entities REST order to match OData order

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -410,8 +410,8 @@ const _get = (includeSource) => {
     ) submissions ON submissions.id = submission_defs."submissionId"
     LEFT JOIN forms ON submissions."formId" = forms.id
   `} 
-  where ${equals(options.condition)} and entities."deletedAt" is ${deleted ? sql`not` : sql``} null
-  order by entity_defs.id, entities."createdAt" desc, entities.id desc
+  WHERE ${equals(options.condition)} AND entities."deletedAt" is ${deleted ? sql`not` : sql``} null
+  ORDER BY entities."createdAt" DESC, entities.id DESC
 `);
 };
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/582

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

The `../entities` REST endpoint was returning entities ordered by entity def id, which doesn't seem very meaningful. That part has been removed and now entities are returned in a stable order that matches the odata endpoint.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I hope no one is relying on that other weird order. It wasn't documented. 

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

We could keep not documenting the order here. The odata endpoint has a more explicit and controllable query param for ordering entities. 

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced