### PR TITLE
Feature #769: Reject duplicate properties with different capitalization

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -45,6 +45,7 @@ info:
     **Changed**:
 
     - [Submissions Odata]() now returns `__system/deletedAt`. It can also be used in $filter, $sort and $select query parameters.
+    - Dataset (Entity List) properties with the same name but different capitalization are not allowed.
 
     ## ODK Central v2024.2
 
@@ -8706,6 +8707,8 @@ paths:
       summary: Adding Properties
       description: |-
         Creates a new Property with a specified name in the Dataset.
+
+        The name of a Property is case-sensitive in that it will keep the capitalization provided (e.g. "Firstname"). But Central will not allow another Property with the same name but different capitalization to be created (e.g. "FIRSTNAME" when "Firstname" already exists).
 
         Property names follow the same rules as form field names (valid XML identifiers) and cannot use the reserved names of `name` or `label`, or begin with the reserved prefix `__`. 
       operationId: Adding Properties

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -143,8 +143,9 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
 
     // Check properties with same name but different capitualization
     const duplicateProperties = newNames
+      .filter(newName => !existingNames.includes(newName))
       .map(newName => ({
-        current: existingNames.find(existingName => existingName !== newName && newName.toLowerCase() === existingName.toLowerCase()),
+        current: existingNames.find(existingName => newName.toLowerCase() === existingName.toLowerCase()),
         provided: newName
       }))
       .filter(property => property.current);
@@ -290,6 +291,7 @@ const publishIfExists = (formDefId, publishedAt) => async ({ all, context, maybe
       AND dp.name != existing_properties.name
     WHERE dpf."formDefId" = ${formDefId}
       AND existing_properties."publishedAt" IS NOT NULL
+      AND dp."publishedAt" IS NULL
   `;
 
   const d = await maybeOne(_datasetNameConflict());

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -11,7 +11,7 @@ const { sql } = require('slonik');
 const { extender, insert, QueryOptions, sqlEquals, unjoiner, updater } = require('../../util/db');
 const { Dataset, Form, Audit } = require('../frames');
 const { validatePropertyName } = require('../../data/dataset');
-const { difference, isEmpty, isNil, either, reduceBy, groupBy, uniqWith, equals, map } = require('ramda');
+const { difference, isEmpty, isNil, either, reduceBy, groupBy, uniqWith, equals, map, pipe, values, any, prop, toLower } = require('ramda');
 
 const Problem = require('../../util/problem');
 const { construct } = require('../../util/util');
@@ -110,21 +110,22 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
   // Prepare dataset properties from form fields:
   // Step 1: Filter to only fields with property name binds
   let dsPropertyFields = fields.filter((field) => (field.propertyName));
-  // Step 2: Check for invalid property names
+  // Step 2a: Check for invalid property names
   if (dsPropertyFields.filter((field) => !validatePropertyName(field.propertyName)).length > 0)
     throw Problem.user.invalidEntityForm({ reason: 'Invalid entity property name.' });
+
+  // Step 2b: Multiple fields trying to save to a single property (case-insensitive)
+  const hasDuplicateProperties = pipe(groupBy(pipe(prop('propertyName'), toLower)), values, any(g => g.length > 1));
+  if (hasDuplicateProperties(dsPropertyFields)) {
+    throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single property.' });
+  }
+
   // Step 3: Build Form Field frames to handle dataset property field insertion
   dsPropertyFields = dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId, formDefId }));
 
   // Insert or update: update dataset, dataset properties, and links to fields and current form
   // result contains action (created or updated) and the id of the dataset.
-  const result = await one(_createOrMerge(partial, acteeId, parsedDataset.actions, dsPropertyFields))
-    .catch(error => {
-      if (error.constraint === 'ds_property_fields_dspropertyid_formdefid_unique') {
-        throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single property.' });
-      }
-      throw error;
-    });
+  const result = await one(_createOrMerge(partial, acteeId, parsedDataset.actions, dsPropertyFields));
 
   // Verify that user has ability to create dataset
   // Updating an unpublished dataset is equivalent to creating the dataset
@@ -139,6 +140,17 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
     const newNames = dsPropertyFields.map(f => f.propertyName);
     if (difference(newNames, existingNames).length > 0)
       await context.auth.canOrReject('dataset.update', { acteeId });
+
+    // Check properties with same name but different capitualization
+    const duplicateProperties = newNames
+      .map(newName => ({
+        current: existingNames.find(existingName => existingName !== newName && newName.toLowerCase() === existingName.toLowerCase()),
+        provided: newName
+      }))
+      .filter(property => property.current);
+    if (duplicateProperties.length > 0) {
+      throw Problem.user.propertyNameConflict({ duplicateProperties });
+    }
   }
 
   // Partial contains acteeId which is needed for auditing.
@@ -184,8 +196,21 @@ DO UPDATE SET "publishedAt" = clock_timestamp()
 WHERE ds_properties."publishedAt" IS NULL
 RETURNING *`;
 
+const _getDuplicatePropertyName = (property) => sql`
+  SELECT name FROM ds_properties 
+  WHERE lower(name) = lower(${property.name})
+    AND "datasetId" = ${property.datasetId} 
+    AND "publishedAt" IS NOT NULL
+`;
+
 // eslint-disable-next-line no-unused-vars
-const createPublishedProperty = (property, dataset) => async ({ all }) => {
+const createPublishedProperty = (property, dataset) => async ({ all, maybeOne }) => {
+
+  const duplicateProperty = await maybeOne(_getDuplicatePropertyName(property));
+  if (duplicateProperty.isDefined()) {
+    throw Problem.user.uniquenessViolation({ table: 'ds_properties', fields: [ 'name', 'datasetId' ], values: [ duplicateProperty.get().name, dataset.id ] });
+  }
+
   const result = await all(_createPublishedProperty(property));
   if (result.length === 0)
     throw Problem.user.uniquenessViolation({ table: 'ds_properties', fields: [ 'name', 'datasetId' ], values: [ property.name, dataset.id ] });
@@ -255,10 +280,27 @@ const publishIfExists = (formDefId, publishedAt) => async ({ all, context, maybe
       AND ds_to_publish."publishedAt" IS NULL
   `;
 
+  const _propertyNameConflict = () => sql`
+    SELECT dp.name as provided, existing_properties.name as current
+    FROM ds_property_fields dpf
+    JOIN ds_properties dp ON dp.id = dpf."dsPropertyId"
+    JOIN datasets ds ON ds.id = dp."datasetId"
+    JOIN ds_properties existing_properties ON existing_properties."datasetId" = ds.id
+      AND LOWER(dp.name) = LOWER(existing_properties.name)
+      AND dp.name != existing_properties.name
+    WHERE dpf."formDefId" = ${formDefId}
+      AND existing_properties."publishedAt" IS NOT NULL
+  `;
+
   const d = await maybeOne(_datasetNameConflict());
   if (d.isDefined()) {
     const { current, provided } = d.get();
     throw Problem.user.datasetNameConflict({ current, provided });
+  }
+
+  const duplicateProperties = await all(_propertyNameConflict());
+  if (duplicateProperties.length > 0) {
+    throw Problem.user.propertyNameConflict({ duplicateProperties });
   }
 
   const properties = await all(_publishIfExists());

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -288,7 +288,6 @@ const publishIfExists = (formDefId, publishedAt) => async ({ all, context, maybe
     JOIN datasets ds ON ds.id = dp."datasetId"
     JOIN ds_properties existing_properties ON existing_properties."datasetId" = ds.id
       AND LOWER(dp.name) = LOWER(existing_properties.name)
-      AND dp.name != existing_properties.name
     WHERE dpf."formDefId" = ${formDefId}
       AND existing_properties."publishedAt" IS NOT NULL
       AND dp."publishedAt" IS NULL

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -225,8 +225,9 @@ const problems = {
 
     datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization.`),
 
-    duplicateSubmission: problem(409.18, () => `This submission has been deleted. You may not resubmit it.`)
+    propertyNameConflict: problem(409.17, () => 'This form attempts to create new Entity properties that match with existing ones except for capitalization.'),
 
+    duplicateSubmission: problem(409.18, () => `This submission has been deleted. You may not resubmit it.`)
   },
   internal: {
     // no detail information, as this is only called when we don't know what happened.

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4063,6 +4063,23 @@ describe('datasets and entities', () => {
             });
 
         }));
+
+        it('should reject when publishing duplicate property with different capitalization', testService(async (service, container) => {
+          const alice = await service.login('alice');
+
+          await alice.post('/v1/projects/1/forms?publish=True')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200);
+
+          await container.run(sql`UPDATE ds_properties SET name='FIRST_NAME' WHERE name='age'`);
+
+          await alice.post('/v1/projects/1/forms/simpleEntity/draft')
+            .expect(200);
+
+          await alice.post('/v1/projects/1/forms/simpleEntity/draft/publish?version=v2')
+            .expect(200);
+        }));
       });
 
       describe('updating datasets through new form drafts', () => {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4028,6 +4028,27 @@ describe('datasets and entities', () => {
             });
         }));
 
+        it('should reject when new Form draft has duplicate property with different capitalization', testService(async (service) => {
+          const alice = await service.login('alice');
+
+          // dataset "people" with property "first_name"
+          await alice.post('/v1/projects/1/forms?publish=True')
+            .send(testData.forms.simpleEntity)
+            .set('Content-Type', 'application/xml')
+            .expect(200);
+
+          // dataset "people" with property "FIRST_NAME" - draft
+          await alice.post('/v1/projects/1/forms')
+            .send(testData.forms.simpleEntity
+              .replace(/simpleEntity/g, 'simpleEntity2')
+              .replace('first_name', 'FIRST_NAME'))
+            .set('Content-Type', 'application/xml')
+            .expect(409)
+            .then(({ body }) => {
+              body.message.should.match(/This form attempts to create new Entity properties that match with existing ones except for capitalization/);
+            });
+        }));
+
         it('reject if the Form contains duplicate properties with different capitalization', testService(async (service) => {
           const alice = await service.login('alice');
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4064,7 +4064,7 @@ describe('datasets and entities', () => {
 
         }));
 
-        it('should reject when publishing duplicate property with different capitalization', testService(async (service, container) => {
+        it('should not reject for existing duplicate properties', testService(async (service, container) => {
           const alice = await service.login('alice');
 
           await alice.post('/v1/projects/1/forms?publish=True')


### PR DESCRIPTION
Closes getodk/central#769

#### What has been done to verify that this works as intended?

Added tests and manual verification.

#### Why is this the best possible solution? Were any other approaches considered?

I initially changed the database column type to `citext` to stop duplicate property names (case insensitive) but that prevented creation even when existing properties were unpublished. With the implemented approach we can have two unpublished Forms with same properties but different capitalization. Error is thrown when user tries to publish second one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Change affects already complicated area of Form and EntityList creation, that should be tested thoroughly.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced