### PR TITLE
Simplify various null comparisons

### DIFF
--- a/lib/data/briefcase.js
+++ b/lib/data/briefcase.js
@@ -114,7 +114,7 @@ const processRow = (xml, instanceId, fields, header, selectValues) => new Promis
     },
     ontext: (text) => {
       const field = schemaStack.head();
-      if ((field != null) && (field.idx != null)) {
+      if (field?.idx != null) {
         // we have a real schema field for this text value and a place to put the
         // value, so inject it into the appropriate spot in the row.
 
@@ -151,7 +151,7 @@ const processRow = (xml, instanceId, fields, header, selectValues) => new Promis
       const row = dataStack.pop();
 
       // if we popped a repeat, we need to write the subrow we just created.
-      if ((field != null) && (field.type === 'repeat'))
+      if (field?.type === 'repeat')
         field.stream.write(row);
 
       // if we popped everything, we've hit the close tag. write out a few special

--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -443,7 +443,7 @@ const rowStreamToOData = (fields, table, domain, originalUrl, query, inStream, t
 
       // if we were given an explicit count, use it from here out, to create
       // @odata.count and nextUrl.
-      const totalCount = (tableCount != null) ? tableCount : counted;
+      const totalCount = tableCount ?? counted;
 
       // How many items are remaining for the next page?
       // if there aren't any then we don't need nextUrl

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -42,7 +42,7 @@ const isWriteRequest = (request) => !phony(request) &&
   (request.method === 'PATCH') || (request.method === 'DELETE'));
 
 // quick and dirty function to wrap plain values in a promise.
-const ensurePromise = (x) => (((x != null) && (typeof x.then === 'function')) ? x : resolve(x));
+const ensurePromise = (x) => ((typeof x?.then === 'function') ? x : resolve(x));
 
 // allows Streams, response-mutating functions, and Problems to be directly returned
 // by a resource handler, and does sane thinsg with each.

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -98,7 +98,7 @@ module.exports = (container) => {
     if (response.headersSent === true) {
       // In this case, we'll just let Express fail the request out.
       next(error);
-    } else if ((error != null) && (error.type === 'entity.parse.failed')) {
+    } else if (error?.type === 'entity.parse.failed') {
       // catch body-parser middleware problems. we only ask it to parse JSON, which
       // isn't part of OpenRosa, so we can assume a plain JSON response.
       defaultErrorWriter(Problem.user.unparseable({ format: 'json', rawLength: error.body.length }), request, response);

--- a/lib/model/container.js
+++ b/lib/model/container.js
@@ -71,7 +71,7 @@ class Container {
 const injector = (base, queries) => {
   // The container is the object that contains all of our (inter-)dependent objects.
   const container = new Container(base);
-  if ((base != null) && (base.db != null)) queryFuncs(base.db, container);
+  if (base?.db != null) queryFuncs(base.db, container);
 
   // Inject container context to query modules.
   for (const queryModule of Object.keys(queries))

--- a/lib/model/frames/config.js
+++ b/lib/model/frames/config.js
@@ -21,7 +21,7 @@ class Config extends Frame.define(
   'setAt',      readable,
   species('config')
 ) {
-  static forKey(key) { return frames[key] != null ? frames[key] : this; }
+  static forKey(key) { return frames[key] ?? this; }
 }
 
 /*

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -61,7 +61,7 @@ class Form extends Frame.define(
 ) {
   get def() { return this.aux.def; }
   get xls() { return this.aux.xls || {}; } // TODO/SL sort of a hack but let's see how it goes.
-  get xml() { return (this.aux.xml != null) ? this.aux.xml.xml : undefined; }
+  get xml() { return this.aux.xml?.xml; }
 
   acceptsSubmissions() { return (this.state === 'open') || (this.state === 'closing'); }
 
@@ -85,7 +85,7 @@ class Form extends Frame.define(
 
   forApi() {
     const enketoId = this._enketoIdForApi();
-    const enketoOnceId = this.def != null && this.def.id === this.currentDefId
+    const enketoOnceId = this.def?.id === this.currentDefId
       ? this.enketoOnceId
       : null;
 


### PR DESCRIPTION
* remove `!= null` where unnecessary
* replace `x != null && x.y ===` with `x?.y ===`
* replace `x != null ? x :` with `x ??`

This should help with readability.