### PR TITLE
Rename taskSchedule.entitySubmissionBacklog config and default to 5 days

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -529,9 +529,12 @@ const _deleteHeldSubmissionByEventId = (eventId) => ({ run }) => run(sql`
 ////////////////////////////////////////////////////////////////////////////////
 // FORCE PROCESSING SUBMISSIONS FROM BACKLOG
 
-const DAY_RANGE = config.has('default.taskSchedule.forceProcess')
-  ? config.get('default.taskSchedule.forceProcess')
-  : 7; // Default is 7 days
+// Submissions that have been held in the backlog for longer than 5 days
+// will be force-processed, including out-of-order updates and updates
+// applied as entity creates.
+const DAY_RANGE = config.has('default.taskSchedule.entitySubmissionBacklog')
+  ? config.get('default.taskSchedule.entitySubmissionBacklog')
+  : 5; // Default is 5 days
 
 const _getHeldSubmissionsAsEvents = (force) => ({ all }) => all(sql`
   SELECT audits.* FROM entity_submission_backlog


### PR DESCRIPTION
Changing entity submission backlog duration from 7 days to 5 days. 7 days felt too long to wait. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced