### PR TITLE
remove dev dependency: node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "mocha": "^10.2.0",
         "mocha-junit-reporter": "^2.2.1",
         "nock": "^13.3.1",
-        "node-fetch": "^2.7.0",
         "node-mocks-http": "^1.12.2",
         "nodemon": "~3",
         "nyc": "~15",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "mocha": "^10.2.0",
     "mocha-junit-reporter": "^2.2.1",
     "nock": "^13.3.1",
-    "node-fetch": "^2.7.0",
     "node-mocks-http": "^1.12.2",
     "nodemon": "~3",
     "nyc": "~15",

--- a/test/e2e/soak/index.js
+++ b/test/e2e/soak/index.js
@@ -216,18 +216,12 @@ function apiPostAndDump(prefix, n, path, body, headers) {
 async function fetchToFile(filenamePrefix, n, method, apiPath, body, headers) {
   const res = await apiFetch(method, apiPath, body, headers);
 
-  try {
-    const filePath = `${logPath}/${filenamePrefix}.${n.toString().padStart(9, '0')}.dump`;
+  const filePath = `${logPath}/${filenamePrefix}.${n.toString().padStart(9, '0')}.dump`;
+  const file = fs.createWriteStream(filePath);
 
-    const file = fs.createWriteStream(filePath);
+  await finished(Readable.fromWeb(res.body).pipe(file));
 
-    await finished(Readable.fromWeb(res.body).pipe(file));
-
-    return fs.statSync(filePath).size;
-  } catch(err) {
-    console.log(err);
-    process.exit(99);
-  }
+  return fs.statSync(filePath).size;
 }
 
 async function apiPost(path, body, headers) {

--- a/test/e2e/soak/index.js
+++ b/test/e2e/soak/index.js
@@ -213,17 +213,17 @@ function apiPostAndDump(prefix, n, path, body, headers) {
   return fetchToFile(prefix, n, 'POST', path, body, headers);
 }
 
-async function fetchToFile(filenamePrefix, n, method, path, body, headers) {
-  const res = await apiFetch(method, path, body, headers);
+async function fetchToFile(filenamePrefix, n, method, apiPath, body, headers) {
+  const res = await apiFetch(method, apiPath, body, headers);
 
   try {
-    const path = `${logPath}/${filenamePrefix}.${n.toString().padStart(9, '0')}.dump`;
+    const filePath = `${logPath}/${filenamePrefix}.${n.toString().padStart(9, '0')}.dump`;
 
-    const file = fs.createWriteStream(path);
+    const file = fs.createWriteStream(filePath);
 
     await finished(Readable.fromWeb(res.body).pipe(file));
 
-    return fs.statSync(path).size;
+    return fs.statSync(filePath).size;
   } catch(err) {
     console.log(err);
     process.exit(99);


### PR DESCRIPTION
`fetch()` global has been available since node v18.  It is still officially "experimental" until node v21, but it seems reasonable to use it in development before then.

See: https://nodejs.org/api/globals.html#fetch

This avoids https://github.com/node-fetch/node-fetch/issues/1735, which I've seen locally when working with e2e tests.  However, it does seem like global `fetch` can exhibit a similar but much less frequent issue.