### PR TITLE
query/sessions: return 401 for invalid Bearer token

### DIFF
--- a/lib/model/query/sessions.js
+++ b/lib/model/query/sessions.js
@@ -32,7 +32,7 @@ const getByBearerToken = (token) => ({ maybeOne }) => (isValidToken(token) ? may
 select ${_unjoiner.fields} from sessions
 join actors on actors.id=sessions."actorId"
 where token=${token} and sessions."expiresAt" > now()`)
-  .then(map(_unjoiner)) : Option.none());
+  .then(map(_unjoiner)) : Promise.resolve(Option.none()));
 
 const terminateByActorId = (actorId, current = undefined) => ({ run }) =>
   run(sql`DELETE FROM sessions WHERE "actorId"=${actorId}

--- a/test/integration/other/bearer-auth.js
+++ b/test/integration/other/bearer-auth.js
@@ -1,6 +1,11 @@
 const { testService } = require('../setup');
 
 describe('bearer authentication', () => {
+  it('should reject 401 if supplied token does not match the expected format', testService((service) => // gh329
+    service.get('/v1/users/current')
+      .set('Authorization', 'Bearer a')
+      .expect(401)));
+
   it('should reject 401 if the header format is wrong', testService((service) => // gh329
     service.get('/v1/users/current')
       .set('Authorization', 'Bearer: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')


### PR DESCRIPTION
Currently passing a `Authorization: Bearer ...` header with a token that fails the `isValidToken()` check will return a 500 response.

To recreate:

```
$ curl https://dev.getodk.cloud/v1/projects/1 --header 'Authorization: Bearer hi'
{"message":"Internal Server Error"}
```
vs
```
$ curl https://dev.getodk.cloud/v1/projects/1 --header 'Authorization: Bearer aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd'
{"message":"Could not authenticate with the provided credentials.","code":401.2}
```

From Sentry (https://getodk.sentry.io/issues/6194482982/?environment=production&project=5724763&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=2), when the supplied token is invalid, `authHandler` can throw.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added a test which fails against `master`, but passes on this branch.

#### Why is this the best possible solution? Were any other approaches considered?

Seems simple.  No other approaches considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not affect users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No?

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced