### PR TITLE
Check approvalRequired reprocessing with offline entity queue

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -201,7 +201,11 @@ const _holdSubmission = (run, submissionId, submissionDefId, branchId, branchBas
   VALUES (${submissionId}, ${submissionDefId}, ${branchId}, ${branchBaseVersion}, CLOCK_TIMESTAMP())
   `);
 
-const _checkHeldSubmission = (maybeOne, branchId, branchBaseVersion) => maybeOne(sql`
+const _checkHeldSubmission = (maybeOne, submissionId) => maybeOne(sql`
+  SELECT * FROM entity_submission_backlog
+  WHERE "submissionId"=${submissionId}`);
+
+const _checkAndDeleteHeldSubmission = (maybeOne, branchId, branchBaseVersion) => maybeOne(sql`
   DELETE FROM entity_submission_backlog
   WHERE "branchId"=${branchId} AND "branchBaseVersion" = ${branchBaseVersion}
   RETURNING *`);
@@ -367,6 +371,12 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
   if (existingEntity.isDefined())
     return null;
 
+  const existingHeldSubmission = await _checkHeldSubmission(maybeOne, submissionId);
+  // If the submission is being held for ordering offline entity processing,
+  // don't try to process it now, it will be dequeued and reprocessed elsewhere.
+  if (existingHeldSubmission.isDefined())
+    return null;
+
   const submission = await Submissions.getSubAndDefById(submissionDefId);
 
   // If Submission is deleted/purged - Safety check, will not be true at this line
@@ -425,7 +435,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
     const { branchId, branchBaseVersion } = maybeEntity.aux.currentVersion;
     // branchBaseVersion could be undefined if handling an offline create
     const currentBranchBaseVersion = branchBaseVersion ?? 0;
-    const nextSub = await _checkHeldSubmission(maybeOne, branchId, currentBranchBaseVersion + 1);
+    const nextSub = await _checkAndDeleteHeldSubmission(maybeOne, branchId, currentBranchBaseVersion + 1);
     if (nextSub.isDefined()) {
       const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId } = nextSub.get();
       await Audits.log({ id: event.actorId }, 'submission.reprocess', { acteeId: event.acteeId },


### PR DESCRIPTION
Small followup to https://github.com/getodk/central/issues/669 

Prevents submissions that are being held for later processing (because of offline entity ordering) are not mishandled
- not reprocessed an extra time
- not re-enqueued
- not causing errors

This PR also tests the (expected) behavior that if an offline branch included create and update, and the dataset required approval before creating the update, that the update would be held until the create submission was approved and applied. (Though it gets pretty hairy on the Collect side to think about keeping all of this information/state in sync when combining approval required + offline. See [forum post](https://forum.getodk.org/t/openrosa-spec-proposal-support-offline-entities/48052) about ideas for syncing.)

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced