### PR TITLE
Remove no-deprecation flags from node invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,19 +101,19 @@ debug: base
 
 .PHONY: test
 test: lint
-	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive
+	BCRYPT=insecure npx mocha --recursive
 
 .PHONY: test-ci
 test-ci: lint
-	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive --reporter test/ci-mocha-reporter.js
+	BCRYPT=insecure npx mocha --recursive --reporter test/ci-mocha-reporter.js
 
 .PHONY: test-fast
 test-fast: node_version
-	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive --fgrep @slow --invert
+	BCRYPT=insecure npx mocha --recursive --fgrep @slow --invert
 
 .PHONY: test-integration
 test-integration: node_version
-	BCRYPT=insecure npx --node-options="--no-deprecation" mocha --recursive test/integration
+	BCRYPT=insecure npx mocha --recursive test/integration
 
 .PHONY: test-unit
 test-unit: node_version
@@ -121,7 +121,7 @@ test-unit: node_version
 
 .PHONY: test-coverage
 test-coverage: node_version
-	npx --node-options="--no-deprecation" nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --recursive test
+	npx nyc -x "**/migrations/**" --reporter=lcov node_modules/.bin/_mocha --recursive test
 
 .PHONY: lint
 lint: node_version

--- a/test/e2e/oidc/run-tests.sh
+++ b/test/e2e/oidc/run-tests.sh
@@ -49,6 +49,6 @@ if [[ ${INSTALL_PLAYWRIGHT_DEPS-} = true ]]; then
   npx playwright install --with-deps
 fi
 log "Running playwright tests..."
-npx --node-options="--no-deprecation" playwright test
+npx playwright test
 
 log "Tests completed OK!"

--- a/test/e2e/s3/run-tests.sh
+++ b/test/e2e/s3/run-tests.sh
@@ -61,7 +61,7 @@ timeout 30 bash -c "while ! curl -s -o /dev/null $serverUrl; do sleep 1; done"
 log 'Backend started!'
 
 cd test/e2e/s3
-npx --node-options="--no-deprecation" mocha test.js
+npx mocha test.js
 
 if ! curl -s -o /dev/null "$serverUrl"; then
   log '!!! Backend died.'

--- a/test/integration/task/task.js
+++ b/test/integration/task/task.js
@@ -36,7 +36,7 @@ describe('task: runner', () => {
   it('should print failure details to stderr and exit nonzero', () => runScript(failure)
     .then(([ error, , stderr ]) => {
       error.code.should.equal(1);
-      stderr.should.match(/^Problem \[Error\]: The resource returned no data./);
+      stderr.should.match(/Problem \[Error\]: The resource returned no data./);
     }));
 });
 


### PR DESCRIPTION
These were initially removed in #1337 due to noise from upgrading to node 22.  However, seeing deprecation warnings in dev & testing is probably helpful.

This change requires a test checking stderr contents to relax its assertion slightly.

Related: #1339