### PR TITLE
entity: add comment explaining UUID regex

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -28,6 +28,7 @@ const odataToColumnMap = new Map([
   ['__system/conflict', 'entities.conflict']
 ]);
 
+// Entity IDs must be UUID v4.  See: https://getodk.github.io/xforms-spec/entities.html#declaring-that-a-form-creates-entities
 const _uuidPattern = /^(uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Per https://getodk.github.io/xforms-spec/entities.html#declaring-that-a-form-creates-entities:

> MUST have attribute id populated by a RFC 4122 version 4 UUID
