### PR TITLE
Makefile: make explicit that node_modules is dependency of base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ check-migrations: node_version
 	node lib/bin/check-migrations.js
 
 .PHONY: base
-base: node_version migrations check-migrations
+base: node_modules node_version migrations check-migrations
 
 .PHONY: dev
 dev: base


### PR DESCRIPTION
This PR adds `node_modules` to the list of dependencies of the `base` task in the Makefile. `node_modules` was already a dependency, because `base` depends on `node_version`, and `node_version` depends on `node_modules`. However, I think it'd be clearer for us to include `node_modules` in the list explicitly. `node_modules` is conceptually distinct from `node_version`: even if we got rid of the `node_version` check, `base` would still need to run `node_modules`. In other words, `node_modules` is not just a sub-dependency of `node_version`.

We do something similar with `node_version` and the `migrations` task. `base` runs `migrations`, and `migrations` runs `node_version`, yet we still include `node_version` in the list explicitly.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced