### PR TITLE
query/blobs: delete comment ref copy/pasted code

### DIFF
--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -31,10 +31,6 @@ const getById = (blobId) => ({ maybeOne }) =>
   maybeOne(sql`select * from blobs where id=${blobId}`)
     .then(map(construct(Blob)));
 
-// NOTE: copypasta alert!
-// The migration 20220121-02-purge-deleted-forms.js also contains a version
-// of the following purge blob query, and if it changes here, it should likely
-// change there, too.
 const purgeUnattached = () => ({ all }) =>
   all(sql`
 delete from blobs


### PR DESCRIPTION
The comment suggested modifying a migration which has since been released.  If there is a problem with the migration, it should be fixed with a subsequent migration.
