### PR TITLE
bin/repl: run NodeJS REPL with initialised container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ node_modules/
 .idea/
 /.eslintcache
 /.pgbadger/
+/.repl-history
 .vscode
 /junit-reports/

--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -1,3 +1,12 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
 #!/usr/bin/env node
 const should = require('should'); // eslint-disable-line import/no-extraneous-dependencies
 require('../../test/assertions');

--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -10,7 +10,7 @@
 const should = require('should'); // eslint-disable-line import/no-extraneous-dependencies
 require('../../test/assertions');
 
-const _ = require('lodash');
+const _ = require('lodash'); // eslint-disable-line import/no-extraneous-dependencies
 const { sql } = require('slonik');
 
 const container = require('../util/default-container');

--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -10,12 +10,13 @@
 const should = require('should'); // eslint-disable-line import/no-extraneous-dependencies
 require('../../test/assertions');
 
+const _ = require('lodash');
 const { sql } = require('slonik');
 
 const container = require('../util/default-container');
 
 (async () => {
-  const context = { ...container, should, sql };
+  const context = { ..._.omit(container, 'with'), container, should, sql };
   const contextKeys = Object.keys(context).sort();
   console.log('Available vars:', contextKeys.join(', '));
 

--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { sql } = require('slonik');
+const container = require('../util/default-container');
+
+(async () => {
+  const containerKeys = Object.keys(container);
+  const contextKeys = [ 'sql', ...containerKeys ].sort();
+  console.log('Available vars:', contextKeys.join(', '));
+
+  const repl = require('repl').start();
+  await new Promise((resolve, reject) => {
+    repl.setupHistory('.repl-history', err => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+  repl.context.sql = sql;
+  containerKeys.forEach(k => { repl.context[k] = container[k]; });
+})();

--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const should = require('should');
+const should = require('should'); // eslint-disable-line import/no-extraneous-dependencies
 require('../../test/assertions');
 
 const { sql } = require('slonik');

--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -7,7 +7,6 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-#!/usr/bin/env node
 const should = require('should'); // eslint-disable-line import/no-extraneous-dependencies
 require('../../test/assertions');
 

--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -1,19 +1,32 @@
 #!/usr/bin/env node
+const should = require('should');
+require('../../test/assertions');
+
 const { sql } = require('slonik');
+
 const container = require('../util/default-container');
 
 (async () => {
-  const containerKeys = Object.keys(container);
-  const contextKeys = [ 'sql', ...containerKeys ].sort();
+  const context = { ...container, should, sql };
+  const contextKeys = Object.keys(context).sort();
   console.log('Available vars:', contextKeys.join(', '));
 
-  const repl = require('repl').start();
+  const repl = require('repl').start({
+    useGlobal: true, // enable should.js prototype pollution
+  });
+
   await new Promise((resolve, reject) => {
     repl.setupHistory('.repl-history', err => {
       if (err) reject(err);
       else resolve();
     });
   });
-  repl.context.sql = sql;
-  containerKeys.forEach(k => { repl.context[k] = container[k]; });
+
+  Object.entries(context).forEach(([k, value]) => {
+    Object.defineProperty(repl.context, k, {
+      configurable: false,
+      enumerable: true,
+      value,
+    });
+  });
 })();

--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -10,44 +10,16 @@
 // This is the main entrypoint for the actual HTTP server. It sets up the
 // dependency container and feeds it to the service infrastructure.
 
-const { mergeRight } = require('ramda');
 const config = require('config');
 const exit = require('express-graceful-exit');
 
 global.tap = (x) => { console.log(x); return x; }; // eslint-disable-line no-console
 
 ////////////////////////////////////////////////////////////////////////////////
-// CONTAINER SETUP
-
-// initialize our slonik connection pool.
-const { slonikPool } = require('../external/slonik');
-const db = slonikPool(config.get('default.database'));
-
-// set up our mailer.
-const env = config.get('default.env');
-const { mailer } = require('../external/mail');
-const mail = mailer(mergeRight(config.get('default.email'), { env }));
-
-// get a sentry and configure errors.
-const Sentry = require('../external/sentry').init(config.get('default.external.sentry'));
-Error.stackTrackLimit = 20;
-
-// get an xlsform client and a password module.
-const xlsform = require('../external/xlsform').init(config.get('default.xlsform'));
-
-// get an Enketo client
-const enketo = require('../external/enketo').init(config.get('default.enketo'));
-
-// get an S3 client.
-const s3 = require('../external/s3').init(config.get('default.external.s3blobStore'));
-
-
-////////////////////////////////////////////////////////////////////////////////
 // START HTTP SERVICE
 
 // initialize our container, then generate an http service out of it.
-const container = require('../model/container')
-  .withDefaults({ db, mail, env, Sentry, xlsform, enketo, s3 });
+const container = require('../util/default-container');
 const service = require('../http/service')(container);
 
 // insert the graceful exit middleware.
@@ -81,7 +53,7 @@ const term = () => {
   exit.gracefulExitHandler(service, server, {
     log: true,
     exitProcess: false,
-    callback: () => db.end().then(() => process.exit(0))
+    callback: () => container.db.end().then(() => process.exit(0))
   });
 };
 

--- a/lib/util/default-container.js
+++ b/lib/util/default-container.js
@@ -1,3 +1,12 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
 const { mergeRight } = require('ramda');
 const config = require('config');
 

--- a/lib/util/default-container.js
+++ b/lib/util/default-container.js
@@ -1,0 +1,32 @@
+const { mergeRight } = require('ramda');
+const config = require('config');
+
+////////////////////////////////////////////////////////////////////////////////
+// CONTAINER SETUP
+
+// initialize our slonik connection pool.
+const { slonikPool } = require('../external/slonik');
+const db = slonikPool(config.get('default.database'));
+
+// set up our mailer.
+const env = config.get('default.env');
+const { mailer } = require('../external/mail');
+const mail = mailer(mergeRight(config.get('default.email'), { env }));
+
+// get a sentry and configure errors.
+const Sentry = require('../external/sentry').init(config.get('default.external.sentry'));
+Error.stackTrackLimit = 20;
+
+// get an xlsform client and a password module.
+const xlsform = require('../external/xlsform').init(config.get('default.xlsform'));
+
+// get an Enketo client
+const enketo = require('../external/enketo').init(config.get('default.enketo'));
+
+// get an S3 client.
+const s3 = require('../external/s3').init(config.get('default.external.s3blobStore'));
+
+const container = require('../model/container')
+  .withDefaults({ db, mail, env, Sentry, xlsform, enketo, s3 });
+
+module.exports = container;


### PR DESCRIPTION
Example use:

    ./lib/bin/repl
    Available vars: Actees, Actors, Analytics, Assignments, Audits, Auth, Blobs, ClientAudits, Comments, Configs, Datasets, Entities, FieldKeys, FormAttachments, Forms, Keys, Projects, PublicLinks, Roles, Sentry, Sessions, SubmissionAttachments, Submissions, Users, all, db, enketo, env, mail, maybeOne, maybeOneFirst, one, oneFirst, run, s3, sql, stream, with, xlsform
    > await db.any(sql`SELECT * FROM blobs`)
    []
