### PR TITLE
Specify that entity uuids need to be version 4

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -37,7 +37,7 @@ const normalizeUuid = (id) => {
 
   const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
   const matches = uuidPattern.exec(id);
-  if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'valid UUID' });
+  if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'valid version 4 UUID' });
   return matches[2].toLowerCase();
 };
 

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2425,7 +2425,7 @@ describe('Entities API', () => {
           .expect(400)
           .then(({ body }) => {
             body.code.should.equal(400.11);
-            body.message.should.equal('Invalid input data type: expected (uuid) to be (valid UUID)');
+            body.message.should.equal('Invalid input data type: expected (uuid) to be (valid version 4 UUID)');
           });
 
         // Entity list is still empty

--- a/test/integration/worker/entity.js
+++ b/test/integration/worker/entity.js
@@ -320,7 +320,7 @@ describe('worker: entity', () => {
         const event = await container.Audits.getLatestByAction('entity.error').then((o) => o.get());
         event.actorId.should.equal(5); // Alice
         event.details.submissionId.should.equal(updateEvent.details.submissionId);
-        event.details.errorMessage.should.equal('Invalid input data type: expected (uuid) to be (valid UUID)');
+        event.details.errorMessage.should.equal('Invalid input data type: expected (uuid) to be (valid version 4 UUID)');
         event.details.problem.problemCode.should.equal(400.11);
       }));
 
@@ -493,7 +493,7 @@ describe('worker: entity', () => {
         const event = await container.Audits.getLatestByAction('entity.error').then((o) => o.get());
         event.actorId.should.equal(5); // Alice
         event.details.submissionId.should.equal(subEvent.details.submissionId);
-        event.details.errorMessage.should.equal('Invalid input data type: expected (uuid) to be (valid UUID)');
+        event.details.errorMessage.should.equal('Invalid input data type: expected (uuid) to be (valid version 4 UUID)');
         event.details.problem.problemCode.should.equal(400.11);
       }));
 

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -39,7 +39,7 @@ describe('extracting and validating entities', () => {
       it('should return problem if invalid uuid passed in', () =>
         assert.throws(() => { normalizeUuid('this_is_not_a_valid_uuid'); }, (err) => {
           err.problemCode.should.equal(400.11);
-          err.message.should.equal('Invalid input data type: expected (uuid) to be (valid UUID)');
+          err.message.should.equal('Invalid input data type: expected (uuid) to be (valid version 4 UUID)');
           return true;
         }));
     });


### PR DESCRIPTION
I randomly generated some UUIDs but they were v1. I was confused for a bit when I got an invalid UUID error.

#### What has been done to verify that this works as intended?
Tests

#### Why is this the best possible solution? Were any other approaches considered?
It gives a hint as to what's going wrong without making invasive changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None, text only.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced