### PR TITLE
Remove use of conditional publish from Forms.createNew

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -43,7 +43,7 @@ const _insertDatasetDef = (dataset, acteeId, actions) => sql`
 
 const _insertProperties = (fields) => sql`
 ,fields("propertyName", "formDefId", "schemaId", path) AS (VALUES      
-  ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.aux.formDefId, p.schemaId, p.path], sql`,`)} )`), sql`,`)}
+  ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.aux.formDefId, p.aux.schemaId, p.path], sql`,`)} )`), sql`,`)}
 ),
 insert_properties AS (
     INSERT INTO ds_properties (id, name, "datasetId")
@@ -82,6 +82,7 @@ SELECT "action", "id" FROM ds
 // * information about the dataset parsed from the form XML
 // * form (a Form frame or object containing projectId, formDefId, and schemaId)
 // * array of field objects and property names that were parsed from the form xml
+//   (form fields do not need any extra IDs of the form, form def, or schema.)
 const createOrMerge = (parsedDataset, form, fields) => async ({ one, Actees, Datasets, Projects }) => {
   const { projectId } = form;
   const { id: formDefId, schemaId } = form.def;

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -87,7 +87,7 @@ const pushFormToEnketo = ({ projectId, xmlFormId, acteeId }, bound = undefined) 
 ////////////////////////////////////////////////////////////////////////////////
 // COMMON FORM UTILITY FUNCTIONS
 
-const _parseFormXml = (partial) => () => Promise.all([
+const _parseFormXml = (partial) => Promise.all([
   getFormFields(partial.xml),
   (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml)) // Don't parse dataset schema if Form has encryption key
 ]);
@@ -127,7 +127,7 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form XML for fields and entity/dataset definitions
-  const [fields, parsedDataset] = await Forms._parseFormXml(partial);
+  const [fields, parsedDataset] = await _parseFormXml(partial);
 
   // Check that meta field (group containing instanceId and name) exists
   await Forms.checkMeta(fields);
@@ -213,7 +213,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form fields and dataset/entity definition from form XML
-  const [fields, parsedDataset] = await Forms._parseFormXml(partial);
+  const [fields, parsedDataset] = await _parseFormXml(partial);
 
   // Compute the intermediate schema ID
   let schemaId;
@@ -789,7 +789,7 @@ const _newSchema = () => ({ one }) =>
 
 module.exports = {
   fromXls, pushDraftToEnketo, pushFormToEnketo,
-  _parseFormXml, _insertFormFields,
+  _insertFormFields,
   _createNew, createNew, _createNewDef, createVersion,
   publish, clearDraft,
   _update, update, _updateDef, del, restore, purge,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -299,11 +299,11 @@ createVersion.audit.withResult = true;
 
 // TODO: we need to make more explicit what .def actually represents throughout.
 // for now, enforce an extra check here just in case.
-const publish = (form, sameAsCreate = false) => async ({ Forms, Datasets, FormAttachments }) => {
+const publish = (form, concurrentWithCreate = false) => async ({ Forms, Datasets, FormAttachments }) => {
   if (form.draftDefId !== form.def.id) throw Problem.internal.unknown();
 
-  // dont use publish sameAsCreate on already published forms
-  if (sameAsCreate && form.publishedAt != null) throw Problem.internal.unknown({ error: 'Attempting to immediately publish a form' });
+  // dont use publish concurrentWithCreate on already published forms
+  if (concurrentWithCreate && form.publishedAt != null) throw Problem.internal.unknown({ error: 'Attempting to immediately publish a form' });
 
   // Try to push the form to Enketo if it hasn't been pushed already. If doing
   // so fails or is too slow, then the worker will try again later.
@@ -311,9 +311,9 @@ const publish = (form, sameAsCreate = false) => async ({ Forms, Datasets, FormAt
     ? await Forms.pushFormToEnketo(form, 0.5)
     : {};
 
-  const publishedAt = sameAsCreate ? form.createdAt.toISOString() : (new Date()).toISOString();
+  const publishedAt = concurrentWithCreate ? form.createdAt.toISOString() : (new Date()).toISOString();
   const [f, fd] = await Promise.all([
-    Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null, ...(sameAsCreate ? { updatedAt: null } : {}), ...enketoIds }),
+    Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null, ...(concurrentWithCreate ? { updatedAt: null } : {}), ...enketoIds }),
     Forms._updateDef(form.def, { draftToken: null, enketoId: null, publishedAt }),
   ])
     .catch(Problem.translate(

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -18,7 +18,7 @@ const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, timebound } = require('../../util/promise');
 const { splitStream } = require('../../util/stream');
-const { construct, noop, pickAll } = require('../../util/util');
+const { construct, pickAll } = require('../../util/util');
 const Option = require('../../util/option');
 const Problem = require('../../util/problem');
 
@@ -84,6 +84,21 @@ const pushFormToEnketo = ({ projectId, xmlFormId, acteeId }, bound = undefined) 
   return timeboundEnketo(enketo.create(path, xmlFormId, token), bound);
 };
 
+////////////////////////////////////////////////////////////////////////////////
+// COMMON FORM UTILITY FUNCTIONS
+
+const _parseFormXml = (partial) => () => Promise.all([
+  getFormFields(partial.xml),
+  (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml)) // Don't parse dataset schema if Form has encryption key
+]);
+
+const _insertFormFields = (fields, formId, schemaId) => async ({ run }) => {
+  // Combine form fields as parsed from the form XML with the top level formId
+  // and the schemaId (rather than formDefId)
+  const ids = { formId, schemaId };
+  const fieldsForInsert = fields.map((field) => new Form.Field(Object.assign(field, ids)));
+  await run(insertMany(fieldsForInsert));
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING NEW FORMS
@@ -107,16 +122,12 @@ select id from form`)
     .then(() => Forms.getByProjectAndXmlFormId(project.id, form.xmlFormId, false, Form.DraftVersion))
     .then((option) => option.get());
 
-const createNew = (partial, project) => async ({ run, Actees, Datasets, FormAttachments, Forms, Keys }) => {
+const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachments, Forms, Keys }) => {
   // Check encryption keys before proceeding
-  const defData = {};
-  defData.keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
+  const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form XML for fields and entity/dataset definitions
-  const [fields, parsedDataset] = await Promise.all([
-    getFormFields(partial.xml),
-    (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml)) // Don't parse dataset schema if Form has encryption key
-  ]);
+  const [fields, parsedDataset] = await Forms._parseFormXml(partial);
 
   // Check that meta field (group containing instanceId and name) exists
   await Forms.checkMeta(fields);
@@ -125,38 +136,34 @@ const createNew = (partial, project) => async ({ run, Actees, Datasets, FormAtta
   await Forms.checkDeletedForms(partial.xmlFormId, project.id);
   await Forms.rejectIfWarnings();
 
-  const formData = {};
-  formData.acteeId = (await Actees.provision('form', project)).id;
+  // Provision Actee for form
+  const acteeId = (await Actees.provision('form', project)).id;
 
   // We will try to push to Enketo. If doing so fails or is too slow, then the
   // worker will try again later.
-  defData.draftToken = generateToken();
-  defData.enketoId = await Forms.pushDraftToEnketo(
-    { projectId: project.id, xmlFormId: partial.xmlFormId, draftToken: defData.draftToken },
+  const draftToken = generateToken();
+  const enketoId = await Forms.pushDraftToEnketo(
+    { projectId: project.id, xmlFormId: partial.xmlFormId, draftToken },
     0.5
   );
 
   // Save draft form
   const savedForm = await Forms._createNew(
-    partial.with(formData),
-    partial.def.with(defData),
+    partial.with({ acteeId }),
+    partial.def.with({ keyId, draftToken, enketoId }),
     project
   );
 
-  // Prepare the form fields
-  const ids = { formId: savedForm.id, schemaId: savedForm.def.schemaId };
+  // Insert form fields and attachments for new form def
+  await Forms._insertFormFields(fields, savedForm.id, savedForm.def.schemaId);
+  await FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets);
 
-  // Insert fields and setup form attachment slots
-  await Promise.all([
-    run(insertMany(fields.map((field) => new Form.Field(Object.assign(field, ids))))),
-    FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets)
-  ]);
-
-  // Update datasets and properties if defined
+  // Update datasets and properties, if defined
   if (parsedDataset.isDefined()) {
     await Datasets.createOrMerge(parsedDataset.get(), savedForm, fields);
   }
 
+  // Return new draft Form frame with Form.Def
   return savedForm;
 };
 
@@ -215,10 +222,10 @@ const _createNewDef = (partial, form, publish, data) => async ({ one, Forms }) =
 // ===========
 // partial:     Partial form definition of the new version
 // form:        Form frame of existing form
-// publish:     set true if you want new version to be published
+// publish:     set true if you want new version to be published (only used by setManagedKey, everywhere else calls publish() explicitly)
 // duplicating: set true if copying form definition from previously uploaded definition, in that cases we don't check for structural change
 //              as user has already been warned otherwise set false
-const createVersion = (partial, form, publish, duplicating = false) => async ({ run, Datasets, FormAttachments, Forms, Keys }) => {
+const createVersion = (partial, form, publish, duplicating = false) => async ({ Datasets, FormAttachments, Forms, Keys }) => {
   // Check xmlFormId match
   if (form.xmlFormId !== partial.xmlFormId)
     return reject(Problem.user.unexpectedValue({ field: 'xmlFormId', value: partial.xmlFormId, reason: 'does not match the form you are updating' }));
@@ -227,10 +234,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form fields and dataset/entity definition from form XML
-  const [fields, parsedDataset] = await Promise.all([
-    getFormFields(partial.xml),
-    (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml))
-  ]);
+  const [fields, parsedDataset] = await Forms._parseFormXml(partial);
 
   // Compute the intermediate schema ID
   let schemaId;
@@ -264,32 +268,28 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
     }
   }
 
+  // Save draft def
   const savedDef = await Forms._createNewDef(partial, form, publish, { schemaId, keyId });
 
-  // Update corresponding form
+  // Prepare the form fields
+  if (!match)
+    await Forms._insertFormFields(fields, form.id, schemaId);
+
+  // Insert attachments
+  await FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish);
+
+  // Update datasets and properties, if defined
+  if (parsedDataset.isDefined()) {
+    await Datasets.createOrMerge(parsedDataset.get(), new Form(form, { def: savedDef }), fields);
+    // Note: Dataset publishing will happen only through an explicit Form publish() call.
+  }
+
+  // Note: It is rare that a form will be published here (and not in a separate step).
+  // publish=true is only used when encrypting a published form
   await ((publish === true)
     ? Forms._update(form, { currentDefId: savedDef.id })
     : Forms._update(form, { draftDefId: savedDef.id }));
 
-  // Prepare the form fields
-  const ids = { formId: form.id, schemaId };
-  const fieldsForInsert = new Array(fields.length);
-  for (let i = 0; i < fields.length; i += 1)
-    fieldsForInsert[i] = new Form.Field(Object.assign({}, fields[i], ids));
-
-  // Insert fields and setup form attachments
-  await Promise.all([
-    (!match) ? run(insertMany(fieldsForInsert)) : noop,
-    FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish)
-  ]);
-
-  // Update datasets and properties if defined
-  if (parsedDataset.isDefined()) {
-    await Datasets.createOrMerge(parsedDataset.get(), new Form(form, { def: savedDef }), fieldsForInsert);
-    if (publish) {
-      await Datasets.publishIfExists(savedDef.id, savedDef.publishedAt.toISOString());
-    }
-  }
   return savedDef;
 };
 
@@ -792,7 +792,9 @@ const _newSchema = () => ({ one }) =>
     .then((s) => s.id);
 
 module.exports = {
-  fromXls, pushDraftToEnketo, pushFormToEnketo, _createNew, createNew, _createNewDef, createVersion,
+  fromXls, pushDraftToEnketo, pushFormToEnketo,
+  _parseFormXml, _insertFormFields,
+  _createNew, createNew, _createNewDef, createVersion,
   publish, clearDraft,
   _update, update, _updateDef, del, restore, purge,
   clearUnneededDrafts,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -18,7 +18,7 @@ const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, equals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, timebound } = require('../../util/promise');
 const { splitStream } = require('../../util/stream');
-const { construct, pickAll } = require('../../util/util');
+const { construct } = require('../../util/util');
 const Option = require('../../util/option');
 const Problem = require('../../util/problem');
 
@@ -180,33 +180,14 @@ createNew.audit.withResult = true;
 // Inserts a new form def into the database for createVersion() below, setting
 // fields on the def according to whether the def will be the current def or the
 // draft def.
-const _createNewDef = (partial, form, publish, data) => async ({ one, Forms }) => {
-  const insertWith = (moreData) => one(insert(partial.def.with({
+const _createNewDef = (partial, form, publish, data) => ({ one }) =>
+  one(insert(partial.def.with({
     formId: form.id,
     xlsBlobId: partial.xls.xlsBlobId,
     xml: partial.xml,
     ...data,
-    ...moreData
+    ...((publish === true) ? { publishedAt: new Date() } : {})
   })));
-
-  if (publish === true) return insertWith({ publishedAt: new Date() });
-
-  // Check whether there is an existing draft that we have access to. If not,
-  // generate a draft token and enketoId.
-  if (form.def.id == null || form.def.id !== form.draftDefId) {
-    const draftToken = generateToken();
-    // Try to push the draft to Enketo. If doing so fails or is too slow, then
-    // the worker will try again later.
-    const enketoId = await Forms.pushDraftToEnketo(
-      { projectId: form.projectId, xmlFormId: form.xmlFormId, draftToken },
-      0.5
-    );
-    return insertWith({ draftToken, enketoId });
-  }
-
-  // Copy forward fields from the existing draft.
-  return insertWith(pickAll(['draftToken', 'enketoId'], form.def));
-};
 
 // creates a new version (formDef) of an existing form.
 //
@@ -268,8 +249,21 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
     }
   }
 
+  // If not publishing, check whether there is an existing draft that we have access to.
+  // If not, generate a draft token and enketoId.
+  let { draftToken, enketoId } = form.def;
+  if (!publish && (form.def.id == null || form.def.id !== form.draftDefId)) {
+    draftToken = generateToken();
+    enketoId = await Forms.pushDraftToEnketo(
+      { projectId: form.projectId, xmlFormId: form.xmlFormId, draftToken },
+      0.5
+    );
+  }
+  // Note: If publish=true, we are in the enabling encryption special case, and we
+  // will just copy over whatever enketo ids do or don't exist already.
+
   // Save draft def
-  const savedDef = await Forms._createNewDef(partial, form, publish, { schemaId, keyId });
+  const savedDef = await Forms._createNewDef(partial, form, publish, { draftToken, enketoId, schemaId, keyId });
 
   // Prepare the form fields
   if (!match)
@@ -281,7 +275,8 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   // Update datasets and properties, if defined
   if (parsedDataset.isDefined()) {
     await Datasets.createOrMerge(parsedDataset.get(), new Form(form, { def: savedDef }), fields);
-    // Note: Dataset publishing will happen only through an explicit Form publish() call.
+    // Note: if publish=true, we are in the enabling encryption special case and won't
+    // do dataset operations. Dataset publishing will happen only through Forms.publish().
   }
 
   // Note: It is rare that a form will be published here (and not in a separate step).

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -96,7 +96,7 @@ const _insertFormFields = (fields, formId, schemaId) => async ({ run }) => {
   // Combine form fields as parsed from the form XML with the top level formId
   // and the schemaId (rather than formDefId)
   const ids = { formId, schemaId };
-  const fieldsForInsert = fields.map((field) => new Form.Field(Object.assign(field, ids)));
+  const fieldsForInsert = fields.map((field) => new Form.Field(Object.assign({}, { ...field, ...ids })));
   await run(insertMany(fieldsForInsert));
 };
 
@@ -168,10 +168,8 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
 };
 
 // (if we are asked to publish right away, log that too:)
-createNew.audit = (form, partial, _, publish) => (log) =>
-  log('form.create', form).then(() => ((publish === true)
-    ? log('form.update.publish', form, { newDefId: form.currentDefId })
-    : null));
+createNew.audit = (form) => (log) =>
+  log('form.create', form);
 createNew.audit.withResult = true;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -334,8 +334,11 @@ const publish = (form, concurrentWithCreate = false) => async ({ Forms, Datasets
 
   return new Form(f, { def: new Form.Def(fd) });
 };
-publish.audit = (form) => (log) => log('form.update.publish', form,
+
+// We don't need the new Form but we do need to wait for the result before logging.
+publish.audit = (_, form) => (log) => log('form.update.publish', form,
   { oldDefId: form.currentDefId, newDefId: form.draftDefId });
+publish.audit.withResult = true;
 
 const clearDraft = (form) => ({ Forms }) => Forms._update(form, { draftDefId: null });
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -88,24 +88,23 @@ const pushFormToEnketo = ({ projectId, xmlFormId, acteeId }, bound = undefined) 
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING NEW FORMS
 
-const _createNew = (form, def, project, publish) => ({ oneFirst, Forms }) =>
+const _createNew = (form, def, project) => ({ oneFirst, Forms }) =>
   oneFirst(sql`
 with sch as
   (insert into form_schemas (id)
     values (default)
     returning *),
 def as
-  (insert into form_defs ("formId", "schemaId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "enketoId", "createdAt", "publishedAt")
-  select nextval(pg_get_serial_sequence('forms', 'id')), sch.id, ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${def.draftToken || null}, ${def.enketoId || null}, clock_timestamp(), ${(publish === true) ? sql`clock_timestamp()` : null}
+  (insert into form_defs ("formId", "schemaId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "enketoId", "createdAt")
+  select nextval(pg_get_serial_sequence('forms', 'id')), sch.id, ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${def.draftToken || null}, ${def.enketoId || null}, clock_timestamp()
     from sch
   returning *),
 form as
-  (insert into forms (id, "xmlFormId", state, "projectId", ${sql.identifier([ (publish === true) ? 'currentDefId' : 'draftDefId' ])}, "acteeId", "enketoId", "enketoOnceId", "createdAt")
+  (insert into forms (id, "xmlFormId", state, "projectId", "draftDefId", "acteeId", "enketoId", "enketoOnceId", "createdAt")
   select def."formId", ${form.xmlFormId}, ${form.state || 'open'}, ${project.id}, def.id, ${form.acteeId}, ${form.enketoId || null}, ${form.enketoOnceId || null}, def."createdAt" from def
   returning forms.*)
 select id from form`)
-    .then(() => Forms.getByProjectAndXmlFormId(project.id, form.xmlFormId, false,
-      (publish === true) ? undefined : Form.DraftVersion))
+    .then(() => Forms.getByProjectAndXmlFormId(project.id, form.xmlFormId, false, Form.DraftVersion))
     .then((option) => option.get());
 
 const createNew = (partial, project) => async ({ run, Actees, Datasets, FormAttachments, Forms, Keys }) => {
@@ -141,8 +140,7 @@ const createNew = (partial, project) => async ({ run, Actees, Datasets, FormAtta
   const savedForm = await Forms._createNew(
     partial.with(formData),
     partial.def.with(defData),
-    project,
-    false // never create with publish=true flag (to be removed soon)
+    project
   );
 
   // Prepare the form fields

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -108,7 +108,7 @@ select id from form`)
       (publish === true) ? undefined : Form.DraftVersion))
     .then((option) => option.get());
 
-const createNew = (partial, project, publish = false) => async ({ run, Actees, Datasets, FormAttachments, Forms, Keys }) => {
+const createNew = (partial, project) => async ({ run, Actees, Datasets, FormAttachments, Forms, Keys }) => {
   // Check encryption keys before proceeding
   const defData = {};
   defData.keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
@@ -131,26 +131,18 @@ const createNew = (partial, project, publish = false) => async ({ run, Actees, D
 
   // We will try to push to Enketo. If doing so fails or is too slow, then the
   // worker will try again later.
-  if (publish !== true) {
-    defData.draftToken = generateToken();
-    defData.enketoId = await Forms.pushDraftToEnketo(
-      { projectId: project.id, xmlFormId: partial.xmlFormId, draftToken: defData.draftToken },
-      0.5
-    );
-  } else {
-    const enketoIds = await Forms.pushFormToEnketo(
-      { projectId: project.id, xmlFormId: partial.xmlFormId, acteeId: formData.acteeId },
-      0.5
-    );
-    Object.assign(formData, enketoIds);
-  }
+  defData.draftToken = generateToken();
+  defData.enketoId = await Forms.pushDraftToEnketo(
+    { projectId: project.id, xmlFormId: partial.xmlFormId, draftToken: defData.draftToken },
+    0.5
+  );
 
-  // Save form
+  // Save draft form
   const savedForm = await Forms._createNew(
     partial.with(formData),
     partial.def.with(defData),
     project,
-    publish
+    false // never create with publish=true flag (to be removed soon)
   );
 
   // Prepare the form fields
@@ -165,13 +157,8 @@ const createNew = (partial, project, publish = false) => async ({ run, Actees, D
   // Update datasets and properties if defined
   if (parsedDataset.isDefined()) {
     await Datasets.createOrMerge(parsedDataset.get(), savedForm, fields);
-
-    if (publish) {
-      await Datasets.publishIfExists(savedForm.def.id, savedForm.def.publishedAt.toISOString());
-    }
   }
 
-  // Return the final saved form
   return savedForm;
 };
 
@@ -319,8 +306,11 @@ createVersion.audit.withResult = true;
 
 // TODO: we need to make more explicit what .def actually represents throughout.
 // for now, enforce an extra check here just in case.
-const publish = (form) => async ({ Forms, Datasets, FormAttachments }) => {
+const publish = (form, sameAsCreate = false) => async ({ Forms, Datasets, FormAttachments }) => {
   if (form.draftDefId !== form.def.id) throw Problem.internal.unknown();
+
+  // dont use publish sameAsCreate on already published forms
+  if (sameAsCreate && form.publishedAt != null) throw Problem.internal.unknown({ error: 'Attempting to immediately publish a form' });
 
   // Try to push the form to Enketo if it hasn't been pushed already. If doing
   // so fails or is too slow, then the worker will try again later.
@@ -328,9 +318,9 @@ const publish = (form) => async ({ Forms, Datasets, FormAttachments }) => {
     ? await Forms.pushFormToEnketo(form, 0.5)
     : {};
 
-  const publishedAt = (new Date()).toISOString();
-  await Promise.all([
-    Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null, ...enketoIds }),
+  const publishedAt = sameAsCreate ? form.createdAt.toISOString() : (new Date()).toISOString();
+  const [f, fd] = await Promise.all([
+    Forms._update(form, { currentDefId: form.draftDefId, draftDefId: null, ...(sameAsCreate ? { updatedAt: null } : {}), ...enketoIds }),
     Forms._updateDef(form.def, { draftToken: null, enketoId: null, publishedAt }),
   ])
     .catch(Problem.translate(
@@ -350,6 +340,8 @@ const publish = (form) => async ({ Forms, Datasets, FormAttachments }) => {
       await FormAttachments.update(form, attachment.get(), null, dataset.id);
     }
   }
+
+  return new Form(f, { def: new Form.Def(fd) });
 };
 publish.audit = (form) => (log) => log('form.update.publish', form,
   { oldDefId: form.currentDefId, newDefId: form.draftDefId });

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -113,7 +113,10 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('form.create', project))
       .then((project) => getPartial(Forms, request, project, Keys)
-        .then((partial) => Forms.createNew(partial, project, isTrue(query.publish))))));
+        .then((partial) => Forms.createNew(partial, project))
+        .then((newForm) => (isTrue(query.publish)
+          ? Forms.publish(newForm, true)
+          : newForm)))));
 
   // can POST empty body to copy the current def to draft.
   service.post('/projects/:projectId/forms/:id/draft', endpoint(({ Forms, Keys, Projects, Submissions }, { params, auth }, request) =>

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -184,6 +184,7 @@ const insertMany = (objs) => {
 };
 
 // generic update utility
+// will set updatedAt if it exists, as long as it is not overwritten in the data
 const updater = (obj, data, whereKey = 'id') => {
   const keys = Object.keys(data);
   if (keys.length === 0) return sql`select true`;
@@ -191,7 +192,7 @@ const updater = (obj, data, whereKey = 'id') => {
   return sql`
 update ${raw(obj.constructor.table)}
 set ${sql.join(keys.map((k) => sql`${sql.identifier([ k ])}=${assigner(k)}`), sql`,`)}
-${obj.constructor.hasUpdatedAt ? sql`,"updatedAt"=clock_timestamp()` : nothing}
+${(obj.constructor.hasUpdatedAt && !keys.includes('updatedAt')) ? sql`,"updatedAt"=clock_timestamp()` : nothing}
 where ${sql.identifier([ whereKey ])}=${obj[whereKey]}
 returning *`;
 };

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -190,7 +190,7 @@ const problems = {
 
     // special version of uniquenessViolation to be more informative about the publish-version
     // conflict case.
-    versionUniquenessViolation: problem(409.6, ({ xmlFormId, version }) => `You tried to publish the form '${xmlFormId}' with version '${version}', but a published form has already existed in this project with those identifiers. Please choose a new name and try again. You can re-request with ?version=xyz to have the version changed in-place for you.`),
+    versionUniquenessViolation: problem(409.6, ({ xmlFormId, version }) => `You tried to publish the form '${xmlFormId}' with version '${version}', but a published form has already existed in this project with those identifiers.`),
 
     // tried to reuse an instanceId
     instanceIdConflict: problem(409.8, () => 'You tried to update a submission, but the instanceID you provided already exists on this server. Please try again with a unique instanceID.'),

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -134,7 +134,7 @@ describe('/audits', () => {
               audits[1].action.should.equal('form.update.publish');
               audits[1].acteeId.should.equal(form.acteeId);
               audits[1].actee.should.eql(plain(form.forApi()));
-              audits[1].details.should.eql({ newDefId: form.currentDefId });
+              audits[1].details.should.eql({ newDefId: form.currentDefId, oldDefId: null });
               audits[1].loggedAt.should.be.a.recentIsoDate();
 
               audits[2].actorId.should.equal(alice.actor.id);
@@ -636,9 +636,9 @@ describe('/audits', () => {
         .then(({ body }) => {
           body.length.should.equal(4);
           body.map(a => a.action).should.eql([
+            'dataset.create',
             'form.update.publish',
             'form.create',
-            'dataset.create',
             'user.session.create'
           ]);
         });

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -636,8 +636,8 @@ describe('/audits', () => {
         .then(({ body }) => {
           body.length.should.equal(4);
           body.map(a => a.action).should.eql([
-            'dataset.create',
             'form.update.publish',
+            'dataset.create',
             'form.create',
             'user.session.create'
           ]);

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -2214,10 +2214,7 @@ describe('datasets and entities', () => {
           </h:head>
         </h:html>`;
 
-        it('should NOT autolink on upload new form and simultaneously publish', testService(async (service) => {
-          // this path of directly publishing a form on upload isn't possible in central
-          // so it's not going to be supported. if it were, logic would go around line #170 in
-          // lib/model/query/forms.js in Forms.createNew after the dataset is published.
+        it('should autolink on upload new form and simultaneously publish', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await asAlice.post('/v1/projects/1/forms?publish=true')
@@ -2228,7 +2225,7 @@ describe('datasets and entities', () => {
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
               body[0].name.should.equal('people.csv');
-              body[0].datasetExists.should.be.false();
+              body[0].datasetExists.should.be.true();
             });
         }));
 

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -139,11 +139,9 @@ describe('api: /projects/:id/forms (drafts)', () => {
         global.enketo.state = 'error';
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         global.enketo.callCount.should.equal(1);
-        // Reset enketo mock (will also reset callCount)
-        global.enketo.reset();
         global.enketo.enketoId = '::ijklmnop';
         await exhaust(container);
-        global.enketo.callCount.should.equal(1);
+        global.enketo.callCount.should.equal(2);
         global.enketo.receivedUrl.startsWith(container.env.domain).should.be.true();
         const match = global.enketo.receivedUrl.match(/\/v1\/test\/([a-z0-9$!]{64})\/projects\/1\/forms\/simple\/draft$/i);
         should.exist(match);
@@ -1159,13 +1157,10 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(draft.enketoId);
         should.not.exist(draft.enketoOnceId);
 
-        // Reset enketo mock (including callCount)
-        global.enketo.reset();
-
         // Publish.
         await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
           .expect(200);
-        global.enketo.callCount.should.equal(1);
+        global.enketo.callCount.should.equal(2);
         global.enketo.receivedUrl.should.equal(`${env.domain}/v1/projects/1`);
         const { body: form } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);
@@ -1219,14 +1214,12 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(v1.enketoId);
         should.not.exist(v1.enketoOnceId);
 
-        // Reset enketo mock (including callCount)
-        global.enketo.reset();
         // Republish
         await asAlice.post('/v1/projects/1/forms/simple2/draft').expect(200);
-        global.enketo.callCount.should.equal(1);
+        global.enketo.callCount.should.equal(3);
         await asAlice.post('/v1/projects/1/forms/simple2/draft/publish?version=new')
           .expect(200);
-        global.enketo.callCount.should.equal(2);
+        global.enketo.callCount.should.equal(4);
         global.enketo.receivedUrl.should.equal(`${env.domain}/v1/projects/1`);
         const { body: v2 } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);
@@ -1274,12 +1267,9 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(beforeWorker.enketoOnceId);
         global.enketo.callCount.should.equal(2);
 
-        // Reset enketo mock (including callCount)
-        global.enketo.reset();
-
         // Second request, from the worker
         await exhaust(container);
-        global.enketo.callCount.should.equal(1);
+        global.enketo.callCount.should.equal(3);
         global.enketo.receivedUrl.should.equal(`${container.env.domain}/v1/projects/1`);
         const { body: afterWorker } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -137,11 +137,11 @@ describe('api: /projects/:id/forms (drafts)', () => {
         global.enketo.state = 'error';
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         global.enketo.callCount.should.equal(1);
-        // Reset enketo error
-        global.enketo.state = undefined;
+        // Reset enketo mock (will also reset callCount)
+        global.enketo.reset();
         global.enketo.enketoId = '::ijklmnop';
         await exhaust(container);
-        global.enketo.callCount.should.equal(2);
+        global.enketo.callCount.should.equal(1);
         global.enketo.receivedUrl.startsWith(container.env.domain).should.be.true();
         const match = global.enketo.receivedUrl.match(/\/v1\/test\/([a-z0-9$!]{64})\/projects\/1\/forms\/simple\/draft$/i);
         should.exist(match);
@@ -1157,11 +1157,13 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(draft.enketoId);
         should.not.exist(draft.enketoOnceId);
 
+        // Reset enketo mock (including callCount)
+        global.enketo.reset();
+
         // Publish.
-        global.enketo.state = undefined;
         await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
           .expect(200);
-        global.enketo.callCount.should.equal(2);
+        global.enketo.callCount.should.equal(1);
         global.enketo.receivedUrl.should.equal(`${env.domain}/v1/projects/1`);
         const { body: form } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);
@@ -1215,13 +1217,14 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(v1.enketoId);
         should.not.exist(v1.enketoOnceId);
 
+        // Reset enketo mock (including callCount)
+        global.enketo.reset();
         // Republish
-        global.enketo.state = undefined;
         await asAlice.post('/v1/projects/1/forms/simple2/draft').expect(200);
-        global.enketo.callCount.should.equal(3);
+        global.enketo.callCount.should.equal(1);
         await asAlice.post('/v1/projects/1/forms/simple2/draft/publish?version=new')
           .expect(200);
-        global.enketo.callCount.should.equal(4);
+        global.enketo.callCount.should.equal(2);
         global.enketo.receivedUrl.should.equal(`${env.domain}/v1/projects/1`);
         const { body: v2 } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);
@@ -1267,12 +1270,14 @@ describe('api: /projects/:id/forms (drafts)', () => {
           .expect(200);
         should.not.exist(beforeWorker.enketoId);
         should.not.exist(beforeWorker.enketoOnceId);
+        global.enketo.callCount.should.equal(2);
+
+        // Reset enketo mock (including callCount)
+        global.enketo.reset();
 
         // Second request, from the worker
-        global.enketo.state = undefined;
-        global.enketo.callCount.should.equal(2);
         await exhaust(container);
-        global.enketo.callCount.should.equal(3);
+        global.enketo.callCount.should.equal(1);
         global.enketo.receivedUrl.should.equal(`${container.env.domain}/v1/projects/1`);
         const { body: afterWorker } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -137,6 +137,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
         global.enketo.state = 'error';
         await asAlice.post('/v1/projects/1/forms/simple/draft').expect(200);
         global.enketo.callCount.should.equal(1);
+        // Reset enketo error
+        global.enketo.state = undefined;
         global.enketo.enketoId = '::ijklmnop';
         await exhaust(container);
         global.enketo.callCount.should.equal(2);
@@ -1156,6 +1158,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(draft.enketoOnceId);
 
         // Publish.
+        global.enketo.state = undefined;
         await asAlice.post('/v1/projects/1/forms/simple2/draft/publish')
           .expect(200);
         global.enketo.callCount.should.equal(2);
@@ -1213,6 +1216,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(v1.enketoOnceId);
 
         // Republish
+        global.enketo.state = undefined;
         await asAlice.post('/v1/projects/1/forms/simple2/draft').expect(200);
         global.enketo.callCount.should.equal(3);
         await asAlice.post('/v1/projects/1/forms/simple2/draft/publish?version=new')
@@ -1265,6 +1269,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         should.not.exist(beforeWorker.enketoOnceId);
 
         // Second request, from the worker
+        global.enketo.state = undefined;
         global.enketo.callCount.should.equal(2);
         await exhaust(container);
         global.enketo.callCount.should.equal(3);

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -298,10 +298,10 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
               body.publishedAt.should.eql(body.createdAt);
               (body.updatedAt == null).should.equal(true);
             })
-            .then(() => asAlice.get('/v1/audits')
+            .then(() => asAlice.get('/v1/audits?action=form')
               .expect(200)
               .then(({ body }) => {
-                body.map((a) => a.action).should.eql(['form.update.publish', 'form.create', 'user.session.create']);
+                body.map((a) => a.action).should.eql(['form.update.publish', 'form.create']);
               }))))));
 
     it('should have published timestamp different from create timestamp if published separately', testService((service) =>
@@ -319,10 +319,10 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
               body.publishedAt.should.not.eql(body.createdAt);
               body.updatedAt.should.be.a.recentIsoDate();
             })
-            .then(() => asAlice.get('/v1/audits')
+            .then(() => asAlice.get('/v1/audits?action=form')
               .expect(200)
               .then(({ body }) => {
-                body.map((a) => a.action).should.eql(['form.update.publish', 'form.create', 'user.session.create']);
+                body.map((a) => a.action).should.eql(['form.update.publish', 'form.create']);
               }))))));
 
     describe('Enketo ID for draft', () => {
@@ -470,7 +470,6 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         global.enketo.reset();
 
         // Second request, from the worker
-        global.enketo.callCount.should.equal(0);
         await exhaust(container);
         global.enketo.callCount.should.equal(1);
         const { body } = await asAlice.get('/v1/projects/1/forms/simple2')

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -465,14 +465,14 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
           .send(testData.forms.simple2)
           .expect(200);
 
-        // in place of global.enketo.reset() function
-        global.enketo.state = undefined;
-        global.enketo.autoReset = true;
+        // reset enketo mock to its default behavior
+        // also resets callCount
+        global.enketo.reset();
 
         // Second request, from the worker
-        global.enketo.callCount.should.equal(2);
+        global.enketo.callCount.should.equal(0);
         await exhaust(container);
-        global.enketo.callCount.should.equal(3);
+        global.enketo.callCount.should.equal(1);
         const { body } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);
         without(['token'], global.enketo.createData).should.eql({

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -74,11 +74,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .set('Content-Type', 'application/xml')
             .expect(409)
             .then(({ body }) => {
-              // eslint-disable-next-line no-multi-str
-              body.message.should.eql("You tried to publish the form 'simple' with version '', \
-but a published form has already existed in this project with those identifiers. \
-Please choose a new name and try again. You can re-request with ?version=xyz \
-to have the version changed in-place for you.");
+              body.message.should.eql("You tried to publish the form 'simple' with version '', but a published form has already existed in this project with those identifiers.");
               body.details.should.eql({ xmlFormId: 'simple', version: '' });
             })))));
 

--- a/test/integration/fixtures/02-forms.js
+++ b/test/integration/fixtures/02-forms.js
@@ -7,13 +7,16 @@ module.exports = async ({ Assignments, Forms, Projects, Roles }) => {
   const project = (await Projects.getById(1)).get();
   const { id: formview } = (await Roles.getBySystemName('formview')).get();
 
-  // Create the forms without Enketo IDs in order to maintain existing tests.
-  global.enketo.state = 'error';
-
   /* eslint-disable no-await-in-loop */
   for (const xml of forms) {
     const partial = await Form.fromXml(xml);
+
+    // Create the form without Enketo IDs in order to maintain existing tests.
+    global.enketo.state = 'error';
     const form = await Forms.createNew(partial, project);
+
+    // Publish the form without Enketo IDs as well
+    global.enketo.state = 'error';
     await Forms.publish(form, true);
 
     // Delete the assignment of the formview actor created by Forms.createNew()
@@ -25,6 +28,5 @@ module.exports = async ({ Assignments, Forms, Projects, Roles }) => {
 
   // Reset enketo call count and error state to not affect tests
   global.enketo.callCount = 0;
-  global.enketo.state = undefined;
 };
 

--- a/test/integration/fixtures/02-forms.js
+++ b/test/integration/fixtures/02-forms.js
@@ -6,18 +6,25 @@ const forms = [ simple, withrepeat ];
 module.exports = async ({ Assignments, Forms, Projects, Roles }) => {
   const project = (await Projects.getById(1)).get();
   const { id: formview } = (await Roles.getBySystemName('formview')).get();
+
+  // Create the forms without Enketo IDs in order to maintain existing tests.
+  global.enketo.state = 'error';
+
   /* eslint-disable no-await-in-loop */
   for (const xml of forms) {
     const partial = await Form.fromXml(xml);
-    // Create the form without Enketo IDs in order to maintain existing tests.
-    global.enketo.state = 'error';
-    const { acteeId } = await Forms.createNew(partial, project, true);
+    const form = await Forms.createNew(partial, project);
+    await Forms.publish(form, true);
 
     // Delete the assignment of the formview actor created by Forms.createNew()
     // in order to maintain existing tests.
-    const [{ actorId }] = await Assignments.getByActeeAndRoleId(acteeId, formview);
+    const [{ actorId }] = await Assignments.getByActeeAndRoleId(form.acteeId, formview);
     await Assignments.revokeByActorId(actorId);
   }
   /* eslint-enable no-await-in-loop */
+
+  // Reset enketo call count and error state to not affect tests
+  global.enketo.callCount = 0;
+  global.enketo.state = undefined;
 };
 

--- a/test/integration/fixtures/02-forms.js
+++ b/test/integration/fixtures/02-forms.js
@@ -7,16 +7,14 @@ module.exports = async ({ Assignments, Forms, Projects, Roles }) => {
   const project = (await Projects.getById(1)).get();
   const { id: formview } = (await Roles.getBySystemName('formview')).get();
 
+  // Create the forms without Enketo IDs in order to maintain existing tests.
+  global.enketo.state = 'error';
+  global.enketo.autoReset = false;
+
   /* eslint-disable no-await-in-loop */
   for (const xml of forms) {
     const partial = await Form.fromXml(xml);
-
-    // Create the form without Enketo IDs in order to maintain existing tests.
-    global.enketo.state = 'error';
     const form = await Forms.createNew(partial, project);
-
-    // Publish the form without Enketo IDs as well
-    global.enketo.state = 'error';
     await Forms.publish(form, true);
 
     // Delete the assignment of the formview actor created by Forms.createNew()
@@ -26,7 +24,7 @@ module.exports = async ({ Assignments, Forms, Projects, Roles }) => {
   }
   /* eslint-enable no-await-in-loop */
 
-  // Reset enketo call count and error state to not affect tests
-  global.enketo.callCount = 0;
+  // Reset enketo to not affect tests
+  global.enketo.reset();
 };
 

--- a/test/integration/other/form-versioning.js
+++ b/test/integration/other/form-versioning.js
@@ -72,7 +72,8 @@ describe('form forward versioning', () => {
       Form.fromXml(testData.forms.withAttachments),
       Blob.fromFile(__filename).then(Blobs.ensure)
     ])
-      .then(([ project, partial, blobId ]) => Forms.createNew(partial, project, true)
+      .then(([ project, partial, blobId ]) => Forms.createNew(partial, project)
+        .then((formDraft) => Forms.publish(formDraft, true))
         .then((savedForm) => Promise.all([ 'goodone.csv', 'goodtwo.mp3' ]
           .map((name) => FormAttachments.getByFormDefIdAndName(savedForm.def.id, name)
             .then(force)
@@ -106,7 +107,8 @@ describe('form forward versioning', () => {
       Form.fromXml(testData.forms.withAttachments),
       Blob.fromFile(__filename).then(Blobs.ensure)
     ])
-      .then(([ project, partial, blobId ]) => Forms.createNew(partial, project, true)
+      .then(([ project, partial, blobId ]) => Forms.createNew(partial, project)
+        .then((formDraft) => Forms.publish(formDraft, true))
         .then((savedForm) => Promise.all([ 'goodone.csv', 'goodtwo.mp3' ]
           .map((name) => FormAttachments.getByFormDefIdAndName(savedForm.def.id, name)
             .then(force)

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -39,7 +39,7 @@ const defaults = {
 let cancelToken = 0;
 
 const reset = () => {
-  if (global.enketo === undefined) global.enketo = {};
+  if (global.enketo === undefined) global.enketo = { reset };
   Object.assign(global.enketo, defaults);
   cancelToken += 1;
 };

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -44,7 +44,7 @@ const reset = () => {
 const request = () => {
   global.enketo.callCount += 1;
   const options = { ...global.enketo };
-  Object.assign(global.enketo, without(['callCount'], defaults));
+  Object.assign(global.enketo, without(['callCount', 'state'], defaults));
   return new Promise((resolve, reject) => {
     const { wait } = options;
     const tokenBeforeWait = cancelToken;

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -29,7 +29,11 @@ const defaults = {
   // The OpenRosa URL that was passed to the create() method
   receivedUrl: undefined,
   // An object with a property for each argument passed to the edit() method
-  editData: undefined
+  editData: undefined,
+
+  // Control whether enketo resets after a request. Set to false in tests that
+  // need multiple error requests or timeouts in a row.
+  autoReset: true,
 };
 
 let cancelToken = 0;
@@ -44,7 +48,10 @@ const reset = () => {
 const request = () => {
   global.enketo.callCount += 1;
   const options = { ...global.enketo };
-  Object.assign(global.enketo, without(['callCount', 'state'], defaults));
+
+  if (global.enketo.autoReset)
+    Object.assign(global.enketo, without(['callCount'], defaults));
+
   return new Promise((resolve, reject) => {
     const { wait } = options;
     const tokenBeforeWait = cancelToken;


### PR DESCRIPTION
Closes https://github.com/getodk/central-backend/issues/1136

This PR consolidates Form publishing in one place, because Dataset publishing is tied to Form publishing. There were three different places to _possibly_ publish a Dataset (creating a new form, updating a form, just publishing a form) and it was too hard to think about which Form scenario led to which Dataset scenario. 

---

As of 5/10/24:

So far, I've removed `publish=true` from `Forms.createNew()`.  Any time creating a new form was also going to publish the form, the `Forms.publish()` is now called separately. 

One downside is that those lines of code aren't as cute and concise anymore. This only happened in one resource, in a test fixture, and in some tests.

Another downside is that the enketo test mock had a way to put it into an erroneous state for the next request, but a certain form POST request will trigger two enketo requests behind the scenes. I mucked with the enketo test mock to require you to remove the error state, but it's kind of ugly and required modifying multiple tests.

As of 5/14/24:

I decided that keeping `publish=true` in `Forms.createVersion()` had utility. There is one rare situation with encrypting existing forms where it really helps to publish concurrently, e.g. when there is both a published version and draft version of a form, and both active versions need to be encrypted. Because this has nothing to do with Datasets, Forms.createVersion does not have code to publish a dataset. I tried to clarify this with comments, too.

I also trie to make `Forms.createNew()` and `Forms.createVersion()` more similar. There are some things they both do (parse the form XML to get form fields and dataset info, insert form fields, insert attachments, do enketo things) and some things that are special (comparing against previous schemas for updated forms).

Checklist 
- [x] I think I want to move enketo draft creation from `_createNewDef` to `createVersion`
- [x] improve enketo test infrastructure 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced