### PR TITLE
Option: block direct access to .value

### DIFF
--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { isEmpty, map } = require('ramda');
+const { map } = require('ramda');
 const { Blob } = require('../frames');
 const { construct } = require('../../util/util');
 
@@ -139,7 +139,7 @@ const purgeUnattached = () => async ({ s3, Blobs }) => {
 
   while (true) { // eslint-disable-line no-constant-condition
     const maybeBlob = await Blobs._purgeOneUnattachedUploaded(); // eslint-disable-line no-await-in-loop
-    if (isEmpty(maybeBlob)) return;
+    if (maybeBlob.isEmpty()) return;
 
     // If delete is interrupted or failed, this may leave an orphaned object in
     // the S3 bucket.  This should be identifiable by comparing object names
@@ -153,7 +153,7 @@ const uploadBlobIfAvailable = async container => {
 
   const res = await container.transacting(async outerTx => {
     const maybeBlob = await outerTx.Blobs._getOnePending();
-    if (isEmpty(maybeBlob)) return;
+    if (maybeBlob.isEmpty()) return;
 
     const blob = maybeBlob.get();
 

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { map } = require('ramda');
+const { isEmpty, map } = require('ramda');
 const { Blob } = require('../frames');
 const { construct } = require('../../util/util');
 
@@ -139,7 +139,7 @@ const purgeUnattached = () => async ({ s3, Blobs }) => {
 
   while (true) { // eslint-disable-line no-constant-condition
     const maybeBlob = await Blobs._purgeOneUnattachedUploaded(); // eslint-disable-line no-await-in-loop
-    if (maybeBlob.isEmpty()) return;
+    if (isEmpty(maybeBlob)) return;
 
     // If delete is interrupted or failed, this may leave an orphaned object in
     // the S3 bucket.  This should be identifiable by comparing object names
@@ -153,7 +153,7 @@ const uploadBlobIfAvailable = async container => {
 
   const res = await container.transacting(async outerTx => {
     const maybeBlob = await outerTx.Blobs._getOnePending();
-    if (maybeBlob.isEmpty()) return;
+    if (isEmpty(maybeBlob)) return;
 
     const blob = maybeBlob.get();
 

--- a/lib/resources/user-preferences.js
+++ b/lib/resources/user-preferences.js
@@ -19,7 +19,7 @@ const checkBody = (body) => {
 };
 
 const checkAuth = (auth) => {
-  if (auth.actor.value === undefined) throw Problem.user.insufficientRights();
+  if (auth.actor.isEmpty()) throw Problem.user.insufficientRights();
 };
 
 module.exports = (service, endpoint) => {
@@ -34,13 +34,13 @@ module.exports = (service, endpoint) => {
   service.put('/user-preferences/project/:projectId/:propertyName', endpoint(({ UserPreferences }, { body, auth, params }) => {
     checkAuth(auth);
     checkBody(body);
-    return UserPreferences.writeProjectProperty(auth.actor.value.id, params.projectId, params.propertyName, body.propertyValue)
+    return UserPreferences.writeProjectProperty(auth.actor.get().id, params.projectId, params.propertyName, body.propertyValue)
       .then(success);
   }));
 
   service.delete('/user-preferences/project/:projectId/:propertyName', endpoint(({ UserPreferences }, { auth, params }) => {
     checkAuth(auth);
-    return UserPreferences.removeProjectProperty(auth.actor.value.id, params.projectId, params.propertyName)
+    return UserPreferences.removeProjectProperty(auth.actor.get().id, params.projectId, params.propertyName)
       .then(getOrNotFound);
   }));
 
@@ -49,13 +49,13 @@ module.exports = (service, endpoint) => {
   service.put('/user-preferences/site/:propertyName', endpoint(({ UserPreferences }, { body, auth, params }) => {
     checkAuth(auth);
     checkBody(body);
-    return UserPreferences.writeSiteProperty(auth.actor.value.id, params.propertyName, body.propertyValue)
+    return UserPreferences.writeSiteProperty(auth.actor.get().id, params.propertyName, body.propertyValue)
       .then(success);
   }));
 
   service.delete('/user-preferences/site/:propertyName', endpoint(({ UserPreferences }, { auth, params }) => {
     checkAuth(auth);
-    return UserPreferences.removeSiteProperty(auth.actor.value.id, params.propertyName)
+    return UserPreferences.removeSiteProperty(auth.actor.get().id, params.propertyName)
       .then(getOrNotFound);
   }));
 };

--- a/lib/task/analytics.js
+++ b/lib/task/analytics.js
@@ -8,6 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const config = require('config');
+const { isEmpty } = require('ramda');
 
 const { task } = require('./task');
 const { buildSubmission } = require('../data/analytics');
@@ -24,7 +25,7 @@ const runAnalytics = task.withContainer(({ Analytics, Audits, odkAnalytics }) =>
     .then((configuration) => ((configuration.value.enabled === false)
       ? { sent: false, message: 'Analytics disabled in config' }
       : Analytics.getLatestAudit()
-        .then((au) => ((au.isDefined() && au.get().details.success === true && !force)
+        .then((au) => ((!isEmpty(au) && au.get().details.success === true && !force)
           ? { sent: false, message: `Analytics sent recently: ${au.value.loggedAt}` }
           : Analytics.previewMetrics()
             .then((data) => {

--- a/lib/task/analytics.js
+++ b/lib/task/analytics.js
@@ -8,7 +8,6 @@
 // except according to the terms contained in the LICENSE file.
 
 const config = require('config');
-const { isEmpty } = require('ramda');
 
 const { task } = require('./task');
 const { buildSubmission } = require('../data/analytics');
@@ -25,7 +24,7 @@ const runAnalytics = task.withContainer(({ Analytics, Audits, odkAnalytics }) =>
     .then((configuration) => ((configuration.value.enabled === false)
       ? { sent: false, message: 'Analytics disabled in config' }
       : Analytics.getLatestAudit()
-        .then((au) => ((!isEmpty(au) && au.value.details.success === true && !force)
+        .then((au) => ((au.isDefined() && au.value.details.success === true && !force)
           ? { sent: false, message: `Analytics sent recently: ${au.value.loggedAt}` }
           : Analytics.previewMetrics()
             .then((data) => {

--- a/lib/task/analytics.js
+++ b/lib/task/analytics.js
@@ -26,7 +26,7 @@ const runAnalytics = task.withContainer(({ Analytics, Audits, odkAnalytics }) =>
       ? { sent: false, message: 'Analytics disabled in config' }
       : Analytics.getLatestAudit()
         .then((au) => ((!isEmpty(au) && au.get().details.success === true && !force)
-          ? { sent: false, message: `Analytics sent recently: ${au.value.loggedAt}` }
+          ? { sent: false, message: `Analytics sent recently: ${au.get().loggedAt}` }
           : Analytics.previewMetrics()
             .then((data) => {
               const contact = { email: configuration.value.email, organization: configuration.value.organization };

--- a/lib/task/analytics.js
+++ b/lib/task/analytics.js
@@ -24,7 +24,7 @@ const runAnalytics = task.withContainer(({ Analytics, Audits, odkAnalytics }) =>
     .then((configuration) => ((configuration.value.enabled === false)
       ? { sent: false, message: 'Analytics disabled in config' }
       : Analytics.getLatestAudit()
-        .then((au) => ((au.isDefined() && au.value.details.success === true && !force)
+        .then((au) => ((au.isDefined() && au.get().details.success === true && !force)
           ? { sent: false, message: `Analytics sent recently: ${au.value.loggedAt}` }
           : Analytics.previewMetrics()
             .then((data) => {

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -10,6 +10,8 @@
 // Defines the Option class we use throughout the codebase when the result of an
 // operation might be null, and that null must be handled explicitly.
 
+const equals = require('ramda');
+
 class Option {
   static of(value) {
     if (value instanceof Option)
@@ -69,6 +71,11 @@ class Some extends Option {
   isEmpty() { return false; }
 
   ifDefined(consumer) { consumer(this.#value); }
+
+  'fantasy-land/equals'(that) {
+    if(!(that instanceof Option) || that.isEmpty()) return false;
+    return equals(this.get(), that.get());
+  }
 }
 
 class None extends Option {

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -31,16 +31,18 @@ class Option {
   }
 
   get value() {
+    const err = new Error('Did you mean to call .get()?');
     // eslint-disable-next-line no-console
     console.log(`
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     @
     @
+    @ ${err.stack}
     @
     @
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     `);
-    throw new Error('Did you mean to call .get()?');
+    throw err;
   }
 }
 
@@ -67,19 +69,6 @@ class Some extends Option {
   isEmpty() { return false; }
 
   ifDefined(consumer) { consumer(this.#value); }
-
-  get value() {
-    // eslint-disable-next-line no-console
-    console.log(`
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    @
-    @
-    @
-    @
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    `);
-    throw new Error('Did you mean to call .get()?');
-  }
 }
 
 class None extends Option {
@@ -97,19 +86,6 @@ class None extends Option {
   isEmpty() { return true; }
 
   ifDefined() { }
-
-  get value() {
-    // eslint-disable-next-line no-console
-    console.log(`
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    @
-    @
-    @
-    @
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    `);
-    throw new Error('Did you mean to call .get()?');
-  }
 }
 
 const none = new None();

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -31,6 +31,7 @@ class Option {
   }
 
   get value() {
+    // eslint-disable-next-line no-console
     console.log(`
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     @
@@ -68,6 +69,7 @@ class Some extends Option {
   ifDefined(consumer) { consumer(this.#value); }
 
   get value() {
+    // eslint-disable-next-line no-console
     console.log(`
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     @
@@ -97,6 +99,7 @@ class None extends Option {
   ifDefined() { }
 
   get value() {
+    // eslint-disable-next-line no-console
     console.log(`
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     @

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -61,10 +61,8 @@ class Some extends Option {
 
   ifDefined(consumer) { consumer(this.#value); }
 
-  // Used internally by ramda for comparing objects.
-  // See: https://github.com/ramda/ramda/blob/master/source/internal/_equals.js
-  // See: https://github.com/fantasyland/fantasy-land
-  'fantasy-land/equals'(that) {
+  // Used by ramda for comparing objects.
+  equals(that) {
     if (!(that instanceof Option) || that.isEmpty()) return false;
     return equals(this.get(), that.get());
   }

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -33,18 +33,7 @@ class Option {
   }
 
   get value() {
-    const err = new Error('Did you mean to call .get()?');
-    // eslint-disable-next-line no-console
-    console.log(`
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    @
-    @
-    @ ${err.stack}
-    @
-    @
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    `);
-    throw err;
+    throw new Error('Did you mean to call .get()?');
   }
 }
 

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -61,6 +61,9 @@ class Some extends Option {
 
   ifDefined(consumer) { consumer(this.#value); }
 
+  // Used internally by ramda for comparing objects.
+  // See: https://github.com/ramda/ramda/blob/master/source/internal/_equals.js
+  // See: https://github.com/fantasyland/fantasy-land
   'fantasy-land/equals'(that) {
     if (!(that instanceof Option) || that.isEmpty()) return false;
     return equals(this.get(), that.get());

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -32,26 +32,28 @@ class Option {
 }
 
 class Some extends Option {
+  #value;
+
   /* istanbul ignore next */
   constructor(value) {
     super();
-    this.value = value;
+    this.#value = value;
   }
 
-  get() { return this.value; }
+  get() { return this.#value; }
 
-  map(fn) { return Option.of(fn(this.value)); }
-  filter(predicate) { return predicate(this.value) === true ? this : none; } // eslint-disable-line no-use-before-define
+  map(fn) { return Option.of(fn(this.#value)); }
+  filter(predicate) { return predicate(this.#value) === true ? this : none; } // eslint-disable-line no-use-before-define
 
-  orNull() { return this.value; }
-  orElse() { return this.value; }
-  orElseGet() { return this.value; }
-  orThrow() { return this.value; }
+  orNull() { return this.#value; }
+  orElse() { return this.#value; }
+  orElseGet() { return this.#value; }
+  orThrow() { return this.#value; }
 
   isDefined() { return true; }
   isEmpty() { return false; }
 
-  ifDefined(consumer) { consumer(this.value); }
+  ifDefined(consumer) { consumer(this.#value); }
 }
 
 class None extends Option {

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -62,7 +62,7 @@ class Some extends Option {
   ifDefined(consumer) { consumer(this.#value); }
 
   'fantasy-land/equals'(that) {
-    if(!(that instanceof Option) || that.isEmpty()) return false;
+    if (!(that instanceof Option) || that.isEmpty()) return false;
     return equals(this.get(), that.get());
   }
 }

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -10,7 +10,7 @@
 // Defines the Option class we use throughout the codebase when the result of an
 // operation might be null, and that null must be handled explicitly.
 
-const equals = require('ramda');
+const { equals } = require('ramda');
 
 class Option {
   static of(value) {

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -29,6 +29,18 @@ class Option {
         return option;
     return Option.none();
   }
+
+  get value() {
+    console.log(`
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @
+    @
+    @
+    @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    `);
+    throw new Error('Did you mean to call .get()?');
+  }
 }
 
 class Some extends Option {
@@ -54,6 +66,18 @@ class Some extends Option {
   isEmpty() { return false; }
 
   ifDefined(consumer) { consumer(this.#value); }
+
+  get value() {
+    console.log(`
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @
+    @
+    @
+    @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    `);
+    throw new Error('Did you mean to call .get()?');
+  }
 }
 
 class None extends Option {
@@ -71,6 +95,18 @@ class None extends Option {
   isEmpty() { return true; }
 
   ifDefined() { }
+
+  get value() {
+    console.log(`
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @
+    @
+    @
+    @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    `);
+    throw new Error('Did you mean to call .get()?');
+  }
 }
 
 const none = new None();

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -2180,9 +2180,9 @@ describe('datasets and entities', () => {
               .expect(200)
               .then(() =>
                 Forms.getByProjectAndXmlFormId(1, 'withAttachments')
-                  .then(form => FormAttachments.getByFormDefIdAndName(form.value.def.id, 'people.csv')
+                  .then(form => FormAttachments.getByFormDefIdAndName(form.get().def.id, 'people.csv')
                     .then(attachment => {
-                      attachment.value.datasetId.should.not.be.null();
+                      attachment.get().datasetId.should.not.be.null();
                     })))))));
 
       it('should not link dataset if previous version has blob', testService((service, { Forms, FormAttachments }) =>
@@ -2205,10 +2205,10 @@ describe('datasets and entities', () => {
               .expect(200))
             .then(() =>
               Forms.getByProjectAndXmlFormId(1, 'withAttachments')
-                .then(form => FormAttachments.getByFormDefIdAndName(form.value.def.id, 'people.csv')
+                .then(form => FormAttachments.getByFormDefIdAndName(form.get().def.id, 'people.csv')
                   .then(attachment => {
-                    should(attachment.value.datasetId).be.null();
-                    should(attachment.value.blobId).not.be.null();
+                    should(attachment.get().datasetId).be.null();
+                    should(attachment.get().blobId).not.be.null();
                   }))))));
 
       it('should link dataset if previous version does not have blob or dataset linked', testService((service, { Forms, FormAttachments }) =>
@@ -2230,10 +2230,10 @@ describe('datasets and entities', () => {
               .expect(200))
             .then(() =>
               Forms.getByProjectAndXmlFormId(1, 'withAttachments')
-                .then(form => FormAttachments.getByFormDefIdAndName(form.value.def.id, 'people.csv')
+                .then(form => FormAttachments.getByFormDefIdAndName(form.get().def.id, 'people.csv')
                   .then(attachment => {
-                    should(attachment.value.datasetId).not.be.null();
-                    should(attachment.value.blobId).be.null();
+                    should(attachment.get().datasetId).not.be.null();
+                    should(attachment.get().blobId).be.null();
                   }))))));
 
       // Verifying autolinking happens only for attachment with "file" type
@@ -2249,9 +2249,9 @@ describe('datasets and entities', () => {
               .expect(200)
               .then(() =>
                 Forms.getByProjectAndXmlFormId(1, 'withAttachments')
-                  .then(form => FormAttachments.getByFormDefIdAndName(form.value.def.id, 'people')
+                  .then(form => FormAttachments.getByFormDefIdAndName(form.get().def.id, 'people')
                     .then(attachment => {
-                      should(attachment.value.datasetId).be.null();
+                      should(attachment.get().datasetId).be.null();
                     })))))));
 
       describe('autolink when publishing form that creates and consumes new dataset', () => {

--- a/test/unit/util/option.js
+++ b/test/unit/util/option.js
@@ -126,6 +126,9 @@ describe('(libs/FP) Option type', () => {
         [ Option.of(''), Option.of(0) ],
         [ Option.of(0),  Option.of(1) ], // eslint-disable-line no-multi-spaces
         [ Option.none(), null ],
+        [ Option.none(), undefined ],
+        [ Option.none(), 0 ],
+        [ Option.none(), false ],
         [ Option.of(1),  1 ], // eslint-disable-line no-multi-spaces
         [ Option.of(1),  { value: 1 } ], // eslint-disable-line no-multi-spaces
       ].forEach(([a, b]) => {

--- a/test/unit/util/option.js
+++ b/test/unit/util/option.js
@@ -1,3 +1,4 @@
+const R = require('ramda');
 const Should = require('should');
 const Option = require('../../../lib/util/option');
 
@@ -107,6 +108,18 @@ describe('(libs/FP) Option type', () => {
     it('It is not empty / It is defined', () => {
       o.isDefined().should.be.false();
       o.isEmpty().should.be.true();
+    });
+  });
+
+  describe('ramda interactions', () => {
+    describe('R.isEmpty()', () => {
+      it('Option.none() should be considered empty', () => {
+        R.isEmpty(Option.none()).should.be.true();
+      });
+
+      it('Option.of(...) should NOT be considered empty', () => {
+        R.isEmpty(Option.of(1)).should.be.false();
+      });
     });
   });
 });

--- a/test/unit/util/option.js
+++ b/test/unit/util/option.js
@@ -124,7 +124,7 @@ describe('(libs/FP) Option type', () => {
       [
         [ Option.none(), Option.of(0) ],
         [ Option.of(''), Option.of(0) ],
-        [ Option.of(0),  Option.of(1) ],
+        [ Option.of(0),  Option.of(1) ], // eslint-disable-line no-multi-spaces
       ].forEach(([a, b]) => {
         it(`${a} should not equal ${b}`, () => {
           R.equals(a, b).should.be.false();

--- a/test/unit/util/option.js
+++ b/test/unit/util/option.js
@@ -125,6 +125,9 @@ describe('(libs/FP) Option type', () => {
         [ Option.none(), Option.of(0) ],
         [ Option.of(''), Option.of(0) ],
         [ Option.of(0),  Option.of(1) ], // eslint-disable-line no-multi-spaces
+        [ Option.none(), null ],
+        [ Option.of(1),  1 ], // eslint-disable-line no-multi-spaces
+        [ Option.of(1),  { value: 1 } ], // eslint-disable-line no-multi-spaces
       ].forEach(([a, b]) => {
         it(`${a} should not equal ${b}`, () => {
           R.equals(a, b).should.be.false();

--- a/test/unit/util/option.js
+++ b/test/unit/util/option.js
@@ -112,6 +112,27 @@ describe('(libs/FP) Option type', () => {
   });
 
   describe('ramda interactions', () => {
+    describe('R.equals()', () => {
+      it('Option.none() should equal Option.none()', () => {
+        R.equals(Option.none(), Option.none()).should.be.true();
+      });
+
+      it('Option.of(...) should equal Option.of(...) the same value', () => {
+        R.equals(Option.of(1), Option.of(1)).should.be.true();
+      });
+
+      [
+        [ Option.none(), Option.of(0) ],
+        [ Option.of(''), Option.of(0) ],
+        [ Option.of(0),  Option.of(1) ],
+      ].forEach(([a, b]) => {
+        it(`${a} should not equal ${b}`, () => {
+          R.equals(a, b).should.be.false();
+          R.equals(b, a).should.be.false();
+        });
+      });
+    });
+
     describe('R.isEmpty()', () => {
       it('Option.none() should be considered empty', () => {
         R.isEmpty(Option.none()).should.be.true();


### PR DESCRIPTION
Guard against none-unsafe derefences of Option values.

This change requires implementation of support for Ramda's `.equals()` function for `Option.of(...)`, which incidentally worked previously due to the underlying implementation.  The main motivation for implementing `.equals()` support is that there are various places in the code which use `Ramda.isEmpty()` instead of `Option.isEmpty()`.  These are likely mistakes, but there is no obvious, elegant way to detect these mistakes.