### PR TITLE
test/e2e/oidc: fix webkit race condition

### DIFF
--- a/test/e2e/oidc/playwright-tests/src/utils.js
+++ b/test/e2e/oidc/playwright-tests/src/utils.js
@@ -76,9 +76,7 @@ async function fillLoginForm(page, { username, password }) {
 
   await page.locator('input[name=login]').fill('playwright-' + username);
   await page.locator('input[name=password]').fill(password);
-
   await page.locator('button[type=submit]').click();
-
   await page.getByRole('button', { name: 'Continue' }).click();
 }
 

--- a/test/e2e/oidc/playwright-tests/src/utils.js
+++ b/test/e2e/oidc/playwright-tests/src/utils.js
@@ -69,9 +69,16 @@ function assertTitle(page, expectedTitle) {
 }
 
 async function fillLoginForm(page, { username, password }) {
+  // Wait for autofocus.  On webkit, it looks like `autofocus` on the username
+  // (`login`) field can sometimes steal focus after the `password` field
+  // locator has been successfully executed.
+  await sleep(1);
+
   await page.locator('input[name=login]').fill('playwright-' + username);
   await page.locator('input[name=password]').fill(password);
+
   await page.locator('button[type=submit]').click();
+
   await page.getByRole('button', { name: 'Continue' }).click();
 }
 
@@ -79,5 +86,11 @@ function initTest({ browserName, page }, testInfo) {
   page.on('console', msg => {
     const level = msg.type().toUpperCase();
     console.log(level, `[${browserName}:${testInfo.title}]`, msg.text());
+  });
+}
+
+async function sleep(seconds) {
+  return new Promise(resolve => {
+    setTimeout(resolve, seconds * 1000);
   });
 }


### PR DESCRIPTION
This seems to solve intermittent (but currently frequent) test failures in webkit.

The cause seems to be the `autofocus` HTML attribute, which was causing the password to be entered into the username form field.

Examples:

* https://github.com/getodk/central-backend/actions/runs/12740996290/job/35506986333
* https://github.com/getodk/central-backend/actions/runs/12750152065/job/35534243596?pr=1358

Seems to be happening a lot at the moment:

![Screenshot_2025-01-13_19-17-46](https://github.com/user-attachments/assets/8603e74f-db0a-4bef-b095-0b2934ad9418)

https://github.com/getodk/central-backend/actions/workflows/oidc-e2e.yml?query=

Screenshot of a failure looks like:

![test-failed-1](https://github.com/user-attachments/assets/9b716d34-9f74-4f51-8bb4-7d82f1a4e1bb)

Maybe related:

* https://github.com/microsoft/playwright/issues/26349
* https://github.com/microsoft/playwright/issues/22631