### PR TITLE
oidc/callback: handle missing state param

### DIFF
--- a/lib/resources/oidc.js
+++ b/lib/resources/oidc.js
@@ -96,7 +96,9 @@ const loaderTemplate = `
 parse(loaderTemplate); // caches template for future perf.
 
 const stateFor = next => [ generators.state(), Buffer.from(next).toString('base64url') ].join(':');
-const nextFrom = state => Buffer.from(state.split(':')[1], 'base64url').toString();
+const nextFrom = state => {
+  if (state) return Buffer.from(state.split(':')[1], 'base64url').toString();
+};
 
 module.exports = (service, endpoint) => {
   if (!isEnabled()) return;

--- a/test/integration/api/oidc.js
+++ b/test/integration/api/oidc.js
@@ -1,0 +1,38 @@
+const { testService } = require('../setup');
+
+describe('api: /oidc/...', () => {
+  if (process.env.TEST_AUTH === 'oidc') {
+    describe('GET /oidc/login', () => {
+      it('should redirect to error page if no parameters are provided', testService(service =>
+        service.get('/v1/oidc/login')
+          .expect(307)
+          .then(({ text, headers }) => {
+            const expectedUrlPrefix = 'http://localhost:9898/auth?client_id=odk-central-backend-dev&scope=openid%20email&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8989%2Fv1%2Foidc%2Fcallback&resource=http%3A%2F%2Flocalhost%3A8989%2Fv1&code_challenge=';
+            text.should.startWith('Temporary Redirect. Redirecting to ' + expectedUrlPrefix);
+            headers.location.should.startWith(expectedUrlPrefix);
+          })));
+    });
+
+    describe('GET /oidc/callback', () => {
+      it('should redirect to error page if no parameters are provided', testService(service =>
+        service.get('/v1/oidc/callback')
+          .expect(303)
+          .then(({ text, headers }) => {
+            text.should.eql('See Other. Redirecting to http://localhost:8989/#/login?oidcError=internal-server-error');
+            headers.location.should.eql('http://localhost:8989/#/login?oidcError=internal-server-error');
+          })));
+    });
+  } else { // OIDC not enabled
+    describe('GET /oidc/login', () => {
+      it('should not exist', testService(service =>
+        service.get('/v1/oidc/login')
+          .expect(404)));
+    });
+
+    describe('GET /oidc/callback', () => {
+      it('should not exist', testService(service =>
+        service.get('/v1/oidc/callback')
+          .expect(404)));
+    });
+  }
+});

--- a/test/integration/api/oidc.js
+++ b/test/integration/api/oidc.js
@@ -3,7 +3,7 @@ const { testService } = require('../setup');
 describe('api: /oidc/...', () => {
   if (process.env.TEST_AUTH === 'oidc') {
     describe('GET /oidc/login', () => {
-      it('should redirect to error page if no parameters are provided', testService(service =>
+      it('should redirect to IdP if no parameters are provided', testService(service =>
         service.get('/v1/oidc/login')
           .expect(307)
           .then(({ text, headers }) => {

--- a/test/integration/api/oidc.js
+++ b/test/integration/api/oidc.js
@@ -2,17 +2,6 @@ const { testService } = require('../setup');
 
 describe('api: /oidc/...', () => {
   if (process.env.TEST_AUTH === 'oidc') {
-    describe('GET /oidc/login', () => {
-      it('should redirect to IdP if no parameters are provided', testService(service =>
-        service.get('/v1/oidc/login')
-          .expect(307)
-          .then(({ text, headers }) => {
-            const expectedUrlPrefix = 'http://localhost:9898/auth?client_id=odk-central-backend-dev&scope=openid%20email&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8989%2Fv1%2Foidc%2Fcallback&resource=http%3A%2F%2Flocalhost%3A8989%2Fv1&code_challenge=';
-            text.should.startWith('Temporary Redirect. Redirecting to ' + expectedUrlPrefix);
-            headers.location.should.startWith(expectedUrlPrefix);
-          })));
-    });
-
     describe('GET /oidc/callback', () => {
       it('should redirect to error page if no parameters are provided', testService(service =>
         service.get('/v1/oidc/callback')
@@ -23,12 +12,6 @@ describe('api: /oidc/...', () => {
           })));
     });
   } else { // OIDC not enabled
-    describe('GET /oidc/login', () => {
-      it('should not exist', testService(service =>
-        service.get('/v1/oidc/login')
-          .expect(404)));
-    });
-
     describe('GET /oidc/callback', () => {
       it('should not exist', testService(service =>
         service.get('/v1/oidc/callback')


### PR DESCRIPTION
Without this check, a request without a state parameter will generate an internal server error and receive a 500-status response.

This change sends the client through the proper error-handling route.

Closes #1391

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added a test!

#### Why is this the best possible solution? Were any other approaches considered?

This could also be an e2e test, but an integration test should run and fail faster, giving faster feedback.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change should only affect users in unhappy paths.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

I don't think so.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced