### PR TITLE
block calling R.isEmpty() on Options

### DIFF
--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { isEmpty, map } = require('ramda');
+const { map } = require('ramda');
 const { Blob } = require('../frames');
 const { construct } = require('../../util/util');
 
@@ -139,7 +139,7 @@ const purgeUnattached = () => async ({ s3, Blobs }) => {
 
   while (true) { // eslint-disable-line no-constant-condition
     const maybeBlob = await Blobs._purgeOneUnattachedUploaded(); // eslint-disable-line no-await-in-loop
-    if (isEmpty(maybeBlob)) return;
+    if (maybeBlob.isEmpty()) return;
 
     // If delete is interrupted or failed, this may leave an orphaned object in
     // the S3 bucket.  This should be identifiable by comparing object names
@@ -153,7 +153,7 @@ const uploadBlobIfAvailable = async container => {
 
   const res = await container.transacting(async outerTx => {
     const maybeBlob = await outerTx.Blobs._getOnePending();
-    if (isEmpty(maybeBlob)) return;
+    if (maybeBlob.isEmpty()) return;
 
     const blob = maybeBlob.get();
 

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { map } = require('ramda');
+const { isEmpty, map } = require('ramda');
 const { Blob } = require('../frames');
 const { construct } = require('../../util/util');
 
@@ -139,7 +139,7 @@ const purgeUnattached = () => async ({ s3, Blobs }) => {
 
   while (true) { // eslint-disable-line no-constant-condition
     const maybeBlob = await Blobs._purgeOneUnattachedUploaded(); // eslint-disable-line no-await-in-loop
-    if (maybeBlob.isEmpty()) return;
+    if (isEmpty(maybeBlob)) return;
 
     // If delete is interrupted or failed, this may leave an orphaned object in
     // the S3 bucket.  This should be identifiable by comparing object names
@@ -153,7 +153,7 @@ const uploadBlobIfAvailable = async container => {
 
   const res = await container.transacting(async outerTx => {
     const maybeBlob = await outerTx.Blobs._getOnePending();
-    if (maybeBlob.isEmpty()) return;
+    if (isEmpty(maybeBlob)) return;
 
     const blob = maybeBlob.get();
 

--- a/lib/util/option.js
+++ b/lib/util/option.js
@@ -29,6 +29,10 @@ class Option {
         return option;
     return Option.none();
   }
+
+  get length() {
+    throw new Error('Calling Ramda.isEmpty(option) is nonsense.  Maybe you meant to call option.isEmpty(), or Ramda.isEmpty(option.get())?');
+  }
 }
 
 class Some extends Option {


### PR DESCRIPTION
Prevent confusion between ramda's isEmpty() function, and Option's .isEmpty() method.