### PR TITLE
Improves #794: Update error message on duplicate submission when original is soft deleted

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -9433,7 +9433,7 @@ paths:
 
         * Central supports the `HEAD` request preflighting recommended by the specification, but does not require it. Because our supported authentication methods do not follow the try/retry pattern, only preflight your request if you want to read the `X-OpenRosa-Accept-Content-Length` header or are concerned about the other issues listed in the standards document, like proxies.
 
-        * As stated in the standards document, it is possible to submit multimedia attachments with the `Submission` across multiple `POST` requests to this API. _However_, we impose the additional restriction that the Submission XML (`xml_submission_file`) _may not change_ between requests. If Central sees a Submission with an `instanceId` it already knows about but the XML has changed in any way, it will respond with a `409 Conflict` error and reject the submission.
+        * As stated in the standards document, it is possible to submit multimedia attachments with the `Submission` across multiple `POST` requests to this API. _However_, we impose the additional restriction that the Submission XML (`xml_submission_file`) _may not change_ between requests. If Central sees a Submission with an `instanceId` it already knows about but the XML has changed in any way, it will respond with a `409 Conflict` error and reject the submission. Additionally, a `409 Conflict` error is returned if the Submission has been deleted in Central while attempting to send further POST requests.
 
         * Central will never return a `202` in any response from this API.
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -129,14 +129,9 @@ module.exports = (service, endpoint) => {
                     Forms.getBinaryFields(form.def.id)
                   ])
                     .then(([ saved, binaryFields ]) => SubmissionAttachments.create(saved, form, binaryFields, files))
-                    .catch((error) => {
-                      // This is only true when submission is soft deleted, if it is hard deleted then there will no error
-                      // and if it is not deleted then `extant` will be not null and this block will not execute.
-                      if (error.isProblem === true && error.problemCode === 409.3) {
-                        throw Problem.user.duplicateSubmission();
-                      }
-                      throw error;
-                    });
+                    // This is only true when submission is soft deleted, if it is hard deleted then there will no error
+                    // and if it is not deleted then `extant` will be not null and this block will not execute.
+                    .catch(Problem.translate(Problem.user.uniquenessViolation, noargs(Problem.user.duplicateSubmission)));
                 });
           })
           .then(always(createdMessage({ message: 'full submission upload was successful!' }))))));

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -127,7 +127,16 @@ module.exports = (service, endpoint) => {
                   return Promise.all([
                     Submissions.createNew(partial, form, query.deviceID, userAgent),
                     Forms.getBinaryFields(form.def.id)
-                  ]).then(([ saved, binaryFields ]) => SubmissionAttachments.create(saved, form, binaryFields, files));
+                  ])
+                    .then(([ saved, binaryFields ]) => SubmissionAttachments.create(saved, form, binaryFields, files))
+                    .catch((error) => {
+                      // This is only true when submission is soft deleted, if it is hard deleted then there will no error
+                      // and if it is not deleted then `extant` will be not null and this block will not execute.
+                      if (error.isProblem === true && error.problemCode === 409.3) {
+                        throw Problem.user.duplicateSubmission();
+                      }
+                      throw error;
+                    });
                 });
           })
           .then(always(createdMessage({ message: 'full submission upload was successful!' }))))));

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -221,7 +221,9 @@ const problems = {
 
     entityVersionConflict: problem(409.15, ({ current, provided }) => `Current version of the Entity is '${current}' and you provided '${provided}'. Please correct the version number or pass '?force=true' in the URL to forcefully update the Entity.`),
 
-    datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization.`)
+    datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization.`),
+
+    duplicateSubmission: problem(409.18, () => `This submission has been deleted. You may not resubmit it.`)
 
   },
   internal: {


### PR DESCRIPTION
Closes getodk/central#794

#### What has been done to verify that this works as intended?

Added tests. Manually tested in dev env.

#### Why is this the best possible solution? Were any other approaches considered?

Uses existing approach and keeps the change limited to OpenRosa endpoint.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced