### PR TITLE
Fix tests on Node 22

### DIFF
--- a/test/e2e/oidc/run-tests.sh
+++ b/test/e2e/oidc/run-tests.sh
@@ -49,6 +49,6 @@ if [[ ${INSTALL_PLAYWRIGHT_DEPS-} = true ]]; then
   npx playwright install --with-deps
 fi
 log "Running playwright tests..."
-npx --node-options="--no-deprecation" playwright test
+NODE_OPTIONS="--no-deprecation" npx playwright test
 
 log "Tests completed OK!"

--- a/test/e2e/oidc/run-tests.sh
+++ b/test/e2e/oidc/run-tests.sh
@@ -49,6 +49,6 @@ if [[ ${INSTALL_PLAYWRIGHT_DEPS-} = true ]]; then
   npx playwright install --with-deps
 fi
 log "Running playwright tests..."
-NODE_OPTIONS="--no-deprecation" npx playwright test
+npx playwright test
 
 log "Tests completed OK!"

--- a/test/e2e/s3/run-tests.sh
+++ b/test/e2e/s3/run-tests.sh
@@ -61,7 +61,7 @@ timeout 30 bash -c "while ! curl -s -o /dev/null $serverUrl; do sleep 1; done"
 log 'Backend started!'
 
 cd test/e2e/s3
-npx --node-options="--no-deprecation" mocha test.js
+NODE_OPTIONS="--no-deprecation" npx mocha test.js
 
 if ! curl -s -o /dev/null "$serverUrl"; then
   log '!!! Backend died.'

--- a/test/e2e/s3/run-tests.sh
+++ b/test/e2e/s3/run-tests.sh
@@ -61,7 +61,7 @@ timeout 30 bash -c "while ! curl -s -o /dev/null $serverUrl; do sleep 1; done"
 log 'Backend started!'
 
 cd test/e2e/s3
-NODE_OPTIONS="--no-deprecation" npx mocha test.js
+npx mocha test.js
 
 if ! curl -s -o /dev/null "$serverUrl"; then
   log '!!! Backend died.'

--- a/test/e2e/s3/test.js
+++ b/test/e2e/s3/test.js
@@ -402,9 +402,9 @@ describe('s3 support', () => {
 function cli(cmd) {
   let pid;
 
-  cmd = `exec node --no-deprecation lib/bin/s3 ${cmd}`; // eslint-disable-line no-param-reassign
+  cmd = `exec node lib/bin/s3 ${cmd}`; // eslint-disable-line no-param-reassign
   log.debug('cli()', 'calling:', cmd);
-  const env = { ..._.pick(process.env, 'PATH'), NODE_CONFIG_ENV:'s3-dev' };
+  const env = { ..._.pick(process.env, 'PATH'), NODE_CONFIG_ENV:'s3-dev', NODE_OPTIONS:'$NODE_OPTIONS --no-deprecation' };
 
   const promise = new Promise((resolve, reject) => {
     const child = exec(cmd, { env, cwd:'../../..' }, (err, stdout) => {

--- a/test/e2e/s3/test.js
+++ b/test/e2e/s3/test.js
@@ -436,9 +436,9 @@ async function expectRejectionFrom(promise, expectedMessage) {
     await promise;
     should.fail('Uploading should have exited with non-zero status.');
   } catch(err) {
-    if(err.message.contains('Command failed: exec node lib/bin/s3 ')) {
+    if(err.message.startsWith('Command failed: exec node lib/bin/s3 ')) {
       // expected
-      if(expectedMessage) err.message.should.match(expectedMessage);
+      if(expectedMessage) err.message.should.containEql(expectedMessage);
     } else {
       throw err;
     }

--- a/test/e2e/s3/test.js
+++ b/test/e2e/s3/test.js
@@ -402,7 +402,7 @@ describe('s3 support', () => {
 function cli(cmd) {
   let pid;
 
-  cmd = `exec node lib/bin/s3 ${cmd}`; // eslint-disable-line no-param-reassign
+  cmd = `exec node --no-deprecation lib/bin/s3 ${cmd}`; // eslint-disable-line no-param-reassign
   log.debug('cli()', 'calling:', cmd);
   const env = { ..._.pick(process.env, 'PATH'), NODE_CONFIG_ENV:'s3-dev' };
 

--- a/test/e2e/s3/test.js
+++ b/test/e2e/s3/test.js
@@ -404,7 +404,7 @@ function cli(cmd) {
 
   cmd = `exec node lib/bin/s3 ${cmd}`; // eslint-disable-line no-param-reassign
   log.debug('cli()', 'calling:', cmd);
-  const env = { ..._.pick(process.env, 'PATH'), NODE_CONFIG_ENV:'s3-dev', NODE_OPTIONS:'$NODE_OPTIONS --no-deprecation' };
+  const env = { ..._.pick(process.env, 'PATH'), NODE_CONFIG_ENV:'s3-dev' };
 
   const promise = new Promise((resolve, reject) => {
     const child = exec(cmd, { env, cwd:'../../..' }, (err, stdout) => {
@@ -436,7 +436,7 @@ async function expectRejectionFrom(promise, expectedMessage) {
     await promise;
     should.fail('Uploading should have exited with non-zero status.');
   } catch(err) {
-    if(err.message.startsWith('Command failed: exec node lib/bin/s3 ')) {
+    if(err.message.contains('Command failed: exec node lib/bin/s3 ')) {
       // expected
       if(expectedMessage) err.message.should.match(expectedMessage);
     } else {


### PR DESCRIPTION
OIDC and S3 end to end tests are failing on `master`. I don't really understand what happened because #1337 showed a green build. Now it's only showing the `build` task but prior runs showed failures from the e2e tests. 

The OIDC tests definitely passed at https://github.com/lognaturel/central-backend/actions/runs/12246914088/job/34163758377 but it did look like the S3 tests had failed at https://github.com/lognaturel/central-backend/actions/runs/12246914096/job/34163758183 I'm not sure why that didn't make the build red that time.

I believe the OIDC tests either have been flaky or are now flaky with Node 22. Here's another run that passes: https://github.com/lognaturel/central-backend/actions/runs/12248587480/job/34168459559

The problem with the S3 tests is that there are some regex that expect an exact output message and the deprecation warnings mess that up ([test run](https://github.com/lognaturel/central-backend/actions/runs/12248901099/job/34169319375)). The call that results in the issue is
https://github.com/getodk/central-backend/blob/4355d9e4c3a0f7bb6b694aad4cf318145905da2e/test/e2e/s3/test.js#L405

I though I could change that to `exec node --node-deprecation lib/bin/s3` but that didn't work. I got desperate and tried some things that make no sense. I'm pretty confident the functionality is working ok. Maybe we just change the regex?

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced