### PR TITLE
Warn about <2024.1 entities spec and update tests

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -82,13 +82,13 @@ const getDataset = (xml) =>
     else if (!semverSatisfies(version.get(), '2022.1.0 - 2024.1.x'))
       throw Problem.user.invalidEntityForm({ reason: `Entities specification version [${version.get()}] is not supported.` });
 
-    let warnings;
-    if (semverSatisfies(version.get(), '<2024.1.x'))
-      warnings = {
+    const warnings = semverSatisfies(version.get(), '>=2024.1.x')
+      ? null
+      : [{
         type: 'oldEntityVersion',
         details: { version: version.get() },
         reason: `Entities specification version [${version.get()}] is not compatible with Offline Entities. Please use version 2024.1.0 or later.`
-      };
+      }];
 
     const strippedAttrs = Object.create(null);
     for (const [name, value] of Object.entries(entityAttrs.get()))

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -82,6 +82,14 @@ const getDataset = (xml) =>
     else if (!semverSatisfies(version.get(), '2022.1.0 - 2024.1.x'))
       throw Problem.user.invalidEntityForm({ reason: `Entities specification version [${version.get()}] is not supported.` });
 
+    let warnings;
+    if (semverSatisfies(version.get(), '<2024.1.x'))
+      warnings = {
+        type: 'oldEntityVersion',
+        details: { version: version.get() },
+        reason: `Entities specification version [${version.get()}] is not compatible with Offline Entities. Please use version 2024.1.0 or later.`
+      };
+
     const strippedAttrs = Object.create(null);
     for (const [name, value] of Object.entries(entityAttrs.get()))
       strippedAttrs[stripNamespacesFromPath(name)] = value;
@@ -101,7 +109,7 @@ const getDataset = (xml) =>
     if (actions.length === 0)
       throw Problem.user.invalidEntityForm({ reason: 'The form must specify at least one entity action, for example, create or update.' });
 
-    return Option.of({ name: datasetName, actions });
+    return Option.of({ name: datasetName, actions, warnings });
   });
 
 module.exports = { getDataset, validateDatasetName, validatePropertyName };

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -134,6 +134,7 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
 
   // Check for xmlFormId collisions with previously deleted forms
   await Forms.checkDeletedForms(partial.xmlFormId, project.id);
+  await Forms.checkDatasetWarnings(parsedDataset);
   await Forms.rejectIfWarnings();
 
   // Provision Actee for form
@@ -761,6 +762,16 @@ const checkDeletedForms = (xmlFormId, projectId) => ({ maybeOne, context }) => (
     }
   }));
 
+const checkDatasetWarnings = (dataset) => ({ context }) => {
+  if (context.query.ignoreWarnings) return resolve();
+
+  if (dataset.isDefined() && dataset.get().warnings != null) {
+    if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
+    context.transitoryData.get('workflowWarnings').push(dataset.get().warnings);
+  }
+  return resolve();
+};
+
 const checkStructuralChange = (existingFields, fields) => ({ context }) => {
   if (context.query.ignoreWarnings) return resolve();
 
@@ -829,7 +840,7 @@ module.exports = {
   getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
-  rejectIfWarnings, checkMeta, checkDeletedForms, checkStructuralChange, checkFieldDowncast,
+  rejectIfWarnings, checkMeta, checkDeletedForms, checkStructuralChange, checkFieldDowncast, checkDatasetWarnings,
   _newSchema,
   lockDefs, getAllSubmitters
 };

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -767,7 +767,7 @@ const checkDatasetWarnings = (dataset) => ({ context }) => {
 
   if (dataset.isDefined() && dataset.get().warnings != null) {
     if (!context.transitoryData.has('workflowWarnings')) context.transitoryData.set('workflowWarnings', []);
-    context.transitoryData.get('workflowWarnings').push(dataset.get().warnings);
+    context.transitoryData.get('workflowWarnings').push(...dataset.get().warnings);
   }
   return resolve();
 };

--- a/test/data/xml.js
+++ b/test/data/xml.js
@@ -348,6 +348,30 @@ module.exports = {
     simpleEntity: `<?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
   <h:head>
+    <model entities:entities-version="2024.1.0">
+      <instance>
+        <data id="simpleEntity" orx:version="1.0">
+          <name/>
+          <age/>
+          <hometown/>
+          <meta>
+            <entity dataset="people" id="" create="">
+              <label/>
+            </entity>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" entities:saveto="first_name"/>
+      <bind nodeset="/data/age" type="int" entities:saveto="age"/>
+      <bind nodeset="/data/hometown" type="string"/>
+    </model>
+  </h:head>
+</h:html>`,
+
+    // Copy of the above form with the original entities-version
+    simpleEntity2022: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
     <model entities:entities-version="2022.1.0">
       <instance>
         <data id="simpleEntity" orx:version="1.0">
@@ -371,7 +395,7 @@ module.exports = {
     multiPropertyEntity: `<?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
   <h:head>
-    <model entities:entities-version="2022.1.0">
+    <model entities:entities-version="2024.1.0">
       <instance>
         <data id="multiPropertyEntity" orx:version="1.0">
           <q1/>
@@ -394,6 +418,29 @@ module.exports = {
 </h:html>`,
 
     updateEntity: `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
+  <h:head>
+    <model entities:entities-version="2024.1.0">
+      <instance>
+        <data id="updateEntity" orx:version="1.0">
+          <name/>
+          <age/>
+          <hometown/>
+          <meta>
+            <entity dataset="people" id="" update="" baseVersion="" branchId="" trunkVersion="">
+              <label/>
+            </entity>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" entities:saveto="first_name"/>
+      <bind nodeset="/data/age" type="int" entities:saveto="age"/>
+    </model>
+  </h:head>
+</h:html>`,
+
+    // Copy of the above form with the original entities-version spec
+    updateEntity2023: `<?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
   <h:head>
     <model entities:entities-version="2023.1.0">

--- a/test/integration/other/empty-entity-structure.js
+++ b/test/integration/other/empty-entity-structure.js
@@ -9,7 +9,7 @@ const { testService } = require('../setup');
 const emptyEntityForm = `<?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms">
   <h:head>
-    <model entities:entities-version="2023.1.0">
+    <model entities:entities-version="2024.1.0">
       <instance>
         <data id="emptyEntity" orx:version="1.0">
           <age/>

--- a/test/integration/other/form-entities-version.js
+++ b/test/integration/other/form-entities-version.js
@@ -59,8 +59,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Publish a form
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -86,8 +86,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form but dont publish, leaving it as a draft
-      await asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -119,8 +119,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -160,20 +160,20 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Publish a form
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
       await asAlice.post('/v1/projects/1/forms/updateEntity/draft')
-        .send(testData.forms.updateEntity.replace('orx:version="1.0"', ' orx:version="2.0"'))
+        .send(testData.forms.updateEntity2023.replace('orx:version="1.0"', ' orx:version="2.0"'))
         .set('Content-Type', 'text/xml')
         .expect(200);
 
       await asAlice.post('/v1/projects/1/forms/updateEntity/draft/publish');
 
       await asAlice.post('/v1/projects/1/forms/updateEntity/draft')
-        .send(testData.forms.updateEntity.replace('orx:version="1.0"', ' orx:version="3.0"'))
+        .send(testData.forms.updateEntity2023.replace('orx:version="1.0"', ' orx:version="3.0"'))
         .set('Content-Type', 'text/xml')
         .expect(200);
 
@@ -197,7 +197,7 @@ describe('Update / migrate entities-version within form', () => {
 
       // Upload updateEntities form with xlsx
       global.xlsformForm = 'updateEntity';
-      await asAlice.post('/v1/projects/1/forms?publish=true')
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
         .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
         .set('Content-Type', 'application/vnd.ms-excel')
         .set('X-XlsForm-FormId-Fallback', 'testformid')
@@ -228,7 +228,7 @@ describe('Update / migrate entities-version within form', () => {
 
       // Upload updateEntities form with xlsx
       global.xlsformForm = 'updateEntity';
-      await asAlice.post('/v1/projects/1/forms')
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
         .send(readFileSync(appRoot + '/test/data/simple.xlsx'))
         .set('Content-Type', 'application/vnd.ms-excel')
         .set('X-XlsForm-FormId-Fallback', 'testformid')
@@ -262,7 +262,7 @@ describe('Update / migrate entities-version within form', () => {
         .replace('</meta>', '<entity dataset="people" id="" update="" baseVersion=""><label/></entity></meta>');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms')
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
         .send(withAttachmentsEntities)
         .set('Content-Type', 'application/xml')
         .expect(200);
@@ -341,8 +341,8 @@ describe('Update / migrate entities-version within form', () => {
       const domain = config.get('default.env.domain');
 
       // Publish a form
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -410,8 +410,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -440,8 +440,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -470,8 +470,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -498,8 +498,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.simpleEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.simpleEntity2022)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -541,8 +541,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -572,8 +572,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -603,8 +603,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Upload a form and publish it
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -640,8 +640,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Publish a form
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .set('Content-Type', 'application/xml')
         .expect(200);
 
@@ -661,8 +661,8 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Publish an invalid XML form
-      const invalidForm = testData.forms.updateEntity.replace('<entity', '<something');
-      await asAlice.post('/v1/projects/1/forms?publish=true')
+      const invalidForm = testData.forms.updateEntity2023.replace('<entity', '<something');
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
         .send(invalidForm)
         .set('Content-Type', 'application/xml')
         .expect(200);
@@ -700,7 +700,7 @@ describe('Update / migrate entities-version within form', () => {
       const asAlice = await service.login('alice');
 
       // Publish an XML form of the right version
-      await asAlice.post('/v1/projects/1/forms?publish=true')
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
         .send(testData.forms.offlineEntity)
         .set('Content-Type', 'application/xml')
         .expect(200);

--- a/test/integration/other/migrations.js
+++ b/test/integration/other/migrations.js
@@ -1063,25 +1063,25 @@ testMigration('20240914-02-remove-orphaned-client-audits.js', () => {
       const asAlice = await service.login('alice');
 
       // Upload one form with multiple versions
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .send(testData.forms.updateEntity)
+      await asAlice.post('/v1/projects/1/forms?publish=true&ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023)
         .expect(200);
 
-      await asAlice.post('/v1/projects/1/forms/updateEntity/draft')
-        .send(testData.forms.updateEntity.replace('orx:version="1.0"', 'orx:version="2.0"'))
+      await asAlice.post('/v1/projects/1/forms/updateEntity/draft?ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023.replace('orx:version="1.0"', 'orx:version="2.0"'))
         .set('Content-Type', 'text/xml')
         .expect(200);
 
       await asAlice.post('/v1/projects/1/forms/updateEntity/draft/publish');
 
-      await asAlice.post('/v1/projects/1/forms/updateEntity/draft')
-        .send(testData.forms.updateEntity.replace('orx:version="1.0"', 'orx:version="3.0"'))
+      await asAlice.post('/v1/projects/1/forms/updateEntity/draft?ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023.replace('orx:version="1.0"', 'orx:version="3.0"'))
         .set('Content-Type', 'text/xml')
         .expect(200);
 
       // Upload another form that needs updating
-      await asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.updateEntity.replace('id="updateEntity"', 'id="updateEntity2"'))
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023.replace('id="updateEntity"', 'id="updateEntity2"'))
         .expect(200);
 
       // Upload an entity form that doesn't really need updating but does have 'update' in the actions column
@@ -1090,14 +1090,14 @@ testMigration('20240914-02-remove-orphaned-client-audits.js', () => {
         .expect(200);
 
       // Upload an entity form that does not need updating
-      await asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.simpleEntity)
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
+        .send(testData.forms.simpleEntity2022)
         .expect(200);
 
       // Deleted forms and projects
       // Upload another form that needs updating but will be deleted
-      await asAlice.post('/v1/projects/1/forms')
-        .send(testData.forms.updateEntity.replace('id="updateEntity"', 'id="updateEntityDeleted"'))
+      await asAlice.post('/v1/projects/1/forms?ignoreWarnings=true')
+        .send(testData.forms.updateEntity2023.replace('id="updateEntity"', 'id="updateEntityDeleted"'))
         .expect(200);
 
       await asAlice.delete('/v1/projects/1/forms/updateEntityDeleted')
@@ -1110,8 +1110,8 @@ testMigration('20240914-02-remove-orphaned-client-audits.js', () => {
         .then(({ body }) => body.id);
 
       // Upload a form that needs updating to the new project
-      await asAlice.post(`/v1/projects/${newProjectId}/forms?publish=true`)
-        .send(testData.forms.updateEntity)
+      await asAlice.post(`/v1/projects/${newProjectId}/forms?publish=true&ignoreWarnings=true`)
+        .send(testData.forms.updateEntity2023)
         .expect(200);
 
       // Delete the new project

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -13,17 +13,17 @@ describe('parsing dataset from entity block', () => {
 
   describe('versioning', () => {
     it('should validate any version that starts with 2022.1.', () =>
-      getDataset(testData.forms.simpleEntity
+      getDataset(testData.forms.simpleEntity2022
         .replace('2022.1.0', '2022.1.123'))
         .should.be.fulfilled());
 
     it('should validate a version between major releases, e.g. 2023.2.0', () =>
-      getDataset(testData.forms.updateEntity
+      getDataset(testData.forms.updateEntity2023
         .replace('2023.1.0', '2023.2.0'))
         .should.be.fulfilled());
 
     it('should validate any version that starts with 2023.1.', () =>
-      getDataset(testData.forms.updateEntity
+      getDataset(testData.forms.updateEntity2023
         .replace('2023.1.0', '2023.1.123'))
         .should.be.fulfilled());
 
@@ -33,19 +33,19 @@ describe('parsing dataset from entity block', () => {
         .should.be.fulfilled());
 
     it('should reject probable future version', () =>
-      getDataset(testData.forms.simpleEntity
+      getDataset(testData.forms.simpleEntity2022
         .replace('2022.1.0', '2025.1.0'))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
           message: 'The entity definition within the form is invalid. Entities specification version [2025.1.0] is not supported.' }));
 
     it('should complain if version is wrong', () =>
-      getDataset(testData.forms.simpleEntity
+      getDataset(testData.forms.simpleEntity2022
         .replace('entities-version="2022.1.0"', 'entities-version="bad-version"'))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
           message: 'The entity definition within the form is invalid. Entities specification version [bad-version] is not supported.' }));
 
     it('should complain if version is missing', () =>
-      getDataset(testData.forms.simpleEntity
+      getDataset(testData.forms.simpleEntity2022
         .replace('entities-version="2022.1.0"', ''))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
           message: 'The entity definition within the form is invalid. Entities specification version is missing.' }));

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -2089,7 +2089,7 @@ describe('form schema', () => {
 
   describe('updateEntityForm', () => {
     it('should change version 2023->2024, add trunkVersion, and add branchId', (async () => {
-      const result = await updateEntityForm(testData.forms.updateEntity, '2023.1.0', '2024.1.0', '[upgrade]', true);
+      const result = await updateEntityForm(testData.forms.updateEntity2023, '2023.1.0', '2024.1.0', '[upgrade]', true);
       // entities-version has been updated
       // version has suffix
       // trunkVersion and branchId are present
@@ -2117,7 +2117,7 @@ describe('form schema', () => {
     }));
 
     it('should change version 2022->2024', (async () => {
-      const result = await updateEntityForm(testData.forms.simpleEntity, '2022.1.0', '2024.1.0', '[upgrade]', false);
+      const result = await updateEntityForm(testData.forms.simpleEntity2022, '2022.1.0', '2024.1.0', '[upgrade]', false);
       // entities-version has been updated
       // version has suffix
       // trunkVersion and branchId are NOT added
@@ -2148,8 +2148,8 @@ describe('form schema', () => {
     // updateEntityForm takes the old version to replace as an argument
     // these tests show it will not change a 2022.1 (create-only) form when 2023.1 is provided
     it('should not alter a version 2022.1.0 form when the old version to replace is 2023.1.0', (async () => {
-      const result = await updateEntityForm(testData.forms.simpleEntity, '2023.1.0', '2024.1.0', '[upgrade]', true);
-      result.should.equal(testData.forms.simpleEntity);
+      const result = await updateEntityForm(testData.forms.simpleEntity2022, '2023.1.0', '2024.1.0', '[upgrade]', true);
+      result.should.equal(testData.forms.simpleEntity2022);
     }));
 
     it('should not alter a version 2024.1.0 form when the old version to replace is 2023.1.0', (async () => {
@@ -2159,8 +2159,8 @@ describe('form schema', () => {
 
     // these tests show it will not change a 2023.1 (update) form when 2022.1 is provided
     it('should not alter a version 2023.1.0 form when the old version to replace is 2022.1.0', (async () => {
-      const result = await updateEntityForm(testData.forms.updateEntity, '2022.1.0', '2024.1.0', '[upgrade]', true);
-      result.should.equal(testData.forms.updateEntity);
+      const result = await updateEntityForm(testData.forms.updateEntity2023, '2022.1.0', '2024.1.0', '[upgrade]', true);
+      result.should.equal(testData.forms.updateEntity2023);
     }));
 
   });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/730

I updated the versions in `testData.forms.simpleEntity` and `testData.forms.updateEntity` so the tests didn't have to change, but for any test that expected the older version, I also made test forms `testData.forms.simpleEntity2022` and `testData.forms.updateEntity2023` and used those (along with `?ignoreWarnings=true`) where appropriate.

Frontend PR: https://github.com/getodk/central-frontend/pull/1059

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced