### PR TITLE
Include entity create 2022.1 forms in 2024.1 upgrade

### DIFF
--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -643,9 +643,9 @@ const _updateEntityVersion = (xml, oldVersion, newVersion) => new Promise((pass,
 // to not change anything about the Form.
 // 2022.1 -> 2024.1 forms only have version changed and suffix added.
 // 2023.1 -> 2024.1 forms (for updating) also have branchId and trunkVersion added.
-const updateEntityForm = (xml, oldVersion, newVersion, suffix) =>
+const updateEntityForm = (xml, oldVersion, newVersion, suffix, addOfflineParams) =>
   _updateEntityVersion(xml, oldVersion, newVersion)
-    .then(x => (oldVersion === '2023.1.0' ? _addBranchIdAndTrunkVersion(x) : x))
+    .then(x => (addOfflineParams ? _addBranchIdAndTrunkVersion(x) : x))
     .then(x => addVersionSuffix(x, suffix))
     .catch(() => xml);
 

--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -641,9 +641,11 @@ const _updateEntityVersion = (xml, oldVersion, newVersion) => new Promise((pass,
 // If there are any problems with updating the XML, this will just
 // return the unaltered XML which will then be a clue for the worker
 // to not change anything about the Form.
+// 2022.1 -> 2024.1 forms only have version changed and suffix added.
+// 2023.1 -> 2024.1 forms (for updating) also have branchId and trunkVersion added.
 const updateEntityForm = (xml, oldVersion, newVersion, suffix) =>
   _updateEntityVersion(xml, oldVersion, newVersion)
-    .then(_addBranchIdAndTrunkVersion)
+    .then(x => (oldVersion === '2023.1.0' ? _addBranchIdAndTrunkVersion(x) : x))
     .then(x => addVersionSuffix(x, suffix))
     .catch(() => xml);
 

--- a/lib/model/migrations/20241029-01-schedule-entity-form-upgrade-create-forms.js
+++ b/lib/model/migrations/20241029-01-schedule-entity-form-upgrade-create-forms.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 // The previous migration only added this event for forms with an
-// upgrade action, which should have been entity spec version 2023.1.0.
+// update action, which should have been entity spec version 2023.1.0.
 // We also need to flag 2022.1.0 forms with the create action.
 // To avoid flagging forms that do both create + update twice, this
 // migration captures the complement set of forms.

--- a/lib/model/migrations/20241029-01-schedule-entity-form-upgrade-create-forms.js
+++ b/lib/model/migrations/20241029-01-schedule-entity-form-upgrade-create-forms.js
@@ -1,0 +1,34 @@
+// Copyright 2024 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+// The previous migration only added this event for forms with an
+// upgrade action, which should have been entity spec version 2023.1.0.
+// We also need to flag 2022.1.0 forms with the create action.
+// To avoid flagging forms that do both create + update twice, this
+// migration captures the complement set of forms.
+// Basically, every existing form should be flagged, but I didn't want
+// to change an old migration.
+
+const up = (db) => db.raw(`
+  INSERT INTO audits ("action", "acteeId", "loggedAt", "details")
+  SELECT 'upgrade.process.form.entities_version', forms."acteeId", clock_timestamp(),
+    '{"upgrade": "As part of upgrading Central to v2024.3, this form is being updated to the latest entities-version spec."}'
+  FROM forms
+  JOIN form_defs fd ON forms."id" = fd."formId"
+  JOIN dataset_form_defs dfd ON fd."id" = dfd."formDefId"
+  JOIN projects ON projects."id" = forms."projectId"
+  WHERE NOT dfd."actions" @> '["update"]'
+  AND forms."deletedAt" IS NULL
+  AND projects."deletedAt" IS NULL
+  GROUP BY forms."acteeId";
+`);
+
+const down = () => {};
+
+module.exports = { up, down };

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -44,10 +44,21 @@ const updateDraftSet = pushDraftToEnketo;
 const updatePublish = pushFormToEnketo;
 
 const _upgradeEntityVersion = async (form) => {
-  const xml = await updateEntityForm(form.xml, '2023.1.0', '2024.1.0', '[upgrade]');
-  // If the XML doesnt change (not the version in question, or a parsing error), don't return the new partial Form
+  // We need to upgrade both 2022.1 and 2023.1 forms to 2024, and we are not sure which it is
+  // without parsing the form.
+  // Try one upgrade and then the other.
+
+  // Attempt the 2023.1 upgrade first:
+  let xml = await updateEntityForm(form.xml, '2023.1.0', '2024.1.0', '[upgrade]');
+
+  // If the XML doesnt change (not the version in question, or a parsing error), try the 2022.1 upgrade:
+  if (xml === form.xml)
+    xml = await updateEntityForm(form.xml, '2022.1.0', '2024.1.0', '[upgrade]');
+
+  // If the XML still has not changed, don't return a partial.
   if (xml === form.xml)
     return null;
+
   const partial = await Form.fromXml(xml);
   return partial.withAux('xls', { xlsBlobId: form.def.xlsBlobId });
 };

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -49,11 +49,11 @@ const _upgradeEntityVersion = async (form) => {
   // Try one upgrade and then the other.
 
   // Attempt the 2023.1 upgrade first:
-  let xml = await updateEntityForm(form.xml, '2023.1.0', '2024.1.0', '[upgrade]');
+  let xml = await updateEntityForm(form.xml, '2023.1.0', '2024.1.0', '[upgrade]', true);
 
   // If the XML doesnt change (not the version in question, or a parsing error), try the 2022.1 upgrade:
   if (xml === form.xml)
-    xml = await updateEntityForm(form.xml, '2022.1.0', '2024.1.0', '[upgrade]');
+    xml = await updateEntityForm(form.xml, '2022.1.0', '2024.1.0', '[upgrade]', false);
 
   // If the XML still has not changed, don't return a partial.
   if (xml === form.xml)

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -2089,7 +2089,7 @@ describe('form schema', () => {
 
   describe('updateEntityForm', () => {
     it('should change version 2023->2024, add trunkVersion, and add branchId', (async () => {
-      const result = await updateEntityForm(testData.forms.updateEntity, '2023.1.0', '2024.1.0', '[upgrade]');
+      const result = await updateEntityForm(testData.forms.updateEntity, '2023.1.0', '2024.1.0', '[upgrade]', true);
       // entities-version has been updated
       // version has suffix
       // trunkVersion and branchId are present
@@ -2117,7 +2117,7 @@ describe('form schema', () => {
     }));
 
     it('should change version 2022->2024', (async () => {
-      const result = await updateEntityForm(testData.forms.simpleEntity, '2022.1.0', '2024.1.0', '[upgrade]');
+      const result = await updateEntityForm(testData.forms.simpleEntity, '2022.1.0', '2024.1.0', '[upgrade]', false);
       // entities-version has been updated
       // version has suffix
       // trunkVersion and branchId are NOT added
@@ -2148,18 +2148,18 @@ describe('form schema', () => {
     // updateEntityForm takes the old version to replace as an argument
     // these tests show it will not change a 2022.1 (create-only) form when 2023.1 is provided
     it('should not alter a version 2022.1.0 form when the old version to replace is 2023.1.0', (async () => {
-      const result = await updateEntityForm(testData.forms.simpleEntity, '2023.1.0', '2024.1.0', '[upgrade]');
+      const result = await updateEntityForm(testData.forms.simpleEntity, '2023.1.0', '2024.1.0', '[upgrade]', true);
       result.should.equal(testData.forms.simpleEntity);
     }));
 
     it('should not alter a version 2024.1.0 form when the old version to replace is 2023.1.0', (async () => {
-      const result = await updateEntityForm(testData.forms.offlineEntity, '2023.1.0', '2024.1.0', '[upgrade]');
+      const result = await updateEntityForm(testData.forms.offlineEntity, '2023.1.0', '2024.1.0', '[upgrade]', true);
       result.should.equal(testData.forms.offlineEntity);
     }));
 
     // these tests show it will not change a 2023.1 (update) form when 2022.1 is provided
     it('should not alter a version 2023.1.0 form when the old version to replace is 2022.1.0', (async () => {
-      const result = await updateEntityForm(testData.forms.updateEntity, '2022.1.0', '2024.1.0', '[upgrade]');
+      const result = await updateEntityForm(testData.forms.updateEntity, '2022.1.0', '2024.1.0', '[upgrade]', true);
       result.should.equal(testData.forms.updateEntity);
     }));
 

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -2116,14 +2116,53 @@ describe('form schema', () => {
 </h:html>`);
     }));
 
+    it('should change version 2022->2024', (async () => {
+      const result = await updateEntityForm(testData.forms.simpleEntity, '2022.1.0', '2024.1.0', '[upgrade]');
+      // entities-version has been updated
+      // version has suffix
+      // trunkVersion and branchId are NOT added
+      result.should.equal(`<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model entities:entities-version="2024.1.0">
+      <instance>
+        <data id="simpleEntity" orx:version="1.0[upgrade]">
+          <name/>
+          <age/>
+          <hometown/>
+          <meta>
+            <entity dataset="people" id="" create="">
+              <label/>
+            </entity>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" entities:saveto="first_name"/>
+      <bind nodeset="/data/age" type="int" entities:saveto="age"/>
+      <bind nodeset="/data/hometown" type="string"/>
+    </model>
+  </h:head>
+</h:html>`);
+    }));
+
+    // updateEntityForm takes the old version to replace as an argument
+    // these tests show it will not change a 2022.1 (create-only) form when 2023.1 is provided
     it('should not alter a version 2022.1.0 form when the old version to replace is 2023.1.0', (async () => {
       const result = await updateEntityForm(testData.forms.simpleEntity, '2023.1.0', '2024.1.0', '[upgrade]');
       result.should.equal(testData.forms.simpleEntity);
     }));
+
     it('should not alter a version 2024.1.0 form when the old version to replace is 2023.1.0', (async () => {
       const result = await updateEntityForm(testData.forms.offlineEntity, '2023.1.0', '2024.1.0', '[upgrade]');
       result.should.equal(testData.forms.offlineEntity);
     }));
+
+    // these tests show it will not change a 2023.1 (update) form when 2022.1 is provided
+    it('should not alter a version 2023.1.0 form when the old version to replace is 2022.1.0', (async () => {
+      const result = await updateEntityForm(testData.forms.updateEntity, '2022.1.0', '2024.1.0', '[upgrade]');
+      result.should.equal(testData.forms.updateEntity);
+    }));
+
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/757

* adds a new migration that flags all the _other_ entity forms in the table `dataset_form_defs` (forms that reference datasets but don't update)
* adds form migration code that can transform a v2022.1 form into a v2024.1 form by changing the entity spec version and adding a suffix to the form version
    * every flagged form is upgraded to the 2024.1 version by trying both 2022 and 2023 upgrades (which have no effect if the specific old version is not found)

I *could* have gone back and changed the existing migration, but since this has already been applied on the QA server, it seemed ok to just add another migration. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced