### PR TITLE
Processing out of order/offline entities by runId and runIndex

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -81,6 +81,8 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
       entity.system.create = field.attrs.create;
       entity.system.update = field.attrs.update;
       entity.system.baseVersion = field.attrs.baseVersion;
+      entity.system.runId = field.attrs.runId;
+      entity.system.runIndex = field.attrs.runIndex;
     } else if (field.path.indexOf('/meta/entity') === 0)
       entity.system[field.name] = text;
     else if (field.propertyName != null)

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -27,7 +27,7 @@ class Entity extends Frame.define(
     'int4', 'int4',
     'conflictType',
     'timestamptz',
-    'timestamptz', 'timestampz',
+    'timestamptz', 'timestamptz',
   ])
 ) {
   get def() { return this.aux.def; }
@@ -39,12 +39,15 @@ class Entity extends Frame.define(
     const uuid = normalizeUuid(entityData.system.id);
     const label = extractLabelFromSubmission(entityData, options);
     const baseVersion = extractBaseVersionFromSubmission(entityData);
+    const { runIndex, runId } = entityData.system;
     const dataReceived = { ...data, ...(label && { label }) };
     return new Entity.Partial({ uuid }, {
       def: new Entity.Def({
         data,
         dataReceived,
         ...(baseVersion && { baseVersion }), // add baseVersion only if it's there
+        ...(runId && { runId }), // add runId only if it's there
+        ...(runIndex && { runIndex }), // add runIndex only if it's there
         ...(label && { label }) // add label only if it's there
       }),
       dataset
@@ -89,6 +92,7 @@ Entity.Def = Frame.define(
   'version',      readable,         'baseVersion',  readable,
   'dataReceived', readable,         'conflictingProperties', readable,
   'createdAt',    readable,
+  'runId', 'runIndex',
   embedded('creator'),
   embedded('source'),
   fieldTypes([
@@ -99,7 +103,8 @@ Entity.Def = Frame.define(
     'jsonb', 'bool',
     'int4', 'int4',
     'jsonb', 'jsonb',
-    'timestamptz'
+    'timestamptz',
+    'uuid', 'int4',
   ])
 );
 

--- a/lib/model/migrations/20240524-01-add-entity-run-info.js
+++ b/lib/model/migrations/20240524-01-add-entity-run-info.js
@@ -1,0 +1,16 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw('ALTER TABLE entity_defs ADD COLUMN "runId" UUID, ADD COLUMN "runIndex" INT4');
+};
+
+const down = (db) => db.raw('ALTER TABLE entity_defs DROP COLUMN "runId", DROP COLUMN "runIndex"');
+
+module.exports = { up, down };

--- a/lib/model/migrations/20240524-02-add-submission-backlog.js
+++ b/lib/model/migrations/20240524-02-add-submission-backlog.js
@@ -1,0 +1,30 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`CREATE TABLE submission_backlog (
+    "submissionId" INT4,
+    "submissionDefId" INT4,
+    "runId" UUID,
+    "runIndex" INT4,
+    "loggedAt" TIMESTAMPTZ(3),
+    CONSTRAINT fk_submission_defs
+      FOREIGN KEY("submissionDefId") 
+      REFERENCES submission_defs(id)
+      ON DELETE CASCADE,
+    CONSTRAINT fk_submissions
+      FOREIGN KEY("submissionId") 
+      REFERENCES submissions(id)
+      ON DELETE CASCADE
+  )`);
+};
+
+const down = (db) => db.raw('DROP TABLE submission_backlog');
+
+module.exports = { up, down };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -34,9 +34,9 @@ const createSource = (details = null, subDefId = null, eventId = null) => ({ one
 ////////////////////////////////////////////////////////////////////////////////
 // ENTITY CREATE
 
-const _defInsert = (id, root, creatorId, userAgent, label, json, version, dataReceived, sourceId = null, baseVersion = null, conflictingProperties = null) => sql`
-  insert into entity_defs ("entityId", "root", "sourceId", "creatorId", "userAgent", "label", "data", "current", "createdAt", "version", "baseVersion", "dataReceived", "conflictingProperties")
-  values (${id}, ${root}, ${sourceId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp(), ${version}, ${baseVersion}, ${dataReceived}, ${conflictingProperties})
+const _defInsert = (id, root, creatorId, userAgent, label, json, version, dataReceived, sourceId, runId = null, runIndex = null, baseVersion = null, conflictingProperties = null) => sql`
+  insert into entity_defs ("entityId", "root", "sourceId", "creatorId", "userAgent", "label", "data", "current", "createdAt", "version", "baseVersion", "dataReceived", "conflictingProperties", "runId", "runIndex")
+  values (${id}, ${root}, ${sourceId}, ${creatorId}, ${userAgent}, ${label}, ${json}, true, clock_timestamp(), ${version}, ${baseVersion}, ${dataReceived}, ${conflictingProperties}, ${runId}, ${runIndex})
   returning *`;
 const nextval = sql`nextval(pg_get_serial_sequence('entities', 'id'))`;
 
@@ -62,7 +62,7 @@ const createNew = (dataset, partial, subDef, sourceId, userAgentIn) => ({ one, c
   const dataReceived = JSON.stringify(partial.def.dataReceived);
 
   return one(sql`
-with def as (${_defInsert(nextval, true, creatorId, userAgent, partial.def.label, json, 1, dataReceived, sourceId)}),
+with def as (${_defInsert(nextval, true, creatorId, userAgent, partial.def.label, json, 1, dataReceived, sourceId, partial.def.runId, partial.def.runIndex)}),
 ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ${dataset.id}, ${partial.uuid}, def."createdAt", ${creatorId} from def
   returning entities.*)
@@ -143,7 +143,7 @@ const createVersion = (dataset, partial, subDef, version, sourceId, baseVersion,
   const _unjoiner = unjoiner(Entity, Entity.Def.into('currentVersion'));
 
   return one(sql`
-  with def as (${_defInsert(partial.id, false, creatorId, userAgent, partial.def.label, json, version, dataReceived, sourceId, baseVersion, conflictingPropJson)}),
+  with def as (${_defInsert(partial.id, false, creatorId, userAgent, partial.def.label, json, version, dataReceived, sourceId, partial.def.runId, partial.def.runIndex, baseVersion, conflictingPropJson)}),
   upd as (update entity_defs set current=false where entity_defs."entityId" = ${partial.id}),
   entities as (update entities set "updatedAt"=clock_timestamp(), conflict=${partial.conflict ?? sql`NULL`}
     where "uuid"=${partial.uuid}
@@ -184,6 +184,16 @@ const _getFormDefActions = (oneFirst, datasetId, formDefId) => oneFirst(sql`
 SELECT actions
 FROM dataset_form_defs
 WHERE "datasetId" = ${datasetId} AND "formDefId" = ${formDefId}`);
+
+const _getLastRunIndex = (maybeOne, datasetId, entityUuid, runId) => maybeOne(sql`
+SELECT "runIndex"
+FROM entity_defs
+JOIN entities ON entity_defs."entityId" = entities."id"
+WHERE entities."datasetId" = ${datasetId}
+  AND entities."uuid" = ${entityUuid}
+  AND entity_defs."runId" = ${runId}
+  AND entity_defs."runId" IS NOT NULL
+ORDER BY "runIndex" DESC LIMIT 1`);
 
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
@@ -257,7 +267,9 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       data: mergedData,
       label: mergedLabel,
       dataReceived: clientEntity.def.dataReceived,
-      conflictingProperties
+      conflictingProperties,
+      runId: clientEntity.def.runId,
+      runIndex: clientEntity.def.runIndex
     })
   });
 
@@ -273,7 +285,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 // Entrypoint to where submissions (a specific version) become entities
-const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms, oneFirst }) => {
+const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms, maybeOne, oneFirst }) => {
   const { submissionId, submissionDefId } = event.details;
 
   const form = await Forms.getByActeeId(event.acteeId);
@@ -324,6 +336,16 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
     if ((submissionAction === '1' || submissionAction === 'true') &&
       !permittedActions.includes(action))
       throw Problem.user.entityActionNotPermitted({ action, permitted: permittedActions });
+  }
+
+  // Check runId and runIndex here
+  if (entityData.system.runId != null) {
+    const newIndex = parseInt(entityData.system.runIndex, 10);
+    if (newIndex !== 1) {
+      const lastRunIndex = await _getLastRunIndex(maybeOne, dataset.id, entityData.system.id, entityData.system.runId);
+      if (!lastRunIndex.isDefined() || (lastRunIndex.get().runIndex + 1) !== newIndex)
+        throw Problem.user.invalidEntity({ reason: 'Run Index doesnt work out.' });
+    }
   }
 
   // Try update before create (if both are specified)

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -195,6 +195,15 @@ WHERE entities."datasetId" = ${datasetId}
   AND entity_defs."runId" IS NOT NULL
 ORDER BY "runIndex" DESC LIMIT 1`);
 
+const _holdSubmission = (run, submissionId, submissionDefId, runId, runIndex) => run(sql`
+INSERT INTO submission_backlog ("submissionId", "submissionDefId", "runId", "runIndex", "loggedAt")
+VALUES (${submissionId}, ${submissionDefId}, ${runId}, ${runIndex}, CLOCK_TIMESTAMP())
+`);
+
+const _checkHeldSubmission = (maybeOne, runId, runIndex) => maybeOne(sql`
+SELECT * FROM submission_backlog
+WHERE "runId"=${runId} AND "runIndex" = ${runIndex}`);
+
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
   // an approval event, then don't create an entity
@@ -219,7 +228,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, maybeOne }) => {
-  if (!(event.action === 'submission.create' || event.action === 'submission.update.version'))
+  if (!(event.action === 'submission.create' || event.action === 'submission.update.version' || event.action === 'submission.reprocess'))
     return null;
 
   // Get client version of entity
@@ -285,9 +294,8 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 // Entrypoint to where submissions (a specific version) become entities
-const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms, maybeOne, oneFirst }) => {
+const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Datasets, Entities, Submissions, Forms, maybeOne, oneFirst, run }) => {
   const { submissionId, submissionDefId } = event.details;
-
   const form = await Forms.getByActeeId(event.acteeId);
 
   // If form is deleted/purged then submission won't be there either.
@@ -343,8 +351,10 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
     const newIndex = parseInt(entityData.system.runIndex, 10);
     if (newIndex !== 1) {
       const lastRunIndex = await _getLastRunIndex(maybeOne, dataset.id, entityData.system.id, entityData.system.runId);
-      if (!lastRunIndex.isDefined() || (lastRunIndex.get().runIndex + 1) !== newIndex)
-        throw Problem.user.invalidEntity({ reason: 'Run Index doesnt work out.' });
+      if (!lastRunIndex.isDefined() || (lastRunIndex.get().runIndex + 1) !== newIndex) {
+        await _holdSubmission(run, submissionDef.submissionId, submissionDef.id, entityData.system.runId, newIndex);
+        return null;
+      }
     }
   }
 
@@ -360,8 +370,17 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
       }
     }
   else if (entityData.system.create === '1' || entityData.system.create === 'true')
-    return Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
+    await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
 
+  if (entityData.system.runId != null) {
+    const newIndex = parseInt(entityData.system.runIndex, 10);
+    const nextSub = await _checkHeldSubmission(maybeOne, entityData.system.runId, newIndex + 1);
+    if (nextSub.isDefined()) {
+      const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId } = nextSub.get();
+      await Audits.log({ id: event.actorId }, 'submission.reprocess', { acteeId: event.acteeId },
+        { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId });
+    }
+  }
   return null;
 };
 

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -169,7 +169,7 @@ const insertMany = (objs) => {
   if (Type.hasCreatedAt) {
     columns = sql`"createdAt", ${raw(without(['createdAt'], Type.insertfields).map((s) => `"${s}"`).join(','))}`;
     rows = objs.map(obj => without(['createdAt'], Type.insertfields).map(_assign(obj)));
-    columnTypes = remove(indexOf(['createdAt'], Type.insertfields), 1, Type.insertFieldTypes);
+    columnTypes = remove(indexOf('createdAt', Type.insertfields), 1, Type.insertFieldTypes);
     selectExp = sql`clock_timestamp(), *`;
   } else {
     columns = Type.insertlist;

--- a/lib/worker/jobs.js
+++ b/lib/worker/jobs.js
@@ -18,6 +18,7 @@ const jobs = {
   'submission.update.version': [ require('./submission').submissionUpdateVersion, require('./entity').createOrUpdateEntityFromSubmission ],
 
   'submission.update': [ require('./entity').createOrUpdateEntityFromSubmission ],
+  'submission.reprocess': [ require('./entity').createOrUpdateEntityFromSubmission ],
 
   'form.create': [ require('./form').create ],
   'form.update.draft.set': [ require('./form').updateDraftSet ],

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -415,6 +415,29 @@ module.exports = {
   </h:head>
 </h:html>`,
 
+    offlineEntity: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model entities:entities-version="2023.1.0">
+      <instance>
+        <data id="offlineEntity" orx:version="1.0">
+          <name/>
+          <age/>
+          <status/>
+          <meta>
+            <entity dataset="people" id="" create="" update="" baseVersion="" runId="" runIndex="">
+              <label/>
+            </entity>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" entities:saveto="first_name"/>
+      <bind nodeset="/data/age" type="int" entities:saveto="age"/>
+      <bind nodeset="/data/status" type="int" entities:saveto="status"/>
+    </model>
+  </h:head>
+</h:html>`,
+
     groupRepeat: `<?xml version="1.0"?>
     <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
         <h:head>
@@ -701,6 +724,33 @@ module.exports = {
         </meta>
         <age>55</age>
       </data>`
+    },
+    offlineEntity: {
+      one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="offlineEntity" version="1.0">
+        <meta>
+          <instanceID>one</instanceID>
+          <orx:instanceName>one</orx:instanceName>
+          <entity dataset="people" id="12345678-1234-4123-8234-123456789abc"
+            baseVersion="1" update="1"
+            runId="" runIndex="1">
+          </entity>
+        </meta>
+        <status>arrived</status>
+      </data>`,
+      two: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="offlineEntity" version="1.0">
+        <meta>
+          <instanceID>two</instanceID>
+          <orx:instanceName>two</orx:instanceName>
+          <entity dataset="people" id="12345678-1234-4123-8234-123456789ddd"
+          baseVersion="1" create="1"
+          runId="" runIndex="1">
+            <label>Megan (20)</label>
+          </entity>
+        </meta>
+        <name>Megan</name>
+        <status>new</status>
+        <age>20</age>
+      </data>`,
     },
     groupRepeat: {
       one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="groupRepeat">

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1,0 +1,176 @@
+const appRoot = require('app-root-path');
+const { testService } = require('../setup');
+const testData = require('../../data/xml');
+const { getOrNotFound } = require('../../../lib/util/promise');
+const uuid = require('uuid').v4;
+
+const { exhaust } = require(appRoot + '/lib/worker/worker');
+
+const testOfflineEntities = (test) => testService(async (service, container) => {
+  const asAlice = await service.login('alice');
+
+  // Publish a form that will set up the dataset with properties
+  await asAlice.post('/v1/projects/1/forms?publish=true')
+    .send(testData.forms.offlineEntity)
+    .set('Content-Type', 'application/xml')
+    .expect(200);
+
+  // Create an entity via the API (to be updated offline)
+  await asAlice.post('/v1/projects/1/datasets/people/entities')
+    .send({
+      uuid: '12345678-1234-4123-8234-123456789abc',
+      label: 'Johnny Doe',
+      data: { first_name: 'Johnny', age: '22' }
+    })
+    .expect(200);
+
+  await exhaust(container);
+
+  await test(service, container);
+});
+
+describe('Offline Entities', () => {
+  describe('parsing runId and runIndex from submission xml', () => {
+    it('should parse and save run info from sub creating an entity', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const runId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.two
+          .replace('runId=""', `runId="${runId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789ddd').then(getOrNotFound);
+      entity.aux.currentVersion.runId.should.equal(runId);
+      entity.aux.currentVersion.runIndex.should.equal(1);
+      entity.aux.currentVersion.data.should.eql({ age: '20', status: 'new', first_name: 'Megan' });
+    }));
+
+    it('should parse and save run info from sub updating an entity', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const runId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('runId=""', `runId="${runId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.runId.should.equal(runId);
+      entity.aux.currentVersion.runIndex.should.equal(1);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'arrived', first_name: 'Johnny' });
+    }));
+
+    it('should complain if run index is not good', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('runId=""', `runId="${uuid()}"`)
+          .replace('runIndex="1"', 'runIndex="2"')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+        .expect(200)
+        .then(({ body }) => {
+          // no status in data because out of order update did not get applied
+          body.currentVersion.data.should.eql({ age: '22', first_name: 'Johnny' });
+        });
+
+      await asAlice.get('/v1/projects/1/forms/offlineEntity/submissions/one/audits')
+        .expect(200)
+        .then(({ body }) => {
+          //console.log(body);
+          body[0].details.problem.should.not.be.null();
+        });
+    }));
+  });
+
+  describe('out of order runs', () => {
+
+    it('should let multiple updates in the same run get applied in order', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const runId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('runId=""', `runId="${runId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('runId=""', `runId="${runId}"`)
+          .replace('one', 'one-update')
+          .replace('runIndex="1"', 'runIndex="2"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.runId.should.equal(runId);
+      entity.aux.currentVersion.runIndex.should.equal(2);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'departed', first_name: 'Johnny' });
+    }));
+
+    it('should not apply out of order update from a run after starting a run', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const runId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      // start run correctly
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('runId=""', `runId="${runId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('runId=""', `runId="${runId}"`)
+          .replace('one', 'one-update2')
+          .replace('runIndex="1"', 'runIndex="3"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('runId=""', `runId="${runId}"`)
+          .replace('one', 'one-update1')
+          .replace('runIndex="1"', 'runIndex="2"')
+          .replace('<status>arrived</status>', '<status>working</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.runId.should.equal(runId);
+      entity.aux.currentVersion.runIndex.should.equal(2);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'working', first_name: 'Johnny' });
+    }));
+  });
+});

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -191,7 +191,9 @@ describe('extracting and validating entities', () => {
               label: 'Alice (88)',
               dataset: 'people',
               update: undefined,
-              baseVersion: undefined
+              baseVersion: undefined,
+              runId: undefined,
+              runIndex: undefined
             });
           }));
 
@@ -206,7 +208,9 @@ describe('extracting and validating entities', () => {
               label: 'Alice (88)',
               dataset: 'people',
               update: undefined,
-              baseVersion: undefined
+              baseVersion: undefined,
+              runId: undefined,
+              runIndex: undefined
             });
           }));
 
@@ -257,8 +261,21 @@ describe('extracting and validating entities', () => {
               label: 'Alicia (85)',
               dataset: 'people',
               update: '1',
-              baseVersion: '1'
+              baseVersion: '1',
+              runId: undefined,
+              runIndex: undefined
             });
+          }));
+    });
+
+    describe('offline entity events', () => {
+      it('should get runId and runIndex if provided', () =>
+        fieldsFor(testData.forms.offlineEntity)
+          .then((fields) => fields.filter((field) => field.propertyName || field.path.indexOf('/meta/entity') === 0))
+          .then((fields) => parseSubmissionXml(fields, testData.instances.offlineEntity.one.replace('runId=""', 'runId="73608072-06b8-4ead-a3bd-82a7078eaa16"')))
+          .then((result) => {
+            result.system.runId.should.equal('73608072-06b8-4ead-a3bd-82a7078eaa16');
+            result.system.runIndex.should.equal('1');
           }));
     });
   });


### PR DESCRIPTION
Part of addressing https://github.com/getodk/central/issues/669 

This is a megabranch/work-in-progress (because of database migrations and naming related to openrosa spec).

It can handle 'runId' and 'runIndex' coming in within the  `<entity>` block in a submission and has a submission backlog for holding onto submissions that come in out of order.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced