### PR TITLE
test/unit: match real querystring processing

### DIFF
--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -1,7 +1,7 @@
 const should = require('should');
 const { EventEmitter } = require('events');
 const { Transform } = require('stream');
-const { createRequest, createResponse } = require('node-mocks-http');
+const { createRequest, createResponse } = require('../../util/node-mocks-http');
 const streamTest = require('streamtest').v2;
 const { always } = require('ramda');
 

--- a/test/unit/http/middleware.js
+++ b/test/unit/http/middleware.js
@@ -1,4 +1,4 @@
-const { createRequest } = require('node-mocks-http');
+const { createRequest } = require('../../util/node-mocks-http');
 
 const appRoot = require('app-root-path');
 const middleware = require(appRoot + '/lib/http/middleware');

--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const { createRequest } = require('node-mocks-http');
+const { createRequest } = require('../../util/node-mocks-http');
 
 const appRoot = require('app-root-path');
 const preprocessors = require(appRoot + '/lib/http/preprocessors');

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -11,11 +11,11 @@ const wrapped = require('node-mocks-http');
 const qs = (() => {
   try {
     // In case express has its own version of qs, try loading that first:
-    return require('./node_modules/express/node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
+    return require('../../node_modules/express/node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
   } catch (err) {
     // Try loading the global qs.  This is not written as `require('qs')` to avoid loading of the qs module from a surprising place.
     try {
-      return require('./node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
+      return require('../../node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
     } catch (err) { // eslint-disable-line no-shadow
       // node_modules layout may change in future (e.g. using yarn with different nodeLinker config)
       throw new Error('Unexpected missing module: qs.  Please confirm node_modules directory is initialised, and dependency resolution has not changed recently.');

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -3,7 +3,21 @@
 
 const wrapped = require('node-mocks-http');
 // qs is an implicit dependency of express:
-const qs = require('qs'); // eslint-disable-line import/no-extraneous-dependencies
+
+const qs = (() => {
+  try {
+    // In case express has its own version of qs, try loading that first:
+    return require('./node_modules/express/node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
+  } catch (err) {
+    // Try loading the global qs:
+    try {
+      return require('./node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
+    } catch (err) { // eslint-disable-line no-shadow
+      // node_modules layout may change in future (e.g. using yarn with different nodeLinker config)
+      throw new Error('Unexpected missing module: qs.  Please confirm node_modules directory is initialised, and dependency resolution has not changed recently.');
+    }
+  }
+})();
 
 const createRequest = options => {
   if (!options?.url) return wrapped.createRequest(options);

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -13,7 +13,7 @@ const createRequest = options => {
 
   if (!search) return wrapped.createRequest(options);
 
-  if (query != null) throw new Error('Unsupported: .query option and query string in .url simultanesously.');
+  if (query != null) throw new Error('Unsupported: .query option and query string in .url simultaneously.');
 
   return wrapped.createRequest({ ...options, query: qs.parse(search.substr(1)) });
 };

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -1,4 +1,8 @@
-// Safe wrapper for node-mocks-http
+// Safe wrapper for node-mocks-http - ensure that query string parsing matches
+// what is happening in production.  N.B. if express's `query parser` option is
+// set, this wrapper will need to change too.
+//
+// See: https://expressjs.com/en/api.html#app.settings.table
 // See: https://github.com/eugef/node-mocks-http/issues/299
 
 const wrapped = require('node-mocks-http');

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -13,7 +13,7 @@ const qs = (() => {
     // In case express has its own version of qs, try loading that first:
     return require('./node_modules/express/node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
   } catch (err) {
-    // Try loading the global qs:
+    // Try loading the global qs.  This is not written as `require('qs')` to avoid loading of the qs module from a surprising place.
     try {
       return require('./node_modules/qs'); // eslint-disable-line import/extensions,import/no-unresolved
     } catch (err) { // eslint-disable-line no-shadow

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -1,0 +1,24 @@
+// Safe wrapper for node-mocks-http
+// See: https://github.com/eugef/node-mocks-http/issues/299
+
+const wrapped = require('node-mocks-http');
+// qs is an implicit dependency of express:
+const qs = require('qs'); // eslint-disable-line import/no-extraneous-dependencies
+
+const createRequest = options => {
+  if (!options?.url) return wrapped.createRequest(options);
+
+  const { search } = new URL(options.url, 'http://example.test');
+  const { query } = options;
+
+  if (!search) return wrapped.createRequest(options);
+
+  if (query != null) throw new Error('Unsupported: .query option and query string in .url simultanesously.');
+
+  return wrapped.createRequest({ ...options, query: qs.parse(search.substr(1)) });
+};
+
+module.exports = {
+  createRequest,
+  createResponse: wrapped.createResponse,
+};

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -6,7 +6,6 @@
 // See: https://github.com/eugef/node-mocks-http/issues/299
 
 const wrapped = require('node-mocks-http');
-// qs is an implicit dependency of express:
 
 const qs = (() => {
   try {


### PR DESCRIPTION
odk-central-backend uses express's default querystring parser (qs), whereas node-mocks-http uses querystring.

See: https://github.com/eugef/node-mocks-http/issues/299
