### PR TITLE
Fix "query returns an unexpected result" bug with entity create-as-update

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -526,7 +526,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Audits, Dataset
       // If it is a uuid collision, check if the entity was created via an update
       // in which case its ok to apply this create as an update
       if (err.problemCode === 409.3 && err.problemDetails?.fields[0] === 'uuid') {
-        const rootDef = await Entities.getDef(dataset.id, entityData.system.id, new QueryOptions({ root: true })).then(o => o.orNull());
+        const rootDef = await Entities.getDef(dataset.id, entityData.system.id, new QueryOptions().withCondition({ root: true })).then(o => o.orNull());
         if (rootDef && rootDef.aux.source.forceProcessed) {
           maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, true);
         } else {

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1768,7 +1768,7 @@ describe('Offline Entities', () => {
   });
 
   describe('miscellaneous', () => {
-    it.only('should handle two updates followed by delayed create', testOfflineEntities(async (service, container) => {
+    it('should handle two updates followed by delayed create', testOfflineEntities(async (service, container) => {
       // Issue c#808
       const asAlice = await service.login('alice');
       const branchId = uuid();
@@ -1817,12 +1817,11 @@ describe('Offline Entities', () => {
       await asAlice.get('/v1/projects/1/forms/offlineEntity/submissions/two/audits')
         .expect(200)
         .then(({ body }) => {
-          // TODO it should update the entity, not have this creation error
-          body[0].details.errorMessage.should.equal('Query returns an unexpected result.');
+          body[0].action.should.equal('entity.update.version');
         });
     }));
 
-    it.only('should handle update from sub and update from API followed by delayed create', testOfflineEntities(async (service, container) => {
+    it('should handle update from sub and update from API followed by delayed create', testOfflineEntities(async (service, container) => {
       // Issue c#810
       const asAlice = await service.login('alice');
       const branchId = uuid();
@@ -1864,8 +1863,7 @@ describe('Offline Entities', () => {
       await asAlice.get('/v1/projects/1/forms/offlineEntity/submissions/two/audits')
         .expect(200)
         .then(({ body }) => {
-          // TODO it should update the entity, not have this creation error
-          body[0].details.errorMessage.should.equal('Query returns an unexpected result.');
+          body[0].action.should.equal('entity.update.version');
         });
     }));
   });

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -851,6 +851,56 @@ describe('Offline Entities', () => {
       count = await container.oneFirst(sql`select count(*) from entity_submission_backlog`);
       count.should.equal(0);
     }));
+
+    it('should not process update submission in backlog if approvalRequired is true', testOfflineEntities(async (service, container) => {
+      // Demonstrating issue c#811
+      const asAlice = await service.login('alice');
+
+      // Configure the entity list to create entities on submission approval
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ approvalRequired: true })
+        .expect(200);
+
+      const branchId = uuid();
+
+      // Send update submission (imagine that registration submission is lost)
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.two
+          .replace('create="1"', 'update="1"')
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('two', 'two-update')
+          .replace('baseVersion=""', 'baseVersion="1"')
+          .replace('<status>new</status>', '<status>checked in</status>')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      // There should be one item in the backlog
+      let count = await container.oneFirst(sql`select count(*) from entity_submission_backlog`);
+      count.should.equal(1);
+
+      // Force process backlog
+      await container.Entities.processBacklog(true);
+
+      // There should be nothing in the backlog
+      count = await container.oneFirst(sql`select count(*) from entity_submission_backlog`);
+      count.should.equal(0);
+
+      // Entity should not exist
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ddd')
+        .expect(404);
+
+      // Submission should not have a processing error, just the create event.
+      await asAlice.get('/v1/projects/1/forms/offlineEntity/submissions/two-update/audits')
+        .expect(200)
+        .then(({ body }) => {
+          body.length.should.equal(1);
+          body[0].action.should.eql('submission.create');
+          should.not.exist(body[0].details.problem);
+        });
+    }));
   });
 
   describe('force-processing held submissions', () => {
@@ -1773,7 +1823,7 @@ describe('Offline Entities', () => {
     }));
 
     it.only('should handle update from sub and update from API followed by delayed create', testOfflineEntities(async (service, container) => {
-      // Issue c#808
+      // Issue c#810
       const asAlice = await service.login('alice');
       const branchId = uuid();
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/808 and https://github.com/getodk/central/issues/810

Also includes test of scenario in this issue: https://github.com/getodk/central/issues/811

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

Just fixed a bug in how this one query was working! Was looking for the root submission def but it wasn't filtering correctly.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced