### PR TITLE
test/e2e/s3: attach stdout & stderr to exec() errors

### DIFF
--- a/test/e2e/s3/test.js
+++ b/test/e2e/s3/test.js
@@ -407,8 +407,12 @@ function cli(cmd) {
   const env = { ..._.pick(process.env, 'PATH'), NODE_CONFIG_ENV:'s3-dev' };
 
   const promise = new Promise((resolve, reject) => {
-    const child = exec(cmd, { env, cwd:'../../..' }, (err, stdout) => {
-      if (err) return reject(err);
+    const child = exec(cmd, { env, cwd:'../../..' }, (err, stdout, stderr) => {
+      if (err) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        return reject(err);
+      }
 
       const res = stdout.toString().trim();
       log.debug('cli()', 'returned:', res);

--- a/test/e2e/s3/test.js
+++ b/test/e2e/s3/test.js
@@ -405,8 +405,8 @@ function cli(cmd) {
   const promise = new Promise((resolve, reject) => {
     const child = exec(cmd, { env, cwd:'../../..' }, (err, stdout, stderr) => {
       if (err) {
-        err.stdout = stdout;
-        err.stderr = stderr;
+        err.stdout = stdout; // eslint-disable-line no-param-reassign
+        err.stderr = stderr; // eslint-disable-line no-param-reassign
         return reject(err);
       }
 


### PR DESCRIPTION
It may not be immediately obvious that stdout and stderr are actually available when a call to `child_process.exec()` fails.  Attaching them here should bring attention to this, and aid future debugging.

This change assisted in debugging #1339
