### PR TITLE
Prevent Forms from introducing dataset name case conflicts

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -324,6 +324,7 @@ const getPublishedBySimilarName = (projectId, name) => ({ maybeOne }) => {
     WHERE LOWER(name) = LOWER(${name})
       AND name != ${name}
       AND "publishedAt" IS NOT NULL
+      AND "projectId" = ${projectId}
     LIMIT 1`)
     .then(map(_unjoiner));
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { extender, insert, QueryOptions, equals, updater } = require('../../util/db');
+const { extender, insert, QueryOptions, equals, unjoiner, updater } = require('../../util/db');
 const { Dataset, Form, Audit } = require('../frames');
 const { validatePropertyName } = require('../../data/dataset');
 const { isEmpty, isNil, either, reduceBy, groupBy, uniqWith, equals: rEquals, map } = require('ramda');
@@ -90,6 +90,14 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ one, Actees, Dat
   // Need to check for existing dataset, and if not found, need to also
   // fetch the project since the dataset will be an actee child of the project.
   const { name } = parsedDataset;
+
+  // Check for a published dataset with a conflicting name (same name, different capitalization).
+  // There can be multiple draft datasets with conflicting names but we won't throw an error
+  // until publishing.
+  const conflictingName = await Datasets.getPublishedBySimilarName(projectId, name);
+  if (conflictingName.isDefined())
+    throw Problem.user.datasetNameConflict({ current: conflictingName.get().name, provided: name });
+
   const existingDataset = await Datasets.get(projectId, name, false);
   const acteeId = existingDataset.isDefined()
     ? existingDataset.get().acteeId
@@ -153,41 +161,63 @@ createPublishedProperty.audit = (property, dataset) => (log) =>
 // `IfExists` part is particularly helpful for `Forms.publish`,
 // with that it doesn't need to ensure the existence of the Dataset
 // and it can call this function blindly
-const publishIfExists = (formDefId, publishedAt) => ({ all }) => all(sql`
-WITH properties_update as (
-  UPDATE ds_properties dp SET "publishedAt" = ${publishedAt}
-  FROM ds_property_fields dpf
-  WHERE dpf."formDefId" = ${formDefId}
-  AND dpf."dsPropertyId" = dp.id
-  AND dp."publishedAt" IS NULL
-  RETURNING dp.*
-), datasets_update as (
-  UPDATE datasets ds SET "publishedAt" = ${publishedAt}
-  FROM dataset_form_defs dfd
+const publishIfExists = (formDefId, publishedAt) => async ({ all, maybeOne }) => {
+
+  // Helper sub-queries
+  const _publishIfExists = () => sql`
+  WITH properties_update as (
+    UPDATE ds_properties dp SET "publishedAt" = ${publishedAt}
+    FROM ds_property_fields dpf
+    WHERE dpf."formDefId" = ${formDefId}
+    AND dpf."dsPropertyId" = dp.id
+    AND dp."publishedAt" IS NULL
+    RETURNING dp.*
+  ), datasets_update as (
+    UPDATE datasets ds SET "publishedAt" = ${publishedAt}
+    FROM dataset_form_defs dfd
+    WHERE dfd."formDefId" = ${formDefId}
+    AND dfd."datasetId" = ds.id
+    AND ds."publishedAt" IS NULL
+    RETURNING *
+  )
+  -- selecting following for publish.audit
+  -- we are returning first row for dataset
+  -- because we want to log it even if no
+  -- property is published.
+  SELECT -1 "propertyId", '' "name", ds.id, ds."acteeId", 'datasetCreated' action
+  FROM datasets_update ds
+  UNION
+  SELECT p.id "propertyId", p.name, ds.id, ds."acteeId", 'propertyAdded' action
+  FROM properties_update p
+  JOIN datasets ds on ds.id = p."datasetId"
+  UNION
+  SELECT p.id "propertyId", p.name, ds.id, ds."acteeId", 'noop' action
+  FROM ds_properties p
+  JOIN datasets ds on ds.id = p."datasetId"
+  JOIN dataset_form_defs dfd on dfd."datasetId" = ds.id
   WHERE dfd."formDefId" = ${formDefId}
-  AND dfd."datasetId" = ds.id
-  AND ds."publishedAt" IS NULL
-  RETURNING *
-)
--- selecting following for publish.audit
--- we are returning first row for dataset
--- because we want to log it even if no
--- property is published.
-SELECT -1 "propertyId", '' "name", ds.id, ds."acteeId", 'datasetCreated' action
-FROM datasets_update ds
-UNION
-SELECT p.id "propertyId", p.name, ds.id, ds."acteeId", 'propertyAdded' action
-FROM properties_update p
-JOIN datasets ds on ds.id = p."datasetId"
-UNION
-SELECT p.id "propertyId", p.name, ds.id, ds."acteeId", 'noop' action
-FROM ds_properties p
-JOIN datasets ds on ds.id = p."datasetId"
-JOIN dataset_form_defs dfd on dfd."datasetId" = ds.id
-WHERE dfd."formDefId" = ${formDefId}
-AND p."publishedAt" IS NOT NULL
-ORDER BY "propertyId"
-`);
+  AND p."publishedAt" IS NOT NULL
+  ORDER BY "propertyId"
+  `;
+
+  const _datasetNameConflict = () => sql`
+    SELECT existing_ds.name as current, ds_to_publish.name as provided FROM dataset_form_defs dfd
+    JOIN datasets ds_to_publish ON dfd."datasetId" = ds_to_publish.id
+    JOIN datasets existing_ds ON LOWER(ds_to_publish.name) = LOWER(existing_ds.name)
+      AND ds_to_publish.id != existing_ds.id
+      AND existing_ds."publishedAt" IS NOT NULL
+      AND ds_to_publish.name != existing_ds.name
+    WHERE dfd."formDefId" = ${formDefId}
+      AND ds_to_publish."publishedAt" IS NULL
+  `;
+
+  const d = await maybeOne(_datasetNameConflict(formDefId));
+  if (d.isDefined()) {
+    const { current, provided } = d.get();
+    throw Problem.user.datasetNameConflict({ current, provided });
+  }
+  return all(_publishIfExists(formDefId, publishedAt));
+};
 
 publishIfExists.audit = (properties) => (log) => {
   const promiseArr = [];
@@ -268,6 +298,17 @@ const getByActeeId = (acteeId, extended = false) => ({ maybeOne }) => {
   return _get(maybeOne, options.withCondition({ acteeId }), true);
 };
 
+// Get any dataset with a similar name (but not exact match)
+// Returns published dataset first.
+const getPublishedBySimilarName = (projectId, name) => ({ maybeOne }) => {
+  const _unjoiner = unjoiner(Dataset);
+  return maybeOne(sql`SELECT ${_unjoiner.fields} FROM datasets
+    WHERE LOWER(name) = LOWER(${name})
+      AND name != ${name}
+      AND "publishedAt" IS NOT NULL
+    LIMIT 1`)
+    .then(map(_unjoiner));
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // DATASET METADATA GETTERS
@@ -514,6 +555,7 @@ module.exports = {
   createPublishedDataset, createPublishedProperty,
   createOrMerge, publishIfExists,
   getList, get, getById, getByActeeId,
+  getPublishedBySimilarName,
   getMetadata, getAllByAuth,
   getProperties, getFieldsByFormDefId,
   getDiff, update, countUnprocessedSubmissions,

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -133,21 +133,21 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ one, Actees, Dat
 // Insert a Dataset when there is no associated form and immediately publish
 const createPublishedDataset = (dataset, project) => async ({ one, Actees, Datasets }) => {
 
+  // Check for a published dataset with a similar name but different capitalization
+  const conflictingName = await Datasets.getPublishedBySimilarName(project.id, dataset.name);
+  if (conflictingName.isDefined())
+    throw Problem.user.datasetNameConflict({ current: conflictingName.get().name, provided: dataset.name });
+
   // Check for existing dataset with the same name
   const existingDataset = await Datasets.get(project.id, dataset.name, false);
   if (existingDataset.isDefined()) {
     const { publishedAt, id: datasetId } = existingDataset.get();
     if (publishedAt)
-      throw Problem.user.uniquenessViolation({ table: 'datasets', fields: [ 'name', 'projectId' ], values: [ dataset.name, project.id ], });
+      throw Problem.user.uniquenessViolation({ table: 'datasets', fields: [ 'name', 'projectId' ], values: [ dataset.name, project.id ] });
 
     // If existing dataset is only a draft, allow it to be published
-    return new Dataset(await one(sql`UPDATE datasets SET "publishedAt" = "createdAt" where id = ${datasetId} RETURNING *`));
+    return new Dataset(await one(sql`UPDATE datasets SET "publishedAt" = clock_timestamp() where id = ${datasetId} RETURNING *`));
   }
-
-  // Check for a published dataset with a similar name but different capitalization
-  const conflictingName = await Datasets.getPublishedBySimilarName(project.id, dataset.name);
-  if (conflictingName.isDefined())
-    throw Problem.user.datasetNameConflict({ current: conflictingName.get().name, provided: dataset.name });
 
   // Final case: publish a completely new dataset
   const actee = await Actees.provision('dataset', project);
@@ -219,22 +219,25 @@ const publishIfExists = (formDefId, publishedAt) => async ({ all, maybeOne }) =>
   `;
 
   const _datasetNameConflict = () => sql`
-    SELECT existing_ds.name as current, ds_to_publish.name as provided FROM dataset_form_defs dfd
+    SELECT existing_ds.name AS current, ds_to_publish.name AS provided
+    FROM dataset_form_defs dfd
+    JOIN form_defs ON form_defs.id = dfd."formDefId"
+    JOIN forms ON forms.id = form_defs."formId"
     JOIN datasets ds_to_publish ON dfd."datasetId" = ds_to_publish.id
     JOIN datasets existing_ds ON LOWER(ds_to_publish.name) = LOWER(existing_ds.name)
       AND ds_to_publish.id != existing_ds.id
       AND existing_ds."publishedAt" IS NOT NULL
-      AND ds_to_publish.name != existing_ds.name
-    WHERE dfd."formDefId" = ${formDefId}
+      AND existing_ds."projectId" = forms."projectId"
+    WHERE form_defs."id" = ${formDefId}
       AND ds_to_publish."publishedAt" IS NULL
   `;
 
-  const d = await maybeOne(_datasetNameConflict(formDefId));
+  const d = await maybeOne(_datasetNameConflict());
   if (d.isDefined()) {
     const { current, provided } = d.get();
     throw Problem.user.datasetNameConflict({ current, provided });
   }
-  return all(_publishIfExists(formDefId, publishedAt));
+  return all(_publishIfExists());
 };
 
 publishIfExists.audit = (properties) => (log) => {

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -131,7 +131,25 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ one, Actees, Dat
 };
 
 // Insert a Dataset when there is no associated form and immediately publish
-const createPublishedDataset = (dataset, project) => async ({ one, Actees }) => {
+const createPublishedDataset = (dataset, project) => async ({ one, Actees, Datasets }) => {
+
+  // Check for existing dataset with the same name
+  const existingDataset = await Datasets.get(project.id, dataset.name, false);
+  if (existingDataset.isDefined()) {
+    const { publishedAt, id: datasetId } = existingDataset.get();
+    if (publishedAt)
+      throw Problem.user.uniquenessViolation({ table: 'datasets', fields: [ 'name', 'projectId' ], values: [ dataset.name, project.id ], });
+
+    // If existing dataset is only a draft, allow it to be published
+    return new Dataset(await one(sql`UPDATE datasets SET "publishedAt" = "createdAt" where id = ${datasetId} RETURNING *`));
+  }
+
+  // Check for a published dataset with a similar name but different capitalization
+  const conflictingName = await Datasets.getPublishedBySimilarName(project.id, dataset.name);
+  if (conflictingName.isDefined())
+    throw Problem.user.datasetNameConflict({ current: conflictingName.get().name, provided: dataset.name });
+
+  // Final case: publish a completely new dataset
   const actee = await Actees.provision('dataset', project);
   const dsWithId = await one(insert(dataset.with({ acteeId: actee.id })));
   return new Dataset(await one(sql`UPDATE datasets SET "publishedAt" = "createdAt" where id = ${dsWithId.id} RETURNING *`));

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -208,7 +208,7 @@ const problems = {
 
     entityVersionConflict: problem(409.15, ({ current, provided }) => `Current version of the Entity is '${current}' and you provided '${provided}'. Please correct the version number or pass '?force=true' in the URL to forcefully update the Entity.`),
 
-    datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization. Please change the capitalization of '${provided}' to match '${current}'.`)
+    datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization.`)
 
   },
   internal: {

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -206,7 +206,10 @@ const problems = {
 
     // 409.14 (entityViolation) was used in the past, but has been deprecated
 
-    entityVersionConflict: problem(409.15, ({ current, provided }) => `Current version of the Entity is '${current}' and you provided '${provided}'. Please correct the version number or pass '?force=true' in the URL to forcefully update the Entity.`)
+    entityVersionConflict: problem(409.15, ({ current, provided }) => `Current version of the Entity is '${current}' and you provided '${provided}'. Please correct the version number or pass '?force=true' in the URL to forcefully update the Entity.`),
+
+    datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization. Please change the capitalization of '${provided}' to match '${current}'.`)
+
   },
   internal: {
     // no detail information, as this is only called when we don't know what happened.


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/627

Prevents Forms and Dataset API from introducing published datasets with conflicting names, specifically the same name with different capitalization. 

* Error on _Form Upload_ if dataset name conflicts with a published dataset
* Error on _Form Publish_ if publishing will introduce a conflict, which can happen if there were multiple draft forms with different name variations, one was published, and then a second is attempted to be published.
* Error on "New Entity List" / API if dataset name conflicts with a published dataset
   * Now allowed to create/publish a dataset that directly collides with an unpublished dataset

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, trying with frontend.

#### Why is this the best possible solution? Were any other approaches considered?

I basically added another database query for a similarly named dataset. In the same area of code, we're also querying for an existing exactly matching dataset so we can reuse its ID and Actee ID for various things. I wasn't comfortable trying to combine these queries at this time, given the complicated logic of draft datasets, similar but not exact matches, multiple similar draft datasets, etc. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

This could potentially be added to the API docs. (https://github.com/getodk/central-backend/issues/1096)

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced