### PR TITLE
Check for large files in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: |
             set +e
             find . -size +1000000c -not -path './.git/*' | grep .
-            (( $? == 1 ))
+            [[ $? -eq 1 ]]
       - run: make check-file-headers
       - run: npm ci --legacy-peer-deps
       - run: node lib/bin/create-docker-databases.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Check for large files
           command: |
             set +e
-            find . -size +1Mc -not -path './.git/*' | grep .
+            find . -size +1000000c -not -path './.git/*' | grep .
             (( $? == 1 ))
       - run: make check-file-headers
       - run: npm ci --legacy-peer-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,12 @@ jobs:
 
     steps:
       - checkout
+      - run:
+          name: Check for large files
+          command: |
+            set +e
+            find . -size +1Mc -not -path './.git/*' | grep .
+            (( $? == 1 ))
       - run: make check-file-headers
       - run: npm ci --legacy-peer-deps
       - run: node lib/bin/create-docker-databases.js


### PR DESCRIPTION
This PR updates CircleCI to check for large files. Any large files will be listed.

#### What has been done to verify that this works as intended?

CircleCI passes currently, but if I reduce the limit from 1 MB to 100 kB, then it fails. See https://app.circleci.com/pipelines/github/getodk/central-backend/2186/workflows/e2e9689b-4e3a-4c28-80bd-392837ccb9d3/jobs/3046 for an example of that.

#### Why is this the best possible solution? Were any other approaches considered?

I'll add a few line comments.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced