### PR TITLE
ci: e2e/oidc: fix artifact upload path

### DIFF
--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -40,4 +40,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Playwright Screenshots
-        path: test/e2e/oidc/playwright-results/**/*.png
+        path: test/e2e/oidc/playwright-tests/results/**/*.png


### PR DESCRIPTION
It looks like this was broken by refactoring in 12635f025493229dc96b3d089153ce38751dc67a

This change was useful for diagnosing https://github.com/getodk/central-backend/pull/1359