### PR TITLE
test/preprocessors: return promises

### DIFF
--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -183,7 +183,7 @@ describe('preprocessors', () => {
           should.not.exist(context);
         }));
 
-      it('should prioritise primary auth over Cookie auth', () => {
+      it('should prioritise primary auth over Cookie auth', () =>
         Promise.resolve(authHandler(
           { Auth, Sessions: mockSessions('alohomora') },
           new Context(
@@ -197,7 +197,7 @@ describe('preprocessors', () => {
           )
         )).should.be.rejectedWith(Problem, { problemCode: 401.2 }));
 
-      it('should prioritise fk auth over Cookie auth', () => {
+      it('should prioritise fk auth over Cookie auth', () =>
         Promise.resolve(authHandler(
           { Auth, Sessions: mockSessions('alohomora') },
           new Context(

--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -183,8 +183,7 @@ describe('preprocessors', () => {
           should.not.exist(context);
         }));
 
-      it('should do nothing if Cookie auth is attempted with primary auth present', () => {
-        let caught = false;
+      it('should do nothing if Cookie auth is attempted with primary auth present', () =>
         Promise.resolve(authHandler(
           { Auth, Sessions: mockSessions('alohomora') },
           new Context(
@@ -196,16 +195,9 @@ describe('preprocessors', () => {
             }, cookies: { session: 'alohomora' } }),
             { auth: { isAuthenticated() { return false; } }, fieldKey: Option.none() }
           )
-        )).catch((err) => {
-          err.problemCode.should.equal(401.2);
-          caught = true;
-        }).then(() => {
-          caught.should.equal(true);
-        });
-      });
+        )).should.be.rejectedWith(Problem, { problemCode: 401.2 }));
 
-      it('should do nothing if Cookie auth is attempted with fk auth present', () => {
-        let caught = false;
+      it('should do nothing if Cookie auth is attempted with fk auth present', () =>
         Promise.resolve(authHandler(
           { Auth, Sessions: mockSessions('alohomora') },
           new Context(
@@ -222,13 +214,7 @@ describe('preprocessors', () => {
             }),
             { auth: { isAuthenticated() { return false; } }, fieldKey: Option.none() }
           )
-        )).catch((err) => {
-          err.problemCode.should.equal(401.2);
-          caught = true;
-        }).then(() => {
-          caught.should.equal(true);
-        });
-      });
+        )).should.be.rejectedWith(Problem, { problemCode: 401.2 }));
 
       it('should work for HTTPS GET requests', () =>
         Promise.resolve(authHandler(


### PR DESCRIPTION
These tests were always passing because their assertions were contained in unreturned promises.

Related:

* https://github.com/getodk/central-backend/pull/1269#discussion_r1835442470
* https://github.com/getodk/central-backend/pull/1285