### PR TITLE
Improve entity details audits query

### DIFF
--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -132,21 +132,9 @@ const getBySubmissionId = (submissionId, options) => ({ all }) => _getBySubmissi
   }));
 
 
-const _getByEntityId = (fields, options, entityId) => sql`
+const _getEntityDefsWithSubs = (fields, entityId) => sql`
 SELECT ${fields} FROM entity_defs
-
   LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
-  INNER JOIN audits ON ((audits.details->>'entityDefId')::INTEGER = entity_defs.id OR (audits.details->>'sourceId')::INTEGER = entity_def_sources.id)
-
-  LEFT JOIN actors ON actors.id=audits."actorId"
-
-  LEFT JOIN audits triggering_event ON entity_def_sources."auditId" = triggering_event.id
-  LEFT JOIN actors triggering_event_actor ON triggering_event_actor.id = triggering_event."actorId"
-
-  -- if triggering event has a submissionId defined, look up creation event for that submission
-  -- it has info about the submission and creator we want to show even if the submission is deleted
-  LEFT JOIN audits submission_create_event ON (triggering_event.details->'submissionId')::INTEGER = (submission_create_event.details->'submissionId')::INTEGER AND submission_create_event.action = 'submission.create'
-  LEFT JOIN actors submission_create_event_actor ON submission_create_event_actor.id = submission_create_event."actorId"
 
   -- if source submissionDefId is defined:
   LEFT JOIN (
@@ -169,60 +157,90 @@ SELECT ${fields} FROM entity_defs
   -- if some other kind of target object defined, add subquery here
   -- ...
   WHERE entity_defs."entityId" = ${entityId}
+  ORDER BY entity_defs.id DESC;
+`;
+
+const _getByEntityId = (fields, options, entityId) => sql`
+SELECT ${fields} FROM entity_defs
+
+  LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
+  INNER JOIN audits ON ((audits.details->>'entityDefId')::INTEGER = entity_defs.id OR (audits.details->>'sourceId')::INTEGER = entity_def_sources.id)
+
+  LEFT JOIN actors ON actors.id=audits."actorId"
+
+  LEFT JOIN audits triggering_event ON entity_def_sources."auditId" = triggering_event.id
+  LEFT JOIN actors triggering_event_actor ON triggering_event_actor.id = triggering_event."actorId"
+
+  -- if triggering event has a submissionId defined, look up creation event for that submission
+  -- it has info about the submission and creator we want to show even if the submission is deleted
+  LEFT JOIN audits submission_create_event ON (triggering_event.details->'submissionId')::INTEGER = (submission_create_event.details->'submissionId')::INTEGER AND submission_create_event.action = 'submission.create'
+  LEFT JOIN actors submission_create_event_actor ON submission_create_event_actor.id = submission_create_event."actorId"
+
+  -- if some other kind of target object defined, add subquery here
+  -- ...
+  WHERE entity_defs."entityId" = ${entityId}
   ORDER BY audits."loggedAt" DESC, audits.id DESC
   ${page(options)}`;
 
 const getByEntityId = (entityId, options) => ({ all }) => {
 
   const _unjoiner = unjoiner(
-    Audit, Actor, Entity.Def.Source,
+    Audit, Actor, Entity.Def, Entity.Def.Source,
     Option.of(Audit.alias('triggering_event', 'triggeringEvent')), Option.of(Actor.alias('triggering_event_actor', 'triggeringEventActor')),
     Option.of(Audit.alias('submission_create_event', 'submissionCreateEvent')), Option.of(Actor.alias('submission_create_event_actor', 'submissionCreateEventActor')),
+  );
+
+  const _defUnjoiner = unjoiner(
+    Entity.Def, Entity.Def.Source,
     Option.of(Submission), Option.of(Submission.Def.alias('current_submission_def', 'currentVersion')),
     Option.of(Actor.alias('current_submission_actor', 'currentSubmissionActor')),
     Option.of(Actor.alias('submission_actor', 'submissionActor')),
     Option.of(Form)
   );
 
-  return all(_getByEntityId(_unjoiner.fields, options, entityId))
-    .then(map(_unjoiner))
-    .then(map(audit => {
+  return Promise.all([
+    all(_getByEntityId(_unjoiner.fields, options, entityId)).then(map(_unjoiner)),
+    all(_getEntityDefsWithSubs(_defUnjoiner.fields, entityId)).then(map(_defUnjoiner))
+  ])
+    .then(([audits, defs]) => {
+      const entityDefDict = Object.fromEntries(defs.map(def => [def.id, def]));
 
-      const entitySourceDetails = audit.aux.source.forApi();
+      return audits.map(audit => {
+        const entitySourceDetails = audit.aux.source.forApi();
 
-      const sourceEvent = audit.aux.triggeringEvent
-        .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
-        .map(a => a.forApi());
+        const sourceEvent = audit.aux.triggeringEvent
+          .map(a => a.withAux('actor', audit.aux.triggeringEventActor.orNull()))
+          .map(a => a.forApi());
 
-      // If the entity event is based on a submission, get submission details from the submission create event,
-      // which should always exist, even if the entity has been deleted.
-      const submission = audit.aux.submissionCreateEvent.map((createEvent) => {
-        const baseSubmission = {
-          instanceId: createEvent.details.instanceId,
-          createdAt: createEvent.loggedAt,
-          submitter: audit.aux.submissionCreateEventActor.get().forApi()
-        };
+        // If the entity event is based on a submission, get submission details from the submission create event,
+        // which should always exist, even if the entity has been deleted.
+        const baseSubmission = audit.aux.submissionCreateEvent.map((createEvent) =>
+          ({
+            instanceId: createEvent.details.instanceId,
+            createdAt: createEvent.loggedAt,
+            submitter: audit.aux.submissionCreateEventActor.get().forApi()
+          }))
+          .orElse(undefined);
 
-        // If the submission has not been deleted, return full submission details, not just what
-        // was in the submission create event details.
-        const fullSubmission = audit.aux.submission
-          .map(s => s.withAux('submitter', audit.aux.submissionActor.orNull()))
-          .map(s => s.withAux('currentVersion', audit.aux.currentVersion.map(v => v.withAux('submitter', audit.aux.currentSubmissionActor.orNull()))))
+        // Looking up in a different dict for the full submission details if they exist
+        const subOption = entityDefDict[audit.aux.def.id];
+        const fullSubmission = subOption.aux.submission
+          .map(s => s.withAux('submitter', subOption.aux.submissionActor.orNull()))
+          .map(s => s.withAux('currentVersion', subOption.aux.currentVersion.map(v => v.withAux('submitter', subOption.aux.currentSubmissionActor.orNull()))))
           .map(s => s.forApi())
-          .map(s => mergeLeft(s, { xmlFormId: audit.aux.form.map(f => f.xmlFormId).orNull() }));
-        return mergeLeft(baseSubmission, fullSubmission.orElse(undefined));
-      })
-        .orElse(undefined);
+          .map(s => mergeLeft(s, { xmlFormId: subOption.aux.form.map(f => f.xmlFormId).orNull() }));
 
-      // Note: The source added to each audit event represents the source of the
-      // corresponding entity _version_, rather than the source of the event.
-      const details = mergeLeft(audit.details, sourceEvent
-        .map(event => ({ source: { event, submission } }))
-        .orElse({ source: entitySourceDetails }));
+        const submission = mergeLeft(baseSubmission, fullSubmission.orElse(undefined));
 
+        // Note: The source added to each audit event represents the source of the
+        // corresponding entity _version_, rather than the source of the event.
+        const details = mergeLeft(audit.details, sourceEvent
+          .map(event => ({ source: { event, submission } }))
+          .orElse({ source: entitySourceDetails }));
 
-      return new Audit({ ...audit, details }, { actor: audit.aux.actor });
-    }));
+        return new Audit({ ...audit, details }, { actor: audit.aux.actor });
+      });
+    });
 };
 
 

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -131,7 +131,57 @@ const getBySubmissionId = (submissionId, options) => ({ all }) => _getBySubmissi
     return new Audit({ ...audit, details: { ...audit.details, entity } }, { actor: audit.aux.actor });
   }));
 
+// Get every audit for an entity. Some audits do not directly reference the
+// entity or def, but instead reference a shared source, e.g. `entity.bulk.create` events.
+// Fetching these events is done by looking at every Def of an Entity and the
+// Source of that Def, then getting audits that reference either the Entity Def
+// itself or the Source.
+//
+// This query also joins in other things linked from the Source, including:
+// - The source's triggering event (e.g. an entity update event) and event actor
+// - a submission creation event (and actor) IF a submission was part of the source.
+//   (This submission creation event is not necessarily the same as the triggering event
+//    but it can be.)
+//
+// This second part to get a submission creation event is to get basic information
+// (mainly instanceId) about the source submission, even if it has been deleted.
+//
+// There is a separate query below to assemble full submission details for non-deleted
+// submissions, but it was far too slow to have be part of this query.
+const _getByEntityId = (fields, options, entityId) => sql`
+SELECT ${fields} FROM entity_defs
 
+  LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
+  INNER JOIN audits ON ((audits.details->>'entityDefId')::INTEGER = entity_defs.id OR (audits.details->>'sourceId')::INTEGER = entity_def_sources.id)
+
+  LEFT JOIN actors ON actors.id=audits."actorId"
+
+  LEFT JOIN audits triggering_event ON entity_def_sources."auditId" = triggering_event.id
+  LEFT JOIN actors triggering_event_actor ON triggering_event_actor.id = triggering_event."actorId"
+
+  -- if triggering event has a submissionId defined, look up creation event for that submission
+  -- it has info about the submission and creator we want to show even if the submission is deleted
+  LEFT JOIN audits submission_create_event ON (triggering_event.details->'submissionId')::INTEGER = (submission_create_event.details->'submissionId')::INTEGER AND submission_create_event.action = 'submission.create'
+  LEFT JOIN actors submission_create_event_actor ON submission_create_event_actor.id = submission_create_event."actorId"
+
+  WHERE entity_defs."entityId" = ${entityId}
+  ORDER BY audits."loggedAt" DESC, audits.id DESC
+    ${page(options)}`;
+
+// Get the full and current Submission linked to each Entity Def of a given Entity.
+// If an Entity is created or updated by a Submission, that Entity Def is linked
+// (via Entity Def Source) to the specific Submission Def that modified it.
+// This query gets all relevant info about each Submission Def linked to each Def
+// in an Entity.
+//
+// It can handle a variety of situations including:
+// - The Def did not come from a Submission
+// - The Submission has been purged, possibly by purging the whole Form
+// - The Form has been soft-deleted so the Submission should not be returned
+// - The Submission has been soft-deleted (though this is not possible to do)
+//
+// It will return the CURRENT version of the Dubmission rather than the version
+// used to create the Entity Def (used to display updated Submission instanceName).
 const _getEntityDefsWithSubs = (fields, entityId) => sql`
 SELECT ${fields} FROM entity_defs
   LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
@@ -154,33 +204,9 @@ SELECT ${fields} FROM entity_defs
   LEFT JOIN actors submission_actor ON submission_actor.id = submissions."submitterId"
   LEFT JOIN actors current_submission_actor on current_submission_actor.id=current_submission_def."submitterId"
 
-  -- if some other kind of target object defined, add subquery here
-  -- ...
   WHERE entity_defs."entityId" = ${entityId}
   ORDER BY entity_defs.id DESC;
 `;
-
-const _getByEntityId = (fields, options, entityId) => sql`
-SELECT ${fields} FROM entity_defs
-
-  LEFT JOIN entity_def_sources on entity_def_sources.id = entity_defs."sourceId"
-  INNER JOIN audits ON ((audits.details->>'entityDefId')::INTEGER = entity_defs.id OR (audits.details->>'sourceId')::INTEGER = entity_def_sources.id)
-
-  LEFT JOIN actors ON actors.id=audits."actorId"
-
-  LEFT JOIN audits triggering_event ON entity_def_sources."auditId" = triggering_event.id
-  LEFT JOIN actors triggering_event_actor ON triggering_event_actor.id = triggering_event."actorId"
-
-  -- if triggering event has a submissionId defined, look up creation event for that submission
-  -- it has info about the submission and creator we want to show even if the submission is deleted
-  LEFT JOIN audits submission_create_event ON (triggering_event.details->'submissionId')::INTEGER = (submission_create_event.details->'submissionId')::INTEGER AND submission_create_event.action = 'submission.create'
-  LEFT JOIN actors submission_create_event_actor ON submission_create_event_actor.id = submission_create_event."actorId"
-
-  -- if some other kind of target object defined, add subquery here
-  -- ...
-  WHERE entity_defs."entityId" = ${entityId}
-  ORDER BY audits."loggedAt" DESC, audits.id DESC
-  ${page(options)}`;
 
 const getByEntityId = (entityId, options) => ({ all }) => {
 
@@ -202,8 +228,10 @@ const getByEntityId = (entityId, options) => ({ all }) => {
     all(_getByEntityId(_unjoiner.fields, options, entityId)).then(map(_unjoiner)),
     all(_getEntityDefsWithSubs(_defUnjoiner.fields, entityId)).then(map(_defUnjoiner))
   ])
-    .then(([audits, defs]) => {
-      const entityDefDict = Object.fromEntries(defs.map(def => [def.id, def]));
+    .then(([audits, defsWithSubs]) => {
+      // Build a map of Entity Def Ids to objects that contain full Submission information
+      // linked to that Def (if Submission exists and if Def is even linked to a Submission).
+      const entityDefDict = Object.fromEntries(defsWithSubs.map(def => [def.id, def]));
 
       return audits.map(audit => {
         const entitySourceDetails = audit.aux.source.forApi();
@@ -222,7 +250,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
           }))
           .orElse(undefined);
 
-        // Looking up in a different dict for the full submission details if they exist
+        // Look up the full Submission information and attempt to merge it in if it exists.
         const subOption = entityDefDict[audit.aux.def.id];
         const fullSubmission = subOption.aux.submission
           .map(s => s.withAux('submitter', subOption.aux.submissionActor.orNull()))


### PR DESCRIPTION
Hopefully addresses https://github.com/getodk/central/issues/618

I ended up pulling out the crazy part of this query that gets all the submission details that are vaguely relevant to an entity. It is now in another query that gets run separately and then if there is submission data to use, it is combined in code.

I'm curious to try this on test! I've been `EXPLAIN ANALYZE`-ing the queries. Hopefully an entity with a bulk source loads _super_ fast, single milliseconds.

### Entity 648 - created from a submission
https://test.getodk.cloud/#/projects/496/entity-lists/participants/entities/b5725bd9-fb5f-41e0-ba30-0eb8e6905e07

Original query (master)
* Planning Time: 10.761 ms
* Execution Time: 1357.950 ms
(I've seen it 800ms to >2 seconds)

New queries
Part 1: get all audit details and source events
* Planning Time: 2.093 ms
* Execution Time: 438.128 ms
(Seen between 300ms to 900ms)

Part 2: get full submission details
* Planning Time: 27.339 ms
* Execution Time: 2.709 ms
(this part is much faster w/o being joined with audits)

### Entity 118019 - created from bulk upload
https://test.getodk.cloud/#/projects/364/entity-lists/trees/entities/1d8cc1ba-fce5-44c9-acc2-e1fbafbaf81e

Original query
* Planning Time: 3.402 ms
* Execution Time: 515.838 ms
(I've seen it much slower though, 400-800ms, maybe longer)

New queries
Part 1
* Planning Time: 9.669 ms
* Execution Time: 5.648 ms

Part 2
* Planning Time: 8.170 ms
* Execution Time: 2.586 ms

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced