### PR TITLE
test/e2e/s3: relax regex for failed connection

### DIFF
--- a/test/e2e/s3/test.js
+++ b/test/e2e/s3/test.js
@@ -247,11 +247,7 @@ describe('s3 support', () => {
     // then
     // N.B. These errors are as observed, and demonstrate that the root error is shared
     // with the user.  They are not something to try to retain if implementation changes.
-    await expectRejectionFrom(uploading, new RegExp(
-      'Command failed: exec node lib/bin/s3 upload-pending\n' +
-          '(AggregateError.*)?Error: (connect ECONNREFUSED|read ECONNRESET|socket hang up|write EPIPE)',
-      's',
-    ));
+    await expectRejectionFrom(uploading, /(AggregateError.*)?Error: (connect ECONNREFUSED|read ECONNRESET|socket hang up|write EPIPE)/);
     // and
     await assertNewStatuses({ uploaded: 1, failed: 1 });
   });


### PR DESCRIPTION
Node 22 introduced deprecation warnings which changed the stderr output of `lib/bin/s3.js`, breaking a test assertion.

Related #1340 
Closes #1339 
