### PR TITLE
test/purge: resolve lint exceptions: no-shadow

### DIFF
--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -54,9 +54,8 @@ describe('task: purge deleted forms', () => {
 
   it('should force purge only specific form', testTask(({ Forms }) =>
     Forms.getByProjectAndXmlFormId(1, 'simple')
-      .then((form) => Forms.del(form.get())
-        .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
-        // eslint-disable-next-line no-shadow
+      .then((form) => Forms.del(form.get()))
+      .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat')
         .then((form) => Forms.del(form.get())
           .then(() => purgeForms(true, 1))
           .then((count) => {
@@ -82,9 +81,8 @@ describe('task: purge deleted forms', () => {
 
     it('should purge specific form', testTask(({ Forms }) =>
       Forms.getByProjectAndXmlFormId(1, 'simple')
-        .then((form) => Forms.del(form.get())
-          .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
-          // eslint-disable-next-line no-shadow
+        .then((form) => Forms.del(form.get()))
+        .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat')
           .then((form) => Forms.del(form.get())
             .then(() => purgeForms(true, 1, 1))
             .then((count) => {
@@ -93,9 +91,8 @@ describe('task: purge deleted forms', () => {
 
     it('should not purge specific form if tied to a different project', testTask(({ Forms }) =>
       Forms.getByProjectAndXmlFormId(1, 'simple')
-        .then((form) => Forms.del(form.get())
-          .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
-          // eslint-disable-next-line no-shadow
+        .then((form) => Forms.del(form.get()))
+        .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat')
           .then((form) => Forms.del(form.get())
             .then(() => purgeForms(true, 1, 2))
             .then((count) => {
@@ -104,9 +101,8 @@ describe('task: purge deleted forms', () => {
 
     it('should not purge all forms if no form ID supplied', testTask(({ Forms }) =>
       Forms.getByProjectAndXmlFormId(1, 'simple')
-        .then((form) => Forms.del(form.get())
-          .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
-          // eslint-disable-next-line no-shadow
+        .then((form) => Forms.del(form.get()))
+        .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat')
           .then((form) => Forms.del(form.get())
             .then(() => purgeForms(true, null, 1))
             .then((count) => {
@@ -115,9 +111,8 @@ describe('task: purge deleted forms', () => {
 
     it('should not purge multiple forms if tied to a different project', testTask(({ Forms }) =>
       Forms.getByProjectAndXmlFormId(1, 'simple')
-        .then((form) => Forms.del(form.get())
-          .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat'))
-          // eslint-disable-next-line no-shadow
+        .then((form) => Forms.del(form.get()))
+        .then(() => Forms.getByProjectAndXmlFormId(1, 'withrepeat')
           .then((form) => Forms.del(form.get())
             .then(() => purgeForms(true, null, 2))
             .then((count) => {


### PR DESCRIPTION
The logic as to when indentation should be increased isn't clear to me, but this removes lint exceptions with minimal change to surrounding code.