### PR TITLE
Speed up entities query for dataset CSV export and entity OData

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -282,7 +282,7 @@ const selectFields = (entity, properties, selectedProperties) => {
     createdAt: entity.createdAt,
     creatorId: entity.aux.creator.id.toString(),
     creatorName: entity.aux.creator.displayName,
-    updates: entity.updates, // 'updates' is a property predating 'version' and will always equal version - 1
+    updates: entity.updates,
     updatedAt: entity.updatedAt,
     version: entity.def.version,
     conflict: entity.conflict

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -238,7 +238,7 @@ const streamEntityCsv = (inStream, properties) => {
 
   // System properties
   header.push(...[ '__createdAt', '__creatorId', '__creatorName', '__updates', '__updatedAt', '__version']);
-  props.push(...['createdAt', 'creatorId', 'aux.creator.displayName', 'aux.stats.updates', 'updatedAt', 'def.version'].map(e => e.split('.')));
+  props.push(...['createdAt', 'creatorId', 'aux.creator.displayName', 'updates', 'updatedAt', 'def.version'].map(e => e.split('.')));
 
   const entityStream = _entityTransformer(header, props);
 
@@ -282,7 +282,7 @@ const selectFields = (entity, properties, selectedProperties) => {
     createdAt: entity.createdAt,
     creatorId: entity.aux.creator.id.toString(),
     creatorName: entity.aux.creator.displayName,
-    updates: entity.aux.stats.updates,
+    updates: entity.updates, // 'updates' is a property predating 'version' and will always equal version - 1
     updatedAt: entity.updatedAt,
     version: entity.def.version,
     conflict: entity.conflict

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -33,6 +33,14 @@ class Entity extends Frame.define(
 ) {
   get def() { return this.aux.def; }
 
+  // Note: we introduced this 'updates' count to entities in datasets (via odata and csv export)
+  // before we exposed a similar idea was exposed through the 'version' property.
+  // This version property increments with each entity update so it is safe to compute 'updates'
+  // from version instead of calculating it in less efficient ways.
+  // Note that 'updates' is used in too many places in frontend code and exposed in the odata/csv
+  // exports to remove it from the system properties.
+  get updates() { return this.aux.def.version - 1; }
+
   static fromParseEntityData(entityData, options = { create: true, update: false }) {
     const { dataset } = entityData.system;
     const { data } = entityData;

--- a/lib/model/frames/entity.js
+++ b/lib/model/frames/entity.js
@@ -34,7 +34,7 @@ class Entity extends Frame.define(
   get def() { return this.aux.def; }
 
   // Note: we introduced this 'updates' count to entities in datasets (via odata and csv export)
-  // before we exposed a similar idea was exposed through the 'version' property.
+  // before we exposed a similar idea through the 'version' property.
   // This version property increments with each entity update so it is safe to compute 'updates'
   // from version instead of calculating it in less efficient ways.
   // Note that 'updates' is used in too many places in frontend code and exposed in the odata/csv
@@ -87,10 +87,6 @@ class Entity extends Frame.define(
 }
 
 Entity.Partial = class extends Entity {};
-
-Entity.Extended = class extends Frame.define(
-  'updates'
-) { };
 
 Entity.Def = Frame.define(
   table('entity_defs', 'def'),

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -744,16 +744,12 @@ resolveConflict.audit = (entity, dataset) => (log) => log('entity.update.resolve
 ////////////////////////////////////////////////////////////////////////////////
 // SERVING ENTITIES
 
-const _exportUnjoiner = unjoiner(Entity, Entity.Def, Entity.Extended.into('stats'), Actor.alias('actors', 'creator'));
+const _exportUnjoiner = unjoiner(Entity, Entity.Def, Actor.alias('actors', 'creator'));
 
 const streamForExport = (datasetId, options = QueryOptions.none) => ({ stream }) =>
   stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"
-INNER JOIN
-  (
-    SELECT "entityId", (COUNT(id) - 1) AS "updates" FROM entity_defs GROUP BY "entityId"
-  ) stats ON stats."entityId"=entity_defs."entityId"
 LEFT JOIN actors ON entities."creatorId"=actors.id
 ${options.skiptoken ? sql`
   INNER JOIN

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -660,11 +660,9 @@ describe('extracting and validating entities', () => {
         creator: {
           id: 'id',
           displayName: 'displayName'
-        },
-        stats: {
-          updates: 0
         }
-      }
+      },
+      updates: 0
     };
     const properties = [{ name: 'firstName' }, { name: 'lastName' }];
 
@@ -743,11 +741,9 @@ describe('extracting and validating entities', () => {
           creator: {
             id: 'id',
             displayName: 'displayName'
-          },
-          stats: {
-            updates: 0
           }
-        }
+        },
+        updates: 0
       };
       const selectedProperties = null;
       const result = selectFields(data, properties, selectedProperties);


### PR DESCRIPTION
We (myself, QA, LN, etc.) have been noticing lately that entity lists, both in frontend and in forms in enketo, have been taking an uncomfortably long time to load.  

* staging: [dataset with 1 entity taking 10 seconds to load](https://staging.getodk.cloud/#/projects/118/entity-lists/movies/entities)
* staging (same dataset as above): [form taking 10 seconds to load](https://staging.getodk.cloud/-/preview/Zk1RSkRhv6avflpna68snsVGynPRMfr)
* staging [dataset with 20 entities taking >10 seconds](https://staging.getodk.cloud/#/projects/103/entity-lists/cacti/entities)
* staging [dataset with 60K entities, loading 250 of them taking 10 seconds](https://staging.getodk.cloud/#/projects/93/entity-lists/entities_60k/entities)
* QA: [dataset 2 entities taking 1 second to load](https://test.getodk.cloud/#/projects/554/entity-lists/trees/entities)
* QA: [dataset with 800 entities and no updates taking ~1 sec to load](https://test.getodk.cloud/#/projects/436/entity-lists/trees/entities)
* K dev: 5 entities (no updates) loading in 2 seconds
* K dev: 5 entities with updates loading in 2 seconds
* K dev: 1.6M entity dataset (no updates) loading in 10 seconds

Notes:
* 1.6M entities on staging
* 240K entities on QA
* 4M entities on Kathleen's local dev database (also experiencing multi-second loading times)

This PR removes a piece of the bulk entity query that computed the # of updates per entity. I did some historical sleuthing to figure out why we return `updates` count as well as `version` when `updates` always seems like it will be `version - 1`. 

* May 2023: `updates` count was [added](https://github.com/getodk/central-backend/pull/853) along with `updatedAt`, which could be selected and filtered on in odata. 
    * we didn't have `version` yet
    * we allowed API updates to entities but not updates via submission
* Sept 2023: entity def `version`s [added](https://github.com/getodk/central-backend/pull/951) to support entity updates via submission
    * did we hold off on versions because we weren't sure how the versioning system was going to work? probably... 
    * there's a `version` for each entity def within an entity, so it's more informative than a simple `updates` count

Anyway, `updates` is baked into a lot of code, e.g. used by frontend, probably expected by people working with entities via odata, and we can't/shouldn't remove it.  However, we always increment the `version` of the def by 1 when we update it, both through an API PATCH request and through a submission, so it's a good proxy for counting `updates`. I tried to make minimal code changes to remove the slow part of the query and calculate `updates` directly from `version`.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests have mostly stayed the same (except for some minor changes to some unit tests) and I've seen queries get much faster locally.

#### Why is this the best possible solution? Were any other approaches considered?

See explanation above.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't change things for users except speed things up.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced