### PR TITLE
test/encryption: increase end-to-end test timeouts

### DIFF
--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -150,7 +150,9 @@ describe('managed encryption', () => {
     }));
   });
 
-  describe('end-to-end', () => {
+  describe('end-to-end @slow', function() {
+    this.timeout(5000);
+
     const { extractPubkey, extractVersion, encryptInstance, sendEncrypted, internal } = require(appRoot + '/test/util/crypto-odk');
 
     describe('odk encryption simulation', () => {


### PR DESCRIPTION
Also mark these tests as @slow.

* these tests have been seen to time out on CI
* these tests time out around 10% of the time on my machine

Closes #1249
