### PR TITLE
Remove X-Powered-By header

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -13,6 +13,7 @@
 
 module.exports = (container) => {
   const service = require('express')();
+  service.disable('x-powered-by');
 
   ////////////////////////////////////////////////////////////////////////////////
   // PRERESOURCE MIDDLEWARE

--- a/test/integration/other/http-headers.js
+++ b/test/integration/other/http-headers.js
@@ -1,0 +1,9 @@
+const should = require('should');
+const { testService } = require('../setup');
+
+describe('http-headers', () => {
+  it('should not include x-powered-by header', testService(async (service) => {
+    const { headers } = await service.get('/v1/users/current');
+    should(headers['x-powered-by']).be.undefined();
+  }));
+});


### PR DESCRIPTION
Follows the OWASP recommendation: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-powered-by

This is not super important because there are many other ways to learn about the stack but it does get flagged by some security scanners.

#### What has been done to verify that this works as intended?
Ran it, looked at headers in console

#### Why is this the best possible solution? Were any other approaches considered?
I think this is the only approach!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Should have no risk of negative effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced