### PR TITLE
Update db index on entity audit query to use entityDefId and sourceId

### DIFF
--- a/lib/model/migrations/20240322-01-add-entity-source-index-to-audits.js
+++ b/lib/model/migrations/20240322-01-add-entity-source-index-to-audits.js
@@ -1,0 +1,24 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw('DROP INDEX audits_details_entity_index');
+  await db.raw("CREATE INDEX audits_details_entity_def_index ON audits USING HASH (((details ->> 'entityDefId')::INTEGER))");
+  await db.raw("CREATE INDEX audits_details_entity_source_index ON audits USING HASH (((details ->> 'sourceId')::INTEGER))");
+};
+
+const down = async (db) => {
+  await db.raw("CREATE INDEX audits_details_entity_index ON audits USING HASH (((details ->> 'entityId')::INTEGER))");
+  await db.raw('DROP INDEX audits_details_entity_def_index');
+  await db.raw('DROP INDEX audits_details_entity_source_index');
+};
+
+module.exports = { up, down };
+
+

--- a/lib/model/migrations/20240322-01-add-entity-source-index-to-audits.js
+++ b/lib/model/migrations/20240322-01-add-entity-source-index-to-audits.js
@@ -8,13 +8,11 @@
 // except according to the terms contained in the LICENSE file.
 
 const up = async (db) => {
-  await db.raw('DROP INDEX audits_details_entity_index');
   await db.raw("CREATE INDEX audits_details_entity_def_index ON audits USING HASH (((details ->> 'entityDefId')::INTEGER))");
   await db.raw("CREATE INDEX audits_details_entity_source_index ON audits USING HASH (((details ->> 'sourceId')::INTEGER))");
 };
 
 const down = async (db) => {
-  await db.raw("CREATE INDEX audits_details_entity_index ON audits USING HASH (((details ->> 'entityId')::INTEGER))");
   await db.raw('DROP INDEX audits_details_entity_def_index');
   await db.raw('DROP INDEX audits_details_entity_source_index');
 };

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -107,7 +107,7 @@ ${extend|| sql`
   LEFT OUTER JOIN actors ON actors.id=audits."actorId"
 
   -- if event references entityId in details
-  LEFT JOIN entities ON (audits.details->'entityId')::INTEGER = entities.id AND entities."deletedAt" IS NULL
+  LEFT JOIN entities ON (audits.details->>'entityId')::INTEGER = entities.id AND entities."deletedAt" IS NULL
   -- join with current entity def even if there is a specific def linked in event
   LEFT JOIN entity_defs AS current_entity_def ON current_entity_def."entityId" = entities.id AND current
 `}
@@ -136,7 +136,7 @@ const _getByEntityId = (fields, options, entityId) => sql`
 SELECT ${fields} FROM entity_defs
 
   LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
-  INNER JOIN audits ON ((audits.details->'entityDefId')::INTEGER = entity_defs.id OR (audits.details->'sourceId')::INTEGER = entity_def_sources.id)
+  INNER JOIN audits ON ((audits.details->>'entityDefId')::INTEGER = entity_defs.id OR (audits.details->>'sourceId')::INTEGER = entity_def_sources.id)
 
   LEFT JOIN actors ON actors.id=audits."actorId"
 


### PR DESCRIPTION
Entity details page was getting really slow. `/audits` and `/versions` endpoints in particular were really slow (order of seconds on test server). Both endpoints use `Audits.getByEntityId()`.

Looking into it, when I updated the entity audit query to use the new `sourceId` for bulk entity uploads, this definitely impacted the query's performance.
https://github.com/getodk/central-backend/commit/f98187d76307dafe76482a882beba16854008c9f?diff=split&w=0#diff-754724053d58d67c63f58d13d8708e4d185a11bb2d172614693cc3f611bb5361R171

The code used to filter on `audits.details->>'entityId'`, which we had an index for. Now, not every audit log will reference an entity directly. Instead, we look up audits by `audits.details->'entityDefId'` or `audits.details->'sourceId'` in a different part of the query. 

This PR removes the index on `details->entityId` and adds two new indexes on `entityDefId` and `sourceId` instead.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I'm trying it locally. I think it's helping a bit but it's hard to tell. I haven't tried it on the test server.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced