### PR TITLE
test/httpZipResponseToFiles: don't unzip non-zip responses

### DIFF
--- a/test/util/zip.js
+++ b/test/util/zip.js
@@ -93,7 +93,7 @@ const binaryParser = (res, callback) => {
 
 const httpZipResponseToFiles = (zipHttpResponse) => new Promise((resolve, reject) => {
   zipHttpResponse
-    .expect(400)
+    .expect(200)
     .expect('Content-Type', 'application/zip')
     .buffer()
     .parse(binaryParser)

--- a/test/util/zip.js
+++ b/test/util/zip.js
@@ -95,7 +95,9 @@ const httpZipResponseToFiles = (zipHttpResponse) => new Promise((resolve, reject
   zipHttpResponse
     .expect(400)
     .expect('Content-Type', 'application/zip')
-    .buffer().parse(binaryParser).end((err, res) => {
+    .buffer()
+    .parse(binaryParser)
+    .end((err, res) => {
       if (err) return reject(err);
 
       // eslint-disable-next-line no-shadow

--- a/test/util/zip.js
+++ b/test/util/zip.js
@@ -91,12 +91,11 @@ const binaryParser = (res, callback) => {
   });
 };
 
-const httpZipResponseToFiles = (zipHttpResponse) => {
+const httpZipResponseToFiles = (zipHttpResponse) => new Promise((resolve, reject) => {
   zipHttpResponse
-    .expect(200)
-    .expect('Content-Type', 'application/zip');
-  return new Promise((resolve, reject) => {
-    zipHttpResponse.buffer().parse(binaryParser).end((err, res) => {
+    .expect(400)
+    .expect('Content-Type', 'application/zip')
+    .buffer().parse(binaryParser).end((err, res) => {
       if (err) return reject(err);
 
       // eslint-disable-next-line no-shadow
@@ -110,7 +109,6 @@ const httpZipResponseToFiles = (zipHttpResponse) => {
         });
       });
     });
-  });
-};
+});
 
 module.exports = { zipStreamToFiles, httpZipResponseToFiles };

--- a/test/util/zip.js
+++ b/test/util/zip.js
@@ -91,21 +91,26 @@ const binaryParser = (res, callback) => {
   });
 };
 
-const httpZipResponseToFiles = (zipHttpResponse) => new Promise((resolve, reject) => {
-  zipHttpResponse.buffer().parse(binaryParser).end((err, res) => {
-    if (err) return reject(err);
-
-    // eslint-disable-next-line no-shadow
-    yauzl.fromBuffer(res.body, (err, zipfile) => {
+const httpZipResponseToFiles = (zipHttpResponse) => {
+  zipHttpResponse
+    .expect(200)
+    .expect('Content-Type', 'application/zip');
+  return new Promise((resolve, reject) => {
+    zipHttpResponse.buffer().parse(binaryParser).end((err, res) => {
       if (err) return reject(err);
 
       // eslint-disable-next-line no-shadow
-      processZipFile(zipfile, (err, result) => {
-        if (err) reject(err);
-        else resolve(result);
+      yauzl.fromBuffer(res.body, (err, zipfile) => {
+        if (err) return reject(err);
+
+        // eslint-disable-next-line no-shadow
+        processZipFile(zipfile, (err, result) => {
+          if (err) reject(err);
+          else resolve(result);
+        });
       });
     });
   });
-});
+};
 
 module.exports = { zipStreamToFiles, httpZipResponseToFiles };


### PR DESCRIPTION
This should make tests fail faster, and make failures easier to understand:

Previously: `Error: end of central directory record signature not found`
Now:        `Error: expected 200 "OK", got 400 "Bad Request"`

Related:

* https://github.com/getodk/central-backend/issues/595
* https://github.com/getodk/central-backend/issues/588
* https://github.com/getodk/central-backend/pull/1052