### PR TITLE
Improvements to offline entity backlog processing

### DIFF
--- a/lib/model/migrations/20240715-01-backlog-add-event-entityuuid.js
+++ b/lib/model/migrations/20240715-01-backlog-add-event-entityuuid.js
@@ -1,0 +1,25 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`ALTER TABLE entity_submission_backlog
+    ADD COLUMN "auditId" INT4 NOT NULL,
+    ADD COLUMN "entityUuid" UUID NOT NULL,
+    ADD CONSTRAINT fk_audit_id
+      FOREIGN KEY("auditId")
+      REFERENCES audits(id)
+      ON DELETE CASCADE`);
+};
+
+const down = (db) => db.raw(`ALTER TABLE entity_submission_backlog
+  DROP COLUMN "auditId",
+  DROP COLUMN "entityUuid"
+`);
+
+module.exports = { up, down };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -322,7 +322,7 @@ const _computeBaseVersion = (eventId, dataset, clientEntity, submissionDef) => a
     else if (clientEntity.def.baseVersion === clientEntity.def.trunkVersion) // Start of an offline branch
       condition = { version: clientEntity.def.baseVersion };
     else // middle of an offline branch
-      condition = { branchBaseVersion: clientEntity.def.baseVersion - 1 };
+      condition = { branchId: clientEntity.def.branchId, branchBaseVersion: clientEntity.def.baseVersion - 1 };
 
     const baseEntityVersion = await Entities.getDef(dataset.id, clientEntity.uuid, new QueryOptions({ condition }));
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -86,8 +86,7 @@ select ins.*, def.id as "entityDefId" from ins, def;`)
       new Entity(entityData, {
         currentVersion: new Entity.Def({
           id: entityDefId,
-          entityId: entityData.id,
-          branchId: partial.def.branchId
+          entityId: entityData.id
         })
       }));
 };
@@ -176,62 +175,7 @@ createVersion.audit = (updatedEntity, dataset, partial, subDef) => (log) => {
 createVersion.audit.withResult = true;
 
 ////////////////////////////////////////////////////////////////////////////////
-// RESOLVE CONFLICT
-
-const resolveConflict = (entity, dataset) => ({ one }) => // eslint-disable-line no-unused-vars
-  one(sql`UPDATE entities SET conflict=NULL, "updatedAt"=CLOCK_TIMESTAMP() WHERE "id"=${entity.id} RETURNING *`)
-    .then(r => entity.with({ conflict: r.conflict, updatedAt: r.updatedAt }));
-
-resolveConflict.audit = (entity, dataset) => (log) => log('entity.update.resolve', dataset, {
-  entityId: entity.id,
-  entityDefId: entity.aux.currentVersion.id,
-  entity: { uuid: entity.uuid, dataset: dataset.name }
-});
-
-/////////////////////////////////////////////////////////////////////////
-// Processing submission events to create and update entities
-
-const _getFormDefActions = (oneFirst, datasetId, formDefId) => oneFirst(sql`
-SELECT actions
-FROM dataset_form_defs
-WHERE "datasetId" = ${datasetId} AND "formDefId" = ${formDefId}`);
-
-const _holdSubmission = (run, submissionId, submissionDefId, branchId, branchBaseVersion) => run(sql`
-  INSERT INTO entity_submission_backlog ("submissionId", "submissionDefId", "branchId", "branchBaseVersion", "loggedAt")
-  VALUES (${submissionId}, ${submissionDefId}, ${branchId}, ${branchBaseVersion}, CLOCK_TIMESTAMP())
-  `);
-
-const _checkHeldSubmission = (maybeOne, submissionId) => maybeOne(sql`
-  SELECT * FROM entity_submission_backlog
-  WHERE "submissionId"=${submissionId}`);
-
-const _checkAndDeleteHeldSubmission = (maybeOne, branchId, branchBaseVersion) => maybeOne(sql`
-  DELETE FROM entity_submission_backlog
-  WHERE "branchId"=${branchId} AND "branchBaseVersion" = ${branchBaseVersion}
-  RETURNING *`);
-
-// Used by _updateVerison below to figure out the intended base version in Central
-// based on the branchId, trunkVersion, and baseVersion in the submission
-const _computeBaseVersion = async (maybeOne, run, dataset, clientEntity, submissionDef) => {
-  if (!clientEntity.def.trunkVersion || clientEntity.def.baseVersion === clientEntity.def.trunkVersion) {
-    // trunk and client baseVersion are the same, indicating the start of a batch
-    return clientEntity.def.baseVersion;
-  } else {
-    const condition = { datasetId: dataset.id, uuid: clientEntity.uuid,
-      branchId: clientEntity.def.branchId,
-      branchBaseVersion: clientEntity.def.baseVersion - 1 };
-
-    // eslint-disable-next-line no-use-before-define
-    const previousInBranch = (await _getDef(maybeOne, new QueryOptions({ condition })));
-    if (!previousInBranch.isDefined()) {
-      // not ready to process this submission. eventually hold it for later.
-      await _holdSubmission(run, submissionDef.submissionId, submissionDef.id, clientEntity.def.branchId, clientEntity.def.baseVersion);
-      return null;
-    } else {
-      return previousInBranch.get().version;
-    }
-  }
-};
+// WRAPPER FUNCTIONS FOR CREATING AND UPDATING ENTITIES
 
 const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
@@ -240,6 +184,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
       (!dataset.approvalRequired && event.action === 'submission.update')) // don't process submission if approval is not required and submission metadata is updated
     return null;
 
+  // TODO: auto-generate a label if forced and if the submission doesn't provide one
   const partial = await Entity.fromParseEntityData(entityData, { create: true });
 
   const sourceDetails = { submission: { instanceId: submissionDef.instanceId }, parentEventId: parentEvent ? parentEvent.id : undefined };
@@ -257,7 +202,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
   return entity;
 };
 
-const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities, maybeOne, run }) => {
+const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event) => async ({ Audits, Entities }) => {
   if (!(event.action === 'submission.create'
     || event.action === 'submission.update.version'
     || event.action === 'submission.reprocess'))
@@ -266,16 +211,20 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   // Get client version of entity
   const clientEntity = await Entity.fromParseEntityData(entityData, { update: true }); // validation happens here
 
+  // Figure out the intended baseVersion
+  // If this is an offline update with a branchId, the baseVersion value is local to that offline context.
+  const baseEntityDef = await Entities._computeBaseVersion(event.id, dataset, clientEntity, submissionDef);
+
+  // If baseEntityVersion is null, we held a submission and will stop processing now.
+  if (baseEntityDef == null)
+    return null;
+
   // Get version of entity on the server
-  // If the entity doesn't exist, check branchId - maybe this is an update for an entity created offline
   let serverEntity = await Entities.getById(dataset.id, clientEntity.uuid, QueryOptions.forUpdate);
   if (!serverEntity.isDefined()) {
-    if (clientEntity.def.branchId == null) {
-      throw Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name });
-    } else {
-      await _holdSubmission(run, submissionDef.submissionId, submissionDef.id, clientEntity.def.branchId, clientEntity.def.baseVersion);
-      return null;
-    }
+    // We probably never get into this case because computeBaseVersion also checks for the existence of the entity
+    // and returns an entity def associated with a top level entity.
+    throw Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name });
   } else {
     serverEntity = serverEntity.get();
   }
@@ -289,27 +238,12 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   let { conflict } = serverEntity;
   let conflictingProperties; // Maybe we don't need to persist this??? just compute at the read time
 
-  // Figure out the intended baseVersion
-  // If this is an offline update with a branchId, the baseVersion value is local to that
-  // offline context and we need to translate it to the correct base version within Central.
-  const baseVersion = await _computeBaseVersion(maybeOne, run, dataset, clientEntity, submissionDef);
-
-  // If baseVersion is null, we held a submission and will stop processing now.
-  if (baseVersion == null)
-    return null;
-
-  if (baseVersion !== serverEntity.aux.currentVersion.version) {
-
-    const condition = { datasetId: dataset.id, uuid: clientEntity.uuid, version: baseVersion };
-    // eslint-disable-next-line no-use-before-define
-    const baseEntityVersion = (await _getDef(maybeOne, new QueryOptions({ condition })))
-      .orThrow(Problem.user.entityVersionNotFound({ baseVersion, entityUuid: clientEntity.uuid, datasetName: dataset.name }));
-
+  if (baseEntityDef.version !== serverEntity.aux.currentVersion.version) {
     // we need to find what changed between baseVersion and lastVersion
     // it is not the data we received in lastVersion
-    const serverVersionDiff = getDiffProp(serverEntity.aux.currentVersion.data, baseEntityVersion.data);
+    const serverVersionDiff = getDiffProp(serverEntity.aux.currentVersion.data, baseEntityDef.data);
     const serverDiffData = pickAll(serverVersionDiff, serverEntity.aux.currentVersion.data);
-    if (serverEntity.aux.currentVersion.label !== baseEntityVersion.label)
+    if (serverEntity.aux.currentVersion.label !== baseEntityDef.label)
       serverDiffData.label = serverEntity.aux.currentVersion.label;
 
     conflictingProperties = Object.keys(clientEntity.def.dataReceived).filter(key => key in serverDiffData && clientEntity.def.dataReceived[key] !== serverDiffData[key]);
@@ -343,7 +277,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   // Assign new version (increment latest server version)
   const version = serverEntity.aux.currentVersion.version + 1;
 
-  const entity = await Entities.createVersion(dataset, partial, submissionDef, version, sourceId, baseVersion);
+  const entity = await Entities.createVersion(dataset, partial, submissionDef, version, sourceId, baseEntityDef.version);
   await Audits.log({ id: event.actorId }, 'entity.update.version', { acteeId: dataset.acteeId },
     {
       entityId: entity.id,
@@ -355,12 +289,71 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   return entity;
 };
 
-// Entrypoint to where submissions (a specific version) become entities
-const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Datasets, Entities, Submissions, Forms, maybeOne, oneFirst }) => {
+////////////////////////////////////////////////////////////////////////////////
+// Create/update helper functions
+
+// Used by _updateVerison to figure out the intended base version in Central
+// based on the branchId, trunkVersion, and baseVersion in the submission
+const _computeBaseVersion = (eventId, dataset, clientEntity, submissionDef) => async ({ Entities }) => {
+  if (!clientEntity.def.branchId) {
+
+    // no offline branching to deal with, use baseVersion as is
+    const condition = { version: clientEntity.def.baseVersion };
+    const maybeDef = await Entities.getDef(dataset.id, clientEntity.uuid, new QueryOptions({ condition }));
+
+    if (!maybeDef.isDefined()) {
+      // If the def doesn't exist, check if the version doesnt exist or the whole entity doesnt exist
+      // There are different problems for each case
+      const maybeEntity = await Entities.getById(dataset.id, clientEntity.uuid);
+      if (maybeEntity.isDefined())
+        throw Problem.user.entityVersionNotFound({ baseVersion: clientEntity.def.baseVersion, entityUuid: clientEntity.uuid, datasetName: dataset.name });
+      else
+        throw Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name });
+    }
+
+    return maybeDef.get();
+
+  } else {
+    // there is a branchId, look up the appropriate base def
+
+    let condition;
+    if (clientEntity.def.baseVersion === 1) // Special case
+      condition = { version: 1 };
+    else if (clientEntity.def.baseVersion === clientEntity.def.trunkVersion) // Start of an offline branch
+      condition = { version: clientEntity.def.baseVersion };
+    else // middle of an offline branch
+      condition = { branchBaseVersion: clientEntity.def.baseVersion - 1 };
+
+    const baseEntityVersion = await Entities.getDef(dataset.id, clientEntity.uuid, new QueryOptions({ condition }));
+
+    if (!baseEntityVersion.isDefined()) {
+      // TODO: add case for force-processing
+      // If there is no base version and we are not forcing the processing, hold submission in the backlog.
+      await Entities._holdSubmission(eventId, submissionDef.submissionId, submissionDef.id, clientEntity.uuid, clientEntity.def.branchId, clientEntity.def.baseVersion);
+      return null;
+    }
+
+    // Return the base entity version
+    return baseEntityVersion.get();
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// PROCESSING A SUBMISSION TO CREATE OR UPDATE AN ENTITY
+
+// Helper function
+const _getFormDefActions = (oneFirst, datasetId, formDefId) => oneFirst(sql`
+  SELECT actions
+  FROM dataset_form_defs
+  WHERE "datasetId" = ${datasetId} AND "formDefId" = ${formDefId}`);
+
+// Main submission event processing function, which runs within a transaction
+// so any errors can be rolled back and logged as an entity processing error.
+const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Datasets, Entities, Submissions, Forms, oneFirst }) => {
   const { submissionId, submissionDefId } = event.details;
+  // TODO: check parentEvent details to determine if this is a forced reprocessing or not
 
   const form = await Forms.getByActeeId(event.acteeId);
-
   // If form is deleted/purged then submission won't be there either.
   if (!form.isDefined())
     return null;
@@ -371,11 +364,12 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
   if (existingEntity.isDefined())
     return null;
 
-  const existingHeldSubmission = await _checkHeldSubmission(maybeOne, submissionId);
+  const existingHeldSubmission = await Entities._checkHeldSubmission(submissionId);
   // If the submission is being held for ordering offline entity processing,
   // don't try to process it now, it will be dequeued and reprocessed elsewhere.
   if (existingHeldSubmission.isDefined())
     return null;
+  // TODO: check how force-reprocessing interacts with this logic above
 
   const submission = await Submissions.getSubAndDefById(submissionDefId);
 
@@ -415,13 +409,15 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
       throw Problem.user.entityActionNotPermitted({ action, permitted: permittedActions });
   }
 
+  // TODO: work out how force-reprocessing interacts with this logic (updateEntity and createEntity should know about it)
   let maybeEntity = null;
   // Try update before create (if both are specified)
   if (entityData.system.update === '1' || entityData.system.update === 'true')
     try {
       maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event);
     } catch (err) {
-      if ((err.problemCode === 404.8) && (entityData.system.create === '1' || entityData.system.create === 'true')) {
+      const attemptCreate = (entityData.system.create === '1' || entityData.system.create === 'true');
+      if ((err.problemCode === 404.8) && attemptCreate) {
         maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
       } else {
         throw (err);
@@ -431,13 +427,17 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
     maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent);
 
   // Check for held submissions that follow this one in the same branch
-  if (maybeEntity != null && maybeEntity.aux.currentVersion.branchId != null) {
+  if (maybeEntity != null) {
+    const { uuid: entityUuid } = maybeEntity;
     const { branchId, branchBaseVersion } = maybeEntity.aux.currentVersion;
     // branchBaseVersion could be undefined if handling an offline create
     const currentBranchBaseVersion = branchBaseVersion ?? 0;
-    const nextSub = await _checkAndDeleteHeldSubmission(maybeOne, branchId, currentBranchBaseVersion + 1);
+    const nextSub = await Entities._getNextHeldSubmissionInBranch(entityUuid, branchId, currentBranchBaseVersion + 1);
+
+    // TODO: don't handle the next submission if the current one was processed forcefully
     if (nextSub.isDefined()) {
-      const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId } = nextSub.get();
+      const { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId, auditId } = nextSub.get();
+      await Entities._deleteHeldSubmissionByEventId(auditId);
       await Audits.log({ id: event.actorId }, 'submission.reprocess', { acteeId: event.acteeId },
         { submissionId: nextSubmissionId, submissionDefId: nextSubmissionDefId });
     }
@@ -464,6 +464,40 @@ const processSubmissionEvent = (event, parentEvent) => (container) =>
           submissionDefId: event.details.submissionDefId,
           errorMessage: err.message,
           problem: (err.isProblem === true) ? err : null }));
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Submission processing helper functions
+
+// Used by _computeBaseVersion to hold submissions that are not yet ready to be processed
+const _holdSubmission = (eventId, submissionId, submissionDefId, entityUuid, branchId, branchBaseVersion) => async ({ run }) => run(sql`
+  INSERT INTO entity_submission_backlog ("auditId", "submissionId", "submissionDefId", "entityUuid", "branchId", "branchBaseVersion", "loggedAt")
+  VALUES (${eventId}, ${submissionId}, ${submissionDefId}, ${entityUuid}, ${branchId}, ${branchBaseVersion}, CLOCK_TIMESTAMP())
+  `);
+
+// Check for a currently-held submission by id
+const _checkHeldSubmission = (submissionId) => ({ maybeOne }) => maybeOne(sql`
+  SELECT * FROM entity_submission_backlog
+  WHERE "submissionId"=${submissionId}`);
+
+// Look up the next submission to process
+const _getNextHeldSubmissionInBranch = (entityUuid, branchId, branchBaseVersion) => ({ maybeOne }) => (
+  (branchId == null)
+    ? maybeOne(sql`
+      SELECT * FROM entity_submission_backlog
+      WHERE "entityUuid" = ${entityUuid} AND "branchBaseVersion" = 1`)
+    : maybeOne(sql`
+      SELECT * FROM entity_submission_backlog
+      WHERE "branchId"=${branchId} AND "branchBaseVersion" = ${branchBaseVersion}`));
+
+// Delete a submission from the backlog
+const _deleteHeldSubmissionByEventId = (eventId) => ({ run }) => run(sql`
+  DELETE FROM entity_submission_backlog
+  WHERE "auditId"=${eventId}`);
+
+
+////////////////////////////////////////////////////////////////////////////////
+// PROCESSING PENDING SUBMISSIONS FROM TOGGLING DATASET APPROVALREQUIRED FLAG
 
 const createEntitiesFromPendingSubmissions = (submissionEvents, parentEvent) => (container) =>
   // run sequentially because we want to isolate transaction for each submission
@@ -545,6 +579,9 @@ const _getDef = extender(Entity.Def, Entity.Def.Source)(Actor.into('creator'))((
   order by entity_defs."createdAt", entity_defs.id
 `);
 
+const getDef = (datasetId, uuid, options = QueryOptions.none) => ({ maybeOne }) =>
+  _getDef(maybeOne, options.withCondition({ datasetId, uuid }));
+
 const getAllDefs = (datasetId, uuid, options = QueryOptions.none) => ({ all }) =>
   _getDef(all, options.withCondition({ datasetId, uuid }))
     .then(map((v) => new Entity.Def(v, { creator: v.aux.creator, source: v.aux.source })));
@@ -560,6 +597,18 @@ const getDefBySubmissionId = (submissionId) => ({ maybeOne }) =>
     .then(map(construct(Entity.Def)));
 
 
+////////////////////////////////////////////////////////////////////////////////
+// RESOLVE CONFLICT
+
+const resolveConflict = (entity, dataset) => ({ one }) => // eslint-disable-line no-unused-vars
+  one(sql`UPDATE entities SET conflict=NULL, "updatedAt"=CLOCK_TIMESTAMP() WHERE "id"=${entity.id} RETURNING *`)
+    .then(r => entity.with({ conflict: r.conflict, updatedAt: r.updatedAt }));
+
+resolveConflict.audit = (entity, dataset) => (log) => log('entity.update.resolve', dataset, {
+  entityId: entity.id,
+  entityDefId: entity.aux.currentVersion.id,
+  entity: { uuid: entity.uuid, dataset: dataset.name }
+});
 
 ////////////////////////////////////////////////////////////////////////////////
 // SERVING ENTITIES
@@ -628,10 +677,13 @@ module.exports = {
   createSource,
   createMany,
   _createEntity, _updateEntity,
+  _computeBaseVersion,
+  _holdSubmission, _checkHeldSubmission,
+  _getNextHeldSubmissionInBranch, _deleteHeldSubmissionByEventId,
   processSubmissionEvent, streamForExport,
   getDefBySubmissionId,
   createVersion,
-  countByDatasetId, getById,
+  countByDatasetId, getById, getDef,
   getAll, getAllDefs, del,
   createEntitiesFromPendingSubmissions,
   resolveConflict


### PR DESCRIPTION
This is meant to be a precursor to another PR for issue https://github.com/getodk/central/issues/682

The main changes here are
* Migration to add more useful columns to submission backlog
* Reordering and reorganizing code in entity query module
* Changing flow of `Entities._updateEntity` to try to determine the base version of an entity _before_ it looks up the existing server version, because this helps with the logic of holding submissions for later processing, and will eventually help with the force-processing case. 
* Removes `branchId` from tests about creating entities

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced