### PR TITLE
Standardise responses for invalid existing passwords

### DIFF
--- a/lib/util/crypto.js
+++ b/lib/util/crypto.js
@@ -35,7 +35,7 @@ const BCRYPT_COST_FACTOR = process.env.BCRYPT === 'insecure' ? 1 : 12;
 // These functions call into bcrypt to hash or verify passwords.
 const hashPassword = (plain) =>
   (isBlank(plain) ? resolve(null) : bcrypt.hash(plain, BCRYPT_COST_FACTOR));
-const verifyPassword = (plain, hash) => ((isBlank(plain) || (isBlank(hash)))
+const verifyPassword = (plain, hash) => ((typeof plain !== 'string' || isBlank(plain) || isBlank(hash))
   ? resolve(false)
   : bcrypt.compare(plain, hash));
 

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -68,12 +68,12 @@ describe('api: /sessions', () => {
           }))));
 
     [
-      [ 'undefined',    undefined, '' ],
-      [ 'null',         null,      '' ],
-      [ 'empty string', '',        '' ],
-      [ 'number',       123,       '' ],
-      [ 'array',        [],        '' ],
-      [ 'object',       {},        '' ],
+      [ 'undefined',    undefined, '' ], // eslint-disable-line no-multi-spaces
+      [ 'null',         null,      '' ], // eslint-disable-line no-multi-spaces
+      [ 'empty string', '',        '' ], // eslint-disable-line no-multi-spaces
+      [ 'number',       123,       '' ], // eslint-disable-line no-multi-spaces
+      [ 'array',        [],        '' ], // eslint-disable-line no-multi-spaces
+      [ 'object',       {},        '' ], // eslint-disable-line no-multi-spaces
     ].forEach(([ description, password, expectedError ]) => {
       it.only(`should return a 400 for invalid password (${description})`, testService((service) =>
         service.post('/v1/sessions')

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -68,25 +68,20 @@ describe('api: /sessions', () => {
           }))));
 
     [
-      [ 'undefined',    undefined, '' ], // eslint-disable-line no-multi-spaces
-      [ 'null',         null,      '' ], // eslint-disable-line no-multi-spaces
-      [ 'empty string', '',        '' ], // eslint-disable-line no-multi-spaces
-      [ 'number',       123,       '' ], // eslint-disable-line no-multi-spaces
-      [ 'array',        [],        '' ], // eslint-disable-line no-multi-spaces
-      [ 'object',       {},        '' ], // eslint-disable-line no-multi-spaces
-    ].forEach(([ description, password, expectedError ]) => {
-      it.only(`should return a 400 for invalid password (${description})`, testService((service) =>
+      [ 'undefined',      undefined, 400, 'Required parameters missing. Expected (email, password), got (email: \'chelsea@getodk.org\', password: undefined).' ], // eslint-disable-line no-multi-spaces
+      [ 'null',           null,      400, 'Required parameters missing. Expected (email, password), got (email: \'chelsea@getodk.org\', password: null).' ], // eslint-disable-line no-multi-spaces
+      [ 'empty string',   '',        400, 'Required parameters missing. Expected (email, password), got (email: \'chelsea@getodk.org\', password: \'\').' ], // eslint-disable-line no-multi-spaces
+      [ 'wrong password', 'letmein', 401, 'Could not authenticate with the provided credentials.' ], // eslint-disable-line no-multi-spaces
+      [ 'number',         123,       401, 'Could not authenticate with the provided credentials.' ], // eslint-disable-line no-multi-spaces
+      [ 'array',          [],        401, 'Could not authenticate with the provided credentials.' ], // eslint-disable-line no-multi-spaces
+      [ 'object',         {},        401, 'Could not authenticate with the provided credentials.' ], // eslint-disable-line no-multi-spaces
+    ].forEach(([ description, password, expectedStatus, expectedError ]) => {
+      it(`should return a ${expectedStatus} for invalid password (${description})`, testService((service) =>
         service.post('/v1/sessions')
           .send({ email: 'chelsea@getodk.org', password })
-          .expect(400)
+          .expect(expectedStatus)
           .then(({ body }) => body.message.should.equal(expectedError))));
     });
-
-    it.only('should return a 401 if the password is wrong', testService((service) =>
-      service.post('/v1/sessions')
-        .send({ email: 'chelsea@getodk.org', password: 'letmein' })
-        .expect(401)
-        .then(({ body }) => body.message.should.equal('Could not authenticate with the provided credentials.'))));
 
     it('should return a 401 if the email is wrong', testService((service) =>
       service.post('/v1/sessions')

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -67,7 +67,22 @@ describe('api: /sessions', () => {
             body[0].details.userAgent.should.equal('central/tests');
           }))));
 
-    it('should return a 401 if the password is wrong', testService((service) =>
+    [
+      [ 'undefined',    undefined, '' ],
+      [ 'null',         null,      '' ],
+      [ 'empty string', '',        '' ],
+      [ 'number',       123,       '' ],
+      [ 'array',        [],        '' ],
+      [ 'object',       {},        '' ],
+    ].forEach(([ description, password, expectedError ]) => {
+      it.only(`should return a 400 for invalid password (${description})`, testService((service) =>
+        service.post('/v1/sessions')
+          .send({ email: 'chelsea@getodk.org', password })
+          .expect(400)
+          .then(({ body }) => body.message.should.equal(expectedError))));
+    });
+
+    it.only('should return a 401 if the password is wrong', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'chelsea@getodk.org', password: 'letmein' })
         .expect(401)


### PR DESCRIPTION
Closes #1406

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added more test cases.

#### Why is this the best possible solution? Were any other approaches considered?

Fixing this at the API layer instead of inside `util/crypto.js` introduces the risk that it may be fixed in one place, but still broken in another.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not affect legitimate use.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

It should not.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced