### PR TITLE
eslint: catch .only() calls in db-migration tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,7 @@
     "no-else-return": "off",
     "no-multiple-empty-lines": "off",
     "no-nested-ternary": "off",
-    "no-only-tests/no-only-tests": "error",
+    "no-only-tests/no-only-tests": [ "error", { "block": [ "describe", "it", "describeMigration" ] } ],
     "no-restricted-syntax": "off",
     "no-underscore-dangle": "off",
     "nonblock-statement-body-position": "off",


### PR DESCRIPTION
Because db-migration tests use a wrapper for mocha describe() calls, extra configuration is required to catch .only() calls.

See: https://www.npmjs.com/package/eslint-plugin-no-only-tests#user-content-options

Issue discovered while working on https://github.com/getodk/central-backend/pull/1355

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested locally while working on https://github.com/getodk/central-backend/pull/1355.

#### Why is this the best possible solution? Were any other approaches considered?

It is consistent with current detection & rejection of `.only()` calls in other tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Only affects test code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced