### PR TITLE
test/http/endpoint: remove cryptic node14 reference

### DIFF
--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -476,7 +476,7 @@ describe('endpoints', () => {
       const responseTest = streamTest.toText((err, result) => {
         err.message.should.equal('ERR_EXPECTED');
         trailers.should.eql({ Status: 'Error' });
-        should(result).be.undefined()
+        should(result).be.undefined();
         done();
       });
       responseTest.addTrailers = function(t) { trailers = t; };

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -476,9 +476,7 @@ describe('endpoints', () => {
       const responseTest = streamTest.toText((err, result) => {
         err.message.should.equal('ERR_EXPECTED');
         trailers.should.eql({ Status: 'Error' });
-        // eslint-disable-next-line no-multi-spaces
-        should.not.exist(result);                  // node v14
-        (result === undefined).should.equal(true); // post node v14.??
+        should(result).be.undefined()
         done();
       });
       responseTest.addTrailers = function(t) { trailers = t; };


### PR DESCRIPTION
Introduced in #403 / 6e075a345b80041dae7c8156e10219fa0a606b21, this appears to be an outdated workaround for different behaviours in legacy node versions.
