### PR TITLE
docker-postgres: centralise logging configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,8 @@ lint: node_version
 run-docker-postgres: stop-docker-postgres
 	docker start odk-postgres14 || (\
 		docker run -d --name odk-postgres14 -p 5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.10-alpine \
-			postgres -c log_statement=all -c log_destination=stderr -c log_parameter_max_length=80 \
 		&& sleep 5 \
-		&& node lib/bin/create-docker-databases.js \
+		&& node lib/bin/create-docker-databases.js --log \
 	)
 
 .PHONY: stop-docker-postgres

--- a/lib/bin/create-docker-databases.js
+++ b/lib/bin/create-docker-databases.js
@@ -39,6 +39,7 @@ const { log } = program.opts();
     await dbmain.raw("alter system set log_destination to 'stderr';");
     await dbmain.raw('alter system set logging_collector to on;');
     await dbmain.raw("alter system set log_statement to 'all';");
+    await dbmain.raw("alter system set log_parameter_max_length to 80");
     await dbmain.raw('select pg_reload_conf();');
   }
 


### PR DESCRIPTION
Clean up changes introduced in #1175 / f5e8f6ea0fb26ae0ebd5a2b346911961cc662917:

* use create-docker-databases --log flag
* remove logging settings duplicated in Makefile
* add log_parameter_max_length to create-docker-databases.js
