### PR TITLE
test/oidc: add missing describe() blocks

### DIFF
--- a/test/integration/api/oidc.js
+++ b/test/integration/api/oidc.js
@@ -35,7 +35,9 @@ describe('api: /oidc/...', () => {
             url.searchParams.get('code_challenge').should.match(/^[a-zA-Z0-9-_]{43}$/);
             url.searchParams.get('state'         ).should.match(/^[a-zA-Z0-9-_]{43}:$/); // eslint-disable-line space-in-parens,no-multi-spaces
           })));
+    });
 
+    describe('GET /oidc/callback', () => {
       it('should redirect to error page if no parameters are provided', testService(service =>
         service.get('/v1/oidc/callback')
           .expect(303)
@@ -49,7 +51,9 @@ describe('api: /oidc/...', () => {
       it('should not exist', testService(service =>
         service.get('/v1/oidc/login')
           .expect(404)));
+    });
 
+    describe('GET /oidc/callback', () => {
       it('should not exist', testService(service =>
         service.get('/v1/oidc/callback')
           .expect(404)));


### PR DESCRIPTION
These were incorrectly excluded while merging #1392 & #1399 into master.

