### PR TITLE
ci: only run soak tests on master branch

### DIFF
--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -1,6 +1,8 @@
 name: Soak Test
 
-on: push
+on:
+  push:
+    branches: master
 
 jobs:
   soak-test:


### PR DESCRIPTION
Spun off from https://github.com/getodk/central-backend/pull/1315.

Soak tests are slow, and are only likely to break occasionally.  Re-enabling them on branches when working on specific features, e.g. `slonik` or `pg` upgrades, would be sensible.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

Another option might be to also run if there are changes in `package.json` or `package-lock.json`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced