### PR TITLE
submissions/attachments: demonstrate current null Content-Type handling

### DIFF
--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -4377,6 +4377,50 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                   body.toString().should.equal('testvideo');
                 })))))));
 
+    // Ref https://github.com/getodk/central-backend/issues/1351
+    it('should attach a given file with empty Content-Type', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+            .send(testData.instances.binaryType.both)
+            .set('Content-Type', 'text/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+              .send('testvideo')
+              .set('Content-Type', '') // N.B. must be called _after_ send()
+              .expect(200)
+              .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+                .expect(200)
+                .then(({ headers, text }) => {
+                  headers['content-type'].should.equal('null');
+                  text.toString().should.equal('testvideo'); // use 'text' instead of 'body' to avoid supertest response parsing
+                })))))));
+
+    // Ref https://github.com/getodk/central-backend/issues/1351
+    it('should attach a given file with missing Content-Type', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+            .send(testData.instances.binaryType.both)
+            .set('Content-Type', 'text/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+              .send('testvideo')
+              .unset('Content-Type') // N.B. must be called _after_ send()
+              .expect(200)
+              .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+                .expect(200)
+                .then(({ headers, text }) => {
+                  headers['content-type'].should.equal('null');
+                  text.toString().should.equal('testvideo'); // use 'text' instead of 'body' to avoid supertest response parsing
+                })))))));
+
     it('should log an audit entry about initial attachment', testService((service, { Audits, Forms, Submissions, SubmissionAttachments }) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms?publish=true')


### PR DESCRIPTION
This probably isn't the desired behaviour, but it *is* the _current_ behaviour.