### PR TITLE
Fix bug with insertMany, createdAt, and entity timestamp

### DIFF
--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -12,7 +12,6 @@
 const { embedded, fieldTypes, Frame, readable, table } = require('../frame');
 const { extractEntity, normalizeUuid, extractLabelFromSubmission, extractBaseVersionFromSubmission } = require('../../data/entity');
 
-// These Frames don't interact with APIs directly, hence no readable/writable
 class Entity extends Frame.define(
   table('entities', 'entity'),
   'id',                     'uuid', readable,

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -27,7 +27,7 @@ class Entity extends Frame.define(
     'int4', 'int4',
     'conflictType',
     'timestamptz',
-    'timestamptz', 'timestampz',
+    'timestamptz', 'timestamptz',
   ])
 ) {
   get def() { return this.aux.def; }

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -169,7 +169,7 @@ const insertMany = (objs) => {
   if (Type.hasCreatedAt) {
     columns = sql`"createdAt", ${raw(without(['createdAt'], Type.insertfields).map((s) => `"${s}"`).join(','))}`;
     rows = objs.map(obj => without(['createdAt'], Type.insertfields).map(_assign(obj)));
-    columnTypes = remove(indexOf(['createdAt'], Type.insertfields), 1, Type.insertFieldTypes);
+    columnTypes = remove(indexOf('createdAt', Type.insertfields), 1, Type.insertFieldTypes);
     selectExp = sql`clock_timestamp(), *`;
   } else {
     columns = Type.insertlist;

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -337,6 +337,18 @@ returning *`);
       ]);
     });
 
+    it('should insert createdAt even if last type is not timestamp', () => {
+      const U = Frame.define(table('dogs'), 'x', 'createdAt', 'age', fieldTypes(['timestamptz', 'timestamptz', 'int4']));
+      const query = insertMany([ new U({ x: new Date('2000-01-01'), age: 14 }), new U({ age: 8 }), new U() ]);
+      query.sql.should.be.eql(`
+  INSERT INTO dogs ("createdAt", "x","age")
+  SELECT clock_timestamp(), * FROM unnest($1::"timestamptz"[], $2::"int4"[]) AS t`);
+      query.values.should.be.eql([
+        ['2000-01-01T00:00:00.000Z', null, null],
+        [14, 8, null]
+      ]);
+    });
+
     it('should throw fieldTypesNotDefined', () => {
       const U = Frame.define(table('dogs'), 'x', 'createdAt');
       (() => insertMany([ new U({ x: new Date('2000-01-01') }), new U() ]))


### PR DESCRIPTION
I noticed this after adding a property to the Entity frame and then trying to "insertMany" entities. 

It's not the `createdAt` timestamp type that gets rearranged in the insertMany query, it's the _last_ type because `indexOf(['createdAt'], Type.insertfields` (with the brackets) always returns -1. `indexOf('createdAt',...` works as intended. Fixing this also led me to fix the typo of `timestampz` in the Entity frame that wasn't being surfaced before.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added a new test, which I verified failed before the code change.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I don't think there was previously a scenario to trigger this bug before. It didn't come up if the last type in a Frame was a timestamp, or if the Frame didn't have a createdAt. 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced