### PR TITLE
s3: remove PGROWLOCKS extension from db-migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,10 @@ CREATE DATABASE jubilant_test WITH OWNER=jubilant ENCODING=UTF8;
 \c jubilant_test;
 CREATE EXTENSION IF NOT EXISTS CITEXT;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
-CREATE EXTENSION IF NOT EXISTS pgrowlocks;
 CREATE DATABASE jubilant WITH OWNER=jubilant ENCODING=UTF8;
 \c jubilant;
 CREATE EXTENSION IF NOT EXISTS CITEXT;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
-CREATE EXTENSION IF NOT EXISTS pgrowlocks;
 ```
 
 If you are using Docker, you may find it easiest to run the database in Docker by running `make run-docker-postgres`.

--- a/lib/model/migrations/20240913-01-add-blob-s3.js
+++ b/lib/model/migrations/20240913-01-add-blob-s3.js
@@ -8,7 +8,6 @@
 // except according to the terms contained in the LICENSE file.
 
 const up = async (db) => {
-  await db.raw('CREATE EXTENSION IF NOT EXISTS pgrowlocks');
   await db.raw(`CREATE TYPE S3_UPLOAD_STATUS AS ENUM ('pending', 'uploaded', 'failed')`);
   await db.raw(`
     ALTER TABLE blobs

--- a/lib/task/s3.js
+++ b/lib/task/s3.js
@@ -19,9 +19,25 @@ const assertEnabled = s3 => {
 
 const getCount = withContainer(({ s3, Blobs }) => async status => {
   assertEnabled(s3);
-  const count = await Blobs.s3CountByStatus(status);
-  console.log(count);
-  return count; // just for testing
+  try {
+    const count = await Blobs.s3CountByStatus(status);
+    console.log(count);
+    return count; // just for testing
+  } catch (err) {
+    if (err.code === '42883' && err.message === 'function pgrowlocks(unknown) does not exist') {
+      console.error(`
+
+Error: cannot count blobs by status due to missing PostgreSQL extension: PGROWLOCKS.
+
+To install this extension, execute the following query in your PostgreSQL instance:
+
+    CREATE EXTENSION IF NOT EXISTS pgrowlocks;
+`)
+      process.exit(1);
+    } else {
+      throw err;
+    }
+  }
 });
 
 const setFailedToPending = withContainer(({ s3, Blobs }) => async () => {

--- a/lib/task/s3.js
+++ b/lib/task/s3.js
@@ -32,7 +32,7 @@ Error: cannot count blobs by status due to missing PostgreSQL extension: PGROWLO
 To install this extension, execute the following query in your PostgreSQL instance:
 
     CREATE EXTENSION IF NOT EXISTS pgrowlocks;
-`)
+`);
       process.exit(1);
     } else {
       throw err;


### PR DESCRIPTION
Only require pgrowlocks extension in testing, because installing/creating the extension can require more privileges than other migrations.
