### PR TITLE
Mark soft conflict if not contiguous with trunk

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -397,6 +397,64 @@ const diffEntityData = (defData) => {
   return diffs;
 };
 
+// Copied from frontend though it may not all be necessary
+// Offline branch
+class Branch {
+  // firstUpdate is the first offline update (not create) to be processed from
+  // the branch. entityRoot is the first version of the entity.
+  constructor(firstUpdate, entityRoot) {
+    if (firstUpdate.trunkVersion != null) {
+      // The first version from the branch to be processed (not necessarily the
+      // first in the original branch order)
+      this.first = firstUpdate;
+
+      // How many versions that have been processed are from the branch?
+      this.length = 1;
+
+      // Was this.first processed in branch order, or was it processed before an
+      // earlier change in the branch?
+      const { trunkVersion } = firstUpdate;
+      this.firstInOrder = firstUpdate.branchBaseVersion === trunkVersion;
+
+      /* this.lastContiguousWithTrunk is the version number of the last version
+      from the branch that is contiguous with the trunk version. In other words,
+      it is the version number of the last version where there has been no
+      update from outside the branch between the version and the trunk version.
+      this.lastContiguousWithTrunk is not related to branch order: as long as
+      there hasn't been an update from outside the branch, the branch is
+      contiguous, regardless of the order of the updates within it. */
+      this.lastContiguousWithTrunk = firstUpdate.version === trunkVersion + 1
+        ? firstUpdate.version
+        : 0;
+    } else {
+      // If the entity was both created and updated offline before being sent to
+      // the server, then we treat the creation as part of the same branch as
+      // the update(s). The creation doesn't have a branch ID, but we treat it
+      // as part of the branch anyway.
+      this.first = entityRoot;
+      // If the submission for the entity creation was received late and
+      // processed out of order, then firstUpdate.version === 1. In that case,
+      // we can't reliably determine which entity version corresponds to the
+      // entity creation, so we don't treat the creation as part of the branch.
+      this.length = firstUpdate.version === 1 ? 1 : 2;
+      this.firstInOrder = this.length === 2;
+      this.lastContiguousWithTrunk = firstUpdate.version === 2 ? 2 : 1;
+    }
+
+    this.id = firstUpdate.branchId;
+    // The last version from the branch to be processed
+    this.last = firstUpdate;
+  }
+
+  add(version) {
+    this.length += 1;
+    this.last = version;
+    if (version.baseVersion === this.lastContiguousWithTrunk &&
+      version.version === version.baseVersion + 1)
+      this.lastContiguousWithTrunk = version.version;
+  }
+}
+
 // Returns an array of properties which are different between
 // `dataReceived` and `otherVersionData`
 const getDiffProp = (dataReceived, otherVersionData) =>
@@ -419,6 +477,26 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
 
   const relevantBaseVersions = new Set();
 
+  // build up branches
+  const branches = new Map();
+  for (const version of defs) {
+    const { branchId } = version;
+    if (branchId != null && version.branchBaseVersion != null) {
+      const existingBranch = branches.get(branchId);
+      if (existingBranch == null) {
+        const newBranch = new Branch(version, defs[0]);
+        branches.set(branchId, newBranch);
+        version.branch = newBranch;
+        // If the entity was created offline, then add the branch to the
+        // entity creation.
+        newBranch.first.branch = newBranch;
+      } else {
+        existingBranch.add(version);
+        version.branch = existingBranch;
+      }
+    }
+  }
+
   for (const def of defs) {
 
     const v = mergeLeft(def.forApi(),
@@ -438,7 +516,12 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
       v.source = event.source;
 
     if (v.version > 1) { // v.root is false here - can use either
-      const conflict = v.version !== (v.baseVersion + 1);
+      let notContiguousWithTrunk = false;
+      if (v.branchId != null) {
+        notContiguousWithTrunk = branches.get(v.branchId).lastContiguousWithTrunk < v.baseVersion;
+      }
+
+      const conflict = v.version !== (v.baseVersion + 1) || notContiguousWithTrunk;
 
       v.baseDiff = getDiffProp(v.dataReceived, { ...defs[v.baseVersion - 1].data, label: defs[v.baseVersion - 1].label });
 

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -397,25 +397,14 @@ const diffEntityData = (defData) => {
   return diffs;
 };
 
-// Copied from frontend though it may not all be necessary
+// Copied from frontend
 // Offline branch
 class Branch {
   // firstUpdate is the first offline update (not create) to be processed from
-  // the branch. entityRoot is the first version of the entity.
-  constructor(firstUpdate, entityRoot) {
+  // the branch.
+  constructor(firstUpdate) {
     if (firstUpdate.trunkVersion != null) {
-      // The first version from the branch to be processed (not necessarily the
-      // first in the original branch order)
-      this.first = firstUpdate;
-
-      // How many versions that have been processed are from the branch?
-      this.length = 1;
-
-      // Was this.first processed in branch order, or was it processed before an
-      // earlier change in the branch?
       const { trunkVersion } = firstUpdate;
-      this.firstInOrder = firstUpdate.branchBaseVersion === trunkVersion;
-
       /* this.lastContiguousWithTrunk is the version number of the last version
       from the branch that is contiguous with the trunk version. In other words,
       it is the version number of the last version where there has been no
@@ -427,28 +416,30 @@ class Branch {
         ? firstUpdate.version
         : 0;
     } else {
-      // If the entity was both created and updated offline before being sent to
-      // the server, then we treat the creation as part of the same branch as
-      // the update(s). The creation doesn't have a branch ID, but we treat it
-      // as part of the branch anyway.
-      this.first = entityRoot;
-      // If the submission for the entity creation was received late and
-      // processed out of order, then firstUpdate.version === 1. In that case,
-      // we can't reliably determine which entity version corresponds to the
-      // entity creation, so we don't treat the creation as part of the branch.
-      this.length = firstUpdate.version === 1 ? 1 : 2;
-      this.firstInOrder = this.length === 2;
+      /*
+      If the entity was both created and updated offline before being sent to
+      the server, then there technically isn't a trunk version. On the flip
+      side, there also isn't a contiguity problem -- except in one special case.
+      If the submission for the entity creation is sent and processed, but the
+      submission for the update is not sent at the same time for some reason,
+      then it's possible for another update to be made between the two. Once the
+      original update is sent and processed, it will no longer be contiguous
+      with the entity creation.
+
+      Another special case is if the submission for the entity creation was sent
+      late and processed out of order. In that case, firstUpdate.version === 1.
+      There's again no contiguity problem (just an order problem), so
+      lastContiguousWithTrunk should equal 1.
+
+      The normal case is if firstUpdate.version === 2.
+      */
       this.lastContiguousWithTrunk = firstUpdate.version === 2 ? 2 : 1;
     }
 
     this.id = firstUpdate.branchId;
-    // The last version from the branch to be processed
-    this.last = firstUpdate;
   }
 
   add(version) {
-    this.length += 1;
-    this.last = version;
     if (version.baseVersion === this.lastContiguousWithTrunk &&
       version.version === version.baseVersion + 1)
       this.lastContiguousWithTrunk = version.version;
@@ -477,27 +468,18 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
 
   const relevantBaseVersions = new Set();
 
-  // build up branches
   const branches = new Map();
-  for (const version of defs) {
-    const { branchId } = version;
-    if (branchId != null && version.branchBaseVersion != null) {
-      const existingBranch = branches.get(branchId);
-      if (existingBranch == null) {
-        const newBranch = new Branch(version, defs[0]);
-        branches.set(branchId, newBranch);
-        version.branch = newBranch;
-        // If the entity was created offline, then add the branch to the
-        // entity creation.
-        newBranch.first.branch = newBranch;
-      } else {
-        existingBranch.add(version);
-        version.branch = existingBranch;
-      }
-    }
-  }
 
   for (const def of defs) {
+    // build up branches
+    const { branchId } = def;
+    if (branchId != null) {
+      const existingBranch = branches.get(branchId);
+      if (existingBranch == null)
+        branches.set(branchId, new Branch(def));
+      else
+        existingBranch.add(def);
+    }
 
     const v = mergeLeft(def.forApi(),
       {
@@ -516,12 +498,10 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
       v.source = event.source;
 
     if (v.version > 1) { // v.root is false here - can use either
-      let notContiguousWithTrunk = false;
-      if (v.branchId != null) {
-        notContiguousWithTrunk = branches.get(v.branchId).lastContiguousWithTrunk < v.baseVersion;
-      }
-
-      const conflict = v.version !== (v.baseVersion + 1) || notContiguousWithTrunk;
+      const baseNotContiguousWithTrunk = v.branchId != null &&
+        branches.get(v.branchId).lastContiguousWithTrunk < v.baseVersion;
+      const conflict = v.version !== (v.baseVersion + 1) ||
+        baseNotContiguousWithTrunk;
 
       v.baseDiff = getDiffProp(v.dataReceived, { ...defs[v.baseVersion - 1].data, label: defs[v.baseVersion - 1].label });
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -304,14 +304,13 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       serverDiffData.label = serverEntity.aux.currentVersion.label;
 
     conflictingProperties = Object.keys(clientEntity.def.dataReceived).filter(key => key in serverDiffData && clientEntity.def.dataReceived[key] !== serverDiffData[key]);
-
     if (conflict !== ConflictType.HARD) { // We don't want to downgrade conflict here
       conflict = conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
     }
   } else {
     // This may still be a soft conflict if the new version is not contiguous with this branch's trunk version
     const interrupted = await Entities._interruptedBranch(serverEntity.id, clientEntity);
-    if (interrupted) {
+    if (interrupted && conflict !== ConflictType.HARD) {
       conflict = ConflictType.SOFT;
     }
   }

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -308,6 +308,12 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
     if (conflict !== ConflictType.HARD) { // We don't want to downgrade conflict here
       conflict = conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
     }
+  } else {
+    // This may still be a soft conflict if the new version is not contiguous with this branch's trunk version
+    const interrupted = await Entities._interruptedBranch(serverEntity.id, clientEntity);
+    if (interrupted) {
+      conflict = ConflictType.SOFT;
+    }
   }
 
   // merge data
@@ -540,6 +546,29 @@ const processSubmissionEvent = (event, parentEvent) => (container) =>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Submission processing helper functions
+
+// Used by _updateEntity to determine if a new offline update is contiguous with its trunk version
+// by searching for an interrupting version with a different or null branchId that has a higher
+// version than the trunk version of the given branch.
+const _interruptedBranch = (entityId, clientEntity) => async ({ maybeOne }) => {
+  // If there is no branchId, the branch cannot be interrupted
+  if (clientEntity.def.branchId == null)
+    return false;
+
+  // look for a version of a different branch that has a version
+  // higher than the trunkVersion, which indicates an interrupting version.
+  // if trunkVersion is null (becuase it is part of a branch beginning with
+  // an offline create), look for a version higher than 1 because version
+  // 1 is implicitly the create action of that offline branch.
+  const interruptingVersion = await maybeOne(sql`
+  SELECT version
+  FROM entity_defs
+  WHERE "branchId" IS DISTINCT FROM ${clientEntity.def.branchId}
+    AND version > ${clientEntity.def.trunkVersion || 1}
+    AND "entityId" = ${entityId}
+    LIMIT 1`);
+  return interruptingVersion.isDefined();
+};
 
 // Used by _computeBaseVersion to hold submissions that are not yet ready to be processed
 const _holdSubmission = (eventId, submissionId, submissionDefId, entityUuid, branchId, branchBaseVersion) => async ({ run }) => run(sql`
@@ -780,7 +809,7 @@ module.exports = {
   createSource,
   createMany,
   _createEntity, _updateEntity,
-  _computeBaseVersion,
+  _computeBaseVersion, _interruptedBranch,
   _holdSubmission, _checkHeldSubmission,
   _getNextHeldSubmissionInBranch, _deleteHeldSubmissionByEventId,
   _getHeldSubmissionsAsEvents,


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/698

This PR makes two changes:
**1: Update per-version conflict state**

The `<entity uuid>/versions` endpoint returns a `conflict` state for each version of the entity, which is computed from other information about the entity versions. These values should stay the same even when the top level `conflict` flag on the entity changes (or is manually resolved). These version-specific conflict states used to be detected just from `baseVersion+1 != version`. 

In this PR, we've copied branch-tracking logic from Frontend to check whether each version if it is contiguous with its trunk version, and return a `soft` conflict state if it is non-contiguous but otherwise not a hard conflict.

We could also consider having backend return more of the details that frontend is currently computing about branch continuity. 

**2. Update top-level conflict state**

The above work to make the per-version conflict state more descriptive wasn't enough. Consider a situation where an offline branch has been interrupted by another branch or online update, a conflict has been resolved, but then another update from that interrupted branch comes in. We want every update that is not contiguous with its trunk version to be a conflict, and that means updating the conflict state on the entity itself, too. 

Before, we only noted a conflict when the base version wasn't what was expected. An offline update would not be counted as conflict as long as the previous action in the branch was present.

This PR adds a check that the new entity is not only contiguous with its base version, but is also contiguous with its specified trunk version. (This is done by looking for a version of a different branch that _interrupts_ the given branch, rather than the other code that tracks the last contiguous version per branch.) If it is not contiguous, i.e. if there is an interruption, the top level `conflict` flag on the entity itself is set to `soft` instead of `null`. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

See explanation above.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Highlights conflicts more.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced