### PR TITLE
Don't encode %24 in docs

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -6358,7 +6358,7 @@ paths:
         schema:
           type: boolean
         example: "true"
-      - name: '%24filter'
+      - name: '$filter'
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
@@ -6461,7 +6461,7 @@ paths:
         schema:
           type: boolean
         example: "true"
-      - name: '%24filter'
+      - name: '$filter'
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
@@ -6561,7 +6561,7 @@ paths:
         schema:
           type: string
         example: simple
-      - name: '%24filter'
+      - name: '$filter'
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
@@ -6630,7 +6630,7 @@ paths:
         schema:
           type: string
         example: simple
-      - name: '%24filter'
+      - name: '$filter'
         in: query
         description: If provided, will filter responses to those matching the given
           OData query. Only [certain fields](/central-api-odata-endpoints/#data-document)
@@ -10499,7 +10499,7 @@ paths:
 
         Please see the [OData documentation](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358948) on `$filter` [operations](http://docs.oasis-open.org/odata/odata/v4.01/cs01/part1-protocol/odata-v4.01-cs01-part1-protocol.html#sec_BuiltinFilterOperations) and [functions](http://docs.oasis-open.org/odata/odata/v4.01/cs01/part1-protocol/odata-v4.01-cs01-part1-protocol.html#sec_BuiltinQueryFunctions) for more information.
 
-        As of ODK Central v1.2, you can use `%24expand=*` to expand all repeat repetitions. This is helpful if you'd rather get one nested JSON data payload of all hierarchical data, rather than retrieve each of repeat as a separate flat table with references.
+        As of ODK Central v1.2, you can use `$expand=*` to expand all repeat repetitions. This is helpful if you'd rather get one nested JSON data payload of all hierarchical data, rather than retrieve each of repeat as a separate flat table with references.
 
         The _nonstandard_ `$wkt` querystring parameter may be set to `true` to request that geospatial data is returned as a [Well-Known Text (WKT) string](https://en.wikipedia.org/wiki/Well-known_text) rather than a GeoJSON structure. This exists primarily to support Tableau, which cannot yet read GeoJSON, but you may find it useful as well depending on your mapping software. **Please note** that both GeoJSON and WKT follow a `(lon, lat, alt)` coördinate ordering rather than the ODK-proprietary `lat lon alt`. This is so that the values map neatly to `(x, y, z)`. GPS accuracy information is not a part of either standards specification, and so is presently omitted from OData output entirely. GeoJSON support may come in a future version.
 
@@ -10537,20 +10537,20 @@ paths:
         schema:
           type: string
         example: Submissions
-      - name: '%24skip'
+      - name: '$skip'
         in: query
         description: If supplied, the first `$skip` rows will be omitted from the
           results.
         schema:
           type: number
         example: "10"
-      - name: '%24top'
+      - name: '$top'
         in: query
         description: If supplied, only up to `$top` rows will be returned in the results.
         schema:
           type: number
         example: "5"
-      - name: '%24count'
+      - name: '$count'
         in: query
         description: If set to `true`, an `@odata.count` property will be added to
           the result indicating the total number of rows, ignoring the above paging
@@ -10558,14 +10558,14 @@ paths:
         schema:
           type: boolean
         example: "true"
-      - name: '%24wkt'
+      - name: '$wkt'
         in: query
         description: If set to `true`, geospatial data will be returned as Well-Known
           Text (WKT) strings rather than GeoJSON structures.
         schema:
           type: boolean
         example: "true"
-      - name: '%24filter'
+      - name: '$filter'
         in: query
         description: If provided, will filter responses to those matching the query.
           Only [certain fields](/central-api-odata-endpoints/#data-document)
@@ -10575,26 +10575,26 @@ paths:
         schema:
           type: string
         example: year(__system/submissionDate) lt year(now())
-      - name: '%24orderby'
+      - name: '$orderby'
         in: query
         description: If provided, will sort responses according to specified order expression. Only the same fields as `$filter` above can be used to sort. Multiple expressions can be used together.
         schema:
           type: string
         example: __system/submitterId asc, __system/updatedAt desc
-      - name: '%24expand'
+      - name: '$expand'
         in: query
         description: Repetitions, which should get expanded. Currently, only `*` is
           implemented, which expands all repetitions.
         schema:
           type: string
         example: '*'
-      - name: '%24select'
+      - name: '$select'
         in: query
         description: If provided, will return only the selected fields.
         schema:
           type: string
         example: __id, age, name, meta/instanceID
-      - name: '%24skiptoken'
+      - name: '$skiptoken'
         in: query
         description: Opaque cursor from `@odata.nextLink` used for paging.
         schema:
@@ -11062,20 +11062,20 @@ paths:
         schema:
           type: string
         example: people
-      - name: '%24skip'
+      - name: '$skip'
         in: query
         description: If supplied, the first `$skip` rows will be omitted from the
           results.
         schema:
           type: number
         example: "10"
-      - name: '%24top'
+      - name: '$top'
         in: query
         description: If supplied, only up to `$top` rows will be returned in the results.
         schema:
           type: number
         example: "5"
-      - name: '%24count'
+      - name: '$count'
         in: query
         description: If set to `true`, an `@odata.count` property will be added to
           the result indicating the total number of rows, ignoring the above paging
@@ -11083,7 +11083,7 @@ paths:
         schema:
           type: boolean
         example: "true"
-      - name: '%24filter'
+      - name: '$filter'
         in: query
         description: If provided, will filter responses to those matching the query.
           Only [certain fields](/central-api-odata-endpoints/#data-document)
@@ -11093,19 +11093,19 @@ paths:
         schema:
           type: string
         example: year(__system/createdAt) lt year(now())
-      - name: '%24orderby'
+      - name: '$orderby'
         in: query
         description: If provided, will sort responses according to specified order expression. Only the same fields as `$filter` above can be used to sort. Multiple expressions can be used together.
         schema:
           type: string
         example: __system/creatorId asc, __system/updatedAt desc
-      - name: '%24select'
+      - name: '$select'
         in: query
         description: If provided, will return only the selected fields.
         schema:
           type: string
         example: __id, label, name
-      - name: '%24skiptoken'
+      - name: '$skiptoken'
         in: query
         description: Opaque cursor from `@odata.nextLink` used for paging.
         schema:
@@ -11485,20 +11485,20 @@ paths:
         schema:
           type: string
         example: Submissions
-      - name: '%24skip'
+      - name: '$skip'
         in: query
         description: If supplied, the first `$skip` rows will be omitted from the
           results.
         schema:
           type: number
         example: "10"
-      - name: '%24top'
+      - name: '$top'
         in: query
         description: If supplied, only up to `$top` rows will be returned in the results.
         schema:
           type: number
         example: "5"
-      - name: '%24count'
+      - name: '$count'
         in: query
         description: If set to `true`, an `@odata.count` property will be added to
           the result indicating the total number of rows, ignoring the above paging
@@ -11506,14 +11506,14 @@ paths:
         schema:
           type: boolean
         example: "true"
-      - name: '%24wkt'
+      - name: '$wkt'
         in: query
         description: If set to `true`, geospatial data will be returned as Well-Known
           Text (WKT) strings rather than GeoJSON structures.
         schema:
           type: boolean
         example: "true"
-      - name: '%24filter'
+      - name: '$filter'
         in: query
         description: If provided, will filter responses to those matching the query.
           Only [certain fields](/central-api-odata-endpoints/#data-document)
@@ -11523,14 +11523,14 @@ paths:
         schema:
           type: string
         example: year(__system/submissionDate) lt year(now())
-      - name: '%24expand'
+      - name: '$expand'
         in: query
         description: Repetitions, which should get expanded. Currently, only `*` is
           implemented, which expands all repetitions.
         schema:
           type: string
         example: '*'
-      - name: '%24select'
+      - name: '$select'
         in: query
         description: If provided, will return only the selected fields.
         schema:

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -2263,8 +2263,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: Standard Response
                 $ref: '#/components/schemas/Project'
               example:
                 id: 1
@@ -2274,8 +2272,6 @@ paths:
                 archived: false
             application/json; extended:
               schema:
-                type: object
-                description: Extended Response
                 $ref: '#/components/schemas/ExtendedProjectWithVerbs'
               example:
                 id: 1
@@ -2342,9 +2338,8 @@ paths:
                 forms:
                   type: array
                   description: If given, the Form metadata to update.
-                  items: {
+                  items:
                     type: object
-                  }
               example:
                 name: New Project Name
                 description: New Project Description
@@ -5704,7 +5699,6 @@ paths:
                     - hasIssues
                     - rejected
                     - approved
-                    - approved
                   createdAt:
                     type: string
                     description: ISO date format. The time that the server received
@@ -5984,7 +5978,6 @@ paths:
                     - hasIssues
                     - rejected
                     - approved
-                    - approved
                   createdAt:
                     type: string
                     description: ISO date format. The time that the server received
@@ -6158,7 +6151,6 @@ paths:
                     - edited
                     - hasIssues
                     - rejected
-                    - approved
                     - approved
                   createdAt:
                     type: string
@@ -7778,7 +7770,6 @@ paths:
                     - hasIssues
                     - rejected
                     - approved
-                    - approved
                   createdAt:
                     type: string
                     description: ISO date format. The time that the server received
@@ -8112,7 +8103,6 @@ paths:
                     - hasIssues
                     - rejected
                     - approved
-                    - approved
                   createdAt:
                     type: string
                     description: ISO date format. The time that the server received
@@ -8250,7 +8240,6 @@ paths:
                     - edited
                     - hasIssues
                     - rejected
-                    - approved
                     - approved
                   createdAt:
                     type: string

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -2263,6 +2263,8 @@ paths:
           content:
             application/json:
               schema:
+                type: object
+                description: Standard Response
                 $ref: '#/components/schemas/Project'
               example:
                 id: 1
@@ -2272,6 +2274,8 @@ paths:
                 archived: false
             application/json; extended:
               schema:
+                type: object
+                description: Extended Response
                 $ref: '#/components/schemas/ExtendedProjectWithVerbs'
               example:
                 id: 1


### PR DESCRIPTION
I noticed that there's a mix of literal $ and %-encoded %24 used. The %24 are not rendered correctly. See for example the request table for https://docs.getodk.org/central-api-odata-endpoints/#data-document

#### What has been done to verify that this works as intended?
Rendered using `make api-docs` (🫡 @sadiqkhoja), spot checked and saw $ as expected.

#### Why is this the best possible solution? Were any other approaches considered?
I considered modifying the docs code to decode values but given that several literal $ already exist and that literal values work without replacement, that didn't feel like the best option.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Could break some docs.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced