### PR TITLE
Use sql unnest to optimize entity insertion

### DIFF
--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -27,7 +27,7 @@ class Entity extends Frame.define(
     'int4', 'int4',
     'conflictType',
     'timestamptz',
-    'timestamptz', 'timestamptz',
+    'timestamptz', 'timestamp',
   ])
 ) {
   get def() { return this.aux.def; }
@@ -94,7 +94,7 @@ Entity.Def = Frame.define(
   fieldTypes([
     'int4', 'int4',
     'bool',
-    'int4', 'varchar',
+    'int4', 'text',
     'int4', 'varchar',
     'jsonb', 'bool',
     'int4', 'int4',

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -9,19 +9,26 @@
 
 /* eslint-disable no-multi-spaces */
 
-const { embedded, Frame, readable, table } = require('../frame');
+const { embedded, fieldTypes, Frame, readable, table } = require('../frame');
 const { extractEntity, normalizeUuid, extractLabelFromSubmission, extractBaseVersionFromSubmission } = require('../../data/entity');
 
 // These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
   table('entities', 'entity'),
   'id',                     'uuid', readable,
-  'datasetId',
-  'createdAt', readable,    'creatorId', readable,
-  'updatedAt', readable,    'deletedAt', readable,
+  'datasetId',              'creatorId', readable,
   'conflict', readable,
+  'createdAt', readable,
+  'updatedAt', readable,    'deletedAt', readable,
   embedded('creator'),
-  embedded('currentVersion')
+  embedded('currentVersion'),
+  fieldTypes([
+    'int4', 'varchar',
+    'int4', 'int4',
+    'conflictType',
+    'timestamptz',
+    'timestamptz', 'timestamptz',
+  ])
 ) {
   get def() { return this.aux.def; }
 
@@ -75,14 +82,25 @@ Entity.Extended = class extends Frame.define(
 Entity.Def = Frame.define(
   table('entity_defs', 'def'),
   'id',                             'entityId',
-  'createdAt',    readable,         'current',      readable,
+  'current',      readable,
   'sourceId',                       'label',        readable,
   'creatorId',    readable,         'userAgent',    readable,
   'data',         readable,         'root',
   'version',      readable,         'baseVersion',  readable,
   'dataReceived', readable,         'conflictingProperties', readable,
+  'createdAt',    readable,
   embedded('creator'),
-  embedded('source')
+  embedded('source'),
+  fieldTypes([
+    'int4', 'int4',
+    'bool',
+    'int4', 'varchar',
+    'int4', 'varchar',
+    'jsonb', 'bool',
+    'int4', 'int4',
+    'jsonb', 'jsonb',
+    'timestamptz'
+  ])
 );
 
 Entity.Def.Metadata = class extends Entity.Def {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -97,7 +97,7 @@ const createMany = (dataset, rawEntities, sourceId, userAgentIn) => async ({ all
   // Augment parsed entity data with dataset and creator IDs
   const entitiesForInsert = rawEntities.map(e => new Entity({ datasetId: dataset.id, creatorId, ...e }));
 
-  const entities = await all(insertMany(entitiesForInsert));
+  const entities = await all(sql`${insertMany(entitiesForInsert)} RETURNING id`);
 
   // Augment defs with IDs of freshly inserted entities and
   // other default values

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -109,8 +109,7 @@ const createMany = (dataset, rawEntities, sourceId, userAgentIn) => async ({ all
     sourceId,
     version: 1,
     userAgent,
-    ...e.def,
-    data: { ...e.def.data }, // was [Object: null prototype]
+    ...e.def
   }));
   return all(insertMany(defsForInsert));
 };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -94,13 +94,14 @@ const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, c
   const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
   const userAgent = blankStringToNull(userAgentIn);
 
-  const entityInsert = sql.join(entities.map(e => sql`(${sql.join([dataset.id, e.uuid, creatorId, sql`clock_timestamp()`], sql`,`)} )`), sql`,`);
+  const entityRows = entities.map(e => [dataset.id, e.uuid, creatorId]);
+  const entityColumnTypes = ['int4', 'uuid', 'int4'];
   const newEntities = await all(sql`
-  INSERT INTO entities ("datasetId", "uuid", "creatorId", "createdAt")
-  VALUES ${entityInsert}
+  INSERT INTO entities ("createdAt", "datasetId", "uuid", "creatorId")
+  SELECT clock_timestamp(), * FROM ${sql.unnest(entityRows, entityColumnTypes)} as t
   RETURNING id`);
 
-  const defInsert = sql.join(entities.map((e, i) => sql`(${sql.join([
+  const defRows = entities.map((e, i) => [
     newEntities[i].id,
     e.def.label,
     JSON.stringify(e.def.data),
@@ -110,16 +111,26 @@ const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, c
     userAgent,
     'true',
     'true',
-    sql`clock_timestamp()`,
     '1'
-  ], sql`,`)} )`), sql`,`);
+  ]);
+  const defColumnTypes = [
+    'int4',
+    'text',
+    'json',
+    'json',
+    'int4',
+    'int4',
+    'text',
+    'bool',
+    'bool',
+    'int4'
+  ];
 
   const defs = await all(sql`
-  INSERT INTO entity_defs ("entityId", "label", "data", "dataReceived",
-    "sourceId", "creatorId", "userAgent", "root", "current", "createdAt", "version")
-  VALUES ${defInsert}
-  RETURNING *
-  `);
+  INSERT INTO entity_defs ("createdAt", "entityId", "label", "data", "dataReceived",
+    "sourceId", "creatorId", "userAgent", "root", "current", "version")
+  SELECT clock_timestamp(), * FROM ${sql.unnest(defRows, defColumnTypes)} as t
+  RETURNING *`);
 
   return defs;
 };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -9,7 +9,7 @@
 
 const { sql } = require('slonik');
 const { Actor, Entity, Submission, Form } = require('../frames');
-const { equals, extender, unjoiner, page, markDeleted } = require('../../util/db');
+const { equals, extender, unjoiner, page, markDeleted, insertMany } = require('../../util/db');
 const { map, mergeRight, pickAll } = require('ramda');
 const { blankStringToNull, construct } = require('../../util/util');
 const { QueryOptions } = require('../../util/db');
@@ -90,49 +90,29 @@ createNew.audit.withResult = true;
 // it could be used in places of createNew() but createNew uses a single query so it may be faster
 // in single entity situations (eg. processing submissions to make entities)
 // Note: if the entity schema changes, createMany and createNew would both need to change.
-const createMany = (dataset, entities, sourceId, userAgentIn) => async ({ all, context }) => {
+const createMany = (dataset, rawEntities, sourceId, userAgentIn) => async ({ all, context }) => {
   const creatorId = context.auth.actor.map((actor) => actor.id).orNull();
   const userAgent = blankStringToNull(userAgentIn);
 
-  const entityRows = entities.map(e => [dataset.id, e.uuid, creatorId]);
-  const entityColumnTypes = ['int4', 'uuid', 'int4'];
-  const newEntities = await all(sql`
-  INSERT INTO entities ("createdAt", "datasetId", "uuid", "creatorId")
-  SELECT clock_timestamp(), * FROM ${sql.unnest(entityRows, entityColumnTypes)} as t
-  RETURNING id`);
+  // Augment parsed entity data with dataset and creator IDs
+  const entitiesForInsert = rawEntities.map(e => new Entity({ datasetId: dataset.id, creatorId, ...e }));
 
-  const defRows = entities.map((e, i) => [
-    newEntities[i].id,
-    e.def.label,
-    JSON.stringify(e.def.data),
-    JSON.stringify(e.def.dataReceived),
-    sourceId,
+  const entities = await all(insertMany(entitiesForInsert));
+
+  // Augment defs with IDs of freshly inserted entities and
+  // other default values
+  const defsForInsert = rawEntities.map((e, i) => new Entity.Def({
+    entityId: entities[i].id,
     creatorId,
+    root: true,
+    current: true,
+    sourceId,
+    version: 1,
     userAgent,
-    'true',
-    'true',
-    '1'
-  ]);
-  const defColumnTypes = [
-    'int4',
-    'text',
-    'json',
-    'json',
-    'int4',
-    'int4',
-    'text',
-    'bool',
-    'bool',
-    'int4'
-  ];
-
-  const defs = await all(sql`
-  INSERT INTO entity_defs ("createdAt", "entityId", "label", "data", "dataReceived",
-    "sourceId", "creatorId", "userAgent", "root", "current", "version")
-  SELECT clock_timestamp(), * FROM ${sql.unnest(defRows, defColumnTypes)} as t
-  RETURNING *`);
-
-  return defs;
+    ...e.def,
+    data: { ...e.def.data }, // was [Object: null prototype]
+  }));
+  return all(insertMany(defsForInsert));
 };
 
 createMany.audit = (dataset, entities, sourceId) => (log) =>

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -135,11 +135,12 @@ const extender = (...standard) => (...extended) => (sqlFunc) => {
 const _assign = (obj) => (k) => {
   if (k === 'createdAt') return sql`clock_timestamp()`;
   const v = obj[k];
-  return (v === null) ? null :
-    (v === undefined) ? null :
-    ((typeof v === 'object') && (v.constructor === Object)) ? JSON.stringify(v) : // eslint-disable-line indent
-    (v instanceof Date) ? v.toISOString() : // eslint-disable-line indent
-    v; // eslint-disable-line indent
+  if (v === null || v === undefined) return null;
+  if (typeof v === 'object') {
+    if (v instanceof Date) return v.toISOString();
+    if (v.constructor === Object || Object.getPrototypeOf(v) == null) return JSON.stringify(v);
+  }
+  return v;
 };
 const insert = (obj) => {
   const keys = Object.keys(obj);

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -179,7 +179,8 @@ const insertMany = (objs) => {
 
   return sql`
   INSERT INTO ${raw(Type.table)} (${columns})
-  SELECT ${selectExp} FROM ${sql.unnest(rows, columnTypes)} AS t`;
+  SELECT ${selectExp} FROM ${sql.unnest(rows, columnTypes)} AS t
+  RETURNING *`;
 };
 
 // generic update utility

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -180,8 +180,7 @@ const insertMany = (objs) => {
 
   return sql`
   INSERT INTO ${raw(Type.table)} (${columns})
-  SELECT ${selectExp} FROM ${sql.unnest(rows, columnTypes)} AS t
-  RETURNING *`;
+  SELECT ${selectExp} FROM ${sql.unnest(rows, columnTypes)} AS t`;
 };
 
 // generic update utility

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -291,10 +291,10 @@ returning *`);
     });
 
     it('should deal with strange data input types', () => {
-      insert(new T({ x: { test: true }, y: undefined, z: new Date('2000-01-01') }))
+      insert(new T({ x: { test: true }, y: undefined, z: new Date('2000-01-01'), w: Object.assign(Object.create(null), { foo: 'bar' }) }))
         .should.eql(sql`
-insert into frames ("x","y","z")
-values (${'{"test":true}'},${null},${'2000-01-01T00:00:00.000Z'})
+insert into frames ("x","y","z","w")
+values (${'{"test":true}'},${null},${'2000-01-01T00:00:00.000Z'},${'{"foo":"bar"}'})
 returning *`);
     });
 
@@ -319,8 +319,7 @@ returning *`);
       const query = insertMany([ new T({ x: 2 }), new T({ y: 3 }) ]);
       query.sql.should.be.eql(`
   INSERT INTO dogs ("x","y")
-  SELECT * FROM unnest($1::"text"[], $2::"text"[]) AS t
-  RETURNING *`);
+  SELECT * FROM unnest($1::"text"[], $2::"text"[]) AS t`);
       query.values.should.be.eql([
         [2, null],
         [null, 3]
@@ -332,8 +331,7 @@ returning *`);
       const query = insertMany([ new U({ x: new Date('2000-01-01') }), new U() ]);
       query.sql.should.be.eql(`
   INSERT INTO dogs ("createdAt", "x")
-  SELECT clock_timestamp(), * FROM unnest($1::"timestamptz"[]) AS t
-  RETURNING *`);
+  SELECT clock_timestamp(), * FROM unnest($1::"timestamptz"[]) AS t`);
       query.values.should.be.eql([
         ['2000-01-01T00:00:00.000Z', null]
       ]);

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -319,7 +319,8 @@ returning *`);
       const query = insertMany([ new T({ x: 2 }), new T({ y: 3 }) ]);
       query.sql.should.be.eql(`
   INSERT INTO dogs ("x","y")
-  SELECT * FROM unnest($1::"text"[], $2::"text"[]) AS t`);
+  SELECT * FROM unnest($1::"text"[], $2::"text"[]) AS t
+  RETURNING *`);
       query.values.should.be.eql([
         [2, null],
         [null, 3]
@@ -331,7 +332,8 @@ returning *`);
       const query = insertMany([ new U({ x: new Date('2000-01-01') }), new U() ]);
       query.sql.should.be.eql(`
   INSERT INTO dogs ("createdAt", "x")
-  SELECT clock_timestamp(), * FROM unnest($1::"timestamptz"[]) AS t`);
+  SELECT clock_timestamp(), * FROM unnest($1::"timestamptz"[]) AS t
+  RETURNING *`);
       query.values.should.be.eql([
         ['2000-01-01T00:00:00.000Z', null]
       ]);


### PR DESCRIPTION
Related to https://github.com/getodk/central-backend/issues/1095 

Happy to report that I was able to insert 500,000 entities w/ 10 properties in about ~30 seconds (on my M3 mac) with this `sql.unnest` change. 

That payload was about `76,000KB` (76MB) and this limit was increased to `250000kb` (250MB)
[service.use(bodyParser.json({ type: 'application/json', limit: '250kb' }));](https://github.com/getodk/central-backend/blob/a04caadcb9052105b03e6be4e431c8f1923b1f4c/lib/http/service.js#L33-L34)



<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests of small insertions still work. 
I tried it on my own with those larger numbers.

#### Why is this the best possible solution? Were any other approaches considered?

There is still more to do to create many entities at once (streaming JSON?), but I think it's worth merging this particular change now so the bottleneck is no longer the database insert.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced