### PR TITLE
Bug Fix for `istrue` & `isfalse` utility function

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -18,8 +18,8 @@ const sanitize = require('sanitize-filename');
 // REQUEST PARSING
 
 // Returns t/f only if the input is a string of any upper/lowercase combination.
-const isTrue = (x) => (!isBlank(x) && (x.toLowerCase() === 'true'));
-const isFalse = (x) => (!isBlank(x) && (x.toLowerCase() === 'false'));
+const isTrue = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() === 'true'));
+const isFalse = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() === 'false'));
 
 // Returns just the pathname of the URL, omitting querystring and other non-path decoration.
 const urlPathname = (x) => parse(x).pathname;

--- a/test/unit/util/http.js
+++ b/test/unit/util/http.js
@@ -17,6 +17,25 @@ describe('util/http', () => {
       isTrue('').should.equal(false);
       isTrue(null).should.equal(false);
       isTrue(undefined).should.equal(false);
+      isTrue(2).should.equal(false);
+    });
+  });
+
+  describe('isFalse', () => {
+    const { isFalse } = http;
+    it('should return true for falsey strings', () => {
+      isFalse('FALSE').should.equal(true);
+      isFalse('False').should.equal(true);
+      isFalse('false').should.equal(true);
+    });
+
+    it('should return false for all other values', () => {
+      isFalse('no').should.equal(false);
+      isFalse('off').should.equal(false);
+      isFalse('').should.equal(false);
+      isFalse(null).should.equal(false);
+      isFalse(undefined).should.equal(false);
+      isFalse(2).should.equal(false);
     });
   });
 


### PR DESCRIPTION
Closes #806

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I have ran `make test-unit` and all the test passed
#### Why is this the best possible solution? Were any other approaches considered?
It was the most straight forward solution. No other approaches were needed, just letting the function consider string only
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't affect much, the function now is doing what is was supposed to do, which is check for string types only.
#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
No
#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced