### PR TITLE
Add pgrowlocks to instructions for manually setting up databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ CREATE DATABASE jubilant_test WITH OWNER=jubilant ENCODING=UTF8;
 \c jubilant_test;
 CREATE EXTENSION IF NOT EXISTS CITEXT;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pgrowlocks;
 CREATE DATABASE jubilant WITH OWNER=jubilant ENCODING=UTF8;
 \c jubilant;
 CREATE EXTENSION IF NOT EXISTS CITEXT;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pgrowlocks;
 ```
 
 If you are using Docker, you may find it easiest to run the database in Docker by running `make run-docker-postgres`.


### PR DESCRIPTION
If I run tests locally using a database that doesn't have `pgrowlocks`, I see an error message:

```
  task: s3
    s3 disabled
      ✔ uploadPending() should fail
      ✔ setFailedToPending() should fail
      ✔ getCount() should fail
    s3 enabled
      getCount()
error: function pgrowlocks(unknown) does not exist

...

Error: cannot count blobs by status due to missing PostgreSQL extension: PGROWLOCKS.

To install this extension, execute the following query in your PostgreSQL instance:

    CREATE EXTENSION IF NOT EXISTS pgrowlocks;
```

The instructions here are clear, and tests pass once I create the extension in my test database. However, I think it'd be worth preventing the error by creating the extensions at the time of database setup. The readme includes instructions to manually set up the databases, and this PR adds the `CREATE EXTENSION` statement from above to those instructions.

#1190 removed the `CREATE EXTENSION` from the migration, which I think makes a lot of sense. #1190 also removed it from the readme instructions, and that's the part that this PR reverts. The readme instructions are for setting up databases for local development and testing, and I think there's no harm in running `CREATE EXTENSION IF NOT EXISTS` in those environments. The readme instructions already assume that the user is permitted to `CREATE USER` and `CREATE DATABASE`.

lib/bin/create-docker-databases.js also runs `CREATE EXTENSION IF NOT EXISTS pgrowlocks;`. In a sense, this PR is updating the readme to match create-docker-databases.js.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced