### PR TITLE
knex: rename connection object

### DIFF
--- a/lib/model/knexfile.js
+++ b/lib/model/knexfile.js
@@ -28,10 +28,10 @@ NODE_CONFIG_DIR=../../config DEBUG=knex:query,knex:bindings npx knex migrate:up 
 */
 
 const config = require('config');
-const { connectionObject } = require('../util/db');
+const { knexConnection } = require('../util/db');
 
 module.exports = {
   client: 'pg',
-  connection: connectionObject(config.get('default.database'))
+  connection: knexConnection(config.get('default.database'))
 };
 

--- a/lib/model/migrate.js
+++ b/lib/model/migrate.js
@@ -11,10 +11,10 @@
 // top-level operations with a database, like migrations.
 
 const knex = require('knex');
-const { connectionObject } = require('../util/db');
+const { knexConnection } = require('../util/db');
 
 // Connects to the postgres database specified in configuration and returns it.
-const connect = (config) => knex({ client: 'pg', connection: connectionObject(config) });
+const connect = (config) => knex({ client: 'pg', connection: knexConnection(config) });
 
 // Connects to a database, passes it to a function for operations, then ensures its closure.
 const withDatabase = (config) => (mutator) => {

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -48,7 +48,7 @@ const connectionString = (config) => {
 };
 
 // Returns an object that Knex will use to connect to the database.
-const connectionObject = (config) => {
+const knexConnection = (config) => {
   const problem = validateConfig(config);
   if (problem != null) throw problem;
   // We ignore maximumPoolSize when using Knex.
@@ -588,7 +588,7 @@ const postgresErrorToProblem = (x) => {
 };
 
 module.exports = {
-  connectionString, connectionObject,
+  connectionString, knexConnection,
   unjoiner, extender, sqlEquals, page, queryFuncs,
   insert, insertMany, updater, markDeleted, markUndeleted,
   QueryOptions,

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -97,11 +97,11 @@ describe('util/db', () => {
     });
   });
 
-  describe('connectionObject', () => {
-    const { connectionObject } = util;
+  describe('knexConnection', () => {
+    const { knexConnection } = util;
 
     it('should return an object with the required options', () => {
-      const result = connectionObject({
+      const result = knexConnection({
         host: 'localhost',
         database: 'foo',
         user: 'bar',
@@ -116,7 +116,7 @@ describe('util/db', () => {
     });
 
     it('should include the port if one is specified', () => {
-      const result = connectionObject({
+      const result = knexConnection({
         host: 'localhost',
         database: 'foo',
         user: 'bar',
@@ -133,7 +133,7 @@ describe('util/db', () => {
     });
 
     it('should return the correct object if ssl is true', () => {
-      const result = connectionObject({
+      const result = knexConnection({
         host: 'localhost',
         database: 'foo',
         user: 'bar',
@@ -150,7 +150,7 @@ describe('util/db', () => {
     });
 
     it('should throw if ssl is false', () => {
-      const result = () => connectionObject({
+      const result = () => knexConnection({
         host: 'localhost',
         database: 'foo',
         user: 'bar',
@@ -161,7 +161,7 @@ describe('util/db', () => {
     });
 
     it('should throw if ssl is an object', () => {
-      const result = () => connectionObject({
+      const result = () => knexConnection({
         host: 'localhost',
         database: 'foo',
         user: 'bar',
@@ -172,7 +172,7 @@ describe('util/db', () => {
     });
 
     it('should allow (but ignore) maximumPoolSize', () => {
-      const result = connectionObject({
+      const result = knexConnection({
         host: 'localhost',
         database: 'foo',
         user: 'bar',
@@ -188,7 +188,7 @@ describe('util/db', () => {
     });
 
     it('should throw for an unsupported option', () => {
-      const result = () => connectionObject({
+      const result = () => knexConnection({
         host: 'localhost',
         database: 'foo',
         user: 'bar',


### PR DESCRIPTION
Renames the knex config object passed as `connection` to `knex()` from generic "connectionObject" to more specific "knexConnection".

This renaming will:

* make intention/use of `connectionObject` clearer
* ease finding of knex-related code across the repo
* aid deprecating and finally removing knex dependency

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI

#### Why is this the best possible solution? Were any other approaches considered?

Not really?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not impact users - it's just a variable/export rename.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced