### PR TITLE
Change entities deletedAt precision and add timezone

### DIFF
--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -27,7 +27,7 @@ class Entity extends Frame.define(
     'int4', 'int4',
     'conflictType',
     'timestamptz',
-    'timestamptz', 'timestamp',
+    'timestamptz', 'timestampz',
   ])
 ) {
   get def() { return this.aux.def; }

--- a/lib/model/migrations/20240515-01-entity-tz-precision.js
+++ b/lib/model/migrations/20240515-01-entity-tz-precision.js
@@ -1,0 +1,18 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw('ALTER TABLE entities ALTER COLUMN "deletedAt" TYPE timestamptz(3)');
+};
+
+const down = async (db) => {
+  await db.raw('ALTER TABLE entities ALTER COLUMN "deletedAt" TYPE timestamp');
+};
+
+module.exports = { up, down };


### PR DESCRIPTION
Closes https://github.com/getodk/central-backend/issues/1104

Makes `deletedAt` field on `entities` table have consistent timestamp type.

In this [issue](https://github.com/getodk/central-backend/issues/459), we chose to use `timestamptz(3)` for timestamps, but that was missed when creating this column in this table and it was just set to `timestamp`. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced