### PR TITLE
Log create-as-update as a conflict

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -500,8 +500,15 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
     if (v.version > 1) { // v.root is false here - can use either
       const baseNotContiguousWithTrunk = v.branchId != null &&
         branches.get(v.branchId).lastContiguousWithTrunk < v.baseVersion;
+
+      // check if it's a create applied as an update, which is also a conflict
+      const createAsUpdate = def.aux.source?.details?.submission?.action === 'create';
+
       const conflict = v.version !== (v.baseVersion + 1) ||
-        baseNotContiguousWithTrunk;
+        baseNotContiguousWithTrunk || createAsUpdate;
+
+      if (createAsUpdate)
+        v.conflictingProperties = Object.keys(v.dataReceived);
 
       v.baseDiff = getDiffProp(v.dataReceived, { ...defs[v.baseVersion - 1].data, label: defs[v.baseVersion - 1].label });
 

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -502,13 +502,10 @@ const getWithConflictDetails = (defs, audits, relevantToConflict) => {
         branches.get(v.branchId).lastContiguousWithTrunk < v.baseVersion;
 
       // check if it's a create applied as an update, which is also a conflict
-      const createAsUpdate = def.aux.source?.details?.submission?.action === 'create';
+      const createAsUpdate = def.aux.source?.details?.action === 'create';
 
       const conflict = v.version !== (v.baseVersion + 1) ||
         baseNotContiguousWithTrunk || createAsUpdate;
-
-      if (createAsUpdate)
-        v.conflictingProperties = Object.keys(v.dataReceived);
 
       v.baseDiff = getDiffProp(v.dataReceived, { ...defs[v.baseVersion - 1].data, label: defs[v.baseVersion - 1].label });
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -332,7 +332,10 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
 
   // make some kind of source object
   const sourceDetails = {
-    submission: { instanceId: submissionDef.instanceId }
+    submission: {
+      instanceId: submissionDef.instanceId,
+      ...createSubAsUpdate ? { action: 'create' } : {}
+    },
   };
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id, forceOutOfOrderProcessing);
   const partial = new Entity.Partial(serverEntity.with({ conflict }), {

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -317,7 +317,17 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       conflict = conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
     }
   } else if (createSubAsUpdate) {
-    conflict = ConflictType.SOFT;
+    const versionDiff = getDiffProp(serverEntity.aux.currentVersion.data, clientEntity.def.dataReceived);
+    const diffData = pickAll(versionDiff, serverEntity.aux.currentVersion.data);
+
+    if (serverEntity.aux.currentVersion.label !== clientEntity.def.label)
+      diffData.label = serverEntity.aux.currentVersion.label;
+
+    conflictingProperties = Object.keys(clientEntity.def.dataReceived).filter(key => key in diffData && clientEntity.def.dataReceived[key] !== diffData[key]);
+
+    if (conflict !== ConflictType.HARD) { // We don't want to downgrade conflict here
+      conflict = conflictingProperties.length > 0 ? ConflictType.HARD : ConflictType.SOFT;
+    }
   } else {
     // This may still be a soft conflict if the new version is not contiguous with this branch's trunk version
     const interrupted = await Entities._interruptedBranch(serverEntity.id, clientEntity);
@@ -334,8 +344,8 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
   const sourceDetails = {
     submission: {
       instanceId: submissionDef.instanceId,
-      ...createSubAsUpdate ? { action: 'create' } : {}
     },
+    ...createSubAsUpdate ? { action: 'create' } : {}
   };
   const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id, forceOutOfOrderProcessing);
   const partial = new Entity.Partial(serverEntity.with({ conflict }), {

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1198,7 +1198,7 @@ describe('Offline Entities', () => {
         .then(({ body }) => {
           body.currentVersion.version.should.equal(2);
           body.currentVersion.data.should.eql({ age: '20', status: 'new', first_name: 'Megan' });
-          body.conflict.should.equal('soft'); // this should be marked as a soft conflict
+          body.conflict.should.equal('hard'); // this should be marked as a soft conflict
           body.currentVersion.baseVersion.should.equal(1); // baseVersion is set, but normally the baseVersion of an entity-create is null
           // the rest of these are null like a normal entity-create
           should.not.exist(body.currentVersion.branchBaseVersion);
@@ -1763,6 +1763,52 @@ describe('Offline Entities', () => {
         .then(({ body }) => {
           body.map(v => v.conflict).should.eql([null, 'hard']);
           body[1].conflictingProperties.should.eql([ 'status', 'age', 'label' ]);
+        });
+    }));
+
+    it('should show proper conflict info on create applied as update that is only a soft conflict', testOfflineEntities(async (service, container) => {
+      const asAlice = await service.login('alice');
+      const branchId = uuid();
+
+      // Send update
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.two
+          .replace('create="1"', 'update="1"')
+          .replace('branchId=""', `branchId="${branchId}"`)
+          .replace('two', 'two-update1')
+          .replace('baseVersion=""', 'baseVersion="1"')
+        )
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      // Check backlog
+      const backlogCount = await container.oneFirst(sql`select count(*) from entity_submission_backlog`);
+      backlogCount.should.equal(1);
+
+      await container.Entities.processBacklog(true);
+
+      // Send registration
+      await asAlice.post('/v1/projects/1/forms/offlineEntity/submissions')
+        .send(testData.instances.offlineEntity.two)
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+
+      await exhaust(container);
+
+      // Check that entity as a whole is a soft conflict
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ddd')
+        .then(({ body }) => {
+          body.conflict.should.equal('soft');
+        });
+
+      // Check versions
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ddd/versions')
+        .expect(200)
+        .then(({ body }) => {
+          body.map(v => v.conflict).should.eql([null, 'soft']);
+          body[1].conflictingProperties.should.eql([]);
         });
     }));
   });

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1715,7 +1715,7 @@ describe('Offline Entities', () => {
         });
     }));
 
-    it.only('should show proper conflict info on create applied as update', testOfflineEntities(async (service, container) => {
+    it('should show proper conflict info on create applied as update', testOfflineEntities(async (service, container) => {
       // Issue c#815
       const asAlice = await service.login('alice');
       const branchId = uuid();
@@ -1758,8 +1758,8 @@ describe('Offline Entities', () => {
       await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ddd/versions')
         .expect(200)
         .then(({ body }) => {
-          // TODO body[1].conflict should actually NOT be null
-          body.map(v => v.conflict).should.eql([null, null]);
+          body.map(v => v.conflict).should.eql([null, 'hard']);
+          body[1].conflictingProperties.should.eql(['age', 'label', 'status', 'first_name']);
         });
     }));
   });

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1748,6 +1748,12 @@ describe('Offline Entities', () => {
 
       await exhaust(container);
 
+      // Check that entity as a whole is a conflict
+      await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ddd')
+        .then(({ body }) => {
+          body.conflict.should.equal('soft');
+        });
+
       // Check versions
       await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ddd/versions')
         .expect(200)

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1728,6 +1728,9 @@ describe('Offline Entities', () => {
           .replace('two', 'two-update1')
           .replace('baseVersion=""', 'baseVersion="1"')
           .replace('<status>new</status>', '<status>checked in</status>')
+          .replace('<age>20</age>', '<age>22</age>')
+          .replace('<name>Megan</name>', '')
+          .replace('<label>Megan (20)</label>', '')
         )
         .set('Content-Type', 'application/xml')
         .expect(200);
@@ -1751,7 +1754,7 @@ describe('Offline Entities', () => {
       // Check that entity as a whole is a conflict
       await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789ddd')
         .then(({ body }) => {
-          body.conflict.should.equal('soft');
+          body.conflict.should.equal('hard');
         });
 
       // Check versions
@@ -1759,7 +1762,7 @@ describe('Offline Entities', () => {
         .expect(200)
         .then(({ body }) => {
           body.map(v => v.conflict).should.eql([null, 'hard']);
-          body[1].conflictingProperties.should.eql(['age', 'label', 'status', 'first_name']);
+          body[1].conflictingProperties.should.eql([ 'status', 'age', 'label' ]);
         });
     }));
   });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/815

From [here](https://github.com/getodk/central/issues/815#issuecomment-2514895303):
> @ktuite, I think what's happening here is that the entity as a whole is being marked as a conflict, but the API is not returning v2 as a conflict (its conflict property is null). Now that https://github.com/getodk/central-backend/pull/1251 has been merged, I think we need to update getWithConflictDetails() in a similar way to how it was updated in https://github.com/getodk/central-backend/pull/1187. There are now three situations in which an entity can be marked as a conflict (described in https://github.com/getodk/central/issues/805), but getWithConflictDetails() only accounts for two of them ([here](https://github.com/getodk/central-backend/blob/0bc6209a81bee6e1a7b3cc86517cb3c4688564b0/lib/data/entity.js#L503-L504)).

<img width="1414" alt="Screenshot 2024-12-06 at 4 45 39 PM" src="https://github.com/user-attachments/assets/05fe3e7b-12df-44a1-86dc-4f5a8f136653">


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced