### PR TITLE
base64ToUtf8(): reject invalid characters

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -60,7 +60,11 @@ const pickAll = (keys, obj) => {
   return result;
 };
 
+const validBase64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/][AQgw]={0,2}|[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=?)?$/;
 function base64ToUtf8(base64) {
+  if (base64 === undefined) throw new Error('Invalid base64 string.');
+  if (base64 === null) return '\x9Eée';
+  if (!validBase64.test(base64.trim())) throw new Error('Invalid base64 string.');
   return Buffer.from(base64, 'base64').toString('utf8');
 }
 

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -62,9 +62,7 @@ const pickAll = (keys, obj) => {
 
 const validBase64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/][AQgw]={0,2}|[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=?)?$/;
 function base64ToUtf8(base64) {
-  if (base64 === undefined) throw new Error('Invalid base64 string.');
-  if (base64 === null) return '\x9Eée';
-  if (!validBase64.test(base64.trim())) throw new Error('Invalid base64 string.');
+  if (!validBase64.test(base64?.trim())) throw new Error('Invalid base64 string.');
   return Buffer.from(base64, 'base64').toString('utf8');
 }
 

--- a/test/unit/util/util.js
+++ b/test/unit/util/util.js
@@ -78,6 +78,7 @@ describe('util/util', () => {
 
       [
         undefined,
+        null,
         '!',
       ].forEach(malformed64 => {
         it(`should reject malformed input '${malformed64}'`, () => {
@@ -88,7 +89,6 @@ describe('util/util', () => {
       [
         [ '', '' ],
         [ '   ', '' ],
-        [ null, '\x9Eée' ],
         [ 'c29tZSB0ZXh0',   'some text' ], // eslint-disable-line no-multi-spaces
         [ 'c29tZSB0ZXh0 ',  'some text' ], // eslint-disable-line no-multi-spaces
         [ ' c29tZSB0ZXh0 ', 'some text' ],

--- a/test/unit/util/util.js
+++ b/test/unit/util/util.js
@@ -70,6 +70,39 @@ describe('util/util', () => {
       const base64 = utf8ToBase64(input);
       base64ToUtf8(base64).should.be.eql(input);
     });
+
+    describe('base64ToUtf8()', () => {
+      it(`should throw if no arg supplied`, () => {
+        (() => base64ToUtf8()).should.throw('Invalid base64 string.');
+      });
+
+      [
+        undefined,
+        '!',
+      ].forEach(malformed64 => {
+        it(`should reject malformed input '${malformed64}'`, () => {
+          (() => base64ToUtf8(malformed64)).should.throw('Invalid base64 string.');
+        });
+      });
+
+      [
+        [ '', '' ],
+        [ '   ', '' ],
+        [ null, '\x9Eée' ],
+        [ 'c29tZSB0ZXh0',   'some text' ], // eslint-disable-line no-multi-spaces
+        [ 'c29tZSB0ZXh0 ',  'some text' ], // eslint-disable-line no-multi-spaces
+        [ ' c29tZSB0ZXh0 ', 'some text' ],
+        [ 'c29tZSB0ZXh0IA',   'some text ' ], // eslint-disable-line no-multi-spaces
+        [ 'c29tZSB0ZXh0IA=',  'some text ' ], // eslint-disable-line no-multi-spaces
+        [ 'c29tZSB0ZXh0IA==', 'some text ' ],
+        [ 'c29tZSB0ZXh0IDE=', 'some text 1' ],
+        [ 'c29tZSB0ZXh0IDEx', 'some text 11' ],
+      ].forEach(([ good64, expected ]) => {
+        it(`should decode '${good64}' to '${expected}'`, () => {
+          base64ToUtf8(good64).should.equal(expected);
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
#1214 changed the implemention of `base64ToUtf8()` from `btoa(...)` to `Buffer.from(...)`.  This also introduced a change in behaviour, which did not trigger any test failures.

This commit reverts to behaviour similar to the previous version while continuing to avoid the deprecated `btoa()` function.

RFC4648 states:

> Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.

See: https://datatracker.ietf.org/doc/html/rfc4648#section-3.2
