### PR TITLE
crypto.generateToken(): use standard base64url encoding

### DIFF
--- a/lib/util/crypto.js
+++ b/lib/util/crypto.js
@@ -38,10 +38,8 @@ const verifyPassword = (plain, hash) => ((isBlank(plain) || (isBlank(hash)))
   ? resolve(false)
   : bcrypt.compare(plain, hash));
 
-// Returns a cryptographically random base64 string of a given length.
-const generateToken = (bytes = 48) => randomBytes(bytes).toString('base64')
-  .replace(/\//g, '!')
-  .replace(/\+/g, '$');
+// Returns a cryptographically random base64url string of a given length.
+const generateToken = (bytes = 48) => randomBytes(bytes).toString('base64url')
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -53,7 +53,7 @@ should.Assertion.add('recentDate', function() {
 
 should.Assertion.add('token', function(length = 64) {
   this.params = { operator: 'to be a token string' };
-  this.obj.should.match(new RegExp(`^[a-z0-9!$]{${length}}$`, 'i'));
+  this.obj.should.match(new RegExp(`^[a-z0-9_-]{${length}}$`, 'i'));
 });
 
 should.Assertion.add('uuid', function() {


### PR DESCRIPTION
crypto.generateToken() replaces non-URL-safe and non-filename-safe characters ('/' & '+') with '!' & '$'.

* '/' was removed from generated token strings in commit 98a26e6e5d464ebf8fc70e49f3de2d5de6f930da with explanation "one fewer thing to url-encode"
* '+' was removed from generated token strings in commit 9a680e02f077c51ab941168036ac19fc7a1b2c8b; that commit does not make the motivation clear

If the intention is to avoid url-encoding, using a known standard with the same aim should be less prone to future encoding problems.

Specifically, base64url uses '_' & '-' in place of '!' & '$', and trims trailing '=' characters.

See: https://nodejs.org/api/buffer.html#buffers-and-character-encodings
See: https://datatracker.ietf.org/doc/html/rfc4648#section-5
