### PR TITLE
Test concurrent submissions that affect same entity

### DIFF
--- a/lib/worker/worker.js
+++ b/lib/worker/worker.js
@@ -11,7 +11,7 @@ const { min } = Math;
 const { inspect } = require('util');
 const { head } = require('ramda');
 const { sql } = require('slonik');
-const { timebound, runSequentially } = require('../util/promise');
+const { timebound, runSequentially, block } = require('../util/promise');
 const defaultJobMap = require('./jobs').jobs;
 const { noop } = require('../util/util');
 
@@ -137,22 +137,50 @@ update audits set claimed=clock_timestamp() from q where audits.id=q.id returnin
     for (let i = 0; i < count; i += 1) loop();
   };
 
-  // for testing: chews through the event queue serially until there is nothing left to process.
-  const exhaust = async () => {
-    const runWait = (event) => new Promise((done) => {
-      if (!runJobs(event, () => { done(true); })) done(false);
-    });
-    while (await check().then(runWait)); // eslint-disable-line no-await-in-loop
-  };
-
   return {
     loop, loops,
     // for testing
-    exhaust, run: runJobs, check
+    run: runJobs, check
   };
 };
 
-const exhaust = (container) => workerQueue(container).exhaust();
+// for testing: chews through the event queue serially until there is nothing left to process.
+const exhaust = async (container) => {
+  const queue = workerQueue(container);
+  const runWait = (event) => new Promise((done) => {
+    if (!queue.run(event, () => { done(true); })) done(false);
+  });
+  while (await queue.check().then(runWait)); // eslint-disable-line no-await-in-loop
+};
 
-module.exports = { workerQueue, exhaust };
+// For testing. Similar to exhaust(), but processes events in parallel rather
+// than serially.
+const exhaustParallel = async (container) => {
+  const queue = workerQueue(container);
+  // The count of events for which a job has started
+  let startCount = 0;
+  const run = (event, done) => { if (queue.run(event, done)) startCount += 1; };
+  // The count of events for which all jobs have finished
+  let doneCount = 0;
+  const [lock, unlock] = block();
+  const done = async () => {
+    // Processing the event may have logged more events. Here, we check for
+    // additional events, processing each immediately.
+    // eslint-disable-next-line no-await-in-loop
+    for (let event = await queue.check(); event != null; event = await queue.check())
+      run(event, done);
+    doneCount += 1;
+    if (doneCount === startCount) unlock();
+  };
+  // Collect all pending events, then process them in parallel.
+  const events = [];
+  // eslint-disable-next-line no-await-in-loop
+  for (let event = await queue.check(); event != null; event = await queue.check())
+    events.push(event);
+  for (const event of events) run(event, done);
+  if (startCount === 0) unlock();
+  return lock;
+};
+
+module.exports = { workerQueue, exhaust, exhaustParallel };
 

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1343,7 +1343,6 @@ describe('Offline Entities', () => {
     });
   });
 
-  // eslint-disable-next-line func-names, space-before-function-paren
   describe('locking an entity while processing a related submission', function() {
     this.timeout(8000);
 


### PR DESCRIPTION
This PR adds a test for getodk/central#705. It runs the race condition described in the issue many times, asserting that it is successful each time.

#### Why is this the best possible solution? Were any other approaches considered?

The test in #1033 takes a more explanatory approach, beginning transactions manually and controlling the timing of queries. I think that test is helpful, but it didn't seem useful to just copy it for this new issue. It's also not easy to control the timing of `Entities._processSubmissionEvent()`, which I think would be needed in order to write such a test.

The test that I wrote runs the race condition described in the issue. Even without locking, things occasionally work fine: the offline update doesn't end up stuck in the backlog. That's the case <10% of the time on my local machine. Given that things sometimes work, I run the race condition 50 times. I think it's nice to have a test that demonstrates the race condition as described in the issue and that fails if locking is removed.

I tried to do more to control the timing of `Entities._processSubmissionEvent()`, thinking that that would allow me to run the race condition only once. Specifically, this is what I had in mind:

- Submit an offline create and an offline update to the same entity.
- Start processing the offline update first.
- Pause the processing of the offline update after `Entities._computeBaseVersion()` is run.
- Start processing the offline create, allowing it to finish before unpausing the offline update.
- Unpause the processing of the offline update.
- Observe that the offline update ends up stuck in the backlog.

However, it turned out to be harder than expected to spy on `Entities._computeBaseVersion()`. Each time a new container is created, it looks like the query modules are recreated (`injector()` in lib/model/container.js). Further, a new container is created when a parent transaction is begun. I was able to spy on `Entities._computeBaseVersion()` in the container supplied to the test, but that didn't end up being the same `Entities._computeBaseVersion()` run by `Entities._processSubmissionEvent()`, as processing an event begins a new transaction.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced