### PR TITLE
Add eslint-plugin-no-only-tests to flag leftover .only tests.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,9 @@
   "extends": "airbnb-base",
   "env": { "node": true },
   "parserOptions": { "ecmaVersion": 2020 },
+  "plugins": [
+    "no-only-tests"
+  ],
   "rules": {
     "array-bracket-spacing": "off",
     "arrow-parens": "off",
@@ -25,6 +28,7 @@
     "no-else-return": "off",
     "no-multiple-empty-lines": "off",
     "no-nested-ternary": "off",
+    "no-only-tests/no-only-tests": "error",
     "no-restricted-syntax": "off",
     "no-underscore-dangle": "off",
     "nonblock-statement-body-position": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint": "^8.44.0",
         "eslint-config-airbnb-base": "~15",
         "eslint-plugin-import": "~2.25",
+        "eslint-plugin-no-only-tests": "~3.1",
         "fetch-cookie": "^2.1.0",
         "http-proxy-middleware": "^2.0.6",
         "lodash": "^4.17.21",
@@ -3505,6 +3506,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "dev": true,
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -13995,6 +14005,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint": "^8.44.0",
     "eslint-config-airbnb-base": "~15",
     "eslint-plugin-import": "~2.25",
+    "eslint-plugin-no-only-tests": "~3.1",
     "fetch-cookie": "^2.1.0",
     "http-proxy-middleware": "^2.0.6",
     "lodash": "^4.17.21",

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -35,6 +35,7 @@ const down = () => withTestDatabase((migrator) =>
 const testMigration = (filename, tests, options = {}) => {
   const { only = false, skip = false } = options;
   const f = only
+    // eslint-disable-next-line no-only-tests/no-only-tests
     ? describe.only.bind(describe)
     : (skip ? describe.skip.bind(describe) : describe);
   // eslint-disable-next-line func-names, space-before-function-paren


### PR DESCRIPTION
It would help if I had the linter yell at me for leaving in .only tests. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced