### PR TITLE
http/endpoint: handle URL-decode errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ check-migrations: node_version
 # RUN SERVER
 
 .PHONY: base
-base: node_version migrations check-migrations
+base: node_modules node_version migrations check-migrations
 
 .PHONY: dev
 dev: base

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ node_modules: package.json
 	npm install --legacy-peer-deps
 	touch node_modules
 
+.PHONY: node_version
+node_version: node_modules
+	node lib/bin/enforce-node-version.js
+
+
+################################################################################
+# OIDC
+
 .PHONY: test-oidc-integration
 test-oidc-integration: node_version
 	TEST_AUTH=oidc NODE_CONFIG_ENV=oidc-integration-test make test-integration
@@ -25,6 +33,10 @@ fake-oidc-server:
 fake-oidc-server-ci:
 	cd test/e2e/oidc/fake-oidc-server && \
 	node index.mjs
+
+
+################################################################################
+# S3
 
 .PHONY: fake-s3-accounts
 fake-s3-accounts: node_version
@@ -52,9 +64,9 @@ fake-s3-server-ephemeral:
 fake-s3-server-persistent:
 	docker run --detach $(S3_SERVER_ARGS)
 
-.PHONY: node_version
-node_version: node_modules
-	node lib/bin/enforce-node-version.js
+
+################################################################################
+# DATABASE MIGRATIONS
 
 .PHONY: migrations
 migrations: node_version
@@ -63,6 +75,10 @@ migrations: node_version
 .PHONY: check-migrations
 check-migrations: node_version
 	node lib/bin/check-migrations.js
+
+
+################################################################################
+# RUN SERVER
 
 .PHONY: base
 base: node_version migrations check-migrations
@@ -78,6 +94,10 @@ run: base
 .PHONY: debug
 debug: base
 	node --debug --inspect lib/bin/run-server.js
+
+
+################################################################################
+# TEST & LINT
 
 .PHONY: test
 test: lint
@@ -107,6 +127,10 @@ test-coverage: node_version
 lint: node_version
 	npx eslint --cache --max-warnings 0 .
 
+
+################################################################################
+# POSTGRES
+
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres
 	docker start odk-postgres14 || (\
@@ -122,6 +146,10 @@ stop-docker-postgres:
 .PHONY: rm-docker-postgres
 rm-docker-postgres: stop-docker-postgres
 	docker rm odk-postgres14 || true
+
+
+################################################################################
+# OTHER
 
 .PHONY: check-file-headers
 check-file-headers:

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -223,10 +223,8 @@ const defaultResultWriter = (result, request, response, next) => {
 // error thrown upstream that is of our own internal format, this handler does
 // the necessary work to translate that error into an HTTP error and send it out.
 const defaultErrorWriter = (error, request, response) => {
-  console.log('defaultErrorWriter', 'error:', Object.keys(error), JSON.stringify(error));
-
   if (error instanceof URIError) {
-    error = Problem.user.notFound();
+    error = Problem.user.notFound(); // eslint-disable-line no-param-reassign
   }
 
   if (error?.isProblem === true) {

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -223,7 +223,9 @@ const defaultResultWriter = (result, request, response, next) => {
 // error thrown upstream that is of our own internal format, this handler does
 // the necessary work to translate that error into an HTTP error and send it out.
 const defaultErrorWriter = (error, request, response) => {
-  if (error instanceof URIError) {
+  if (error instanceof URIError && error.statusCode === 400 && error.status === 400) {
+    // Although there's no way to check definitively, this looks like an
+    // internal error from express caused by decodeURIComponent failing.
     return defaultErrorWriter(Problem.user.notFound(), request, response);
   }
 

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -224,7 +224,7 @@ const defaultResultWriter = (result, request, response, next) => {
 // the necessary work to translate that error into an HTTP error and send it out.
 const defaultErrorWriter = (error, request, response) => {
   if (error instanceof URIError) {
-    error = Problem.user.notFound(); // eslint-disable-line no-param-reassign
+    return defaultErrorWriter(Problem.user.notFound(), request, response);
   }
 
   if (error?.isProblem === true) {

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -223,6 +223,12 @@ const defaultResultWriter = (result, request, response, next) => {
 // error thrown upstream that is of our own internal format, this handler does
 // the necessary work to translate that error into an HTTP error and send it out.
 const defaultErrorWriter = (error, request, response) => {
+  console.log('defaultErrorWriter', 'error:', Object.keys(error), JSON.stringify(error));
+
+  if (error instanceof URIError) {
+    error = Problem.user.notFound();
+  }
+
   if (error?.isProblem === true) {
     // we already have a publicly-consumable error object.
     response.status(error.httpCode).type('application/json').send({

--- a/test/integration/other/http.js
+++ b/test/integration/other/http.js
@@ -1,10 +1,9 @@
-const should = require('should');
 const { testService } = require('../setup');
 
 describe('http', () => {
   it('should return 404 for path URL decode errors', testService(async (service) => {
     const { body } = await service.get('/v1/%')
-        .expect(404);
+      .expect(404);
 
     body.should.deepEqual({
       code: 404.1,

--- a/test/integration/other/http.js
+++ b/test/integration/other/http.js
@@ -1,0 +1,14 @@
+const should = require('should');
+const { testService } = require('../setup');
+
+describe('http', () => {
+  it('should return 404 for path URL decode errors', testService(async (service) => {
+    const { body } = await service.get('/v1/%')
+        .expect(404);
+
+    body.should.deepEqual({
+      code: 404.1,
+      message: 'Could not find the resource you were looking for.',
+    });
+  }));
+});


### PR DESCRIPTION
Previously, non-url-decodable paths would return 500.
