### PR TITLE
 SchemaStack: use .hasExited() consistently

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "airbnb-base",
   "env": { "node": true },
-  "parserOptions": { "ecmaVersion": 2020 },
+  "parserOptions": { "ecmaVersion": 2022 },
   "plugins": [
     "no-only-tests"
   ],

--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -188,7 +188,7 @@ class SchemaStack {
   }
 
   head() { return last(this.fieldStack); }
-  hasExited() { return this.exited === true; }
+  hasExited() { return this.#exited === true; }
 
   // if you do not give a path to find the children of, the current stack
   // path is used.
@@ -252,7 +252,7 @@ class SchemaStack {
   pop() {
     // if we have /already/ hit depth 0 and we try to pop again, we must be trying
     // to close the wrapper tag, so mark exited as true.
-    if (this.pathStack.length === 0) this.exited = true;
+    if (this.pathStack.length === 0) this.#exited = true;
     this.path = this.pathStack.pop();
     this.iterationStack.pop();
     return this.fieldStack.pop();

--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -173,6 +173,8 @@ const getFormFields = (xml) => {
 // when processing incoming attachments; we can select only binary fields from
 // the database.
 class SchemaStack {
+  #exited;
+
   constructor(fieldList, allowEmptyNavigation = false) {
     this.fieldList = fieldList;
     this.fields = {};

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -197,7 +197,7 @@ const _hashedTree = (structurals, xml) => {
     },
     onclosetag: (tagName) => {
       const structural = stack.pop();
-      if (stack.exited === true) {
+      if (stack.hasExited()) {
         // nothing routine to do, but since we are done let's digest the root hash.
         tree[subhash] = tree[subhash].digest('base64');
       } else if (structural == null) {


### PR DESCRIPTION
Enforced via making the `exited` prop private.

This makes use of "private properties", which have been available since node 12(?).

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties

Eslint's ecmaVersion needed updating to allow eslint to parse `lib/data/schema.js`.