### PR TITLE
Changes to API docs for 2024.3 release

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -42,10 +42,14 @@ info:
 
     ## ODK Central v2024.3
 
+    **Added**:
+    - Endpoints for managing [User Preferences](/central-api-accounts-and-users/#user-preferences), mainly to be used by Frontend.
+
     **Changed**:
 
     - [Submissions Odata]() now returns `__system/deletedAt`. It can also be used in $filter, $sort and $select query parameters.
     - Dataset (Entity List) properties with the same name but different capitalization are not allowed.
+    - Form Attachments for both [published Forms](/central-api-form-management/#listing-form-attachments) and [draft Forms](/central-api-form-management/#listing-expected-draft-form-attachments) now return a property representing the hash of the attachment file.
 
     ## ODK Central v2024.2
 
@@ -847,6 +851,7 @@ tags:
     * `form.update.draft.set` when a Draft Form definition is set.
     * `form.update.draft.delete` when a Draft Form definition is deleted.
     * `form.update.publish` when a Draft Form is published to the Form.
+    * `form.update.draft.replace` when a Draft Form is changed in place.
     * `form.attachment.update` when a Form Attachment binary is set or cleared.
     * `form.submissions.export` when a Form's Submissions are exported to CSV.
     * `form.delete` when a Form is deleted.
@@ -872,6 +877,7 @@ tags:
     * `submission.backlog.hold` when an Entity Submission is first held in processing backlog.
     * `submission.backlog.reprocess` when an Entity Submission is reprocessed and removed from the backlog.
     * `submission.backlog.force` when an Entity Submission is force-processed after being in backlog.
+    * `upgrade.process.form.entities_version` when a Form about Entities is automatically upgraded by Central.
     * `dataset.create` when a Dataset is created.
     * `dataset.update` when a Dataset is updated.
     * `dataset.update.publish` when a Dataset is published.
@@ -1553,13 +1559,6 @@ paths:
           schema:
             type: string
           example: "frobwazzleEnabled"
-        - name: Authorization
-          in: header
-          description: Bearer encoding of a token of the user whose preferences to operate on
-          required: true
-          schema:
-            type: string
-          example: Bearer lSpAIeksRu1CNZs7!qjAot2T17dPzkrw9B4iTtpj7OoIJBmXvnHM8z8Ka4QPEjR7
       responses:
         200:
           description: The preference was stored
@@ -1592,13 +1591,6 @@ paths:
           schema:
             type: string
           example: "frobwazzleEnabled"
-        - name: Authorization
-          in: header
-          description: Bearer encoding of a token of the user whose preferences to operate on
-          required: true
-          schema:
-            type: string
-          example: Bearer lSpAIeksRu1CNZs7!qjAot2T17dPzkrw9B4iTtpj7OoIJBmXvnHM8z8Ka4QPEjR7
       requestBody:
         content:
           'application/json':
@@ -1639,13 +1631,6 @@ paths:
           schema:
             type: string
           example: "frobwazzleEnabled"
-        - name: Authorization
-          in: header
-          description: Bearer encoding of a token of the user whose preferences to operate on
-          required: true
-          schema:
-            type: string
-          example: Bearer lSpAIeksRu1CNZs7!qjAot2T17dPzkrw9B4iTtpj7OoIJBmXvnHM8z8Ka4QPEjR7
       responses:
         200:
           description: The preference was deleted
@@ -3852,7 +3837,9 @@ paths:
       summary: Listing Form Attachments
       description: This endpoint allows you to fetch the list of expected attachment
         files, and will tell you whether the server is in possession of each file
-        or not. To modify an attachment, you'll need to create a Draft.
+        or not, and a hash of the file contents. To modify an attachment, you'll need to
+        create a Draft. The property `datasetExists` indicates whether  the attachment is
+        a link to a Dataset instead of an actual file.
       operationId: Listing Form Attachments
       parameters:
       - name: projectId
@@ -3883,7 +3870,8 @@ paths:
                 type: image
                 exists: true
                 blobExists: true
-                datasetExists: true
+                datasetExists: false
+                hash: 'B8347436F16EC9358CA6649169D8DA58'
                 updatedAt: 2018-03-21T12:45:02.312Z
         403:
           description: Forbidden
@@ -4411,7 +4399,8 @@ paths:
                 type: image
                 exists: true
                 blobExists: true
-                datasetExists: true
+                datasetExists: false
+                hash: 'B8347436F16EC9358CA6649169D8DA58'
                 updatedAt: 2018-03-21T12:45:02.312Z
         403:
           description: Forbidden
@@ -5112,7 +5101,8 @@ paths:
                 type: image
                 exists: true
                 blobExists: true
-                datasetExists: true
+                datasetExists: false
+                hash: 'B8347436F16EC9358CA6649169D8DA58'
                 updatedAt: 2018-03-21T12:45:02.312Z
         403:
           description: Forbidden

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -43,7 +43,7 @@ info:
     ## ODK Central v2024.3
 
     **Added**:
-    - Endpoints for managing [User Preferences](/central-api-accounts-and-users/#user-preferences), mainly to be used by Frontend.
+    - Endpoints for managing [User Preferences](/central-api-accounts-and-users/#user-preferences), mainly to be used by the frontend.
 
     **Changed**:
 
@@ -877,7 +877,7 @@ tags:
     * `submission.backlog.hold` when an Entity Submission is first held in processing backlog.
     * `submission.backlog.reprocess` when an Entity Submission is reprocessed and removed from the backlog.
     * `submission.backlog.force` when an Entity Submission is force-processed after being in backlog.
-    * `upgrade.process.form.entities_version` when a Form about Entities is automatically upgraded by Central.
+    * `upgrade.process.form.entities_version` when Central flags an Entity-related Form for a potential automatic upgrade.
     * `dataset.create` when a Dataset is created.
     * `dataset.update` when a Dataset is updated.
     * `dataset.update.publish` when a Dataset is published.
@@ -3871,7 +3871,7 @@ paths:
                 exists: true
                 blobExists: true
                 datasetExists: false
-                hash: 'B8347436F16EC9358CA6649169D8DA58'
+                hash: 'd41d8cd98f00b204e9800998ecf8427e'
                 updatedAt: 2018-03-21T12:45:02.312Z
         403:
           description: Forbidden
@@ -4400,7 +4400,7 @@ paths:
                 exists: true
                 blobExists: true
                 datasetExists: false
-                hash: 'B8347436F16EC9358CA6649169D8DA58'
+                hash: 'd41d8cd98f00b204e9800998ecf8427e'
                 updatedAt: 2018-03-21T12:45:02.312Z
         403:
           description: Forbidden
@@ -5102,7 +5102,7 @@ paths:
                 exists: true
                 blobExists: true
                 datasetExists: false
-                hash: 'B8347436F16EC9358CA6649169D8DA58'
+                hash: 'd41d8cd98f00b204e9800998ecf8427e'
                 updatedAt: 2018-03-21T12:45:02.312Z
         403:
           description: Forbidden


### PR DESCRIPTION
Closes https://github.com/getodk/central-backend/issues/1211

This PR
- adds 2 missing form actions (`form.update.draft.replace` and `upgrade.process.form.entities_version`) 
    - the other place in this release that we added new actions (for the submission backlog) already have these actions mentioned in the API docs.
- adds the user preferences endpoint to the changelog and removes some extra auth headers in the examples for those endpoints
- adds the file attachment hash to the form attachment endpoint with a little bit of explainer text and changing the example responses to be more consistent

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced