### PR TITLE
Endpoint for retrieving a form by enketo ID

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -671,6 +671,10 @@ const getByProjectId = (auth, projectId, xml, version, options = QueryOptions.no
   _get(all, options.withCondition({ projectId }), xml, version, deleted, auth.actor.map((actor) => actor.id).orElse(-1));
 const getByProjectAndXmlFormId = (projectId, xmlFormId, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ projectId, xmlFormId }), xml, version, deleted);
+const getByEnketoId = (enketoId, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) => {
+  const enketoIdFilter = [{ 'form_defs.enketoId': enketoId }, { 'forms.enketoId': enketoId }]; // hack: the array makes lib/util/db.sqlEquals turn this into a disjunction (OR)
+  return _get(maybeOne, options.withCondition(enketoIdFilter), xml, version, deleted);
+};
 const getByProjectAndNumericId = (projectId, id, xml, version, options = QueryOptions.none, deleted = false) => ({ maybeOne }) =>
   _get(maybeOne, options.withCondition({ projectId, 'forms.id': id }), xml, version, deleted);
 const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
@@ -843,7 +847,7 @@ module.exports = {
   setManagedKey,
   getByAuthForOpenRosa,
   getVersions, getByActeeIdForUpdate, getByActeeId,
-  getByProjectId, getByProjectAndXmlFormId, getByProjectAndNumericId,
+  getByProjectId, getByProjectAndXmlFormId, getByEnketoId, getByProjectAndNumericId,
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
   rejectIfWarnings, checkMeta, checkDeletedForms, checkStructuralChange, checkFieldDowncast, checkDatasetWarnings,

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -319,7 +319,9 @@ module.exports = (service, endpoint) => {
   formResource('/projects/:projectId/forms/:id', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, null, options)
       .then(getOrNotFound));
-
+  formResource('/forms/:enketoId', (Forms, params, withXml = true, options = QueryOptions.none) =>
+    Forms.getByEnketoId(params.enketoId, withXml, null, options)
+      .then(getOrNotFound));
   formResource('/projects/:projectId/forms/:id/versions/:version', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, params.version, options)
       .then(getOrNotFound)

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -214,6 +214,17 @@ const markUndeleted = (obj) =>
 // query fragment util
 
 const sqlEquals = (obj) => {
+
+  let connective = sql` AND `;
+
+  if (Object.entries(obj).every(([k, v]) => !Number.isNaN(parseInt(k, 10) && typeof v === 'object'))) {
+    // hack: passing an array to options.withCondition (eg `[{ id: 10 }, { name: 'foo' }]`)
+    // will create a disjunction (OR) rather than a conjunction (AND) of these conditions.
+    connective = sql` OR `;
+    // eslint-disable-next-line no-param-reassign
+    obj = Object.assign({}, ...Object.values(obj));
+  }
+
   const keys = Object.keys(obj);
   if (keys.length === 0) return sql`true`;
 
@@ -224,7 +235,7 @@ const sqlEquals = (obj) => {
     parts[i] = (v === null) ? sql`${sql.identifier(k.split('.'))} is null`
       : sql`${sql.identifier(k.split('.'))}=${obj[k]}`;
   }
-  return sql.join(parts, sql` and `);
+  return sql.join(parts, connective);
 };
 
 const page = (options) => {


### PR DESCRIPTION
Towards getodk/web-forms#23

Related: getodk/central-frontend#1125

For the Webforms integration, or rather the current approach to it, we need to be able to retrieve a form by its `enketoId`. Straightforward, were it not that the ID can be either in the `forms` table's `enketoId` column, or (in case of a draft) in the `form_defs` table's `enketoId` column (a specific ID will be in at most 1 of these tables, IIUC).

So this contains an unacceptable hack to do an SQL OR via `options.withCondition()`. [Slack thread on the subject](https://getodk.slack.com/archives/C01TKJ7TG7J/p1737124297753169). After discussing with @lognaturel it seems best to leave it to those with some experience in Central's half-an-ORM to sanitize this code ;-)