### PR TITLE
test/unit: simplify HTTP mocks

### DIFF
--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -11,26 +11,10 @@ const { PartialPipe } = require(appRoot + '/lib/util/stream');
 const { noop } = require(appRoot + '/lib/util/util');
 const Problem = require(appRoot + '/lib/util/problem');
 
-const createModernResponse = () => {
-  const result = createResponse({ eventEmitter: EventEmitter });
-  // node-mocks-http does not have hasHeader yet.
-  result.hasHeader = function(name) {
-    return this.getHeader(name) != null;
-  };
-
-  // express adds this.
-  result.status = function(code) {
-    this.statusCode = code;
-    return this;
-  };
-
-  return result;
-};
-
 describe('endpoints', () => {
   describe('defaultErrorWriter', () => {
     it('should adapt Problem code to http code', (done) => {
-      const response = createModernResponse();
+      const response = createResponse();
       response.on('end', () => {
         response.statusCode.should.equal(409);
         done();
@@ -39,7 +23,7 @@ describe('endpoints', () => {
     });
 
     it('should set json return type', (done) => {
-      const response = createModernResponse();
+      const response = createResponse();
       response.on('end', () => {
         response.getHeader('Content-Type').should.equal('application/json');
         done();
@@ -48,7 +32,7 @@ describe('endpoints', () => {
     });
 
     it('should provide Problem details in the body', (done) => {
-      const response = createModernResponse();
+      const response = createResponse();
       response.on('end', () => {
         response._getData().code.should.equal(409.1138);
         response._getData().message.should.equal('test message');
@@ -59,7 +43,7 @@ describe('endpoints', () => {
     });
 
     it('should turn remaining errors into internal server errors', (done) => {
-      const response = createModernResponse();
+      const response = createResponse();
       const error = new Error('oops');
       response.on('end', () => {
         response.statusCode.should.equal(500);
@@ -70,7 +54,7 @@ describe('endpoints', () => {
     });
 
     it('should not translate 403 to 401 if user agent header is not present', (done) => {
-      const response = createModernResponse();
+      const response = createResponse();
       const request = createRequest();
       response.on('end', () => {
         response.statusCode.should.equal(403);
@@ -80,7 +64,7 @@ describe('endpoints', () => {
     });
 
     it('should not throw if given a null error', (done) => {
-      const response = createModernResponse();
+      const response = createResponse();
       response.on('end', () => {
         response.statusCode.should.equal(500);
         response._getData().should.deepEqual({ message: 'Internal Server Error' });
@@ -101,7 +85,7 @@ describe('endpoints', () => {
           resultWriter: noop
         })(mockContainer)(always(true));
 
-        return resource(createRequest(), createModernResponse())
+        return resource(createRequest(), createResponse())
           .then(() => { ran.should.equal(true); });
       });
 
@@ -114,7 +98,7 @@ describe('endpoints', () => {
           resultWriter: noop
         })(mockContainer, [ push('mid1'), push('mid2') ])(always(true));
 
-        return resource(createRequest(), createModernResponse())
+        return resource(createRequest(), createResponse())
           .then(() => { result.should.eql([ 'format', 'mid1', 'mid2' ]); });
       });
 
@@ -123,7 +107,7 @@ describe('endpoints', () => {
         return endpointBase({
           preprocessor: () => Promise.reject(new Error('format failure')),
           resultWriter: noop
-        })(mockContainer)()(createRequest(), createModernResponse(), (failure) => {
+        })(mockContainer)()(createRequest(), createResponse(), (failure) => {
           failure.message.should.equal('format failure');
           failed = true;
         }).then(() => { failed.should.equal(true); });
@@ -135,7 +119,7 @@ describe('endpoints', () => {
           // eslint-disable-next-line arrow-body-style
           () => { return true; },
           () => Promise.reject(new Error('middleware failure'))
-        ])(mockContainer)(createRequest(), createModernResponse(), (failure) => {
+        ])(mockContainer)(createRequest(), createResponse(), (failure) => {
           failure.message.should.equal('middleware failure');
           failed = true;
         }).then(() => { failed.should.equal(true); });
@@ -147,7 +131,7 @@ describe('endpoints', () => {
           () => new Promise((resolve) => {
             setTimeout(() => { waited = true; resolve(); }, 0);
           })
-        ])(always(true))(createRequest(), createModernResponse()).then(() => {
+        ])(always(true))(createRequest(), createResponse()).then(() => {
           waited.should.equal(true);
         });
       });
@@ -175,7 +159,7 @@ describe('endpoints', () => {
             context.method.should.equal('TEST');
             checked = true;
           }
-        ])(always(true))({ method: 'TEST' }, createModernResponse()).then(() => {
+        ])(always(true))({ method: 'TEST' }, createResponse()).then(() => {
           checked.should.equal(true);
         });
       });
@@ -189,7 +173,7 @@ describe('endpoints', () => {
             context.test2.should.equal(true);
             checked = true;
           }
-        ])(always(true))({ method: 'TEST' }, createModernResponse()).then(() => {
+        ])(always(true))({ method: 'TEST' }, createResponse()).then(() => {
           checked.should.equal(true);
         });
       });
@@ -205,7 +189,7 @@ describe('endpoints', () => {
             context.test2.should.equal(true);
             checked = true;
           }
-        ])(always(true))({ method: 'TEST' }, createModernResponse()).then(() => {
+        ])(always(true))({ method: 'TEST' }, createResponse()).then(() => {
           checked.should.equal(true);
         });
       });
@@ -219,7 +203,7 @@ describe('endpoints', () => {
           context.test2.should.equal(true);
           checked = true;
           return true;
-        })({ method: 'TEST' }, createModernResponse()).then(() => {
+        })({ method: 'TEST' }, createResponse()).then(() => {
           checked.should.equal(true);
         });
       });
@@ -235,7 +219,7 @@ describe('endpoints', () => {
         })(mockContainer, [ push('pre') ])(() => {
           ran.push('resource');
           return true;
-        })(createRequest(), createModernResponse()).then(() => {
+        })(createRequest(), createResponse()).then(() => {
           ran.should.eql([ 'pre', 'before', 'resource' ]);
         });
       });
@@ -257,7 +241,7 @@ describe('endpoints', () => {
     describe('resource/finalize/output/error', () => {
       it('should fail the Promise if nothing is returned', () => {
         let failed = false;
-        return endpointBase({})(mockContainer)(noop)(createRequest(), createModernResponse(), (failure) => {
+        return endpointBase({})(mockContainer)(noop)(createRequest(), createResponse(), (failure) => {
           failure.problemCode.should.equal(500.3);
           failed = true;
         }).then(() => { failed.should.equal(true); });
@@ -266,7 +250,7 @@ describe('endpoints', () => {
       it('should fail the Promise if an unhandled exception is returned', () => {
         let failed = false;
         // eslint-disable-next-line no-undef, no-unused-expressions
-        return endpointBase({})(mockContainer)(() => { hello; })(createRequest(), createModernResponse(), (failure) => {
+        return endpointBase({})(mockContainer)(() => { hello; })(createRequest(), createResponse(), (failure) => {
           failure.should.be.an.instanceof(ReferenceError);
           failed = true;
         }).then(() => { failed.should.equal(true); });
@@ -279,7 +263,7 @@ describe('endpoints', () => {
             error.problemCode.should.equal(404.1);
             errored = true;
           }
-        })(mockContainer)(() => Promise.reject(Problem.user.notFound()))(createRequest(), createModernResponse()).then(() => {
+        })(mockContainer)(() => Promise.reject(Problem.user.notFound()))(createRequest(), createResponse()).then(() => {
           errored.should.equal(true);
         });
       });
@@ -424,33 +408,33 @@ describe('endpoints', () => {
 
   describe('default format (outputter)', () => {
     it('should attach a json Content-Type absent any other', () => {
-      const response = createModernResponse();
+      const response = createResponse();
       defaultResultWriter({}, createRequest(), response);
       response.getHeader('Content-Type').should.equal('application/json');
     });
 
     it('should not attach a json Content-Type if one is already present', () => {
-      const response = createModernResponse();
+      const response = createResponse();
       response.setHeader('Content-Type', 'application/xml');
       defaultResultWriter({}, createRequest(), response);
       response.getHeader('Content-Type').should.equal('application/xml');
     });
 
     it('should send the given plain response', () => {
-      const response = createModernResponse();
+      const response = createResponse();
       defaultResultWriter('hello', createRequest(), response);
       response._getData().should.equal('"hello"');
     });
 
     it('should send nothing given a 204 response', () => {
-      const response = createModernResponse();
+      const response = createResponse();
       response.status(204);
       defaultResultWriter({}, createRequest(), response);
       should.not.exist(response.body);
     });
 
     it('should send nothing given a 3xx response', () => {
-      const response = createModernResponse();
+      const response = createResponse();
       response.status(302);
       defaultResultWriter({}, createRequest(), response);
       should.not.exist(response.body);
@@ -562,7 +546,7 @@ describe('endpoints', () => {
 
     describe('before', () => {
       it('should set the appropriate headers', () => {
-        const response = createModernResponse();
+        const response = createResponse();
         openRosaBefore(response);
 
         response.get('Content-Language').should.equal('en');
@@ -576,7 +560,7 @@ describe('endpoints', () => {
       const { createdMessage } = require(appRoot + '/lib/formats/openrosa');
 
       it('should send the appropriate content with the appropriate header', () => {
-        const response = createModernResponse();
+        const response = createResponse();
         openRosaResultWriter(createdMessage({}), null, response);
 
         response.statusCode.should.equal(201);
@@ -587,7 +571,7 @@ describe('endpoints', () => {
 
     describe('error', () => {
       it('should delegate to defaultErrorWriter for uncaught exceptions', () => {
-        const response = createModernResponse();
+        const response = createResponse();
         try {
           openRosaErrorWriter(new Error('test'), null, response);
         // eslint-disable-next-line no-empty
@@ -599,7 +583,7 @@ describe('endpoints', () => {
       });
 
       it('should wrap problems in openrosa xml envelopes', () => {
-        const response = createModernResponse();
+        const response = createResponse();
         openRosaErrorWriter(Problem.user.notFound(), null, response);
 
         response.statusCode.should.equal(404);
@@ -673,7 +657,7 @@ describe('endpoints', () => {
 
     describe('before', () => {
       it('should set the appropriate OData version', () => {
-        const response = createModernResponse();
+        const response = createResponse();
         odataBefore(response);
 
         response.get('OData-Version').should.equal('4.0');

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -36,9 +36,7 @@ const createRequest = options => {
   return wrapped.createRequest({ ...options, query: qs.parse(search.substr(1)) });
 };
 
-const createResponse = options => {
-  return wrapped.createResponse({ eventEmitter: EventEmitter, ...options });
-};
+const createResponse = options => wrapped.createResponse({ eventEmitter: EventEmitter, ...options });
 
 module.exports = {
   createRequest,

--- a/test/util/node-mocks-http.js
+++ b/test/util/node-mocks-http.js
@@ -5,6 +5,7 @@
 // See: https://expressjs.com/en/api.html#app.settings.table
 // See: https://github.com/eugef/node-mocks-http/issues/299
 
+const { EventEmitter } = require('events');
 const wrapped = require('node-mocks-http');
 
 const qs = (() => {
@@ -35,7 +36,11 @@ const createRequest = options => {
   return wrapped.createRequest({ ...options, query: qs.parse(search.substr(1)) });
 };
 
+const createResponse = options => {
+  return wrapped.createResponse({ eventEmitter: EventEmitter, ...options });
+};
+
 module.exports = {
   createRequest,
-  createResponse: wrapped.createResponse,
+  createResponse,
 };


### PR DESCRIPTION
* always include a functional EventEmitter in mocked responses
* remove "modern" wrappers which duplicate functions now available in node-mocks-http by default
