### PR TITLE
Update Submissions OData to include `deletedAt`

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -40,6 +40,12 @@ info:
 
     Here major and breaking changes to the API are listed by version.
 
+    ## ODK Central v2024.3
+
+    **Changed**:
+
+    - [Submissions Odata]() now returns `__system/deletedAt`. It can also be used in $filter, $sort and $select query parameters.
+
     ## ODK Central v2024.2
 
     **Added**:
@@ -5622,6 +5628,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -5643,6 +5650,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -5704,84 +5712,7 @@ paths:
           content:
             application/json:
               schema:
-                required:
-                - createdAt
-                - instanceId
-                - submitterId
-                type: object
-                properties:
-                  instanceId:
-                    type: string
-                    description: The `instanceId` of the `Submission`, given by the
-                      Submission XML.
-                  submitterId:
-                    type: number
-                    description: The ID of the `Actor` (`App User`, `User`, or `Public
-                      Link`) that originally submitted this `Submission`.
-                  deviceId:
-                    type: string
-                    description: The self-identified `deviceId` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `deviceId` will be returned here.
-                  userAgent:
-                    type: string
-                    description: The self-identified `userAgent` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `userAgent` will be returned here.
-                  reviewState:
-                    type: string
-                    description: The current review state of the submission.
-                    enum:
-                    - null
-                    - edited
-                    - hasIssues
-                    - rejected
-                    - approved
-                  createdAt:
-                    type: string
-                    description: ISO date format. The time that the server received
-                      the Submission.
-                  updatedAt:
-                    type: string
-                    description: ISO date format. `null` when the Submission is first
-                      created, then updated when the Submission's XML data or metadata
-                      is updated.
-                  currentVersion:
-                    required:
-                    - createdAt
-                    - current
-                    - instanceId
-                    - submitterId
-                    type: object
-                    properties:
-                      instanceId:
-                        type: string
-                        description: The `instanceId` of the `Submission` version,
-                          given by the Submission XML.
-                      instanceName:
-                        type: string
-                        description: The `instanceName`, if any, given by the Submission
-                          XML in the metadata section.
-                      submitterId:
-                        type: number
-                        description: The ID of the `Actor` (`App User`, `User`, or
-                          `Public Link`) that submitted this `Submission` version.
-                      deviceId:
-                        type: string
-                        description: The self-identified `deviceId` of the device
-                          that submitted the `Submission` version.
-                      userAgent:
-                        type: string
-                        description: The self-identified `userAgent` of the device
-                          that submitted the `Submission` version.
-                      createdAt:
-                        type: string
-                        description: ISO date format. The time that the server received
-                          the `Submission` version.
-                      current:
-                        type: boolean
-                        description: Whether the version is current or not.
-                    description: The current version of the `Submission`.
+                $ref: '#/components/schemas/Submission'
               example:
                 instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                 submitterId: 23
@@ -5790,6 +5721,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -5893,6 +5825,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -5912,6 +5845,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -5983,84 +5917,7 @@ paths:
           content:
             application/json:
               schema:
-                required:
-                - createdAt
-                - instanceId
-                - submitterId
-                type: object
-                properties:
-                  instanceId:
-                    type: string
-                    description: The `instanceId` of the `Submission`, given by the
-                      Submission XML.
-                  submitterId:
-                    type: number
-                    description: The ID of the `Actor` (`App User`, `User`, or `Public
-                      Link`) that originally submitted this `Submission`.
-                  deviceId:
-                    type: string
-                    description: The self-identified `deviceId` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `deviceId` will be returned here.
-                  userAgent:
-                    type: string
-                    description: The self-identified `userAgent` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `userAgent` will be returned here.
-                  reviewState:
-                    type: string
-                    description: The current review state of the submission.
-                    enum:
-                    - null
-                    - edited
-                    - hasIssues
-                    - rejected
-                    - approved
-                  createdAt:
-                    type: string
-                    description: ISO date format. The time that the server received
-                      the Submission.
-                  updatedAt:
-                    type: string
-                    description: ISO date format. `null` when the Submission is first
-                      created, then updated when the Submission's XML data or metadata
-                      is updated.
-                  currentVersion:
-                    required:
-                    - createdAt
-                    - current
-                    - instanceId
-                    - submitterId
-                    type: object
-                    properties:
-                      instanceId:
-                        type: string
-                        description: The `instanceId` of the `Submission` version,
-                          given by the Submission XML.
-                      instanceName:
-                        type: string
-                        description: The `instanceName`, if any, given by the Submission
-                          XML in the metadata section.
-                      submitterId:
-                        type: number
-                        description: The ID of the `Actor` (`App User`, `User`, or
-                          `Public Link`) that submitted this `Submission` version.
-                      deviceId:
-                        type: string
-                        description: The self-identified `deviceId` of the device
-                          that submitted the `Submission` version.
-                      userAgent:
-                        type: string
-                        description: The self-identified `userAgent` of the device
-                          that submitted the `Submission` version.
-                      createdAt:
-                        type: string
-                        description: ISO date format. The time that the server received
-                          the `Submission` version.
-                      current:
-                        type: boolean
-                        description: Whether the version is current or not.
-                    description: The current version of the `Submission`.
+                $ref: '#/components/schemas/Submission'
               example:
                 instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                 submitterId: 23
@@ -6069,6 +5926,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -6157,84 +6015,7 @@ paths:
           content:
             application/json:
               schema:
-                required:
-                - createdAt
-                - instanceId
-                - submitterId
-                type: object
-                properties:
-                  instanceId:
-                    type: string
-                    description: The `instanceId` of the `Submission`, given by the
-                      Submission XML.
-                  submitterId:
-                    type: number
-                    description: The ID of the `Actor` (`App User`, `User`, or `Public
-                      Link`) that originally submitted this `Submission`.
-                  deviceId:
-                    type: string
-                    description: The self-identified `deviceId` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `deviceId` will be returned here.
-                  userAgent:
-                    type: string
-                    description: The self-identified `userAgent` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `userAgent` will be returned here.
-                  reviewState:
-                    type: string
-                    description: The current review state of the submission.
-                    enum:
-                    - null
-                    - edited
-                    - hasIssues
-                    - rejected
-                    - approved
-                  createdAt:
-                    type: string
-                    description: ISO date format. The time that the server received
-                      the Submission.
-                  updatedAt:
-                    type: string
-                    description: ISO date format. `null` when the Submission is first
-                      created, then updated when the Submission's XML data or metadata
-                      is updated.
-                  currentVersion:
-                    required:
-                    - createdAt
-                    - current
-                    - instanceId
-                    - submitterId
-                    type: object
-                    properties:
-                      instanceId:
-                        type: string
-                        description: The `instanceId` of the `Submission` version,
-                          given by the Submission XML.
-                      instanceName:
-                        type: string
-                        description: The `instanceName`, if any, given by the Submission
-                          XML in the metadata section.
-                      submitterId:
-                        type: number
-                        description: The ID of the `Actor` (`App User`, `User`, or
-                          `Public Link`) that submitted this `Submission` version.
-                      deviceId:
-                        type: string
-                        description: The self-identified `deviceId` of the device
-                          that submitted the `Submission` version.
-                      userAgent:
-                        type: string
-                        description: The self-identified `userAgent` of the device
-                          that submitted the `Submission` version.
-                      createdAt:
-                        type: string
-                        description: ISO date format. The time that the server received
-                          the `Submission` version.
-                      current:
-                        type: boolean
-                        description: Whether the version is current or not.
-                    description: The current version of the `Submission`.
+                $ref: '#/components/schemas/Submission'
               example:
                 instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                 submitterId: 23
@@ -6243,6 +6024,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -7892,84 +7674,7 @@ paths:
           content:
             application/json:
               schema:
-                required:
-                - createdAt
-                - instanceId
-                - submitterId
-                type: object
-                properties:
-                  instanceId:
-                    type: string
-                    description: The `instanceId` of the `Submission`, given by the
-                      Submission XML.
-                  submitterId:
-                    type: number
-                    description: The ID of the `Actor` (`App User`, `User`, or `Public
-                      Link`) that originally submitted this `Submission`.
-                  deviceId:
-                    type: string
-                    description: The self-identified `deviceId` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `deviceId` will be returned here.
-                  userAgent:
-                    type: string
-                    description: The self-identified `userAgent` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `userAgent` will be returned here.
-                  reviewState:
-                    type: string
-                    description: The current review state of the submission.
-                    enum:
-                    - null
-                    - edited
-                    - hasIssues
-                    - rejected
-                    - approved
-                  createdAt:
-                    type: string
-                    description: ISO date format. The time that the server received
-                      the Submission.
-                  updatedAt:
-                    type: string
-                    description: ISO date format. `null` when the Submission is first
-                      created, then updated when the Submission's XML data or metadata
-                      is updated.
-                  currentVersion:
-                    required:
-                    - createdAt
-                    - current
-                    - instanceId
-                    - submitterId
-                    type: object
-                    properties:
-                      instanceId:
-                        type: string
-                        description: The `instanceId` of the `Submission` version,
-                          given by the Submission XML.
-                      instanceName:
-                        type: string
-                        description: The `instanceName`, if any, given by the Submission
-                          XML in the metadata section.
-                      submitterId:
-                        type: number
-                        description: The ID of the `Actor` (`App User`, `User`, or
-                          `Public Link`) that submitted this `Submission` version.
-                      deviceId:
-                        type: string
-                        description: The self-identified `deviceId` of the device
-                          that submitted the `Submission` version.
-                      userAgent:
-                        type: string
-                        description: The self-identified `userAgent` of the device
-                          that submitted the `Submission` version.
-                      createdAt:
-                        type: string
-                        description: ISO date format. The time that the server received
-                          the `Submission` version.
-                      current:
-                        type: boolean
-                        description: Whether the version is current or not.
-                    description: The current version of the `Submission`.
+                $ref: '#/components/schemas/Submission'
               example:
                 instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                 submitterId: 23
@@ -7978,6 +7683,7 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -8222,121 +7928,9 @@ paths:
           description: 'This is the Extended Metadata response, if requested via the
             appropriate header:'
           content:
-            application/json; extended:
+            application/json:
               schema:
-                required:
-                - createdAt
-                - instanceId
-                - submitter
-                - submitterId
-                type: object
-                properties:
-                  instanceId:
-                    type: string
-                    description: The `instanceId` of the `Submission`, given by the
-                      Submission XML.
-                  submitterId:
-                    type: number
-                    description: The ID of the `Actor` (`App User`, `User`, or `Public
-                      Link`) that originally submitted this `Submission`.
-                  deviceId:
-                    type: string
-                    description: The self-identified `deviceId` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `deviceId` will be returned here.
-                  userAgent:
-                    type: string
-                    description: The self-identified `userAgent` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `userAgent` will be returned here.
-                  reviewState:
-                    type: string
-                    description: The current review state of the submission.
-                    enum:
-                    - null
-                    - edited
-                    - hasIssues
-                    - rejected
-                    - approved
-                  createdAt:
-                    type: string
-                    description: ISO date format. The time that the server received
-                      the Submission.
-                  updatedAt:
-                    type: string
-                    description: ISO date format. `null` when the Submission is first
-                      created, then updated when the Submission's XML data or metadata
-                      is updated.
-                  currentVersion:
-                    required:
-                    - createdAt
-                    - current
-                    - instanceId
-                    - submitterId
-                    type: object
-                    properties:
-                      instanceId:
-                        type: string
-                        description: The `instanceId` of the `Submission` version,
-                          given by the Submission XML.
-                      instanceName:
-                        type: string
-                        description: The `instanceName`, if any, given by the Submission
-                          XML in the metadata section.
-                      submitterId:
-                        type: number
-                        description: The ID of the `Actor` (`App User`, `User`, or
-                          `Public Link`) that submitted this `Submission` version.
-                      deviceId:
-                        type: string
-                        description: The self-identified `deviceId` of the device
-                          that submitted the `Submission` version.
-                      userAgent:
-                        type: string
-                        description: The self-identified `userAgent` of the device
-                          that submitted the `Submission` version.
-                      createdAt:
-                        type: string
-                        description: ISO date format. The time that the server received
-                          the `Submission` version.
-                      current:
-                        type: boolean
-                        description: Whether the version is current or not.
-                    description: The current version of the `Submission`.
-                  submitter:
-                    required:
-                    - createdAt
-                    - displayName
-                    - id
-                    - type
-                    type: object
-                    properties:
-                      createdAt:
-                        type: string
-                        description: ISO date format
-                      displayName:
-                        type: string
-                        description: All `Actor`s, regardless of type, have a display
-                          name
-                      id:
-                        type: number
-                      type:
-                        type: string
-                        description: the Type of this Actor; typically this will be
-                          `user`.
-                        enum:
-                        - user
-                        - field_key
-                        - public_link
-                        - singleUse
-                      updatedAt:
-                        type: string
-                        description: ISO date format
-                      deletedAt:
-                        type: string
-                        description: ISO date format
-                    description: The full details of the `Actor` that submitted this
-                      `Submission`.
+                $ref: '#/components/schemas/Submission'
               example:
                 instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                 submitterId: 23
@@ -8345,6 +7939,27 @@ paths:
                 reviewState: approved
                 createdAt: 2018-01-19T23:58:03.395Z
                 updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
+                currentVersion:
+                  instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
+                  instanceName: village third house
+                  submitterId: 23
+                  deviceId: imei:123456
+                  userAgent: Enketo/3.0.4
+                  createdAt: 2018-01-19T23:58:03.395Z
+                  current: true
+            application/json; extended:
+              schema:
+                $ref: '#/components/schemas/ExtendedSubmission'
+              example:
+                instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
+                submitterId: 23
+                deviceId: imei:123456
+                userAgent: Enketo/3.0.4
+                reviewState: approved
+                createdAt: 2018-01-19T23:58:03.395Z
+                updatedAt: 2018-03-21T12:45:02.312Z
+                deletedAt: null
                 currentVersion:
                   instanceId: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
                   instanceName: village third house
@@ -8360,121 +7975,6 @@ paths:
                   type: user
                   updatedAt: 2018-04-18T23:42:11.406Z
                   deletedAt: 2018-04-18T23:42:11.406Z
-            application/json:
-              schema:
-                required:
-                - createdAt
-                - instanceId
-                - submitter
-                - submitterId
-                type: object
-                properties:
-                  instanceId:
-                    type: string
-                    description: The `instanceId` of the `Submission`, given by the
-                      Submission XML.
-                  submitterId:
-                    type: number
-                    description: The ID of the `Actor` (`App User`, `User`, or `Public
-                      Link`) that originally submitted this `Submission`.
-                  deviceId:
-                    type: string
-                    description: The self-identified `deviceId` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `deviceId` will be returned here.
-                  userAgent:
-                    type: string
-                    description: The self-identified `userAgent` of the device that
-                      collected the data, sent by it upon submission to the server.
-                      The initial submission `userAgent` will be returned here.
-                  reviewState:
-                    type: string
-                    description: The current review state of the submission.
-                    enum:
-                    - null
-                    - edited
-                    - hasIssues
-                    - rejected
-                    - approved
-                  createdAt:
-                    type: string
-                    description: ISO date format. The time that the server received
-                      the Submission.
-                  updatedAt:
-                    type: string
-                    description: ISO date format. `null` when the Submission is first
-                      created, then updated when the Submission's XML data or metadata
-                      is updated.
-                  currentVersion:
-                    required:
-                    - createdAt
-                    - current
-                    - instanceId
-                    - submitterId
-                    type: object
-                    properties:
-                      instanceId:
-                        type: string
-                        description: The `instanceId` of the `Submission` version,
-                          given by the Submission XML.
-                      instanceName:
-                        type: string
-                        description: The `instanceName`, if any, given by the Submission
-                          XML in the metadata section.
-                      submitterId:
-                        type: number
-                        description: The ID of the `Actor` (`App User`, `User`, or
-                          `Public Link`) that submitted this `Submission` version.
-                      deviceId:
-                        type: string
-                        description: The self-identified `deviceId` of the device
-                          that submitted the `Submission` version.
-                      userAgent:
-                        type: string
-                        description: The self-identified `userAgent` of the device
-                          that submitted the `Submission` version.
-                      createdAt:
-                        type: string
-                        description: ISO date format. The time that the server received
-                          the `Submission` version.
-                      current:
-                        type: boolean
-                        description: Whether the version is current or not.
-                    description: The current version of the `Submission`.
-                  submitter:
-                    required:
-                    - createdAt
-                    - displayName
-                    - id
-                    - type
-                    type: object
-                    properties:
-                      createdAt:
-                        type: string
-                        description: ISO date format
-                      displayName:
-                        type: string
-                        description: All `Actor`s, regardless of type, have a display
-                          name
-                      id:
-                        type: number
-                      type:
-                        type: string
-                        description: the Type of this Actor; typically this will be
-                          `user`.
-                        enum:
-                        - user
-                        - field_key
-                        - public_link
-                        - singleUse
-                      updatedAt:
-                        type: string
-                        description: ISO date format
-                      deletedAt:
-                        type: string
-                        description: ISO date format
-                    description: The full details of the `Actor` that submitted this
-                      `Submission`.
         403:
           description: Forbidden
           content:
@@ -10654,12 +10154,13 @@ paths:
 
         The fields you can query against are as follows:
 
-        | Submission Metadata         | REST API Name | OData Field Name          |
-        | --------------------------- | ------------- | ------------------------- |
-        | Submitter Actor ID          | `submitterId` | `__system/submitterId`    |
-        | Submission Timestamp        | `createdAt`   | `__system/submissionDate` |
-        | Submission Update Timestamp | `updatedAt`   | `__system/updatedAt`      |
-        | Review State                | `reviewState` | `__system/reviewState`    |
+        | Submission Metadata                      | REST API Name | OData Field Name          |
+        | ---------------------------------------- | ------------- | ------------------------- |
+        | Submitter Actor ID                       | `submitterId` | `__system/submitterId`    |
+        | Submission Timestamp                     | `createdAt`   | `__system/submissionDate` |
+        | Submission Update Timestamp              | `updatedAt`   | `__system/updatedAt`      |
+        | Review State                             | `reviewState` | `__system/reviewState`    |
+        | Submission Delete Timestamp (v2024.3)    | `deletedAt`   | `__system/deletedAt`      |
 
         You can use `$root` expression to filter subtables (repeats) by Submission Metadata, you'll have to prefix above fields by `$root/Submissions/` in the filter criteria. For example, to filter a repeat table by Submission Timestamp you can pass `$filter=$root/Submissions/__system/submissionDate gt 2020-01-31T23:59:59.999Z` in the query parameter.
 
@@ -13060,6 +12561,10 @@ components:
           type: string
           example: '2018-03-21T12:45:02.312Z'
           description: ISO date format. `null` when the Submission is first created, then updated when the Submission's XML data or metadata is updated.
+        deletedAt:
+          type: string
+          description: Timestamp of the deletion in ISO date format. `null` if the Submission is not deleted.
+          example: 2018-04-18T23:42:11.406Z
         currentVersion:
           $ref: '#/components/schemas/SubmissionVersion'
           description: The current version of the `Submission`.

--- a/lib/data/odata-filter.js
+++ b/lib/data/odata-filter.js
@@ -87,6 +87,50 @@ const odataFilter = (expr, odataToColumnMap) => {
   return op(ast);
 };
 
+// Returns sql expression to exclude deleted records if provided OData filter
+// expression doesn't use `__system/deletedAt` field. Logic of this function
+// can easily be merged with `OdataFilter()` but it is kept separate for the
+// for the sake of simplicity and for separation of concerns.
+const odataExcludeDeleted = (expr, odataToColumnMap) => {
+  const deleteAtColumn = odataToColumnMap.get('__system/deletedAt')
+    ?? odataToColumnMap.get('$root/Submissions/__system/deletedAt');
+
+  const filterOutDeletedRecordsExp = sql`(${sql.identifier(deleteAtColumn.split('.'))} is null)`;
+
+  if (expr == null) return filterOutDeletedRecordsExp;
+
+  let ast; // still hate this.
+  try { ast = odataParser.filter(expr); } // eslint-disable-line brace-style
+  catch (ex) { throw Problem.user.unparseableODataExpression({ reason: ex.message }); }
+
+  const hasDeletedAtClause = (node) => {
+    if (node.type === 'FirstMemberExpression' || node.type === 'RootExpression') {
+      if (node.raw === '__system/deletedAt'
+        || node.raw === '$root/Submissions/__system/deletedAt') return true;
+    } else if (node.type === 'MethodCallExpression') {
+      // n.b. we only support Unary (single-arity functions)
+      return hasDeletedAtClause(node.value.parameters[0]);
+    } else if (node.type === 'EqualsExpression'
+            || node.type === 'NotEqualsExpression'
+            || node.type === 'LesserThanExpression'
+            || node.type === 'LesserOrEqualsExpression'
+            || node.type === 'GreaterThanExpression'
+            || node.type === 'GreaterOrEqualsExpression'
+            || node.type === 'AndExpression'
+            || node.type === 'OrExpression') {
+      return hasDeletedAtClause(node.value.left) || hasDeletedAtClause(node.value.right);
+    } else if (node.type === 'BoolParenExpression'
+            || node.type === 'NotExpression') {
+      return hasDeletedAtClause(node.value);
+    }
+    return false;
+  };
+
+  if (!hasDeletedAtClause(ast)) return filterOutDeletedRecordsExp;
+
+  return sql`true`;
+};
+
 const odataOrderBy = (expr, odataToColumnMap, stableOrderColumn = null) => {
   let initialOrder = null;
   const clauses = expr.split(',').map((exp) => {
@@ -115,5 +159,4 @@ const odataOrderBy = (expr, odataToColumnMap, stableOrderColumn = null) => {
   return sql`ORDER BY ${sql.join(clauses, sql`,`)}`;
 };
 
-module.exports = { odataFilter, odataOrderBy };
-
+module.exports = { odataFilter, odataOrderBy, odataExcludeDeleted };

--- a/lib/data/odata.js
+++ b/lib/data/odata.js
@@ -150,7 +150,8 @@ const submissionToOData = (fields, table, submission, options = {}) => new Promi
       deviceId: submission.deviceId || null,
       // because of how we compute this value we don't need to default it to 0:
       edits: submission.aux.edit.count,
-      formVersion: submission.aux.exports.formVersion
+      formVersion: submission.aux.exports.formVersion,
+      deletedAt: submission.deletedAt
     };
 
     if (!options.metadata || options.metadata.__system) {
@@ -363,6 +364,7 @@ const systemFields = new Set([
   '__system/deviceId',
   '__system/edits',
   '__system/formVersion',
+  '__system/deletedAt'
 ]);
 
 module.exports = { submissionToOData, systemFields };

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -342,7 +342,8 @@ const filterableFields = [
   ['__system/submissionDate', 'submissions.createdAt'],
   ['__system/updatedAt', 'submissions.updatedAt'],
   ['__system/submitterId', 'submissions.submitterId'],
-  ['__system/reviewState', 'submissions.reviewState']
+  ['__system/reviewState', 'submissions.reviewState'],
+  ['__system/deletedAt', 'submissions.deletedAt']
 ];
 
 const odataToColumnMap = new Map(filterableFields.concat(filterableFields.map(f => ([`$root/Submissions/${f[0]}`, f[1]]))));

--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -126,6 +126,7 @@ const edmxTemplater = template(`<?xml version="1.0" encoding="UTF-8"?>
       <ComplexType Name="metadata">
         <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
         <Property Name="updatedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="submitterId" Type="Edm.String"/>
         <Property Name="submitterName" Type="Edm.String"/>
         <Property Name="attachmentsPresent" Type="Edm.Int64"/>

--- a/lib/model/frames/submission.js
+++ b/lib/model/frames/submission.js
@@ -25,6 +25,7 @@ class Submission extends Frame.define(
   'deviceId',   readable,               'createdAt',    readable,
   'updatedAt',  readable,               'reviewState',  readable, writable,
   'userAgent',  readable,               'draft',
+  'deletedAt',  readable,
   embedded('submitter'),
   embedded('currentVersion')
 ) {

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -12,7 +12,7 @@ const { map } = require('ramda');
 const { sql } = require('slonik');
 const { Frame, table } = require('../frame');
 const { Actor, Form, Submission } = require('../frames');
-const { odataFilter, odataOrderBy } = require('../../data/odata-filter');
+const { odataFilter, odataOrderBy, odataExcludeDeleted } = require('../../data/odata-filter');
 const { odataToColumnMap, odataSubTableToColumnMap } = require('../../data/submission');
 const { unjoiner, extender, equals, page, updater, QueryOptions, insertMany, markDeleted, markUndeleted } = require('../../util/db');
 const { blankStringToNull, construct } = require('../../util/util');
@@ -231,7 +231,7 @@ const joinOnSkiptoken = (skiptoken, formId, draft) => {
 
 const countByFormId = (formId, draft, options = QueryOptions.none) => ({ one }) => {
   const filter = sql`${equals({ formId, draft })} AND
-"deletedAt" IS NULL AND
+${odataExcludeDeleted(options.filter, odataToColumnMap)} AND
 ${odataFilter(options.filter, odataToColumnMap)}`;
   return one(sql`
 SELECT * FROM
@@ -382,7 +382,7 @@ where
   ${encrypted ? sql`(form_defs."encKeyId" is null or form_defs."encKeyId" in (${sql.join(keyIds, sql`,`)})) and` : sql``}
   ${odataFilter(options.filter, options.isSubmissionsTable ? odataToColumnMap : odataSubTableToColumnMap)} and
   ${equals(options.condition)}
-  and submission_defs.current=true and submissions."formId"=${formId} and submissions."deletedAt" is null
+  and submission_defs.current=true and submissions."formId"=${formId} and ${odataExcludeDeleted(options.filter, options.isSubmissionsTable ? odataToColumnMap : odataSubTableToColumnMap)}
 ${options.orderby ? sql`
   ${odataOrderBy(options.orderby, odataToColumnMap, 'submissions.id')}`
     : sql`order by submissions."createdAt" desc, submissions.id desc`}

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -150,6 +150,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above!
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -223,6 +224,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above!
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -265,6 +267,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above!
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 1,
@@ -417,6 +420,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above!
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -477,6 +481,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above!
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -596,6 +601,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above,
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -617,6 +623,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above,
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -638,6 +645,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above,
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -676,6 +684,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above,
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -697,6 +706,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above,
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -711,6 +721,46 @@ describe('api: /forms/:id.svc', () => {
                   name: 'Alice',
                   age: 30,
                   children: {}
+                }]
+              });
+            })))));
+
+    it('should return deleted submission', testService((service) =>
+      withSubmissions(service, (asAlice) =>
+        asAlice.delete('/v1/projects/1/forms/withrepeat/submissions/rthree')
+          .expect(200)
+          .then(() => asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions?$filter=not __system/deletedAt eq null')
+            .expect(200)
+            .then(({ body }) => {
+              body.value[0].__system.submissionDate.should.be.an.isoDate();
+              // eslint-disable-next-line no-param-reassign
+              delete body.value[0].__system.submissionDate;
+              body.value[0].__system.deletedAt.should.be.an.isoDate();
+              // eslint-disable-next-line no-param-reassign
+              delete body.value[0].__system.deletedAt;
+
+              body.should.eql({
+                '@odata.context': 'http://localhost:8989/v1/projects/1/forms/withrepeat.svc/$metadata#Submissions',
+                value: [{
+                  __id: 'rthree',
+                  __system: {
+                    updatedAt: null,
+                    submitterId: '5',
+                    submitterName: 'Alice',
+                    attachmentsPresent: 0,
+                    attachmentsExpected: 0,
+                    status: null,
+                    reviewState: null,
+                    deviceId: null,
+                    edits: 0,
+                    formVersion: '1.0'
+                  },
+                  meta: { instanceID: 'rthree' },
+                  name: 'Chelsea',
+                  age: 38,
+                  children: {
+                    'child@odata.navigationLink': "Submissions('rthree')/children/child"
+                  }
                 }]
               });
             })))));
@@ -766,6 +816,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above,
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -1023,6 +1074,7 @@ describe('api: /forms/:id.svc', () => {
                 __system: {
                   // submissionDate is checked above,
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,
@@ -1078,6 +1130,7 @@ describe('api: /forms/:id.svc', () => {
                     __system: {
                       // submissionDate is checked above,
                       updatedAt: null,
+                      deletedAt: null,
                       submitterId: '5',
                       submitterName: 'Alice',
                       attachmentsPresent: 0,
@@ -1099,6 +1152,7 @@ describe('api: /forms/:id.svc', () => {
                     __system: {
                       // submissionDate is checked above,
                       updatedAt: null,
+                      deletedAt: null,
                       submitterId: '5',
                       submitterName: 'Alice',
                       attachmentsPresent: 0,
@@ -1138,6 +1192,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     submissionDate: '2010-06-01T00:00:00.000Z',
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -1207,6 +1262,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     submissionDate: '2010-06-01T00:00:00.000Z',
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -1252,6 +1308,7 @@ describe('api: /forms/:id.svc', () => {
                   __id: 'rone',
                   __system: {
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -1307,6 +1364,7 @@ describe('api: /forms/:id.svc', () => {
                     reviewState: 'rejected',
                     deviceId: null,
                     edits: 0,
+                    deletedAt: null,
                     formVersion: '1.0'
                   },
                   meta: { instanceID: 'rtwo' },
@@ -1350,6 +1408,7 @@ describe('api: /forms/:id.svc', () => {
                 reviewState: 'rejected',
                 deviceId: null,
                 edits: 0,
+                deletedAt: null,
                 formVersion: '1.0'
               },
               meta: { instanceID: 'rtwo' },
@@ -1611,6 +1670,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above!
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -1626,6 +1686,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above!
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 0,
@@ -1678,6 +1739,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above!
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 1,
@@ -1693,6 +1755,7 @@ describe('api: /forms/:id.svc', () => {
                   __system: {
                     // submissionDate is checked above!
                     updatedAt: null,
+                    deletedAt: null,
                     submitterId: '5',
                     submitterName: 'Alice',
                     attachmentsPresent: 1,
@@ -1841,6 +1904,20 @@ describe('api: /forms/:id.svc', () => {
         });
 
 
+    }));
+
+    it('should return subtable from deleted submissions', testService(async (service) => {
+      const asAlice = await withSubmissions(service, identity);
+
+      await asAlice.delete('/v1/projects/1/forms/withrepeat/submissions/rtwo')
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions.children.child?$filter=not $root/Submissions/__system/deletedAt eq null')
+        .expect(200)
+        .then(({ body }) => {
+          body.value[0].name.should.be.eql('Billy');
+          body.value[1].name.should.be.eql('Blaine');
+        });
     }));
 
     // we cheat here. see mark1.
@@ -2237,6 +2314,7 @@ describe('api: /forms/:id.svc', () => {
                     __system: {
                       // submissionDate is checked above!
                       updatedAt: null,
+                      deletedAt: null,
                       submitterId: '5',
                       submitterName: 'Alice',
                       attachmentsPresent: 0,
@@ -2319,6 +2397,7 @@ describe('api: /forms/:id.svc', () => {
                     __system: {
                       // submissionDate is checked above,
                       updatedAt: null,
+                      deletedAt: null,
                       submitterId: '5',
                       submitterName: 'Alice',
                       attachmentsPresent: 0,
@@ -2340,6 +2419,7 @@ describe('api: /forms/:id.svc', () => {
                     __system: {
                       // submissionDate is checked above,
                       updatedAt: null,
+                      deletedAt: null,
                       submitterId: '5',
                       submitterName: 'Alice',
                       attachmentsPresent: 0,
@@ -2361,6 +2441,7 @@ describe('api: /forms/:id.svc', () => {
                     __system: {
                       // submissionDate is checked above,
                       updatedAt: null,
+                      deletedAt: null,
                       submitterId: '5',
                       submitterName: 'Alice',
                       attachmentsPresent: 0,

--- a/test/unit/data/odata.js
+++ b/test/unit/data/odata.js
@@ -7,6 +7,7 @@ const testData = require(appRoot + '/test/data/xml');
 const __system = {
   submissionDate: '2017-09-20T17:10:43Z',
   updatedAt: null,
+  deletedAt: null,
   submitterId: '5',
   submitterName: 'Alice',
   attachmentsPresent: 0,
@@ -22,6 +23,7 @@ const mockSubmission = (instanceId, xml) => ({
   instanceId,
   createdAt: '2017-09-20T17:10:43Z',
   updatedAt: null,
+  deletedAt: null,
   def: {},
   aux: {
     submitter: { id: 5, displayName: 'Alice' },
@@ -96,6 +98,7 @@ describe('submissionToOData', () => {
         __system: {
           submissionDate: '2017-09-20T17:10:43Z',
           updatedAt: null,
+          deletedAt: null,
           submitterId: null,
           submitterName: null,
           attachmentsPresent: 0,
@@ -554,6 +557,7 @@ describe('submissionToOData', () => {
                 __system: {
                   submissionDate: '2017-09-20T17:10:43Z',
                   updatedAt: null,
+                  deletedAt: null,
                   submitterId: '5',
                   submitterName: 'Alice',
                   attachmentsPresent: 0,

--- a/test/unit/formats/odata.js
+++ b/test/unit/formats/odata.js
@@ -74,6 +74,7 @@ describe('odata message composition', () => {
       <ComplexType Name="metadata">
         <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
         <Property Name="updatedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="submitterId" Type="Edm.String"/>
         <Property Name="submitterName" Type="Edm.String"/>
         <Property Name="attachmentsPresent" Type="Edm.Int64"/>
@@ -119,6 +120,7 @@ describe('odata message composition', () => {
       <ComplexType Name="metadata">
         <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
         <Property Name="updatedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="submitterId" Type="Edm.String"/>
         <Property Name="submitterName" Type="Edm.String"/>
         <Property Name="attachmentsPresent" Type="Edm.Int64"/>
@@ -182,6 +184,7 @@ describe('odata message composition', () => {
       <ComplexType Name="metadata">
         <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
         <Property Name="updatedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="submitterId" Type="Edm.String"/>
         <Property Name="submitterName" Type="Edm.String"/>
         <Property Name="attachmentsPresent" Type="Edm.Int64"/>
@@ -235,6 +238,7 @@ describe('odata message composition', () => {
       <ComplexType Name="metadata">
         <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
         <Property Name="updatedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="submitterId" Type="Edm.String"/>
         <Property Name="submitterName" Type="Edm.String"/>
         <Property Name="attachmentsPresent" Type="Edm.Int64"/>
@@ -387,6 +391,7 @@ describe('odata message composition', () => {
       <ComplexType Name="metadata">
         <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
         <Property Name="updatedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="submitterId" Type="Edm.String"/>
         <Property Name="submitterName" Type="Edm.String"/>
         <Property Name="attachmentsPresent" Type="Edm.Int64"/>
@@ -465,6 +470,7 @@ describe('odata message composition', () => {
       <ComplexType Name="metadata">
         <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
         <Property Name="updatedAt" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedAt" Type="Edm.DateTimeOffset"/>
         <Property Name="submitterId" Type="Edm.String"/>
         <Property Name="submitterName" Type="Edm.String"/>
         <Property Name="attachmentsPresent" Type="Edm.Int64"/>


### PR DESCRIPTION
Part of getodk/central#709

#### What has been done to verify that this works as intended?

- Added unit and integration tests. 
- Manually verified with the frontend.
- Checked with Excel to ensure there's no regression.

#### Why is this the best possible solution? Were any other approaches considered?

I have added `__system/deletedAt` field in the OData response and made it filterable. If client’s `$filter` expression doesn’t contain `__system/deletedAt` related clause then default `__system/deletedAt eq null` is added.

This approach keeps our Odata API consistent with respect to other system fields and quite useful for clients who are interested in filtering Submissions by deletedAt column. Maybe in future we also want to add this on the frontend.

Other option was to add a special filterable boolean field `__system/deleted`, which is simple but doesn't come with the benefits mentioned above.

OData spec doesn’t have anything explicit mechanism to track deleted records. There is a concept of deltaLink that returns list of new/changed/deleted records since last request. That concept is not related to what are looking for here.

<hr>

I have added a new function `odataExcludeDeleted` that analyzes `$filter` expression for the existence of `__system/deletedAt` related clause. Initially, I had modified `odataFilter` function with the same logic but that made it convoluted, hence I refactored it into a separate function for the sake of simplicity at the cost of parsing `$filter` expression twice.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Done.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced