### PR TITLE
ci: run github actions on pull requests

### DIFF
--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -1,6 +1,12 @@
 name: OIDC e2e tests
 
-on: push
+on:
+  push:
+    branches:
+    - master
+    # contributors who develop on branches in this repo:
+    - 'ktuite/*'
+  pull_request:
 
 env:
   DEBUG: pw:api

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -1,6 +1,12 @@
 name: OIDC integration tests
 
-on: push
+on:
+  push:
+    branches:
+    - master
+    # contributors who develop on branches in this repo:
+    - 'ktuite/*'
+  pull_request:
 
 jobs:
   oidc-integration-test:

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -1,6 +1,12 @@
 name: S3 E2E Tests
 
-on: push
+on:
+  push:
+    branches:
+    - master
+    # contributors who develop on branches in this repo:
+    - 'ktuite/*'
+  pull_request:
 
 jobs:
   s3-e2e:

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -1,6 +1,10 @@
 name: Soak Test
 
-on: push
+on:
+  push:
+    branches:
+    - master
+  workflow_dispatch:
 
 jobs:
   soak-test:

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
     - master
-  workflow_dispatch:
+    # contributors who develop on branches in this repo:
+    - 'ktuite/*'
+  pull_request:
 
 jobs:
   soak-test:

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -1,6 +1,12 @@
 name: Standard E2E Tests
 
-on: push
+on:
+  push:
+    branches:
+    - master
+    # contributors who develop on branches in this repo:
+    - 'ktuite/*'
+  pull_request:
 
 env:
   LOG_LEVEL: DEBUG

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -1,6 +1,12 @@
 name: Full Standard Test Suite
 
-on: push
+on:
+  push:
+    branches:
+    - master
+    # contributors who develop on branches in this repo:
+    - 'ktuite/*'
+  pull_request:
 
 jobs:
   standard-tests:


### PR DESCRIPTION
Closes #1308

There is some subtlety here:

* to allow personal development branches, exceptions can be included.  As @ktuite names branches consistently, I've included that exception here.  For other contributors, they could pick a naming scheme and add to the config
* ~i don't think soak tests need to run on every PR, so they're restricted to `master`, and also can be triggered manually from https://github.com/getodk/central-backend/actions~ this change has been moved to https://github.com/getodk/central-backend/pull/1320 to avoid discussions getting entangled

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

It's not always 100% possible to test github actions config without merging it.

#### Why is this the best possible solution? Were any other approaches considered?

See #1308 for alternative suggestions(s).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced