### PR TITLE
dev/postgres: log statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,12 @@ lint: node_version
 
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres
-	docker start odk-postgres14 || (docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.10-alpine && sleep 5 && node lib/bin/create-docker-databases.js)
+	docker start odk-postgres14 || (\
+		docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.10-alpine \
+			postgres -c log_statement=all -c log_destination=stderr -c log_parameter_max_length=80 \
+		&& sleep 5 \
+		&& node lib/bin/create-docker-databases.js \
+	)
 
 .PHONY: stop-docker-postgres
 stop-docker-postgres:


### PR DESCRIPTION
Enable statement logging in local PostgreSQL docker containers launched with `make run-docker-postgres`.

This is very helpful if trying to understand exactly what SQL queries are being made, and fiddly to enable.
