### PR TITLE
Fixing leftover .only mistake in a tests

### DIFF
--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -3894,7 +3894,7 @@ describe('datasets and entities', () => {
         }));
       });
 
-      describe.only('dataset-specific verbs', () => {
+      describe('dataset-specific verbs', () => {
         describe('dataset.create', () => {
           it('should NOT allow a new form that creates a dataset without user having dataset.create verb', testServiceFullTrx(async (service, { run }) => {
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.create') WHERE system in ('manager')`);


### PR DESCRIPTION


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced