### PR TITLE
api/sessions: document bcrypt implementation curiosity

### DIFF
--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -20,7 +20,8 @@ describe('api: /sessions', () => {
     // and reject them before passing the values to bcrypt.
     describe('weird bcrypt implementation details', () => {
       [
-        [ 'repeated once', 'chelsea\0chelsea' ],
+        [ 'repeated once',             'chelsea\0chelsea' ],          // eslint-disable-line no-multi-spaces
+        [ 'repeated twice',            'chelsea\0chelsea\0chelsea' ], // eslint-disable-line no-multi-spaces
         [ 'repeated until truncation', 'chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0' ],
       ].forEach(([ description, password ]) => {
         it(`should treat a password ${description} as the singular version of the same`, testService((service) =>

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -14,6 +14,18 @@ describe('api: /sessions', () => {
           body.should.be.a.Session();
         })));
 
+    // This demonstrates a strange feature of bcrypt - a valid password can be
+    // repeated multiple times and still validate successfully.  An alternative
+    // to this test would be to check for NUL characters in supplied passwords
+    // and reject them before passing the values to bcrypt.
+    it.only('should leak bcrypt implementation details', testService((service) =>
+      service.post('/v1/sessions')
+        .send({ email: 'chelsea@getodk.org', password: 'chelsea\0chelsea' })
+        .expect(200)
+        .then(({ body }) => {
+          body.should.be.a.Session();
+        })));
+
     it('should treat email addresses case insensitively', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'cHeLsEa@getodk.OrG', password: 'chelsea' })

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -18,7 +18,7 @@ describe('api: /sessions', () => {
     // repeated multiple times and still validate successfully.  An alternative
     // to this test would be to check for NUL characters in supplied passwords
     // and reject them before passing the values to bcrypt.
-    it.only('should leak bcrypt implementation details', testService((service) =>
+    it('should leak bcrypt implementation details', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'chelsea@getodk.org', password: 'chelsea\0chelsea' })
         .expect(200)


### PR DESCRIPTION
This behaviour was noted by @sadiqkhoja, and seemed at least worth documenting if not fixing.

Closes #1409

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added a test.

#### Why is this the best possible solution? Were any other approaches considered?

An alternative to this test would be to check for NUL characters in supplied passwords and reject them before passing the values to bcrypt.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced