### PR TITLE
oidc: include response_type for client.callback()

### DIFF
--- a/lib/resources/oidc.js
+++ b/lib/resources/oidc.js
@@ -139,7 +139,7 @@ module.exports = (service, endpoint) => {
 
       const params = client.callbackParams(req);
 
-      const tokenSet = await client.callback(getRedirectUri(), params, { response_type:RESPONSE_TYPE, code_verifier });
+      const tokenSet = await client.callback(getRedirectUri(), params, { response_type: RESPONSE_TYPE, code_verifier });
 
       const { access_token } = tokenSet;
 

--- a/lib/resources/oidc.js
+++ b/lib/resources/oidc.js
@@ -22,6 +22,7 @@ const { redirect } = require('../util/http');
 const { createUserSession } = require('../http/sessions');
 const { // eslint-disable-line object-curly-newline
   CODE_CHALLENGE_METHOD,
+  RESPONSE_TYPE,
   SCOPES,
   getClient,
   getRedirectUri,
@@ -137,7 +138,8 @@ module.exports = (service, endpoint) => {
       const client = await getClient();
 
       const params = client.callbackParams(req);
-      const tokenSet = await client.callback(getRedirectUri(), params, { code_verifier });
+
+      const tokenSet = await client.callback(getRedirectUri(), params, { response_type:RESPONSE_TYPE, code_verifier });
 
       const { access_token } = tokenSet;
 

--- a/lib/util/oidc.js
+++ b/lib/util/oidc.js
@@ -25,6 +25,7 @@ const TOKEN_ENDPOINT_AUTH_METHOD = 'client_secret_basic';
 
 module.exports = {
   CODE_CHALLENGE_METHOD,
+  RESPONSE_TYPE,
   SCOPES,
   getClient,
   getRedirectUri,


### PR DESCRIPTION
* imposes stricter checks on callback params, making /callback fail faster if `code_verifier` cookie is missing & code is missing from callback params
* recommended at https://github.com/panva/openid-client/tree/v5.4.3/docs#clientcallbackredirecturi-parameters-checks-extras