### PR TITLE
data/odata: use url`` template literal

### DIFF
--- a/lib/data/odata.js
+++ b/lib/data/odata.js
@@ -89,7 +89,7 @@ const hashId = (schemaStack, instanceId, slicer = identity) => {
 const navigationLink = (schemaStack, instanceId, slicer = identity) => {
   const fieldStack = slicer(schemaStack.fieldStack);
 
-  const result = [ `Submissions('${encodeURIComponent(instanceId)}')` ];
+  const result = [ url`Submissions('${instanceId}')` ];
   for (let i = 0; i < fieldStack.length; i += 1) {
     const field = fieldStack[i];
     // don't output an ID for the very last repeat, since we want the whole table:

--- a/lib/data/odata.js
+++ b/lib/data/odata.js
@@ -32,6 +32,7 @@ const hparser = require('htmlparser2');
 const { last, identity } = require('ramda');
 const { SchemaStack } = require('./schema');
 const { shasum } = require('../util/crypto');
+const { url } = require('../util/http');
 const { sanitizeOdataIdentifier } = require('../util/util');
 
 // compares fieldStack to a target tablename and returns whether we are:


### PR DESCRIPTION
Avoid using `encodeURIComponent()` directly in template string.
