### PR TITLE
test: move createConflict() from fixtures to util

### DIFF
--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -8,7 +8,7 @@ const { getOrNotFound } = require('../../../lib/util/promise');
 const should = require('should');
 const { sql } = require('slonik');
 const { QueryOptions } = require('../../../lib/util/db');
-const { createConflict } = require('../fixtures/scenarios');
+const { createConflict } = require('../../util/scenarios');
 const { omit } = require('ramda');
 
 const { exhaust } = require(appRoot + '/lib/worker/worker');

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -5,7 +5,7 @@ const { testService } = require('../setup');
 const testData = require('../../data/xml');
 const { QueryOptions } = require('../../../lib/util/db');
 const { Actor } = require('../../../lib/model/frames');
-const { createConflict } = require('../fixtures/scenarios');
+const { createConflict } = require('../../util/scenarios');
 // eslint-disable-next-line import/no-dynamic-require
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 

--- a/test/util/scenarios.js
+++ b/test/util/scenarios.js
@@ -1,6 +1,6 @@
 const appRoot = require('app-root-path');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
-const testData = require('../../data/xml');
+const testData = require(appRoot + '/test/data/xml');
 
 const createConflict = async (user, container) => {
   await user.post('/v1/projects/1/forms/simpleEntity/submissions')


### PR DESCRIPTION
The files in test/integration/fixtures are repeatedly `require()`d and run in the `initialize()` function of `test/integration/setup.js`.  The `scenarios.js` does not need this treatment.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI

#### Why is this the best possible solution? Were any other approaches considered?

A location in `test/integration/` might be more appropriate.  However, there are already various integration-test-specific files in `test/util`, so the proposed move is following existing conventions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced