### PR TITLE
Add example content to OData `/datasets/{name}.svc` 200 response

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -11834,7 +11834,76 @@ paths:
       responses:
         200:
           description: OK
-          content: {}
+          content:
+            application/json; charset=utf-8; odata.metadata=minimal:
+              schema:
+                type: object
+                properties:
+                  '@odata.context':
+                    type: string
+                  value:
+                    type: array
+                    items:
+                      required:
+                      - kind
+                      - name
+                      - url
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                example:
+                  '@odata.context': https://your.odk.server/v1/projects/7/datasets/sample.svc/$metadata
+                  value:
+                  - kind: EntitySet
+                    name: Entities
+                    url: Entities
+                  - kind: EntitySet
+                    name: Entities.children.child
+                    url: Entities.children.child
+              example:
+                '@odata.context': https://your.odk.server/v1/projects/7/datasets/sample.svc/$metadata
+                value:
+                - kind: EntitySet
+                  name: Entities
+                  url: Entities
+                - kind: EntitySet
+                  name: Entities.children.child
+                  url: Entities.children.child
+            application/json:
+              schema:
+                type: object
+                properties:
+                  '@odata.context':
+                    type: string
+                  value:
+                    type: array
+                    items:
+                      required:
+                      - kind
+                      - name
+                      - url
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                example:
+                  '@odata.context': https://your.odk.server/v1/projects/7/datasets/sample.svc/$metadata
+                  value:
+                  - kind: EntitySet
+                    name: Entities
+                    url: Entities
+                  - kind: EntitySet
+                    name: Entities.children.child
+                    url: Entities.children.child
         403:
           description: Forbidden
           content:


### PR DESCRIPTION
#### The problem this PR solves

The `Service Document` endpoint for datasets was missing an example 200 response:
https://docs.getodk.org/central-api-odata-endpoints/#id1

![image](https://github.com/getodk/central-backend/assets/78538841/2fd0bc83-eb0c-4602-9582-ce5a0bde46e0)

#### What was done to fix it

- Previously we had: `content: {}`.
- Updated to include actual content.

#### What has been done to verify that this works as intended?

Loaded the yaml into https://editor.swagger.io/

![image](https://github.com/getodk/central-backend/assets/78538841/60c36259-769d-4218-802b-469119e14e0a)

![image](https://github.com/getodk/central-backend/assets/78538841/5f8e292f-25a7-412d-bc86-57f617f6cd63)

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- I assume this will be copied to getodk/docs, so is user facing.

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

- I think this PR template needs an update to reference `docs/api.yaml` ! 😄 

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced