### PR TITLE
Fix intermittently failing S3 test

### DIFF
--- a/test/integration/task/s3.js
+++ b/test/integration/task/s3.js
@@ -9,7 +9,7 @@ const { Blob } = require(appRoot + '/lib/model/frames');
 // eslint-disable-next-line camelcase
 const aBlobExistsWith = async (container, { status }) => {
   const blob = await Blob.fromBuffer(crypto.randomBytes(100));
-  container.run(sql`
+  await container.run(sql`
     INSERT INTO BLOBS (sha, md5, content, "contentType", s3_status)
       VALUES (${blob.sha}, ${blob.md5}, ${sql.binary(blob.content)}, ${blob.contentType || null}, ${status})
   `);


### PR DESCRIPTION
Hopefully closes https://github.com/getodk/central-backend/issues/1208 

Did a bunch of sleuthing and saw that `uploadPending` was trying to upload 0 pending blobs. I overlooked `aBlobExistsWith` at first because I thought it was checking an assertion or something, but when I finally revisited what it was really doing (inserting a blob), I noticed this way in which it could be contributing to failing tests. 

This would not have been possible without the previous PR (https://github.com/getodk/central-backend/pull/1213) to clean up around the tests, so thanks!

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced