### PR TITLE
Use node 22, now in maintenance LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:22.12.0
       - image: cimg/postgres:14.10
         environment:
           POSTGRES_PASSWORD: odktest

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -27,10 +27,10 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 20
+    - name: Set node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20.17.0
+        node-version: 22.12.0
         cache: 'npm'
     - run: make test-oidc-e2e
     - name: Archive playwright screenshots

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -23,10 +23,10 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 20
+    - name: Set node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20.17.0
+        node-version: 22.12.0
         cache: 'npm'
     - run: npm ci
     - run: FAKE_OIDC_ROOT_URL=http://localhost:9898 make fake-oidc-server-ci > fake-oidc-server.log &

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -41,10 +41,10 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 20
+    - name: Set node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20.17.0
+        node-version: 22.12.0
         cache: 'npm'
     - run: npm ci
     - run: node lib/bin/create-docker-databases.js

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -25,10 +25,10 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 20
+    - name: Set node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20.17.0
+        node-version: 22.12.0
         cache: 'npm'
     - run: npm ci
     - run: node lib/bin/create-docker-databases.js

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20.10.0
+        node-version: 22.12.0
         cache: 'npm'
     - run: npm ci
     - run: node lib/bin/create-docker-databases.js

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -26,7 +26,7 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 20
+    - name: Set node version
       uses: actions/setup-node@v4
       with:
         node-version: 20.10.0

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -23,10 +23,10 @@ jobs:
           --health-retries 5
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 20
+    - name: Set node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20.17.0
+        node-version: 22.12.0
         cache: 'npm'
     - run: npm ci
     - run: node lib/bin/create-docker-databases.js

--- a/Makefile
+++ b/Makefile
@@ -101,19 +101,19 @@ debug: base
 
 .PHONY: test
 test: lint
-	BCRYPT=insecure npx mocha --recursive
+	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive
 
 .PHONY: test-ci
 test-ci: lint
-	BCRYPT=insecure npx mocha --recursive --reporter test/ci-mocha-reporter.js
+	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive --reporter test/ci-mocha-reporter.js
 
 .PHONY: test-fast
 test-fast: node_version
-	BCRYPT=insecure npx mocha --recursive --fgrep @slow --invert
+	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive --fgrep @slow --invert
 
 .PHONY: test-integration
 test-integration: node_version
-	BCRYPT=insecure npx mocha --recursive test/integration
+	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive test/integration
 
 .PHONY: test-unit
 test-unit: node_version
@@ -121,7 +121,7 @@ test-unit: node_version
 
 .PHONY: test-coverage
 test-coverage: node_version
-	npx nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --recursive test
+	npx --node-options="--no-deprecation" nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --recursive test
 
 .PHONY: lint
 lint: node_version

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "tmp": "~0.2"
       },
       "engines": {
-        "node": "20"
+        "node": "22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "volta": {
-    "node": "20.17.0"
+    "node": "22.12.0"
   },
   "dependencies": {
     "@sentry/node": "~7",

--- a/test/e2e/oidc/run-tests.sh
+++ b/test/e2e/oidc/run-tests.sh
@@ -49,6 +49,6 @@ if [[ ${INSTALL_PLAYWRIGHT_DEPS-} = true ]]; then
   npx playwright install --with-deps
 fi
 log "Running playwright tests..."
-npx playwright test
+npx --node-options="--no-deprecation" playwright test
 
 log "Tests completed OK!"

--- a/test/e2e/s3/run-tests.sh
+++ b/test/e2e/s3/run-tests.sh
@@ -61,7 +61,7 @@ timeout 30 bash -c "while ! curl -s -o /dev/null $serverUrl; do sleep 1; done"
 log 'Backend started!'
 
 cd test/e2e/s3
-npx mocha test.js
+npx --node-options="--no-deprecation" mocha test.js
 
 if ! curl -s -o /dev/null "$serverUrl"; then
   log '!!! Backend died.'

--- a/test/integration/task/task.js
+++ b/test/integration/task/task.js
@@ -36,7 +36,7 @@ describe('task: runner', () => {
   it('should print failure details to stderr and exit nonzero', () => runScript(failure)
     .then(([ error, , stderr ]) => {
       error.code.should.equal(1);
-      stderr.should.match(/^Problem \[Error\]: The resource returned no data./);
+      stderr.should.containEql('Problem [Error]: The resource returned no data.');
     }));
 });
 

--- a/test/integration/task/task.js
+++ b/test/integration/task/task.js
@@ -36,7 +36,7 @@ describe('task: runner', () => {
   it('should print failure details to stderr and exit nonzero', () => runScript(failure)
     .then(([ error, , stderr ]) => {
       error.code.should.equal(1);
-      stderr.should.containEql('Problem [Error]: The resource returned no data.');
+      stderr.should.match(/^Problem \[Error\]: The resource returned no data./);
     }));
 });
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

Ran backend and frontend, clicked around to see whether there are any obvious issues.

There are a handful of deprecation warnings which we can take care of whenever.

#### Why is this the best possible solution? Were any other approaches considered?

We could stay on Node 20 which is still in maintenance LTS for over a year. But Node 22 has been in active LTS for a couple of months now and I'd rather we follow the active LTS releases unless there are any breaking changes we can't adapt to quickly. Making this change before regression testing gives us the best safety net we can get. Any issues there may be would probably only crop up under real usage.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There are some risks of subtle behavior changes, especially around things like streams. For streams in particular, the `highWaterMark` default is now 64k so the streams we don't explicitly configure will be impacted. There's also been a V8 engine upgrade that could lead to performance changes.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced