### PR TITLE
ci: test/e2e/standard: fix kill_child_processes()

### DIFF
--- a/test/e2e/standard/run-tests.sh
+++ b/test/e2e/standard/run-tests.sh
@@ -17,7 +17,7 @@ node ./lib/bin/cli.js user-promote -u "$userEmail" && log "User promoted."
 
 kill_child_processes() {
   log "Killing child processes..."
-  kill -- -$$
+  kill -- -$$ || true
 }
 trap kill_child_processes EXIT
 


### PR DESCRIPTION
Fixes https://github.com/getodk/central-backend/actions/workflows/standard-e2e.yml.

It looks like the final cleanup kills the process itself.

Locally this returns exit code `0`, but on CI it returns `1`.