### PR TITLE
odata-filter: remove no-op case-change of function name

### DIFF
--- a/lib/data/odata-filter.js
+++ b/lib/data/odata-filter.js
@@ -26,9 +26,8 @@ const odataFilter = (expr, odataToColumnMap) => {
   const extractFunctions = ['year', 'month', 'day', 'hour', 'minute', 'second'];
   const methodCall = (fn, params) => {
     // n.b. odata-v4-parser appears to already validate function name and arity.
-    const lowerName = fn.toLowerCase();
-    if (extractFunctions.includes(lowerName))
-      return sql`extract(${raw(lowerName)} from ${op(params[0])})`; // eslint-disable-line no-use-before-define
+    if (extractFunctions.includes(fn))
+      return sql`extract(${raw(fn)} from ${op(params[0])})`; // eslint-disable-line no-use-before-define
     else if (fn === 'now')
       return sql`now()`;
   };


### PR DESCRIPTION
odata-v4-parser treats function names as case-sensitive, so non-lowercase extractFunction names ever reach this code.

Closes #

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced