### PR TITLE
test/crypto: use assert.throw() instead of hand-rolling

### DIFF
--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -5,7 +5,7 @@ const should = require('should');
 const streamTest = require('streamtest').v2;
 const crypto = require(appRoot + '/lib/util/crypto');
 
-describe('util/crypto', () => {
+describe.only('util/crypto', () => {
   describe('hashPassword/verifyPassword', () => {
     const { hashPassword, verifyPassword } = crypto;
 
@@ -289,19 +289,15 @@ describe('util/crypto', () => {
           }));
       });
 
-      it('should throw a Problem if the padding is invalid', () => {
+      it.only('should throw a Problem if the padding is invalid', () => {
         const unpaddedCiphertext = Buffer.from('kMhJdk0mZOqvlxndUO3v4+UPvfYoc+bbkPmF3QmhoP7lP/QjHbzqw/IfZxQ54D328eCc4V6jtbrjeAXV+m1cWsCGGLW5KwTAxBjPBXzsZrUeY0RISVJ1g9BJoXfSRAjYMrFYOM907BFUIYYxMqpVWGy1lo8ljqY+Sgq1VphkQk/TQGgOVYFALHDLOYnLKuLHvwBLQQwK3lje8CwNlf/b2rY9qfGC4P1emoiP+YzkLp8eH6x/HfMvRIFoZEaom1i5s3SU4WVwe2Tno4jKD69ojMlQN6VKB7DK4xaRSs2C7zfDm63n1WCyyOAj8mASIFhb3sc3hD56HTJFUV/TH3UVlzP7oPm/Mm7nEcU3+HdSSwm3I1qFYhsXfVRym41IlbC4Twf660/kUZrugA7Zqd5K9Un3lOVTzYowaF+m5OIOO56wff3zPBxeOVjANA==', 'base64');
         const aesKey = getSubmissionKey(priv, encAesKey);
         const ivs = getSubmissionIvs(instanceId, aesKey);
 
-        let thrown = false;
-        try { // i know about should.throws but i can't get it to assert the specific error type.
-          getSubmissionCleartext(aesKey, ivs(1), unpaddedCiphertext);
-        } catch (ex) {
-          ex.message.should.equal('Could not perform decryption. Double check your passphrase and your data and try again.');
-          thrown = true;
-        }
-        thrown.should.equal(true);
+        should.throws(
+          () => getSubmissionCleartext(aesKey, ivs(1), unpaddedCiphertext),
+          /^Error: Could not perform decryption\. Double check your passphrase and your data and try again\.$/,
+        );
       });
     });
   });

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -5,7 +5,7 @@ const should = require('should');
 const streamTest = require('streamtest').v2;
 const crypto = require(appRoot + '/lib/util/crypto');
 
-describe.only('util/crypto', () => {
+describe('util/crypto', () => {
   describe('hashPassword/verifyPassword', () => {
     const { hashPassword, verifyPassword } = crypto;
 
@@ -289,7 +289,7 @@ describe.only('util/crypto', () => {
           }));
       });
 
-      it.only('should throw a Problem if the padding is invalid', () => {
+      it('should throw a Problem if the padding is invalid', () => {
         const unpaddedCiphertext = Buffer.from('kMhJdk0mZOqvlxndUO3v4+UPvfYoc+bbkPmF3QmhoP7lP/QjHbzqw/IfZxQ54D328eCc4V6jtbrjeAXV+m1cWsCGGLW5KwTAxBjPBXzsZrUeY0RISVJ1g9BJoXfSRAjYMrFYOM907BFUIYYxMqpVWGy1lo8ljqY+Sgq1VphkQk/TQGgOVYFALHDLOYnLKuLHvwBLQQwK3lje8CwNlf/b2rY9qfGC4P1emoiP+YzkLp8eH6x/HfMvRIFoZEaom1i5s3SU4WVwe2Tno4jKD69ojMlQN6VKB7DK4xaRSs2C7zfDm63n1WCyyOAj8mASIFhb3sc3hD56HTJFUV/TH3UVlzP7oPm/Mm7nEcU3+HdSSwm3I1qFYhsXfVRym41IlbC4Twf660/kUZrugA7Zqd5K9Un3lOVTzYowaF+m5OIOO56wff3zPBxeOVjANA==', 'base64');
         const aesKey = getSubmissionKey(priv, encAesKey);
         const ivs = getSubmissionIvs(instanceId, aesKey);

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const { KeyObject } = require('node:crypto');
 const appRoot = require('app-root-path');
 const { readFileSync } = require('fs');
@@ -294,9 +295,9 @@ describe('util/crypto', () => {
         const aesKey = getSubmissionKey(priv, encAesKey);
         const ivs = getSubmissionIvs(instanceId, aesKey);
 
-        should.throws(
+        assert.throws(
           () => getSubmissionCleartext(aesKey, ivs(1), unpaddedCiphertext),
-          /^Error: Could not perform decryption\. Double check your passphrase and your data and try again\.$/,
+          { message: 'Could not perform decryption. Double check your passphrase and your data and try again.' },
         );
       });
     });


### PR DESCRIPTION
While working on https://github.com/getodk/central-backend/pull/1411, I initially copy/pasted another test which contained the following comment:

```
// i know about should.throws but i can't get it to assert the specific error type.
```

This PR cleans up that comment and simplifies error checking in the related test.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Checked the test passes, and that it fails with different error messages.

#### Why is this the best possible solution? Were any other approaches considered?

Considered using `should.throws()` but it doesn't support a simple way to assert on the error message without using regex.  There's precedent for using `assert.throws()` instead:

```sh
git grep -F .throws -- test/unit | awk '
  /assert.throw/ { a += 1 }
  /should.throw/ { s += 1 }
  END {
    print "assert.throws(): " a;
    print "should.throws(): " s;
  }
'

assert.throws(): 36
should.throws(): 3
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced