### PR TITLE
[Docs] add response example for bulk entities upload

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -9161,6 +9161,9 @@ paths:
                     label: John (88)
                     firstName: John
                     age: '88'
+            application/json; bulk:
+              schema:
+                $ref: '#/components/schemas/Success'
         403:
           description: Forbidden
           content:


### PR DESCRIPTION
## Issue

- Currently the docs for `POST /projects/{projectId}/datasets/{name}/entities` show the response type for uploading a single Entity.
- They have not been updated to show the response type when bulk uploading multiple Entities.
- Ideally the response would return the Entity data, but this is not trivial, due to having to re-fetch data from the db for each Entity (line 98 & 113):
    https://github.com/getodk/central-backend/blob/fb96aa3333d3442ea43365755766262f21de3969/lib/resources/entities.js#L93-L114

## Solution

- The endpoint currently returns `'success': true`.
- I updated the docs to reflect this, until the endpoint returns the Entity data (if possible).
- I reused the pattern in the docs for return type `application/json; extended` to use `application/json; bulk`, allowing us to display two examples side-by-side - not sure if this is the preferred approach!