### PR TITLE
Apply increased json body limit to entity post endpoint

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -10,6 +10,7 @@
 // This file glues together all the middleware and the HTTP REST resources we have
 // defined elsewhere into an actual Express service. The only thing it needs in
 // order to do this is a valid dependency injection context container.
+const { match } = require('path-to-regexp');
 
 module.exports = (container) => {
   const service = require('express')();
@@ -31,7 +32,17 @@ module.exports = (container) => {
   // automatically parse JSON if it is marked as such. otherwise, just pull the
   // plain-text body contents.
   const bodyParser = require('body-parser');
-  service.use(bodyParser.json({ type: 'application/json', limit: '250kb' }));
+
+  // use a default json limit except for URLs that explicitly need a larger limit.
+  const defaultJsonLimit = bodyParser.json({ type: 'application/json', limit: '250kb' });
+  const largeJsonLimit = bodyParser.json({ type: 'application/json', limit: '100mb' });
+  const largeJsonUrlMatch = match('/:apiVersion/projects/:id/datasets/:name/entities');
+
+  service.use((req, res, next) => {
+    if (largeJsonUrlMatch(req.url))
+      return largeJsonLimit(req, res, next);
+    return defaultJsonLimit(req, res, next);
+  });
 
   // apache request commonlog.
   const morgan = require('morgan');

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -39,7 +39,7 @@ module.exports = (container) => {
   const largeJsonUrlMatch = match('/:apiVersion/projects/:id/datasets/:name/entities');
 
   service.use((req, res, next) => {
-    if (largeJsonUrlMatch(req.url))
+    if (req.method === 'POST' && largeJsonUrlMatch(req.path))
       return largeJsonLimit(req, res, next);
     return defaultJsonLimit(req, res, next);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "nodemailer": "~6",
         "odata-v4-parser": "~0.1",
         "openid-client": "^5.4.3",
+        "path-to-regexp": "^6.2.2",
         "pg": "~8",
         "pg-query-stream": "~4",
         "pm2": "^5.2.2",
@@ -972,12 +973,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/@koa/router/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -3890,6 +3885,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -8169,9 +8169,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -12036,12 +12036,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "path-to-regexp": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-          "dev": true
         }
       }
     },
@@ -14263,6 +14257,11 @@
           "requires": {
             "ee-first": "1.1.1"
           }
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
         },
         "safe-buffer": {
           "version": "5.2.1",
@@ -17468,9 +17467,9 @@
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ=="
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
     },
     "pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "nodemailer": "~6",
     "odata-v4-parser": "~0.1",
     "openid-client": "^5.4.3",
+    "path-to-regexp": "^6.2.2",
     "pg": "~8",
     "pg-query-stream": "~4",
     "pm2": "^5.2.2",


### PR DESCRIPTION
Part of https://github.com/getodk/central-backend/issues/1095

Adds custom middleware to use a higher JSON size limit for `bodyParser` middleware for the specific entity bulk creation route.

Uses `path-to-regex` to match the route, because I think that is what express is using internally, so this dependency should technically already be included.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced