### PR TITLE
npm: stop using --legacy-peer-deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             find . -size +1000000c -not -path './.git/*' | grep .
             [[ $? -eq 1 ]]
       - run: make check-file-headers
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       - run: node lib/bin/create-docker-databases.js
       - run: make test-ci
       - store_test_results:

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         node-version: 20.17.0
         cache: 'npm'
-    - run: npm ci --legacy-peer-deps
+    - run: npm ci
     - run: FAKE_OIDC_ROOT_URL=http://localhost:9898 make fake-oidc-server-ci > fake-oidc-server.log &
     - run: node lib/bin/create-docker-databases.js
     - run: make test-oidc-integration

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         node-version: 20.17.0
         cache: 'npm'
-    - run: npm ci --legacy-peer-deps
+    - run: npm ci
     - run: node lib/bin/create-docker-databases.js
     - name: E2E Test
       timeout-minutes: 10

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         node-version: 20.17.0
         cache: 'npm'
-    - run: npm ci --legacy-peer-deps
+    - run: npm ci
     - run: node lib/bin/create-docker-databases.js
     - name: Soak Test
       timeout-minutes: 10

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         node-version: 20.10.0
         cache: 'npm'
-    - run: npm ci --legacy-peer-deps
+    - run: npm ci
     - run: node lib/bin/create-docker-databases.js
     - name: E2E Test
       timeout-minutes: 10

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -28,6 +28,6 @@ jobs:
       with:
         node-version: 20.17.0
         cache: 'npm'
-    - run: npm ci --legacy-peer-deps
+    - run: npm ci
     - run: node lib/bin/create-docker-databases.js
     - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: base
 
 node_modules: package.json
-	npm install --legacy-peer-deps
+	npm install
 	touch node_modules
 
 .PHONY: node_version

--- a/test/e2e/oidc/run-tests.sh
+++ b/test/e2e/oidc/run-tests.sh
@@ -15,7 +15,7 @@ if [[ ${CI-} = true ]]; then
   sudo apt-get install -y wait-for-it
 
   log "Creating database users..."
-  npm ci --legacy-peer-deps
+  npm ci
   node lib/bin/create-docker-databases.js
 
   START_SERVICES=true


### PR DESCRIPTION
* it looks like it's no longer required
* it seems to introduce inconsistent/unnecessary changes in package-lock.json
