### PR TITLE
Change analytics queries to run sequentially

### DIFF
--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -10,6 +10,7 @@
 const config = require('config');
 const { sql } = require('slonik');
 const { clone } = require('ramda');
+const { runSequentially } = require('../../util/promise');
 const { metricsTemplate } = require('../../data/analytics');
 const oidc = require('../../util/oidc');
 
@@ -557,24 +558,24 @@ JOIN submission_defs as sd
 const getProjectsWithDescriptions = () => ({ all }) => all(sql`
 select id as "projectId", length(trim(description)) as description_length from projects where coalesce(trim(description),'')!=''`);
 
-const projectMetrics = () => (({ Analytics }) => Promise.all([
-  Analytics.countUsersPerRole(),
-  Analytics.countAppUsers(),
-  Analytics.countDeviceIds(),
-  Analytics.countPublicLinks(),
-  Analytics.countForms(),
-  Analytics.countFormFieldTypes(),
-  Analytics.countFormsEncrypted(),
-  Analytics.countFormsInStates(),
-  Analytics.countReusedFormIds(),
-  Analytics.countSubmissions(),
-  Analytics.countSubmissionReviewStates(),
-  Analytics.countSubmissionsEdited(),
-  Analytics.countSubmissionsComments(),
-  Analytics.countSubmissionsByUserType(),
-  Analytics.getProjectsWithDescriptions(),
-  Analytics.getDatasets(),
-  Analytics.getDatasetEvents()
+const projectMetrics = () => (({ Analytics }) => runSequentially([
+  Analytics.countUsersPerRole,
+  Analytics.countAppUsers,
+  Analytics.countDeviceIds,
+  Analytics.countPublicLinks,
+  Analytics.countForms,
+  Analytics.countFormFieldTypes,
+  Analytics.countFormsEncrypted,
+  Analytics.countFormsInStates,
+  Analytics.countReusedFormIds,
+  Analytics.countSubmissions,
+  Analytics.countSubmissionReviewStates,
+  Analytics.countSubmissionsEdited,
+  Analytics.countSubmissionsComments,
+  Analytics.countSubmissionsByUserType,
+  Analytics.getProjectsWithDescriptions,
+  Analytics.getDatasets,
+  Analytics.getDatasetEvents
 ]).then(([ userRoles, appUsers, deviceIds, pubLinks,
   forms, formGeoRepeats, formsEncrypt, formStates, reusedIds,
   subs, subStates, subEdited, subComments, subUsers,
@@ -725,24 +726,24 @@ const projectMetrics = () => (({ Analytics }) => Promise.all([
   return projArray;
 }));
 
-const previewMetrics = () => (({ Analytics }) => Promise.all([
-  Analytics.databaseSize(),
-  Analytics.encryptedProjects(),
-  Analytics.biggestForm(),
-  Analytics.countAdmins(),
-  Analytics.auditLogs(),
-  Analytics.archivedProjects(),
-  Analytics.countUniqueManagers(),
-  Analytics.countUniqueViewers(),
-  Analytics.countUniqueDataCollectors(),
-  Analytics.countClientAuditAttachments(),
-  Analytics.countClientAuditProcessingFailed(),
-  Analytics.countClientAuditRows(),
-  Analytics.countOfflineBranches(),
-  Analytics.countInterruptedBranches(),
-  Analytics.countSubmissionReprocess(),
-  Analytics.measureEntityProcessingTime(),
-  Analytics.projectMetrics()
+const previewMetrics = () => (({ Analytics }) => runSequentially([
+  Analytics.databaseSize,
+  Analytics.encryptedProjects,
+  Analytics.biggestForm,
+  Analytics.countAdmins,
+  Analytics.auditLogs,
+  Analytics.archivedProjects,
+  Analytics.countUniqueManagers,
+  Analytics.countUniqueViewers,
+  Analytics.countUniqueDataCollectors,
+  Analytics.countClientAuditAttachments,
+  Analytics.countClientAuditProcessingFailed,
+  Analytics.countClientAuditRows,
+  Analytics.countOfflineBranches,
+  Analytics.countInterruptedBranches,
+  Analytics.countSubmissionReprocess,
+  Analytics.measureEntityProcessingTime,
+  Analytics.projectMetrics
 ]).then(([db, encrypt, bigForm, admins, audits,
   archived, managers, viewers, collectors,
   caAttachments, caFailures, caRows,

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -2143,9 +2143,6 @@ describe('analytics task queries', function () {
     }));
 
     it('should fill in all project.datasets queries', testService(async (service, container) => {
-      const { defaultMaxListeners } = require('events').EventEmitter;
-      require('events').EventEmitter.defaultMaxListeners = 30;
-
       const asAlice = await service.login('alice');
 
       // Create first Dataset
@@ -2308,9 +2305,6 @@ describe('analytics task queries', function () {
 
       // Assert that a Project without a Dataset returns an empty array
       res.projects[1].datasets.should.be.eql([]);
-
-      // revert to original default
-      require('events').defaultMaxListeners = defaultMaxListeners;
     }));
   });
 


### PR DESCRIPTION
Closes https://github.com/getodk/central-backend/issues/1228

Makes use of `runSequentially` instead of Promise.all() to do multiple database queries for computing usage metrics.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced