### PR TITLE
Update api.md to api.yaml in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
 
 #### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
 
-#### Does this change require updates to the API documentation? If so, please update docs/api.md as part of this PR.
+#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.
 
 #### Before submitting this PR, please make sure you have:
 


### PR DESCRIPTION
api.md was replaced by api.yaml in #955, but the PR template still references api.md. This PR updates the template to reference api.yaml instead.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced