### PR TITLE
Log when sub is force applied and apply create as update

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -431,11 +431,18 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
       });
 
     // If there is a create or update audit event for this def, attach the source from the audit event
-    // because it will be as detailed as possible (full submission, event, etc.)
-    // Otherwise use the details found in the source table for this entity def.
+    // because it will be as detailed as possible (full submission, event, etc.) and then merge in any
+    // additional details from the entity def source.
+    // example v.source: { submission: { instanceId: 'one' }, forceProcessed: true }
+    // example event.source: {
+    //      event: { action: 'submission.create', actor: {...}, ... },
+    //      submission: { xmlFormId, instanceId, submitter: {...}, currentVersion: {...}, ... }
+    // }
+    //
+    // If there is no event source, just use the details found in the source table for this entity def.
     const event = auditMap.get(def.id);
     if (event)
-      v.source = event.source;
+      v.source = mergeLeft(event.source, v.source);
 
     if (v.version > 1) { // v.root is false here - can use either
       const conflict = v.version !== (v.baseVersion + 1);

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -264,7 +264,7 @@ const getByEntityId = (entityId, options) => ({ all }) => {
         // Note: The source added to each audit event represents the source of the
         // corresponding entity _version_, rather than the source of the event.
         const details = mergeLeft(audit.details, sourceEvent
-          .map(event => ({ source: { event, submission } }))
+          .map(event => ({ source: mergeLeft({ event, submission }, entitySourceDetails) }))
           .orElse({ source: entitySourceDetails }));
 
         return new Audit({ ...audit, details }, { actor: audit.aux.actor });

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -230,6 +230,13 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
     ? _partial.auxWith('def', { branchBaseVersion: _partial.def.baseVersion })
     : _partial;
 
+  // Because of entity processing flow, we need to check for a conflict explicitly without
+  // distrupting the database transaction.
+  const maybeEntity = await Entities.getById(dataset.id, partial.uuid);
+  if (maybeEntity.isDefined())
+    throw Problem.user.uniquenessViolation({ fields: ['uuid'], values: partial.uuid });
+
+
   const sourceDetails = {
     submission: { instanceId: submissionDef.instanceId },
     parentEventId: parentEvent ? parentEvent.id : undefined,
@@ -252,14 +259,14 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
   return entity;
 };
 
-const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing = false) => async ({ Audits, Entities }) => {
+const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing = false, createAsUpdate = false) => async ({ Audits, Entities }) => {
   if (!(event.action === 'submission.create'
     || event.action === 'submission.update.version'
     || event.action === 'submission.reprocess'))
     return null;
 
   // Get client version of entity
-  const clientEntity = await Entity.fromParseEntityData(entityData, { update: true }); // validation happens here
+  const clientEntity = await Entity.fromParseEntityData(entityData, createAsUpdate ? { create: true } : { update: true }); // validation happens here
 
   // Figure out the intended baseVersion
   // If this is an offline update with a branchId, the baseVersion value is local to that offline context.
@@ -268,7 +275,7 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   // Try computing base version.
   // But if there is a 404.8 not found error, double-check if the entity never existed or was deleted.
   try {
-    baseEntityDef = await Entities._computeBaseVersion(event.id, dataset, clientEntity, submissionDef, forceOutOfOrderProcessing);
+    baseEntityDef = await Entities._computeBaseVersion(event.id, dataset, clientEntity, submissionDef, forceOutOfOrderProcessing, createAsUpdate);
   } catch (err) {
     if (err.problemCode === 404.8) {
       // Look up deleted entity by passing deleted as option argData
@@ -315,6 +322,8 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
     if (conflict !== ConflictType.HARD) { // We don't want to downgrade conflict here
       conflict = conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
     }
+  } else if (createAsUpdate) {
+    conflict = ConflictType.SOFT;
   }
 
   // merge data
@@ -324,7 +333,8 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   // make some kind of source object
   const sourceDetails = {
     submission: { instanceId: submissionDef.instanceId },
-    forceProcessed: forceOutOfOrderProcessing
+    forceProcessed: forceOutOfOrderProcessing,
+    createAsUpdate
   };
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id);
   const partial = new Entity.Partial(serverEntity.with({ conflict }), {
@@ -359,8 +369,16 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 
 // Used by _updateVerison to figure out the intended base version in Central
 // based on the branchId, trunkVersion, and baseVersion in the submission
-const _computeBaseVersion = (eventId, dataset, clientEntity, submissionDef, forceOutOfOrderProcessing = false) => async ({ Entities }) => {
-  if (!clientEntity.def.branchId) {
+const _computeBaseVersion = (eventId, dataset, clientEntity, submissionDef, forceOutOfOrderProcessing = false, createAsUpdate = false) => async ({ Entities }) => {
+  if (clientEntity.def.baseVersion == null && createAsUpdate) {
+    // if no baseVersion is specified but we are updating and trying to find the base version
+    // we are probably in the special case of force-apply create-as-update. get the latest version.
+
+    const latestEntity = await Entities.getById(dataset.id, clientEntity.uuid)
+      .then(getOrReject(Problem.user.entityNotFound({ entityUuid: clientEntity.uuid, datasetName: dataset.name })));
+    return latestEntity.aux.currentVersion;
+
+  } else if (!clientEntity.def.branchId) {
 
     // no offline branching to deal with, use baseVersion as is
     const condition = { version: clientEntity.def.baseVersion };
@@ -504,8 +522,26 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
         throw (err);
       }
     }
-  else if (entityData.system.create === '1' || entityData.system.create === 'true')
-    maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
+  else if (entityData.system.create === '1' || entityData.system.create === 'true') {
+    // note i dont think (???) forceOutOfOrderProcessing will ever be true here?
+    try {
+      maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
+    } catch (err) {
+      // There was a problem creating the entity
+      // If it is a uuid collision, check if the entity was created via an update
+      // in which case its ok to apply this create as an update
+      if (err.problemCode === 409.3) {
+        const rootDef = await Entities.getDef(dataset.id, entityData.system.id, new QueryOptions({ root: true })).then(o => o.orNull());
+        if (rootDef && rootDef.aux.source.details.updateAsCreate && rootDef.aux.source.details.forceProcessed) {
+          maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, true);
+        } else {
+          throw (err);
+        }
+      } else {
+        throw (err);
+      }
+    }
+  }
 
   // Check for held submissions that follow this one in the same branch
   if (maybeEntity != null) {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -211,7 +211,7 @@ const _lockEntity = (exec, uuid) => {
 ////////////////////////////////////////////////////////////////////////////////
 // WRAPPER FUNCTIONS FOR CREATING AND UPDATING ENTITIES
 
-const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing = false) => async ({ Audits, Entities }) => {
+const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing = false, upsert = false) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
   // an approval event, then don't create an entity
   if ((dataset.approvalRequired && event.details.reviewState !== 'approved') ||
@@ -230,7 +230,14 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
     ? _partial.auxWith('def', { branchBaseVersion: _partial.def.baseVersion })
     : _partial;
 
-  const sourceDetails = { submission: { instanceId: submissionDef.instanceId }, parentEventId: parentEvent ? parentEvent.id : undefined };
+  const sourceDetails = {
+    submission: { instanceId: submissionDef.instanceId },
+    parentEventId: parentEvent ? parentEvent.id : undefined,
+    forceProcessed: forceOutOfOrderProcessing,
+    upsert,
+    updateAsCreate: forceOutOfOrderProcessing && upsert,
+  };
+
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id);
   const entity = await Entities.createNew(dataset, partial, submissionDef, sourceId);
 
@@ -316,7 +323,8 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 
   // make some kind of source object
   const sourceDetails = {
-    submission: { instanceId: submissionDef.instanceId }
+    submission: { instanceId: submissionDef.instanceId },
+    forceProcessed: forceOutOfOrderProcessing
   };
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id);
   const partial = new Entity.Partial(serverEntity.with({ conflict }), {
@@ -491,7 +499,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
       // 2. baseVersion is empty and failed to parse in the update case
       // This second one is a special case related to issue c#727
       if ((err.problemCode === 404.8 || (err.problemCode === 400.2 && err.problemDetails.field === 'baseVersion')) && attemptCreate) {
-        maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
+        maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing, true);
       } else {
         throw (err);
       }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/702 and https://github.com/getodk/central/issues/720

Should also help with https://github.com/getodk/central/issues/699 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced