### PR TITLE
test/integration/api: de-duplicate test name

### DIFF
--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -738,7 +738,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
               .expect(304)));
       }));
 
-      it('should return the xlsx file originally provided', testService((service) => {
+      it('should return the xlsx file originally provided for a draft', testService((service) => {
         const input = readFileSync(appRoot + '/test/data/simple.xlsx');
         return service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms?publish=true')


### PR DESCRIPTION
There were previously two adjacent tests both called:

> should return the xlsx file originally provided
