### PR TITLE
Add submissionId in delete and restore audit

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -407,11 +407,11 @@ const getForExport = (formId, instanceId, draft, options = QueryOptions.none) =>
 
 const del = (submission) => ({ run }) =>
   run(markDeleted(submission));
-del.audit = (submission, form) => (log) => log('submission.delete', { acteeId: form.acteeId }, { instanceId: submission.instanceId });
+del.audit = (submission, form) => (log) => log('submission.delete', { acteeId: form.acteeId }, { submissionId: submission.id, instanceId: submission.instanceId });
 
 const restore = (submission) => ({ run }) =>
   run(markUndeleted(submission));
-restore.audit = (submission, form) => (log) => log('submission.restore', { acteeId: form.acteeId }, { instanceId: submission.instanceId });
+restore.audit = (submission, form) => (log) => log('submission.restore', { acteeId: form.acteeId }, { submissionId: submission.id, instanceId: submission.instanceId });
 
 ////////////////////////////////////////////////////////////////////////////////
 // PURGING SOFT-DELETED SUBMISSIONS


### PR DESCRIPTION
Part of getodk/central#789

#### What has been done to verify that this works as intended?

Updated existing test.

#### Why is this the best possible solution? Were any other approaches considered?

~This is the simplest approach. Other options is to backfill submissionId in the audit table for submission.delete and submission.restore events.~

Added `submissionId` in delete and restore audit.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

NA

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced