### PR TITLE
Remove function: global.tap()

### DIFF
--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -14,8 +14,6 @@ const { mergeRight } = require('ramda');
 const config = require('config');
 const exit = require('express-graceful-exit');
 
-global.tap = (x) => { console.log(x); return x; }; // eslint-disable-line no-console
-
 ////////////////////////////////////////////////////////////////////////////////
 // CONTAINER SETUP
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -3,10 +3,6 @@ const { DateTime } = require('luxon');
 
 /* eslint-disable space-before-function-paren, func-names */
 
-// debugging things.
-// eslint-disable-next-line no-console
-global.tap = (x) => { console.log(x); return x; };
-
 should.Assertion.add('httpDate', function() {
   this.params = { operator: 'to be an HTTP date string' };
   DateTime.fromHTTP(this.obj).isValid.should.equal(true);


### PR DESCRIPTION
It looks like this was used historically in development.
