### PR TITLE
task: remove remapping of node:util.promisify()

### DIFF
--- a/lib/task/db.js
+++ b/lib/task/db.js
@@ -11,11 +11,11 @@
 // for backups. See ./task.js for more information on what tasks are.
 
 const { exec } = require('child_process');
+const { promisify } = require('node:util');
 const { writeFile } = require('fs');
 const config = require('config');
 const { mergeRight } = require('ramda');
 const { isBlank } = require('../util/util');
-const { task } = require('./task');
 const tmp = require('tmp-promise');
 
 // Performs a pg_dump on the configured database into the given directory. Does
@@ -26,7 +26,7 @@ const pgdump = (directory) => {
   const dbConfig = config.get('default.database');
   const command = `pg_dump -j 4 -F d -f ${directory} -h ${dbConfig.host} -U ${dbConfig.user} ${dbConfig.database}`;
   const env = mergeRight(process.env, { PGPASSWORD: dbConfig.password });
-  return task.promisify(exec)(command, { env });
+  return promisify(exec)(command, { env });
 };
 
 // Given a directory containing a valid pg_dump produced by the above task, restores the database
@@ -46,21 +46,21 @@ const pgrestore = async (directory, namespace = 'default') => {
     SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${dbConfig.database}';
   `;
   await tmp.withFile(async (tmpfile) => {
-    await task.promisify(writeFile)(tmpfile.path, script);
+    await promisify(writeFile)(tmpfile.path, script);
 
     // now run that script:
     const runScript = `psql -h ${dbConfig.host} -U ${dbConfig.user} -d template1 -f ${tmpfile.path}`;
-    const result = await task.promisify(exec)(runScript, { env });
+    const result = await promisify(exec)(runScript, { env });
     if (!isBlank(result.stderr)) throw new Error(result.stderr);
   });
 
   // actually do the restore:
   const invokeRestore = `pg_restore -e -j 4 -F d -C -c -h ${dbConfig.host} -U ${dbConfig.user} -d template1 ${directory}`;
-  await task.promisify(exec)(invokeRestore, { env });
+  await promisify(exec)(invokeRestore, { env });
 
   // now we have to allow connections again:
   const enableConnections = `ALTER DATABASE ${dbConfig.database} ALLOW_CONNECTIONS TRUE;`;
-  return task.promisify(exec)(`psql -h ${dbConfig.host} -U ${dbConfig.user} -d template1 -c "${enableConnections}"`, { env });
+  return promisify(exec)(`psql -h ${dbConfig.host} -U ${dbConfig.user} -d template1 -c "${enableConnections}"`, { env });
 };
 
 module.exports = { pgdump, pgrestore };

--- a/lib/task/fs.js
+++ b/lib/task/fs.js
@@ -12,11 +12,11 @@
 // on what tasks are.
 
 const { readdir, createReadStream, createWriteStream, unlinkSync } = require('fs');
+const { promisify } = require('node:util');
 const { join, basename } = require('path');
 const { mergeRight } = require('ramda');
 const archiver = require('archiver');
 const yauzl = require('yauzl');
-const { task } = require('./task');
 const Problem = require('../util/problem');
 const { generateLocalCipherer, getLocalDecipherer } = require('../util/crypto');
 
@@ -38,7 +38,7 @@ const encryptToArchive = (directory, tmpFilePath, keys) => {
   const local = { key: localkey, ivs: {} };
 
   // call up all files in the directory.
-  return task.promisify(readdir)(directory).then((files) => new Promise((resolve, reject) => {
+  return promisify(readdir)(directory).then((files) => new Promise((resolve, reject) => {
     // stream each file into the zip, encrypting on the way in. clean up each
     // plaintext file as soon as we're done with them.
     // TODO: copypasted for now to lib/resources/backup
@@ -71,7 +71,7 @@ const encryptToArchive = (directory, tmpFilePath, keys) => {
 const decryptFromArchive = (archivePath, directory, passphrase = '') =>
   // we take a slower readpath here than in the test util to safeguard against
   // various zipbombing attacks.
-  task.promisify(yauzl.open)(archivePath, { autoClose: false, lazyEntries: true, validateEntrySizes: true })
+  promisify(yauzl.open)(archivePath, { autoClose: false, lazyEntries: true, validateEntrySizes: true })
     .then((zipfile) => new Promise((resolve, reject) => {
       const entries = [];
       let completed = 0;

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -14,10 +14,6 @@
 // Ultimately, they serve as a way of running application code outside the context
 // of the full application, on the command line, and standardizing command-line
 // output.
-//
-// A task takes the form of a function that returns:
-//
-//     Promise[Resolve[Serializable]|Problem]
 
 const { inspect } = require('util');
 const { mergeRight, compose, identity } = require('ramda');
@@ -42,6 +38,10 @@ const s3 = require('../external/s3').init(config.get('default.external.s3blobSto
 // If a task that requires a container context is run (.then is called on it)
 // then we spawn a container and use that for all subsequent dependents. Unlike
 // in the application, tasks are independent and share no state or transactions.
+//
+// A task takes the form of a function that returns:
+//
+//     Promise[Resolve[Serializable]|Problem]
 
 const task = {
   // not thread-safe! but we don't have threads..

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -14,6 +14,10 @@
 // Ultimately, they serve as a way of running application code outside the context
 // of the full application, on the command line, and standardizing command-line
 // output.
+//
+// A task takes the form of a function that returns:
+//
+//     Promise[Resolve[Serializable]|Problem]
 
 const { inspect } = require('util');
 const { mergeRight, compose, identity } = require('ramda');

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -15,7 +15,7 @@
 // of the full application, on the command line, and standardizing command-line
 // output.
 
-const { promisify, inspect } = require('util');
+const { inspect } = require('util');
 const { mergeRight, compose, identity } = require('ramda');
 const config = require('config');
 const container = require('../model/container');
@@ -38,10 +38,6 @@ const s3 = require('../external/s3').init(config.get('default.external.s3blobSto
 // If a task that requires a container context is run (.then is called on it)
 // then we spawn a container and use that for all subsequent dependents. Unlike
 // in the application, tasks are independent and share no state or transactions.
-//
-// We also provide a quick shortcut to promisify. If you have a function that
-// already returns a Promise[Resolve[Serializable]|Problem] then congratulations,
-// it's already a task!
 
 const task = {
   // not thread-safe! but we don't have threads..
@@ -64,7 +60,6 @@ const task = {
     return result;
   },
   noop: Promise.resolve(null),
-  promisify
 };
 
 


### PR DESCRIPTION
# Motivation

Reading the current task code, it's not immediately clear why `task.promisify` is used in place of node's built-in `promisify` function.  Digging deeper, it turns out that this is exactly the same function.  This PR aims to save future developers from the overhead of understanding that `task.promisify === require('node:util').promisify`.

# PR Template

#### What has been done to verify that this works as intended?

Ran tests

#### Why is this the best possible solution? Were any other approaches considered?

It simplifies the code.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change should not affect users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced