### PR TITLE
Specify mediaFile type=entityList for datasets in form manifest

### DIFF
--- a/lib/formats/openrosa.js
+++ b/lib/formats/openrosa.js
@@ -62,7 +62,7 @@ const formManifestTemplate = template(200, `<?xml version="1.0" encoding="UTF-8"
   <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
   {{#attachments}}
     {{#hasSource}}
-    <mediaFile>
+    <mediaFile{{#isDataset}} type="entityList"{{/isDataset}}>
       <filename>{{name}}</filename>
       <hash>md5:{{openRosaHash}}</hash>
       <downloadUrl>{{{domain}}}{{{basePath}}}/attachments/{{urlName}}</downloadUrl>
@@ -76,7 +76,8 @@ const formManifest = (data) => formManifestTemplate(mergeRight(data, {
   attachments: data.attachments.map((attachment) =>
     attachment.with({
       hasSource: attachment.blobId || attachment.datasetId,
-      urlName: encodeURIComponent(attachment.name)
+      urlName: encodeURIComponent(attachment.name),
+      isDataset: attachment.datasetId != null
     }))
 }));
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1884,7 +1884,7 @@ describe('datasets and entities', () => {
         const domain = config.get('default.env.domain');
         manifest.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
   <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-    <mediaFile>
+    <mediaFile type="entityList">
       <filename>goodone.csv</filename>
       <hash>md5:${etag.replace(/"/g, '')}</hash>
       <downloadUrl>${domain}/v1/projects/1/forms/withAttachments/attachments/goodone.csv</downloadUrl>
@@ -1968,7 +1968,7 @@ describe('datasets and entities', () => {
         const domain = config.get('default.env.domain');
         manifest.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
   <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-    <mediaFile>
+    <mediaFile type="entityList">
       <filename>goodone.csv</filename>
       <hash>md5:${etag.replace(/"/g, '')}</hash>
       <downloadUrl>${domain}/v1/projects/1/forms/withAttachments/attachments/goodone.csv</downloadUrl>
@@ -2843,7 +2843,7 @@ describe('datasets and entities', () => {
             const domain = config.get('default.env.domain');
             text.should.be.eql(`<?xml version="1.0" encoding="UTF-8"?>
   <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-    <mediaFile>
+    <mediaFile type="entityList">
       <filename>people.csv</filename>
       <hash>md5:${etag.replace(/"/g, '')}</hash>
       <downloadUrl>${domain}/v1/projects/1/forms/withAttachments/attachments/people.csv</downloadUrl>


### PR DESCRIPTION
Part of https://github.com/getodk/central/issues/665 and larger issue https://github.com/getodk/central/issues/668

Adds **type=”entityList”** to manifest for attachments that are actually datasets/entity lists. (integrityUrl coming next.)

```
<mediaFile type=”entityList”>
  <filename>people.csv</filename>
  <hash>md5:9fd39ac868eccdc0c134b3b7a6a25eb7</hash>
  <downloadUrl>http://other.appspot.com/blobSource?foo=222</downloadUrl>
  <integrityUrl>http://blah</integrityUrl>
 </mediaFile>
```

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced