### PR TITLE
forms.purge(): don't return unused columns

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -435,7 +435,7 @@ with redacted_audits as (
   ), deleted_forms as (
     delete from forms
     where ${_trashedFilter(force, id, projectId, xmlFormId)}
-    returning *
+    returning 1
   )
 select count(*) from deleted_forms`)
     .then((count) => Blobs.purgeUnattached()


### PR DESCRIPTION
CTE results are materialised, so this change should make the query faster & use less resources.