### PR TITLE
submissionXmlToFieldStream: extend test cases for malformed XML

### DIFF
--- a/test/unit/data/submission.js
+++ b/test/unit/data/submission.js
@@ -42,19 +42,31 @@ describe('submission field streamer', () => {
       })));
   });
 
-  it('should not hang given malformed non-closing xml', (done) => {
-    fieldsFor(testData.forms.simple).then((fields) => {
-      const stream = submissionXmlToFieldStream(fields, '<data><meta><instanceID>');
-      stream.on('data', () => {});
-      stream.on('end', done); // not hanging/timing out is the assertion here
-    });
-  });
-
-  it('should not crash given malformed over-closing xml', (done) => {
-    fieldsFor(testData.forms.simple).then((fields) => {
-      const stream = submissionXmlToFieldStream(fields, '<data></goodbye></goodbye></goodbye>');
-      stream.on('data', () => {});
-      stream.on('end', done); // not hanging/timing out is the assertion here
+  [
+    '<data>', // no closing tags
+    '<data><meta><instanceID>', // no closing tags
+    '<data></goodbye></goodbye></goodbye>', // over-closing
+    // trailing content:
+    '<doc/><boom>',
+    '<doc/></boom>',
+    '<doc/> boom',
+    '<doc></doc><boom>',
+    '<doc></doc></boom>',
+    '<doc></doc> boom',
+    // leading content:
+    '<boom><doc/>',
+    '</boom><doc/>',
+    'boom <doc/>',
+    '<boom><doc></doc>',
+    '</boom><doc></doc>',
+    'boom <doc></doc>',
+  ].forEach(xml => {
+    it(`should not hang given malformed xml: ${xml}`, (done) => {
+      fieldsFor(testData.forms.simple).then((fields) => {
+        const stream = submissionXmlToFieldStream(fields, xml);
+        stream.on('data', () => {});
+        stream.on('end', done); // not hanging/timing out is the assertion here
+      });
     });
   });
 


### PR DESCRIPTION
Working on https://github.com/getodk/central-backend/pull/1256, a number of cases were noted where expected XML parsing behaviour was undefined.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

These are just new test cases.

#### Why is this the best possible solution? Were any other approaches considered?

Perhaps errors should be thrown for malformed XML.  That's a larger question, and shouldn't block documentation of existing behaviour.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced