### PR TITLE
Handle offline entities with baseVersion and trunkVersion

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -80,11 +80,15 @@ const extractTrunkVersionFromSubmission = (entity) => {
 
     return parseInt(entity.system.trunkVersion, 10);
   }
+  return null;
 };
 
 // TODO: write unit tests of this
 const extractBranchIdFromSubmission = (entity) => {
   const { branchId } = entity.system;
+  if (branchId === '')
+    return null;
+
   if (branchId) {
     const matches = _uuidPattern.exec(branchId);
     if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'branchId', expected: 'valid version 4 UUID' });

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -69,14 +69,12 @@ const extractBaseVersionFromSubmission = (entity) => {
 
 const extractBranchIdFromSubmission = (entity) => {
   const { branchId } = entity.system;
-  if (branchId === '')
+  if (branchId === '' || branchId == null)
     return null;
 
-  if (branchId) {
-    const matches = _uuidPattern.exec(branchId);
-    if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'branchId', expected: 'valid version 4 UUID' });
-    return matches[2].toLowerCase();
-  }
+  const matches = _uuidPattern.exec(branchId);
+  if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'branchId', expected: 'valid version 4 UUID' });
+  return matches[2].toLowerCase();
 };
 
 const extractTrunkVersionFromSubmission = (entity) => {

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -28,6 +28,8 @@ const odataToColumnMap = new Map([
   ['__system/conflict', 'entities.conflict']
 ]);
 
+const _uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+
 ////////////////////////////////////////////////////////////////////////////
 // ENTITY PARSING
 
@@ -35,8 +37,7 @@ const normalizeUuid = (id) => {
   if (!id || id.trim() === '')
     throw Problem.user.missingParameter({ field: 'uuid' });
 
-  const uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
-  const matches = uuidPattern.exec(id);
+  const matches = _uuidPattern.exec(id);
   if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'uuid', expected: 'valid version 4 UUID' });
   return matches[2].toLowerCase();
 };
@@ -66,6 +67,31 @@ const extractBaseVersionFromSubmission = (entity) => {
   }
 };
 
+// TODO: write unit tests of this
+const extractTrunkVersionFromSubmission = (entity) => {
+  const { trunkVersion, branchId } = entity.system;
+  if (trunkVersion) {
+    // branchId must be present with trunk version
+    if (!branchId)
+      throw Problem.user.missingParameter({ field: 'branchId' });
+
+    if (!/^\d+$/.test(trunkVersion))
+      throw Problem.user.invalidDataTypeOfParameter({ field: 'trunkVersion', expected: 'integer' });
+
+    return parseInt(entity.system.trunkVersion, 10);
+  }
+};
+
+// TODO: write unit tests of this
+const extractBranchIdFromSubmission = (entity) => {
+  const { branchId } = entity.system;
+  if (branchId) {
+    const matches = _uuidPattern.exec(branchId);
+    if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'branchId', expected: 'valid version 4 UUID' });
+    return matches[2].toLowerCase();
+  }
+};
+
 // This works similarly to processing submissions for export, but also note:
 // 1. this is expecting the entityFields to be filled in with propertyName attributes
 // 2. the "meta/entity" structural field should be included to get necessary
@@ -81,6 +107,8 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
       entity.system.create = field.attrs.create;
       entity.system.update = field.attrs.update;
       entity.system.baseVersion = field.attrs.baseVersion;
+      entity.system.trunkVersion = field.attrs.trunkVersion;
+      entity.system.branchId = field.attrs.branchId;
     } else if (field.path.indexOf('/meta/entity') === 0)
       entity.system[field.name] = text;
     else if (field.propertyName != null)
@@ -451,6 +479,8 @@ module.exports = {
   normalizeUuid,
   extractLabelFromSubmission,
   extractBaseVersionFromSubmission,
+  extractTrunkVersionFromSubmission,
+  extractBranchIdFromSubmission,
   extractBulkSource,
   streamEntityCsv, streamEntityCsvAttachment,
   streamEntityOdata, odataToColumnMap,

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -67,23 +67,6 @@ const extractBaseVersionFromSubmission = (entity) => {
   }
 };
 
-// TODO: write unit tests of this
-const extractTrunkVersionFromSubmission = (entity) => {
-  const { trunkVersion, branchId } = entity.system;
-  if (trunkVersion) {
-    // branchId must be present with trunk version
-    if (!branchId)
-      throw Problem.user.missingParameter({ field: 'branchId' });
-
-    if (!/^\d+$/.test(trunkVersion))
-      throw Problem.user.invalidDataTypeOfParameter({ field: 'trunkVersion', expected: 'integer' });
-
-    return parseInt(entity.system.trunkVersion, 10);
-  }
-  return null;
-};
-
-// TODO: write unit tests of this
 const extractBranchIdFromSubmission = (entity) => {
   const { branchId } = entity.system;
   if (branchId === '')
@@ -94,6 +77,22 @@ const extractBranchIdFromSubmission = (entity) => {
     if (matches == null) throw Problem.user.invalidDataTypeOfParameter({ field: 'branchId', expected: 'valid version 4 UUID' });
     return matches[2].toLowerCase();
   }
+};
+
+const extractTrunkVersionFromSubmission = (entity) => {
+  const { trunkVersion } = entity.system;
+  if (trunkVersion) {
+    // branchId must be present with trunk version
+    const branchId = extractBranchIdFromSubmission(entity);
+    if (!branchId)
+      throw Problem.user.missingParameter({ field: 'branchId' });
+
+    if (!/^\d+$/.test(trunkVersion))
+      throw Problem.user.invalidDataTypeOfParameter({ field: 'trunkVersion', expected: 'integer' });
+
+    return parseInt(entity.system.trunkVersion, 10);
+  }
+  return null;
 };
 
 // This works similarly to processing submissions for export, but also note:

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -10,7 +10,9 @@
 /* eslint-disable no-multi-spaces */
 
 const { embedded, fieldTypes, Frame, readable, table } = require('../frame');
-const { extractEntity, normalizeUuid, extractLabelFromSubmission, extractBaseVersionFromSubmission } = require('../../data/entity');
+const { extractEntity, normalizeUuid,
+  extractLabelFromSubmission, extractBaseVersionFromSubmission,
+  extractTrunkVersionFromSubmission, extractBranchIdFromSubmission } = require('../../data/entity');
 
 class Entity extends Frame.define(
   table('entities', 'entity'),
@@ -38,13 +40,17 @@ class Entity extends Frame.define(
     const uuid = normalizeUuid(entityData.system.id);
     const label = extractLabelFromSubmission(entityData, options);
     const baseVersion = extractBaseVersionFromSubmission(entityData);
+    const trunkVersion = extractTrunkVersionFromSubmission(entityData);
+    const branchId = extractBranchIdFromSubmission(entityData);
     const dataReceived = { ...data, ...(label && { label }) };
     return new Entity.Partial({ uuid }, {
       def: new Entity.Def({
         data,
         dataReceived,
+        ...(label && { label }), // add label only if it's there
         ...(baseVersion && { baseVersion }), // add baseVersion only if it's there
-        ...(label && { label }) // add label only if it's there
+        ...(trunkVersion && { trunkVersion }), // add trunkVersion only if it's there
+        ...(branchId && { branchId }), // add branchId only if it's there
       }),
       dataset
     });
@@ -88,6 +94,7 @@ Entity.Def = Frame.define(
   'version',      readable,         'baseVersion',  readable,
   'dataReceived', readable,         'conflictingProperties', readable,
   'createdAt',    readable,
+  'branchId', 'trunkVersion', 'branchBaseVersion',
   embedded('creator'),
   embedded('source'),
   fieldTypes([
@@ -98,7 +105,8 @@ Entity.Def = Frame.define(
     'jsonb', 'bool',
     'int4', 'int4',
     'jsonb', 'jsonb',
-    'timestamptz'
+    'timestamptz',
+    'uuid', 'int4', 'int4',
   ])
 );
 

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -94,7 +94,9 @@ Entity.Def = Frame.define(
   'version',      readable,         'baseVersion',  readable,
   'dataReceived', readable,         'conflictingProperties', readable,
   'createdAt',    readable,
-  'branchId', 'trunkVersion', 'branchBaseVersion',
+  'branchId',     readable,
+  'trunkVersion', readable,
+  'branchBaseVersion', readable,
   embedded('creator'),
   embedded('source'),
   fieldTypes([

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -40,8 +40,8 @@ class Entity extends Frame.define(
     const uuid = normalizeUuid(entityData.system.id);
     const label = extractLabelFromSubmission(entityData, options);
     const baseVersion = extractBaseVersionFromSubmission(entityData);
-    const trunkVersion = extractTrunkVersionFromSubmission(entityData);
     const branchId = extractBranchIdFromSubmission(entityData);
+    const trunkVersion = extractTrunkVersionFromSubmission(entityData);
     const dataReceived = { ...data, ...(label && { label }) };
     return new Entity.Partial({ uuid }, {
       def: new Entity.Def({

--- a/lib/model/migrations/20240607-01-add-offline-entity-branch-trunk-info.js
+++ b/lib/model/migrations/20240607-01-add-offline-entity-branch-trunk-info.js
@@ -1,0 +1,23 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`ALTER TABLE entity_defs
+    ADD COLUMN "branchId" UUID,
+    ADD COLUMN "trunkVersion" INT4,
+    ADD COLUMN "branchBaseVersion" INT4`);
+};
+
+const down = (db) => db.raw(`ALTER TABLE entity_defs
+  DROP COLUMN "branchId",
+  DROP COLUMN "trunkVersion",
+  DROP COLUMN "branchBaseVersion"
+  `);
+
+module.exports = { up, down };

--- a/lib/model/migrations/20240607-02-add-submission-backlog.js
+++ b/lib/model/migrations/20240607-02-add-submission-backlog.js
@@ -12,7 +12,7 @@ const up = async (db) => {
     "submissionId" INT4,
     "submissionDefId" INT4,
     "branchId" UUID,
-    "baseVersion" INT4,
+    "branchBaseVersion" INT4,
     "loggedAt" TIMESTAMPTZ(3),
     CONSTRAINT fk_submission_defs
       FOREIGN KEY("submissionDefId") 
@@ -21,7 +21,8 @@ const up = async (db) => {
     CONSTRAINT fk_submissions
       FOREIGN KEY("submissionId") 
       REFERENCES submissions(id)
-      ON DELETE CASCADE
+      ON DELETE CASCADE,
+    UNIQUE ("branchId", "branchBaseVersion")
   )`);
 };
 

--- a/lib/model/migrations/20240607-02-add-submission-backlog.js
+++ b/lib/model/migrations/20240607-02-add-submission-backlog.js
@@ -9,11 +9,11 @@
 
 const up = async (db) => {
   await db.raw(`CREATE TABLE entity_submission_backlog (
-    "submissionId" INT4,
-    "submissionDefId" INT4,
-    "branchId" UUID,
-    "branchBaseVersion" INT4,
-    "loggedAt" TIMESTAMPTZ(3),
+    "submissionId" INT4 NOT NULL,
+    "submissionDefId" INT4 NOT NULL,
+    "branchId" UUID NOT NULL,
+    "branchBaseVersion" INT4 NOT NULL,
+    "loggedAt" TIMESTAMPTZ(3) NOT NULL,
     CONSTRAINT fk_submission_defs
       FOREIGN KEY("submissionDefId") 
       REFERENCES submission_defs(id)

--- a/lib/model/migrations/20240607-02-add-submission-backlog.js
+++ b/lib/model/migrations/20240607-02-add-submission-backlog.js
@@ -1,0 +1,30 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`CREATE TABLE entity_submission_backlog (
+    "submissionId" INT4,
+    "submissionDefId" INT4,
+    "branchId" UUID,
+    "baseVersion" INT4,
+    "loggedAt" TIMESTAMPTZ(3),
+    CONSTRAINT fk_submission_defs
+      FOREIGN KEY("submissionDefId") 
+      REFERENCES submission_defs(id)
+      ON DELETE CASCADE,
+    CONSTRAINT fk_submissions
+      FOREIGN KEY("submissionId") 
+      REFERENCES submissions(id)
+      ON DELETE CASCADE
+  )`);
+};
+
+const down = (db) => db.raw('DROP TABLE entity_submission_backlog');
+
+module.exports = { up, down };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -195,6 +195,15 @@ SELECT actions
 FROM dataset_form_defs
 WHERE "datasetId" = ${datasetId} AND "formDefId" = ${formDefId}`);
 
+const _holdSubmission = (run, submissionId, submissionDefId, branchId, baseVersion) => run(sql`
+  INSERT INTO entity_submission_backlog ("submissionId", "submissionDefId", "branchId", "baseVersion", "loggedAt")
+  VALUES (${submissionId}, ${submissionDefId}, ${branchId}, ${baseVersion}, CLOCK_TIMESTAMP())
+  `);
+
+const _checkHeldSubmission = (maybeOne, branchId, baseVersion) => maybeOne(sql`
+  SELECT * FROM entity_submission_backlog
+  WHERE "branchId"=${branchId} AND "baseVersion" = ${baseVersion}`);
+
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
   // an approval event, then don't create an entity
@@ -218,8 +227,10 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
     });
 };
 
-const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, maybeOne }) => {
-  if (!(event.action === 'submission.create' || event.action === 'submission.update.version'))
+const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, maybeOne, run }) => {
+  if (!(event.action === 'submission.create'
+    || event.action === 'submission.update.version'
+    || event.action === 'submission.reprocess'))
     return null;
 
   // Get client version of entity
@@ -246,6 +257,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
     const previousInBranch = (await _getDef(maybeOne, new QueryOptions({ condition })));
     if (!previousInBranch.isDefined()) {
       // not ready to process this submission. eventually hold it for later.
+      await _holdSubmission(run, submissionDef.submissionId, submissionDef.id, clientEntity.def.branchId, clientEntity.def.baseVersion);
       return null;
     } else {
       baseVersion = previousInBranch.get().version;
@@ -309,7 +321,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 };
 
 // Entrypoint to where submissions (a specific version) become entities
-const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms, oneFirst }) => {
+const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Datasets, Entities, Submissions, Forms, maybeOne, oneFirst }) => {
   const { submissionId, submissionDefId } = event.details;
 
   const form = await Forms.getByActeeId(event.acteeId);
@@ -374,7 +386,19 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
       }
     }
   else if (entityData.system.create === '1' || entityData.system.create === 'true')
-    return Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
+    await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
+
+  // Check for held submissions that follow this one in the same branch
+  if (entityData.system.branchId != null) {
+    // baseVersion could be '', meaning its a create
+    const currentBaseVersion = entityData.system.baseVersion === '' ? 1 : parseInt(entityData.system.baseVersion, 10);
+    const nextSub = await _checkHeldSubmission(maybeOne, entityData.system.branchId, currentBaseVersion + 1);
+    if (nextSub.isDefined()) {
+      const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId } = nextSub.get();
+      await Audits.log({ id: event.actorId }, 'submission.reprocess', { acteeId: event.acteeId },
+        { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId });
+    }
+  }
 
   return null;
 };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -206,6 +206,29 @@ const _checkHeldSubmission = (maybeOne, branchId, branchBaseVersion) => maybeOne
   WHERE "branchId"=${branchId} AND "branchBaseVersion" = ${branchBaseVersion}
   RETURNING *`);
 
+// Used by _updateVerison below to figure out the intended base version in Central
+// based on the branchId, trunkVersion, and baseVersion in the submission
+const _computeBaseVersion = async (maybeOne, run, dataset, clientEntity, submissionDef) => {
+  if (!clientEntity.def.trunkVersion || clientEntity.def.baseVersion === clientEntity.def.trunkVersion) {
+    // trunk and client baseVersion are the same, indicating the start of a batch
+    return clientEntity.def.baseVersion;
+  } else {
+    const condition = { datasetId: dataset.id, uuid: clientEntity.uuid,
+      branchId: clientEntity.def.branchId,
+      branchBaseVersion: clientEntity.def.baseVersion - 1 };
+
+    // eslint-disable-next-line no-use-before-define
+    const previousInBranch = (await _getDef(maybeOne, new QueryOptions({ condition })));
+    if (!previousInBranch.isDefined()) {
+      // not ready to process this submission. eventually hold it for later.
+      await _holdSubmission(run, submissionDef.submissionId, submissionDef.id, clientEntity.def.branchId, clientEntity.def.baseVersion);
+      return null;
+    } else {
+      return previousInBranch.get().version;
+    }
+  }
+};
+
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
   // an approval event, then don't create an entity
@@ -257,26 +280,14 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   let { conflict } = serverEntity;
   let conflictingProperties; // Maybe we don't need to persist this??? just compute at the read time
 
-  // TODO: comments about what is happening here
-  let baseVersion;
-  if (!clientEntity.def.trunkVersion || clientEntity.def.baseVersion === clientEntity.def.trunkVersion) {
-    // trunk and client baseVersion are the same, indicating the start of a batch
-    baseVersion = clientEntity.def.baseVersion;
-  } else {
-    const condition = { datasetId: dataset.id, uuid: clientEntity.uuid,
-      branchId: clientEntity.def.branchId,
-      branchBaseVersion: clientEntity.def.baseVersion - 1 };
+  // Figure out the intended baseVersion
+  // If this is an offline update with a branchId, the baseVersion value is local to that
+  // offline context and we need to translate it to the correct base version within Central.
+  const baseVersion = await _computeBaseVersion(maybeOne, run, dataset, clientEntity, submissionDef);
 
-    // eslint-disable-next-line no-use-before-define
-    const previousInBranch = (await _getDef(maybeOne, new QueryOptions({ condition })));
-    if (!previousInBranch.isDefined()) {
-      // not ready to process this submission. eventually hold it for later.
-      await _holdSubmission(run, submissionDef.submissionId, submissionDef.id, clientEntity.def.branchId, clientEntity.def.baseVersion);
-      return null;
-    } else {
-      baseVersion = previousInBranch.get().version;
-    }
-  }
+  // If baseVersion is null, we held a submission and will stop processing now.
+  if (baseVersion == null)
+    return;
 
   if (baseVersion !== serverEntity.aux.currentVersion.version) {
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -240,7 +240,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   const clientEntity = await Entity.fromParseEntityData(entityData, { update: true }); // validation happens here
 
   // Get version of entity on the server
-  // TODO: comments about what is happening here, too
+  // If the entity doesn't exist, check branchId - maybe this is an update for an entity created offline
   let serverEntity = await Entities.getById(dataset.id, clientEntity.uuid, QueryOptions.forUpdate);
   if (!serverEntity.isDefined()) {
     if (clientEntity.def.branchId == null) {
@@ -313,9 +313,9 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       data: mergedData,
       label: mergedLabel,
       dataReceived: clientEntity.def.dataReceived,
-      trunkVersion: clientEntity.def.trunkVersion,
       branchId: clientEntity.def.branchId,
-      branchBaseVersion: clientEntity.def.baseVersion,
+      trunkVersion: clientEntity.def.trunkVersion,
+      branchBaseVersion: (clientEntity.def.branchId != null) ? clientEntity.def.baseVersion : null,
       conflictingProperties
     })
   });

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -195,14 +195,15 @@ SELECT actions
 FROM dataset_form_defs
 WHERE "datasetId" = ${datasetId} AND "formDefId" = ${formDefId}`);
 
-const _holdSubmission = (run, submissionId, submissionDefId, branchId, baseVersion) => run(sql`
-  INSERT INTO entity_submission_backlog ("submissionId", "submissionDefId", "branchId", "baseVersion", "loggedAt")
-  VALUES (${submissionId}, ${submissionDefId}, ${branchId}, ${baseVersion}, CLOCK_TIMESTAMP())
+const _holdSubmission = (run, submissionId, submissionDefId, branchId, branchBaseVersion) => run(sql`
+  INSERT INTO entity_submission_backlog ("submissionId", "submissionDefId", "branchId", "branchBaseVersion", "loggedAt")
+  VALUES (${submissionId}, ${submissionDefId}, ${branchId}, ${branchBaseVersion}, CLOCK_TIMESTAMP())
   `);
 
-const _checkHeldSubmission = (maybeOne, branchId, baseVersion) => maybeOne(sql`
-  SELECT * FROM entity_submission_backlog
-  WHERE "branchId"=${branchId} AND "baseVersion" = ${baseVersion}`);
+const _checkHeldSubmission = (maybeOne, branchId, branchBaseVersion) => maybeOne(sql`
+  DELETE FROM entity_submission_backlog
+  WHERE "branchId"=${branchId} AND "branchBaseVersion" = ${branchBaseVersion}
+  RETURNING *`);
 
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -276,6 +276,11 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
     serverEntity = serverEntity.get();
   }
 
+  // If the trunk version exists but is higher than current server version,
+  // that is a weird case that should not be processed OR held, and should log an error.
+  if (clientEntity.def.trunkVersion && clientEntity.def.trunkVersion > serverEntity.aux.currentVersion.version) {
+    throw Problem.user.entityVersionNotFound({ baseVersion: `trunkVersion=${clientEntity.def.trunkVersion}`, entityUuid: clientEntity.uuid, datasetName: dataset.name });
+  }
 
   let { conflict } = serverEntity;
   let conflictingProperties; // Maybe we don't need to persist this??? just compute at the read time
@@ -287,7 +292,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 
   // If baseVersion is null, we held a submission and will stop processing now.
   if (baseVersion == null)
-    return;
+    return null;
 
   if (baseVersion !== serverEntity.aux.currentVersion.version) {
 
@@ -416,14 +421,11 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
     maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
 
   // Check for held submissions that follow this one in the same branch
-  // TODO: consider changing checkHeldSub query to check for existing version of entity
-  // so that return value of create/update above doesn't matter as much.
-  // Also consider actually checking entity uuid, in query.
   if (maybeEntity != null && maybeEntity.aux.currentVersion.branchId != null) {
-    const { branchId } = maybeEntity.aux.currentVersion;
-    // baseVersion could be '', meaning its an offline create
-    const currentBaseVersion = entityData.system.baseVersion === '' ? 0 : parseInt(entityData.system.baseVersion, 10);
-    const nextSub = await _checkHeldSubmission(maybeOne, branchId, currentBaseVersion + 1);
+    const { branchId, branchBaseVersion } = maybeEntity.aux.currentVersion;
+    // branchBaseVersion could be undefined if handling an offline create
+    const currentBranchBaseVersion = branchBaseVersion ?? 0;
+    const nextSub = await _checkHeldSubmission(maybeOne, branchId, currentBranchBaseVersion + 1);
     if (nextSub.isDefined()) {
       const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId } = nextSub.get();
       await Audits.log({ id: event.actorId }, 'submission.reprocess', { acteeId: event.acteeId },

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -217,7 +217,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id);
   const entity = await Entities.createNew(dataset, partial, submissionDef, sourceId);
 
-  return Audits.log({ id: event.actorId }, 'entity.create', { acteeId: dataset.acteeId },
+  await Audits.log({ id: event.actorId }, 'entity.create', { acteeId: dataset.acteeId },
     {
       entityId: entity.id, // Added in v2023.3 and backfilled
       entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 and backfilled
@@ -225,6 +225,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
       submissionId,
       submissionDefId
     });
+  return entity;
 };
 
 const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, maybeOne, run }) => {
@@ -321,7 +322,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   const version = serverEntity.aux.currentVersion.version + 1;
 
   const entity = await Entities.createVersion(dataset, partial, submissionDef, version, sourceId, baseVersion);
-  return Audits.log({ id: event.actorId }, 'entity.update.version', { acteeId: dataset.acteeId },
+  await Audits.log({ id: event.actorId }, 'entity.update.version', { acteeId: dataset.acteeId },
     {
       entityId: entity.id,
       entityDefId: entity.aux.currentVersion.id,
@@ -329,6 +330,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       submissionId,
       submissionDefId
     });
+  return entity;
 };
 
 // Entrypoint to where submissions (a specific version) become entities
@@ -385,23 +387,27 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
       throw Problem.user.entityActionNotPermitted({ action, permitted: permittedActions });
   }
 
+  let maybeEntity = null;
   // Try update before create (if both are specified)
   if (entityData.system.update === '1' || entityData.system.update === 'true')
     try {
-      await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event);
+      maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event);
     } catch (err) {
       if ((err.problemCode === 404.8) && (entityData.system.create === '1' || entityData.system.create === 'true')) {
-        await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
+        maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
       } else {
         throw (err);
       }
     }
   else if (entityData.system.create === '1' || entityData.system.create === 'true')
-    await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
+    maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
 
   // Check for held submissions that follow this one in the same branch
-  if (entityData.system.branchId != null) {
-    // baseVersion could be '', meaning its a create
+  // TODO: consider changing checkHeldSub query to check for existing version of entity
+  // so that return value of create/update above doesn't matter as much.
+  // Also consider actually checking entity uuid, in query.
+  if (maybeEntity != null && entityData.system.branchId != null) {
+    // baseVersion could be '', meaning its an offline create
     const currentBaseVersion = entityData.system.baseVersion === '' ? 0 : parseInt(entityData.system.baseVersion, 10);
     const nextSub = await _checkHeldSubmission(maybeOne, entityData.system.branchId, currentBaseVersion + 1);
     if (nextSub.isDefined()) {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -44,12 +44,14 @@ const _defInsert = (id, root, creatorId, userAgent, partial, version, sourceId =
     "sourceId", "creatorId", "userAgent",
     "label", "data", "dataReceived",
     "version", "baseVersion",
+    "trunkVersion", "branchId", "branchBaseVersion",
     "conflictingProperties")
   values (${id}, clock_timestamp(),
     ${root}, true,
     ${sourceId}, ${creatorId}, ${userAgent},
     ${partial.def.label}, ${json}, ${dataReceived},
     ${version}, ${baseVersion},
+    ${partial.def.trunkVersion ?? null}, ${partial.def.branchId ?? null}, ${partial.def.branchBaseVersion ?? null},
     ${conflictingProperties})
   returning *`;
 };
@@ -230,12 +232,32 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   let { conflict } = serverEntity;
   let conflictingProperties; // Maybe we don't need to persist this??? just compute at the read time
 
-  if (clientEntity.def.baseVersion !== serverEntity.aux.currentVersion.version) {
+  // TODO: comments about what is happening here
+  let baseVersion;
+  if (!clientEntity.def.trunkVersion || clientEntity.def.baseVersion === clientEntity.def.trunkVersion) {
+    // trunk and client baseVersion are the same, indicating the start of a batch
+    baseVersion = clientEntity.def.baseVersion;
+  } else {
+    const condition = { datasetId: dataset.id, uuid: clientEntity.uuid,
+      branchId: clientEntity.def.branchId,
+      branchBaseVersion: clientEntity.def.baseVersion - 1 };
 
-    const condition = { datasetId: dataset.id, uuid: clientEntity.uuid, version: clientEntity.def.baseVersion };
+    // eslint-disable-next-line no-use-before-define
+    const previousInBranch = (await _getDef(maybeOne, new QueryOptions({ condition })));
+    if (!previousInBranch.isDefined()) {
+      // not ready to process this submission. eventually hold it for later.
+      return null;
+    } else {
+      baseVersion = previousInBranch.get().version;
+    }
+  }
+
+  if (baseVersion !== serverEntity.aux.currentVersion.version) {
+
+    const condition = { datasetId: dataset.id, uuid: clientEntity.uuid, version: baseVersion };
     // eslint-disable-next-line no-use-before-define
     const baseEntityVersion = (await _getDef(maybeOne, new QueryOptions({ condition })))
-      .orThrow(Problem.user.entityVersionNotFound({ baseVersion: clientEntity.def.baseVersion, entityUuid: clientEntity.uuid, datasetName: dataset.name }));
+      .orThrow(Problem.user.entityVersionNotFound({ baseVersion, entityUuid: clientEntity.uuid, datasetName: dataset.name }));
 
     // we need to find what changed between baseVersion and lastVersion
     // it is not the data we received in lastVersion
@@ -265,11 +287,17 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       data: mergedData,
       label: mergedLabel,
       dataReceived: clientEntity.def.dataReceived,
+      trunkVersion: clientEntity.def.trunkVersion,
+      branchId: clientEntity.def.branchId,
+      branchBaseVersion: clientEntity.def.baseVersion,
       conflictingProperties
     })
   });
 
-  const entity = await Entities.createVersion(dataset, partial, submissionDef, serverEntity.aux.currentVersion.version + 1, sourceId, clientEntity.def.baseVersion);
+  // Assign new version (increment latest server version)
+  const version = serverEntity.aux.currentVersion.version + 1;
+
+  const entity = await Entities.createVersion(dataset, partial, submissionDef, version, sourceId, baseVersion);
   return Audits.log({ id: event.actorId }, 'entity.update.version', { acteeId: dataset.acteeId },
     {
       entityId: entity.id,

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -237,8 +237,19 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   const clientEntity = await Entity.fromParseEntityData(entityData, { update: true }); // validation happens here
 
   // Get version of entity on the server
-  const serverEntity = (await Entities.getById(dataset.id, clientEntity.uuid, QueryOptions.forUpdate))
-    .orThrow(Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name }));
+  // TODO: comments about what is happening here, too
+  let serverEntity = await Entities.getById(dataset.id, clientEntity.uuid, QueryOptions.forUpdate);
+  if (!serverEntity.isDefined()) {
+    if (clientEntity.def.branchId == null) {
+      throw Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name });
+    } else {
+      await _holdSubmission(run, submissionDef.submissionId, submissionDef.id, clientEntity.def.branchId, clientEntity.def.baseVersion);
+      return null;
+    }
+  } else {
+    serverEntity = serverEntity.get();
+  }
+
 
   let { conflict } = serverEntity;
   let conflictingProperties; // Maybe we don't need to persist this??? just compute at the read time
@@ -391,7 +402,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
   // Check for held submissions that follow this one in the same branch
   if (entityData.system.branchId != null) {
     // baseVersion could be '', meaning its a create
-    const currentBaseVersion = entityData.system.baseVersion === '' ? 1 : parseInt(entityData.system.baseVersion, 10);
+    const currentBaseVersion = entityData.system.baseVersion === '' ? 0 : parseInt(entityData.system.baseVersion, 10);
     const nextSub = await _checkHeldSubmission(maybeOne, entityData.system.branchId, currentBaseVersion + 1);
     if (nextSub.isDefined()) {
       const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId } = nextSub.get();

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -82,11 +82,12 @@ ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ${dataset.id}, ${partial.uuid}, def."createdAt", ${creatorId} from def
   returning entities.*)
 select ins.*, def.id as "entityDefId" from ins, def;`)
-    .then(({ entityDefId, ...entityData }) => // TODO/HACK: reassemble just enough to log audit event
+    .then(({ entityDefId, ...entityData }) => // TODO/HACK: starting to need more reassembling
       new Entity(entityData, {
         currentVersion: new Entity.Def({
           id: entityDefId,
-          entityId: entityData.id
+          entityId: entityData.id,
+          branchId: partial.def.branchId
         })
       }));
 };
@@ -407,10 +408,11 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
   // TODO: consider changing checkHeldSub query to check for existing version of entity
   // so that return value of create/update above doesn't matter as much.
   // Also consider actually checking entity uuid, in query.
-  if (maybeEntity != null && entityData.system.branchId != null) {
+  if (maybeEntity != null && maybeEntity.aux.currentVersion.branchId != null) {
+    const { branchId } = maybeEntity.aux.currentVersion;
     // baseVersion could be '', meaning its an offline create
     const currentBaseVersion = entityData.system.baseVersion === '' ? 0 : parseInt(entityData.system.baseVersion, 10);
-    const nextSub = await _checkHeldSubmission(maybeOne, entityData.system.branchId, currentBaseVersion + 1);
+    const nextSub = await _checkHeldSubmission(maybeOne, branchId, currentBaseVersion + 1);
     if (nextSub.isDefined()) {
       const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId } = nextSub.get();
       await Audits.log({ id: event.actorId }, 'submission.reprocess', { acteeId: event.acteeId },

--- a/lib/worker/jobs.js
+++ b/lib/worker/jobs.js
@@ -18,6 +18,7 @@ const jobs = {
   'submission.update.version': [ require('./submission').submissionUpdateVersion, require('./entity').createOrUpdateEntityFromSubmission ],
 
   'submission.update': [ require('./entity').createOrUpdateEntityFromSubmission ],
+  'submission.reprocess': [ require('./entity').createOrUpdateEntityFromSubmission ],
 
   'form.create': [ require('./form').create ],
   'form.update.draft.set': [ require('./form').updateDraftSet ],

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -415,6 +415,29 @@ module.exports = {
   </h:head>
 </h:html>`,
 
+    offlineEntity: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model entities:entities-version="2023.1.0">
+      <instance>
+        <data id="offlineEntity" orx:version="1.0">
+          <name/>
+          <age/>
+          <status/>
+          <meta>
+            <entity dataset="people" id="" create="" update="" baseVersion="" trunkVersion="" branchId="">
+              <label/>
+            </entity>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" entities:saveto="first_name"/>
+      <bind nodeset="/data/age" type="int" entities:saveto="age"/>
+      <bind nodeset="/data/status" type="int" entities:saveto="status"/>
+    </model>
+  </h:head>
+</h:html>`,
+
     groupRepeat: `<?xml version="1.0"?>
     <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
         <h:head>
@@ -701,6 +724,33 @@ module.exports = {
         </meta>
         <age>55</age>
       </data>`
+    },
+    offlineEntity: {
+      one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="offlineEntity" version="1.0">
+        <meta>
+          <instanceID>one</instanceID>
+          <orx:instanceName>one</orx:instanceName>
+          <entity dataset="people" id="12345678-1234-4123-8234-123456789abc"
+            baseVersion="1" update="1"
+            trunkVersion="1" branchId="">
+          </entity>
+        </meta>
+        <status>arrived</status>
+      </data>`,
+      two: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms" id="offlineEntity" version="1.0">
+        <meta>
+          <instanceID>two</instanceID>
+          <orx:instanceName>two</orx:instanceName>
+          <entity dataset="people" id="12345678-1234-4123-8234-123456789ddd"
+          baseVersion="" create="1"
+          trunkVersion="" branchId="">
+            <label>Megan (20)</label>
+          </entity>
+        </meta>
+        <name>Megan</name>
+        <status>new</status>
+        <age>20</age>
+      </data>`,
     },
     groupRepeat: {
       one: `<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="groupRepeat">

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1,0 +1,336 @@
+const appRoot = require('app-root-path');
+const { testService } = require('../setup');
+const testData = require('../../data/xml');
+const { getOrNotFound } = require('../../../lib/util/promise');
+const uuid = require('uuid').v4;
+const should = require('should');
+
+const { exhaust } = require(appRoot + '/lib/worker/worker');
+
+const testOfflineEntities = (test) => testService(async (service, container) => {
+  const asAlice = await service.login('alice');
+
+  // Publish a form that will set up the dataset with properties
+  await asAlice.post('/v1/projects/1/forms?publish=true')
+    .send(testData.forms.offlineEntity)
+    .set('Content-Type', 'application/xml')
+    .expect(200);
+
+  // Create an entity via the API (to be updated offline)
+  await asAlice.post('/v1/projects/1/datasets/people/entities')
+    .send({
+      uuid: '12345678-1234-4123-8234-123456789abc',
+      label: 'Johnny Doe',
+      data: { first_name: 'Johnny', age: '22' }
+    })
+    .expect(200);
+
+  await exhaust(container);
+
+  await test(service, container);
+});
+
+describe('Offline Entities', () => {
+  describe('parsing branchId and trunkVersion from submission xml', () => {
+    it('should parse and save run info from sub creating an entity', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.two
+          .replace('branchId=""', `branchId="${branchId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789ddd').then(getOrNotFound);
+      entity.aux.currentVersion.branchId.should.equal(branchId);
+      entity.aux.currentVersion.version.should.equal(1);
+      // This is the first version of the entity so there should be no base or trunk versions
+      should.not.exist(entity.aux.currentVersion.trunkVersion);
+      should.not.exist(entity.aux.currentVersion.baseVersion);
+      entity.aux.currentVersion.data.should.eql({ age: '20', status: 'new', first_name: 'Megan' });
+    }));
+
+    it('should parse and save run info from sub updating an entity', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      // Check base version through API
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+        .expect(200)
+        .then(({ body }) => {
+          body.currentVersion.version.should.equal(2);
+          body.currentVersion.baseVersion.should.equal(1);
+        });
+
+      // Check entity details on Frame
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.branchId.should.equal(branchId);
+      entity.aux.currentVersion.baseVersion.should.equal(1);
+      entity.aux.currentVersion.branchBaseVersion.should.equal(1);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'arrived', first_name: 'Johnny' });
+    }));
+  });
+
+  describe('offline branches submitted in order', () => {
+    it('should let multiple updates in the same branch get applied in order', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('one', 'one-update')
+          .replace('baseVersion="1"', 'baseVersion="2"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.branchId.should.equal(branchId);
+      entity.aux.currentVersion.baseVersion.should.equal(2);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'departed', first_name: 'Johnny' });
+    }));
+
+    it('should apply update branch in order after server version has advanced', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?baseVersion=1')
+        .send({ label: 'Johnny Doe (age 22)' })
+        .expect(200);
+
+      // the trunk version of these submissions is 1, but the server version has advanced beyond that
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('one', 'one-update')
+          .replace('baseVersion="1"', 'baseVersion="2"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.branchId.should.equal(branchId);
+      entity.aux.currentVersion.baseVersion.should.equal(3);
+      entity.aux.currentVersion.trunkVersion.should.equal(1);
+      entity.aux.currentVersion.branchBaseVersion.should.equal(2);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'departed', first_name: 'Johnny' });
+    }));
+
+    it('should handle updating a branch in order, but with an interruption', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      // Update entity on the server (interrupt at beginning, too)
+      await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?baseVersion=1')
+        .send({ label: 'Johnny - changed label' })
+        .expect(200);
+
+      // Submit the first update in the branch
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      // Apply the update from the submission
+      await exhaust(container);
+
+      // Update entity on the server (server version is now 3)
+      await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?baseVersion=3')
+        .send({ label: 'Johnny Doe (age 22)' })
+        .expect(200);
+
+      // Submit second update in branch
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('one', 'one-update')
+          .replace('baseVersion="1"', 'baseVersion="2"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.version.should.equal(5);
+      entity.aux.currentVersion.branchId.should.equal(branchId);
+      entity.aux.currentVersion.baseVersion.should.equal(3);
+      entity.aux.currentVersion.trunkVersion.should.equal(1);
+      entity.aux.currentVersion.branchBaseVersion.should.equal(2);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'departed', first_name: 'Johnny' });
+    }));
+  });
+
+  describe('out of order runs', () => {
+    it('should quietly process submission without entity work if trunk and base versions are not good', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      // trunk version is 1, but base version is higher than trunk version indicating it is later in the run
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${uuid()}"`)
+          .replace('baseVersion="1"', 'baseVersion="2"')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+        .expect(200)
+        .then(({ body }) => {
+          // no status property in data because out of order update did not get applied
+          body.currentVersion.data.should.eql({ age: '22', first_name: 'Johnny' });
+        });
+
+      // Processing this should not yeild an error even if update doesnt get applied
+      await asAlice.get('/v1/projects/1/forms/offlineEntity/submissions/one/audits')
+        .expect(200)
+        .then(({ body }) => {
+          should.not.exist(body[0].details.problem);
+        });
+    }));
+
+    it('should not apply out of order update from a run after starting a run', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      // start run correctly
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      // much later run index
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('one', 'one-update2')
+          .replace('baseVersion="1"', 'baseVersion="3"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.branchId.should.equal(branchId);
+      entity.aux.currentVersion.baseVersion.should.equal(1);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'arrived', first_name: 'Johnny' });
+    }));
+
+    it('should not apply later trunkVersion when run has not even started', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      // much later run index
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('one', 'one-update2')
+          .replace('baseVersion="1"', 'baseVersion="2"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      should.not.exist(entity.aux.currentVersion.branchId);
+      //should.not.exist(entity.aux.currentVersion.runIndex);
+      // something about base version
+      entity.aux.currentVersion.data.should.eql({ age: '22', first_name: 'Johnny' });
+    }));
+
+    it.skip('should apply later run received earlier', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+
+      // start run correctly
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('one', 'one-update2')
+          .replace('baseVersion="1"', 'baseVersion="3"')
+          .replace('<status>arrived</status>', '<status>departed</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.one
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('one', 'one-update1')
+          .replace('baseVersion="1"', 'baseVersion="2"')
+          .replace('<status>arrived</status>', '<status>working</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      const entity = await container.Entities.getById(dataset.id, '12345678-1234-4123-8234-123456789abc').then(getOrNotFound);
+      entity.aux.currentVersion.branchId.should.equal(branchId);
+      entity.aux.currentVersion.baseVersion.should.equal(3);
+      entity.aux.currentVersion.data.should.eql({ age: '22', status: 'departed', first_name: 'Johnny' });
+    }));
+  });
+});

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -191,7 +191,9 @@ describe('extracting and validating entities', () => {
               label: 'Alice (88)',
               dataset: 'people',
               update: undefined,
-              baseVersion: undefined
+              baseVersion: undefined,
+              branchId: undefined,
+              trunkVersion: undefined
             });
           }));
 
@@ -206,7 +208,9 @@ describe('extracting and validating entities', () => {
               label: 'Alice (88)',
               dataset: 'people',
               update: undefined,
-              baseVersion: undefined
+              baseVersion: undefined,
+              branchId: undefined,
+              trunkVersion: undefined
             });
           }));
 
@@ -257,7 +261,9 @@ describe('extracting and validating entities', () => {
               label: 'Alicia (85)',
               dataset: 'people',
               update: '1',
-              baseVersion: '1'
+              baseVersion: '1',
+              branchId: undefined,
+              trunkVersion: undefined
             });
           }));
     });


### PR DESCRIPTION
Possible backend solution for https://github.com/getodk/central/issues/669 

[XML form](https://drive.google.com/file/d/1G3rPaca3d34XpVgdaEvd_S1451EuEX4U/view?usp=sharing) that allows branch id / base version / trunk version to be set. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced