### PR TITLE
Standardise responses for invalid new passwords

### DIFF
--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -34,11 +34,7 @@ const update = (user, data) => ({ run, one }) => {
 update.audit = (user, data) => (log) => log('user.update', user.actor, { data: data.with(data.actor) });
 
 const updatePassword = (user, cleartext) => ({ run }) =>
-  (cleartext.length < 10
-    ? reject(Problem.user.passwordTooShort())
-    : Buffer.from(cleartext).length > 72
-      ? reject(Problem.user.passwordTooLong())
-      : hashPassword(cleartext))
+  hashPassword(cleartext)
     .then((hash) => run(sql`update users set password=${hash} where "actorId"=${user.actor.id}`));
 updatePassword.audit = (user) => (log) => log('user.update', user.actor, { data: { password: true } });
 

--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -12,8 +12,6 @@ const { map } = require('ramda');
 const { Actor, User } = require('../frames');
 const { hashPassword } = require('../../util/crypto');
 const { unjoiner, page, sqlEquals, QueryOptions } = require('../../util/db');
-const { reject } = require('../../util/promise');
-const Problem = require('../../util/problem');
 
 const create = (user) => ({ Actors }) => Actors.createSubtype(user);
 create.audit = (user) => (log) => log('user.create', user.actor, { data: user });

--- a/lib/util/crypto.js
+++ b/lib/util/crypto.js
@@ -19,7 +19,7 @@ const { PartialPipe } = require('./stream');
 const { unpadPkcs1OaepMgf1Sha256 } = require('./quarantine/oaep');
 const { unpadPkcs7 } = require('./quarantine/pkcs7');
 const { promisify } = require('util');
-const { resolve } = require('./promise');
+const { resolve, reject } = require('./promise');
 const Problem = require('./problem');
 const { isBlank } = require('./util');
 
@@ -33,8 +33,12 @@ const { isBlank } = require('./util');
 const BCRYPT_COST_FACTOR = process.env.BCRYPT === 'insecure' ? 1 : 12;
 
 // These functions call into bcrypt to hash or verify passwords.
-const hashPassword = (plain) =>
-  (isBlank(plain) ? resolve(null) : bcrypt.hash(plain, BCRYPT_COST_FACTOR));
+const hashPassword = (plain) => {
+  if (typeof plain !== 'string') return reject(Problem.user.invalidDataTypeOfParameter({ value: plain, expected: 'string' }));
+  if (plain.length < 10) return reject(Problem.user.passwordTooShort());
+  if (plain.length > 72) return reject(Problem.user.passwordTooLong());
+  return isBlank(plain) ? resolve(null) : bcrypt.hash(plain, BCRYPT_COST_FACTOR);
+};
 const verifyPassword = (plain, hash) => ((isBlank(plain) || (isBlank(hash)))
   ? resolve(false)
   : bcrypt.compare(plain, hash));

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -8,7 +8,7 @@ describe('api: /sessions', () => {
 
     it('should return a new session if the information is valid', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
+        .send({ email: 'chelsea@getodk.org', password: 'password4chelsea' })
         .expect(200)
         .then(({ body }) => {
           body.should.be.a.Session();
@@ -16,7 +16,7 @@ describe('api: /sessions', () => {
 
     it('should treat email addresses case insensitively', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'cHeLsEa@getodk.OrG', password: 'chelsea' })
+        .send({ email: 'cHeLsEa@getodk.OrG', password: 'password4chelsea' })
         .expect(200)
         .then(({ body }) => {
           body.should.be.a.Session();
@@ -24,7 +24,7 @@ describe('api: /sessions', () => {
 
     it('should provide a csrf token when the session returns', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
+        .send({ email: 'chelsea@getodk.org', password: 'password4chelsea' })
         .expect(200)
         .then(({ body }) => {
           body.csrf.should.be.a.token();
@@ -32,7 +32,7 @@ describe('api: /sessions', () => {
 
     it('should set cookie information when the session returns', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
+        .send({ email: 'chelsea@getodk.org', password: 'password4chelsea' })
         .expect(200)
         .then(({ body, headers }) => {
           // i don't know how this becomes an array but i think superagent does it.
@@ -51,7 +51,7 @@ describe('api: /sessions', () => {
 
     it('should log the action in the audit log', testService((service) =>
       service.post('/v1/sessions')
-        .send({ email: 'alice@getodk.org', password: 'alice' })
+        .send({ email: 'alice@getodk.org', password: 'password4alice' })
         .set('User-Agent', 'central/tests')
         .expect(200)
         .then(({ body }) => body.token)

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -20,9 +20,9 @@ describe('api: /sessions', () => {
     // and reject them before passing the values to bcrypt.
     describe('weird bcrypt implementation details', () => {
       [
-        [ 'repeated once',             'chelsea\0chelsea' ],          // eslint-disable-line no-multi-spaces
-        [ 'repeated twice',            'chelsea\0chelsea\0chelsea' ], // eslint-disable-line no-multi-spaces
-        [ 'repeated until truncation', 'chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0chelsea\0' ],
+        [ 'repeated once',             'password4chelsea\0password4chelsea' ],                   // eslint-disable-line no-multi-spaces
+        [ 'repeated twice',            'password4chelsea\0password4chelsea\0password4chelsea' ], // eslint-disable-line no-multi-spaces
+        [ 'repeated until truncation', 'password4chelsea\0password4chelsea\0password4chelsea\0password4chelsea\0password4' ],
       ].forEach(([ description, password ]) => {
         it(`should treat a password ${description} as the singular version of the same`, testService((service) =>
           service.post('/v1/sessions')

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -140,7 +140,7 @@ describe('api: /users', () => {
           [ 'array',     [] ], // eslint-disable-line no-multi-spaces
           [ 'number',    123 ], // eslint-disable-line no-multi-spaces
         ].forEach(([ description, password ]) => {
-          it.only(`should not accept a ${description} password`, testService((service) =>
+          it.only(`should not accept ${description} password`, testService((service) =>
             service.login('alice', (asAlice) =>
               asAlice.post('/v1/users')
                 .send({ email: 'david@getodk.org', password })
@@ -358,7 +358,7 @@ describe('api: /users', () => {
                 email.subject.should.equal('ODK Central account password reset');
 
                 return service.post('/v1/sessions')
-                  .send({ email: 'bob@getodk.org', password: 'bob' })
+                  .send({ email: 'bob@getodk.org', password: 'password4bob' })
                   .expect(401);
               }))));
 
@@ -544,7 +544,7 @@ describe('api: /users', () => {
               } else {
                 after.body.email.should.equal('newbob@odk.org');
                 return service.post('/v1/sessions')
-                  .send({ email: 'newbob@odk.org', password: 'bob' })
+                  .send({ email: 'newbob@odk.org', password: 'password4bob' })
                   .expect(200);
               }
             })))));
@@ -828,7 +828,7 @@ describe('api: /users', () => {
                   }
                 } else {
                   return service.post('/v1/sessions')
-                    .send({ email: 'chelsea@getodk.org', password: 'chelsea' })
+                    .send({ email: 'chelsea@getodk.org', password: 'password4chelsea' })
                     .expect(401);
                 }
               }))))));

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -78,7 +78,7 @@ describe('api: /users', () => {
           }))));
   });
 
-  describe.only('POST', () => {
+  describe('POST', () => {
     it('should prohibit non-admins from creating users', testService((service) =>
       service.login('bob', (asBob) =>
         asBob.post('/v1/users')
@@ -140,7 +140,7 @@ describe('api: /users', () => {
           [ 'array',     [] ], // eslint-disable-line no-multi-spaces
           [ 'number',    123 ], // eslint-disable-line no-multi-spaces
         ].forEach(([ description, password ]) => {
-          it.only(`should not accept ${description} password`, testService((service) =>
+          it(`should not accept ${description} password`, testService((service) =>
             service.login('alice', (asAlice) =>
               asAlice.post('/v1/users')
                 .send({ email: 'david@getodk.org', password })
@@ -631,7 +631,7 @@ describe('api: /users', () => {
             asAlice.get('/v1/users/current')
               .expect(200)
               .then(({ body }) => asAlice.put(`/v1/users/${body.id}/password`)
-                .send({ old: 'alice', new: 'newpassword' })
+                .send({ old: 'password4alice', new: 'newpassword' })
                 .expect(404)))));
       });
     } else {
@@ -642,13 +642,13 @@ describe('api: /users', () => {
               .expect(200)
               .then(({ body }) => service.login('chelsea', (asChelsea) =>
                 asChelsea.put(`/v1/users/${body.id}/password`)
-                  .send({ old: 'alice', new: 'chelsea' })
+                  .send({ old: 'password4alice', new: 'chelsea' })
                   .expect(403))))));
 
         it('should reject if the user does not exist', testService((service) =>
           service.login('alice', (asAlice) =>
             asAlice.put('/v1/users/9999/password')
-              .send({ old: 'alice', new: 'chelsea' })
+              .send({ old: 'password4alice', new: 'password4chelsea' })
               .expect(404))));
 
         it('should reject if the old password is not correct', testService((service) =>
@@ -664,7 +664,7 @@ describe('api: /users', () => {
             asAlice.get('/v1/users/current')
               .expect(200)
               .then(({ body }) => asAlice.put(`/v1/users/${body.id}/password`)
-                .send({ old: 'alice', new: 'newpassword' })
+                .send({ old: 'password4alice', new: 'newpassword' })
                 .expect(200))
               .then(({ body }) => {
                 body.success.should.equal(true);
@@ -678,14 +678,14 @@ describe('api: /users', () => {
             asAlice.get('/v1/users/current')
               .expect(200)
               .then(({ body }) => asAlice.put(`/v1/users/${body.id}/password`)
-                .send({ old: 'alice', new: '123456789' })
+                .send({ old: 'password4alice', new: '123456789' })
                 .expect(400))))); // 400.21
 
         it('should allow nonadministrator users to set their own password', testService((service) =>
           service.login('chelsea', (asChelsea) =>
             asChelsea.get('/v1/users/current').expect(200).then(({ body }) => body.id)
               .then((chelseaId) => asChelsea.put(`/v1/users/${chelseaId}/password`)
-                .send({ old: 'chelsea', new: 'newchelsea' })
+                .send({ old: 'password4chelsea', new: 'newchelsea' })
                 .expect(200)
                 .then(() => service.post('/v1/sessions')
                   .send({ email: 'chelsea@getodk.org', password: 'newchelsea' })
@@ -698,7 +698,7 @@ describe('api: /users', () => {
             .expect(200);
           await anotherAlice.get('/v1/users/current').expect(200);
           await asAlice.put(`/v1/users/${id}/password`)
-            .send({ old: 'alice', new: 'newpassword' })
+            .send({ old: 'password4alice', new: 'newpassword' })
             .expect(200);
           // The other session has been deleted.
           await anotherAlice.get('/v1/users/current').expect(401);
@@ -710,11 +710,11 @@ describe('api: /users', () => {
           const asAlice = await service.login('alice');
           const { body: { id } } = await asAlice.get('/v1/users/current')
             .expect(200);
-          const basic = Buffer.from('alice@getodk.org:alice').toString('base64');
+          const basic = Buffer.from('alice@getodk.org:password4alice').toString('base64');
           await service.put(`/v1/users/${id}/password`)
             .set('Authorization', `Basic ${basic}`)
             .set('X-Forwarded-Proto', 'https')
-            .send({ old: 'alice', new: 'newpassword' })
+            .send({ old: 'password4alice', new: 'newpassword' })
             .expect(200);
           await asAlice.get('/v1/users/current').expect(401);
         }));
@@ -724,7 +724,7 @@ describe('api: /users', () => {
             asAlice.get('/v1/users/current')
               .expect(200)
               .then(({ body }) => asAlice.put(`/v1/users/${body.id}/password`)
-                .send({ old: 'alice', new: 'newpassword' })
+                .send({ old: 'password4alice', new: 'newpassword' })
                 .expect(200)
                 .then(() => {
                   const email = global.inbox.pop();
@@ -738,7 +738,7 @@ describe('api: /users', () => {
             asAlice.get('/v1/users/current')
               .expect(200)
               .then(({ body }) => asAlice.put(`/v1/users/${body.id}/password`)
-                .send({ old: 'alice', new: 'newpassword' })
+                .send({ old: 'password4alice', new: 'newpassword' })
                 .expect(200)
                 .then(() => Promise.all([
                   Users.getByEmail('alice@getodk.org').then((o) => o.get()),

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -78,7 +78,7 @@ describe('api: /users', () => {
           }))));
   });
 
-  describe('POST', () => {
+  describe.only('POST', () => {
     it('should prohibit non-admins from creating users', testService((service) =>
       service.login('bob', (asBob) =>
         asBob.post('/v1/users')
@@ -133,11 +133,19 @@ describe('api: /users', () => {
                   .then(({ password }) => { should.not.exist(password); })
               ])))));
 
-        it('should not accept a password that is too short', testService((service) =>
-          service.login('alice', (asAlice) =>
-            asAlice.post('/v1/users')
-              .send({ email: 'david@getodk.org', password: 'short' })
-              .expect(400))));
+        [
+          [ 'too short', 'short' ],
+          [ 'too long',  'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong' ], // eslint-disable-line no-multi-spaces
+          [ 'object',    {} ], // eslint-disable-line no-multi-spaces
+          [ 'array',     [] ], // eslint-disable-line no-multi-spaces
+          [ 'number',    123 ], // eslint-disable-line no-multi-spaces
+        ].forEach(([ description, password ]) => {
+          it.only(`should not accept a ${description} password`, testService((service) =>
+            service.login('alice', (asAlice) =>
+              asAlice.post('/v1/users')
+                .send({ email: 'david@getodk.org', password })
+                .expect(400))));
+        });
 
         it('should send an email to provisioned users', testService((service) =>
           service.login('alice', (asAlice) =>

--- a/test/integration/fixtures/01-users.js
+++ b/test/integration/fixtures/01-users.js
@@ -7,9 +7,9 @@ module.exports = ({ Assignments, Users, Projects }) => {
   const proj = new Project({ name: 'Default Project' });
 
   const users = [
-    new User({ email: 'alice@getodk.org', password: 'alice' }, { actor: new Actor({ type: 'user', displayName: 'Alice' }) }),
-    new User({ email: 'bob@getodk.org', password: 'bob' }, { actor: new Actor({ type: 'user', displayName: 'Bob' }) }),
-    new User({ email: 'chelsea@getodk.org', password: 'chelsea' }, { actor: new Actor({ type: 'user', displayName: 'Chelsea' }) })
+    new User({ email: 'alice@getodk.org', password: 'password4alice' }, { actor: new Actor({ type: 'user', displayName: 'Alice' }) }),
+    new User({ email: 'bob@getodk.org', password: 'password4bob' }, { actor: new Actor({ type: 'user', displayName: 'Bob' }) }),
+    new User({ email: 'chelsea@getodk.org', password: 'password4chelsea' }, { actor: new Actor({ type: 'user', displayName: 'Chelsea' }) })
   ];
 
   // hash the passwords, create our three test users, then add grant Alice and Bob their rights.

--- a/test/integration/other/basic-auth.js
+++ b/test/integration/other/basic-auth.js
@@ -5,13 +5,13 @@ describe('basic authentication', () => {
     it('should not accept email and password', testService((service) =>
       service.get('/v1/users/current')
         .set('x-forwarded-proto', 'https')
-        .auth('alice@getodk.org', 'alice')
+        .auth('alice@getodk.org', 'password4alice')
         .expect(401)));
   } else {
     it('should accept email and password', testService((service) =>
       service.get('/v1/users/current')
         .set('x-forwarded-proto', 'https')
-        .auth('alice@getodk.org', 'alice')
+        .auth('alice@getodk.org', 'password4alice')
         .expect(200)));
   }
 });

--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -125,12 +125,12 @@ describe('preprocessors', () => {
         )).should.be.rejectedWith(Problem, { problemCode: 401.2 }));
 
       it('should set the appropriate session if valid Basic auth credentials are given @slow', () =>
-        hashPassword('alice').then((hashed) =>
+        hashPassword('password4alice').then((hashed) =>
           Promise.resolve(authHandler(
             { Auth, Users: mockUsers('alice@getodk.org', hashed) },
             new Context(
               createRequest({ headers: {
-                Authorization: `Basic ${Buffer.from('alice@getodk.org:alice', 'utf8').toString('base64')}`,
+                Authorization: `Basic ${Buffer.from('alice@getodk.org:password4alice', 'utf8').toString('base64')}`,
                 'X-Forwarded-Proto': 'https'
               } }),
               { fieldKey: Option.none() }

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -19,7 +19,8 @@ describe('util/crypto', () => {
       hashPassword('password', 'hashhash').should.be.a.Promise();
     });
 
-    it('should reject given a blank plaintext', () => hashPassword('').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
+    it('should reject given a blank plaintext', () =>
+      hashPassword('').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
 
     it('should not attempt to verify empty plaintext', (done) => {
       verifyPassword('', '$2a$12$hCRUXz/7Hx2iKPLCduvrWugC5Q/j5e3bX9KvaYvaIvg/uvFYEpzSy').then((result) => {

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -19,16 +19,7 @@ describe('util/crypto', () => {
       hashPassword('password', 'hashhash').should.be.a.Promise();
     });
 
-    it('should reject given a blank plaintext', async () => {
-        let thrown = false;
-        try { // i know about should.throws but i can't get it to assert the specific error type.
-          await hashPassword('');
-        } catch (ex) {
-          ex.message.should.equal('The password or passphrase provided does not meet the required length.');
-          thrown = true;
-        }
-        thrown.should.equal(true);
-    });
+    it('should reject given a blank plaintext', () => hashPassword('').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
 
     it('should not attempt to verify empty plaintext', (done) => {
       verifyPassword('', '$2a$12$hCRUXz/7Hx2iKPLCduvrWugC5Q/j5e3bX9KvaYvaIvg/uvFYEpzSy').then((result) => {

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -19,11 +19,15 @@ describe('util/crypto', () => {
       hashPassword('password', 'hashhash').should.be.a.Promise();
     });
 
-    it('should return a Promise of null given a blank plaintext', (done) => {
-      hashPassword('').then((result) => {
-        should(result).equal(null);
-        done();
-      });
+    it('should reject given a blank plaintext', async () => {
+        let thrown = false;
+        try { // i know about should.throws but i can't get it to assert the specific error type.
+          await hashPassword('');
+        } catch (ex) {
+          ex.message.should.equal('The password or passphrase provided does not meet the required length.');
+          thrown = true;
+        }
+        thrown.should.equal(true);
     });
 
     it('should not attempt to verify empty plaintext', (done) => {

--- a/test/util/authenticate-user.js
+++ b/test/util/authenticate-user.js
@@ -15,7 +15,7 @@ module.exports = async (service, user, includeCsrf) => {
     return body.token;
   } else {
     const credentials = (typeof user === 'string')
-      ? { email: `${user}@getodk.org`, password: user }
+      ? { email: `${user}@getodk.org`, password: `password4${user}` }
       : user;
     const { body } = await service.post('/v1/sessions')
       .send(credentials)


### PR DESCRIPTION
Closes #1407

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

New test cases, and existing test cases.

#### Why is this the best possible solution? Were any other approaches considered?

The fix is pushed deeper into the `util/crypto.js` code than where validation previously occurred.  This means that validation only needs to be performed in a single place, rather than every point of use.  This in turn means it should be harder to forget validation & edge cases in future use of `hashPassword()`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

More consistent errors when passwords are unexpected data types.  Users are unlikely to encounter the change in behaviour.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

It should not.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced