### PR TITLE
Handle missing baseVersion in entity upsert (create and update) case

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -55,9 +55,10 @@ const extractLabelFromSubmission = (entity, options = { create: true }) => {
 };
 
 // Input: object representing entity, parsed from submission XML
-const extractBaseVersionFromSubmission = (entity) => {
-  const { baseVersion, update } = entity.system;
-  if ((update === '1' || update === 'true')) {
+const extractBaseVersionFromSubmission = (entity, options = { update: true }) => {
+  const { update } = options;
+  const { baseVersion } = entity.system;
+  if (update) {
     if (!baseVersion)
       throw Problem.user.missingParameter({ field: 'baseVersion' });
 

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -19,7 +19,7 @@ const { PartialPipe } = require('../util/stream');
 const Problem = require('../util/problem');
 const { submissionXmlToFieldStream } = require('./submission');
 const { nextUrlFor, getServiceRoot, jsonDataFooter, extractPaging } = require('../util/odata');
-const { sanitizeOdataIdentifier, blankStringToNull } = require('../util/util');
+const { sanitizeOdataIdentifier, blankStringToNull, isBlank } = require('../util/util');
 
 const odataToColumnMap = new Map([
   ['__system/createdAt', 'entities.createdAt'],
@@ -61,12 +61,15 @@ const extractBaseVersionFromSubmission = (entity, options = { update: true }) =>
   if (update) {
     if (!baseVersion)
       throw Problem.user.missingParameter({ field: 'baseVersion' });
-
+  }
+  if (!isBlank(baseVersion)) {
+    // Check type and parseInt in both create and update case
     if (!/^\d+$/.test(baseVersion))
       throw Problem.user.invalidDataTypeOfParameter({ field: 'baseVersion', expected: 'integer' });
 
     return parseInt(entity.system.baseVersion, 10);
   }
+  return null;
 };
 
 const extractBranchIdFromSubmission = (entity) => {

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -56,20 +56,18 @@ const extractLabelFromSubmission = (entity, options = { create: true }) => {
 
 // Input: object representing entity, parsed from submission XML
 const extractBaseVersionFromSubmission = (entity, options = { update: true }) => {
-  const { update } = options;
+  const { update = false } = options;
   const { baseVersion } = entity.system;
-  if (update) {
-    if (!baseVersion)
+  if (isBlank(baseVersion)) {
+    if (update)
       throw Problem.user.missingParameter({ field: 'baseVersion' });
+    return null;
   }
-  if (!isBlank(baseVersion)) {
-    // Check type and parseInt in both create and update case
-    if (!/^\d+$/.test(baseVersion))
-      throw Problem.user.invalidDataTypeOfParameter({ field: 'baseVersion', expected: 'integer' });
 
-    return parseInt(entity.system.baseVersion, 10);
-  }
-  return null;
+  if (!/^\d+$/.test(baseVersion))
+    throw Problem.user.invalidDataTypeOfParameter({ field: 'baseVersion', expected: 'integer' });
+
+  return parseInt(entity.system.baseVersion, 10);
 };
 
 const extractBranchIdFromSubmission = (entity) => {

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -39,7 +39,7 @@ class Entity extends Frame.define(
     // validation for each field happens within each function
     const uuid = normalizeUuid(entityData.system.id);
     const label = extractLabelFromSubmission(entityData, options);
-    const baseVersion = extractBaseVersionFromSubmission(entityData);
+    const baseVersion = extractBaseVersionFromSubmission(entityData, options);
     const branchId = extractBranchIdFromSubmission(entityData);
     const trunkVersion = extractTrunkVersionFromSubmission(entityData);
     const dataReceived = { ...data, ...(label && { label }) };

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -486,7 +486,11 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
       maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing);
     } catch (err) {
       const attemptCreate = (entityData.system.create === '1' || entityData.system.create === 'true') || forceOutOfOrderProcessing;
-      if ((err.problemCode === 404.8) && attemptCreate) {
+      // The two cases we attempt to create after a failed update:
+      // 1. entity not found
+      // 2. baseVersion is empty and failed to parse in the update case
+      // This second one is a special case related to issue c#727
+      if ((err.problemCode === 404.8 || err.problemCode === 400.2) && attemptCreate) {
         maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
       } else {
         throw (err);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -486,11 +486,11 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
       maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing);
     } catch (err) {
       const attemptCreate = (entityData.system.create === '1' || entityData.system.create === 'true') || forceOutOfOrderProcessing;
-      // The two cases we attempt to create after a failed update:
+      // The two types of errors for which we attempt to create after a failed update:
       // 1. entity not found
       // 2. baseVersion is empty and failed to parse in the update case
       // This second one is a special case related to issue c#727
-      if ((err.problemCode === 404.8 || err.problemCode === 400.2) && attemptCreate) {
+      if ((err.problemCode === 404.8 || (err.problemCode === 400.2 && err.problemDetails.field === 'baseVersion')) && attemptCreate) {
         maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
       } else {
         throw (err);

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -131,32 +131,26 @@ describe('extracting and validating entities', () => {
 
     describe('extractBaseVersionFromSubmission', () => {
       it('should extract integer base version when update is true', () => {
-        const entity = { system: { update: '1', baseVersion: '99' } };
-        extractBaseVersionFromSubmission(entity).should.equal(99);
+        const entity = { system: { baseVersion: '99' } };
+        extractBaseVersionFromSubmission(entity, { update: true }).should.equal(99);
       });
 
       it('not return base version if create is true because it is not relevant', () => {
-        const entity = { system: { create: '1', baseVersion: '99' } };
-        should.not.exist(extractBaseVersionFromSubmission(entity));
-      });
-
-      it('not return base version if neither create nor update are provided', () => {
         const entity = { system: { baseVersion: '99' } };
-        should.not.exist(extractBaseVersionFromSubmission(entity));
+        should.not.exist(extractBaseVersionFromSubmission(entity, { create: true }));
       });
 
-      it('should complain if baseVersion is missing when update is true (update = 1)', () => {
+      it('not complain if baseVersion is missing when update is false and create is true', () => {
+        const entity = { system: { update: '1', create: '1' } };
+        // the create/update values do not get pulled from the entity system data here
+        // but rather from the branch in the code that decides whether a create
+        // or update is currently being attempted.
+        should.not.exist(extractBaseVersionFromSubmission(entity, { create: true }));
+      });
+
+      it('should complain if baseVersion is missing when update is true', () => {
         const entity = { system: { update: '1' } };
-        assert.throws(() => { extractBaseVersionFromSubmission(entity); }, (err) => {
-          err.problemCode.should.equal(400.2);
-          err.message.should.equal('Required parameter baseVersion missing.');
-          return true;
-        });
-      });
-
-      it('should complain if baseVersion is missing when update is true (update = true)', () => {
-        const entity = { system: { update: 'true' } };
-        assert.throws(() => { extractBaseVersionFromSubmission(entity); }, (err) => {
+        assert.throws(() => { extractBaseVersionFromSubmission(entity, { update: true }); }, (err) => {
           err.problemCode.should.equal(400.2);
           err.message.should.equal('Required parameter baseVersion missing.');
           return true;

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -135,17 +135,9 @@ describe('extracting and validating entities', () => {
         extractBaseVersionFromSubmission(entity, { update: true }).should.equal(99);
       });
 
-      it('not return base version if create is true because it is not relevant', () => {
+      it('should extract base version even if create is true and update is not', () => {
         const entity = { system: { baseVersion: '99' } };
-        should.not.exist(extractBaseVersionFromSubmission(entity, { create: true }));
-      });
-
-      it('not complain if baseVersion is missing when update is false and create is true', () => {
-        const entity = { system: { update: '1', create: '1' } };
-        // the create/update values do not get pulled from the entity system data here
-        // but rather from the branch in the code that decides whether a create
-        // or update is currently being attempted.
-        should.not.exist(extractBaseVersionFromSubmission(entity, { create: true }));
+        extractBaseVersionFromSubmission(entity, { create: true }).should.equal(99);
       });
 
       it('should complain if baseVersion is missing when update is true', () => {
@@ -155,6 +147,14 @@ describe('extracting and validating entities', () => {
           err.message.should.equal('Required parameter baseVersion missing.');
           return true;
         });
+      });
+
+      it('not complain if baseVersion is missing when update is false and create is true', () => {
+        const entity = { system: { } };
+        // the create/update values do not get pulled from the entity system data here
+        // but rather from the branch in the code that decides whether a create
+        // or update is currently being attempted.
+        should.not.exist(extractBaseVersionFromSubmission(entity, { create: true }));
       });
 
       it('should complain if baseVersion not an integer', () => {

--- a/test/unit/model/frames/entity.js
+++ b/test/unit/model/frames/entity.js
@@ -1,5 +1,7 @@
 const appRoot = require('app-root-path');
 const { Entity } = require(appRoot + '/lib/model/frames');
+const assert = require('assert');
+
 
 describe('entity', () => {
   describe('fromParseEntityData', () => {
@@ -22,6 +24,57 @@ describe('entity', () => {
         dataReceived: { field: 'value', label: 'label' }
       }));
       partial.aux.should.have.property('dataset', 'people');
+    });
+
+    describe('baseVersion', () => {
+      it('should parse successfully for empty baseVersion, create: true', () => {
+        const partial = Entity.fromParseEntityData({
+          system: {
+            label: 'label',
+            id: 'uuid:12345678-1234-4123-8234-abcd56789abc',
+            create: '1',
+            baseVersion: '',
+            dataset: 'people'
+          },
+          data: { field: 'value' }
+        },
+        { create: true });
+        partial.aux.def.should.not.have.property('baseVersion');
+      });
+
+      it('should return baseVersion even when create: true', () => {
+        const partial = Entity.fromParseEntityData({
+          system: {
+            label: 'label',
+            id: 'uuid:12345678-1234-4123-8234-abcd56789abc',
+            create: '1',
+            baseVersion: '73',
+            dataset: 'people'
+          },
+          data: { field: 'value' }
+        },
+        { create: true });
+        partial.aux.def.baseVersion.should.equal(73);
+      });
+
+      it('should complain about missing baseVersion when update: true', () => {
+        const entity = {
+          system: {
+            label: 'label',
+            id: 'uuid:12345678-1234-4123-8234-abcd56789abc',
+            create: '1',
+            baseVersion: '',
+            dataset: 'people'
+          },
+          data: { field: 'value' }
+        };
+
+        assert.throws(() => { Entity.fromParseEntityData(entity, { update: true }); }, (err) => {
+          err.problemCode.should.equal(400.2);
+          err.message.should.equal('Required parameter baseVersion missing.');
+          return true;
+        });
+      });
     });
   });
 });

--- a/test/unit/model/frames/entity.js
+++ b/test/unit/model/frames/entity.js
@@ -26,6 +26,26 @@ describe('entity', () => {
       partial.aux.should.have.property('dataset', 'people');
     });
 
+    it('should throw 400.2 for other problems like missing branchId when trunkVersion is present', () => {
+      const entity = {
+        system: {
+          label: 'label',
+          id: 'uuid:12345678-1234-4123-8234-abcd56789abc',
+          update: '1',
+          trunkVersion: '1',
+          baseVersion: '3',
+          dataset: 'people'
+        },
+        data: { field: 'value' }
+      };
+
+      assert.throws(() => { Entity.fromParseEntityData(entity, { update: true }); }, (err) => {
+        err.problemCode.should.equal(400.2);
+        err.message.should.equal('Required parameter branchId missing.');
+        return true;
+      });
+    });
+
     describe('baseVersion', () => {
       it('should parse successfully for empty baseVersion, create: true', () => {
         const partial = Entity.fromParseEntityData({
@@ -62,7 +82,7 @@ describe('entity', () => {
           system: {
             label: 'label',
             id: 'uuid:12345678-1234-4123-8234-abcd56789abc',
-            create: '1',
+            update: '1',
             baseVersion: '',
             dataset: 'people'
           },


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/727

Thanks for the example test, @sadiqkhoja! I used it to debug and then made a simplified test.

When create and update are both present in an entity, Central first tries to update and then tries to create if the update failed in a certain way. 

In this scenario, the update step was failing at the parsing step. The update flag in the entity system data is set to true, but there is no base version, and that causes an error. The code changes how the parsing works a little bit to not use what is written in the entity system data directly, but to use the context of whether it is currently trying to update or create. A similar change was made to the label parsing method.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced