### PR TITLE
http: don't double-decode session cookie

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -114,7 +114,7 @@ const authHandler = ({ Sessions, Users, Auth }, context) => {
 
     // actually try to authenticate with it. no Problem on failure. short circuit
     // out if we have a GET or HEAD request.
-    const maybeSession = authBySessionToken(decodeURIComponent(token));
+    const maybeSession = authBySessionToken(token);
     if ((context.method === 'GET') || (context.method === 'HEAD')) return maybeSession;
 
     // if non-GET run authentication as usual but we'll have to check CSRF afterwards.


### PR DESCRIPTION
Cookies are already url-decoded by `cookie-parser`, introduced in #910.

Alternative to https://github.com/getodk/central-backend/pull/1269