### PR TITLE
test/integration: allow use of this.timeout() in all tests

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -149,12 +149,14 @@ const baseContainer = withDefaults({ db, mail, env, xlsform, enketo, Sentry, odk
 // called to get a service context per request. we do some work to hijack the
 // transaction system so that each test runs in a single transaction that then
 // gets rolled back for a clean slate on the next test.
-const testService = (test) => () => new Promise((resolve, reject) => {
-  baseContainer.transacting((container) => {
-    const rollback = (f) => (x) => container.run(sql`rollback`).then(() => f(x));
-    return test(augment(request(service(container))), container).then(rollback(resolve), rollback(reject));
-  });//.catch(Promise.resolve.bind(Promise)); // TODO/SL probably restore
-});
+const testService = (test) => function() {
+  return new Promise((resolve, reject) => {
+    baseContainer.transacting((container) => {
+      const rollback = (f) => (x) => container.run(sql`rollback`).then(() => f(x));
+      return test.call(this, augment(request(service(container))), container).then(rollback(resolve), rollback(reject));
+    });//.catch(Promise.resolve.bind(Promise)); // TODO/SL probably restore
+  });
+};
 
 // for some tests we explicitly need to make concurrent requests, in which case
 // the transaction butchering we do for testService will not work. for these cases,
@@ -166,12 +168,14 @@ const testServiceFullTrx = (test) => function() {
 
 // for some tests we just want a container, without any of the webservice stuffs between.
 // this is that, with the same transaction trickery as a normal test.
-const testContainer = (test) => () => new Promise((resolve, reject) => {
-  baseContainer.transacting((container) => {
-    const rollback = (f) => (x) => container.run(sql`rollback`).then(() => f(x));
-    return test(container).then(rollback(resolve), rollback(reject));
-  });//.catch(Promise.resolve.bind(Promise));
-});
+const testContainer = (test) => function () {
+  return new Promise((resolve, reject) => {
+    baseContainer.transacting((container) => {
+      const rollback = (f) => (x) => container.run(sql`rollback`).then(() => f(x));
+      return test.call(this, container).then(rollback(resolve), rollback(reject));
+    });//.catch(Promise.resolve.bind(Promise));
+  });
+};
 
 // complete the square of options:
 const testContainerFullTrx = (test) => function() {
@@ -182,16 +186,18 @@ const testContainerFullTrx = (test) => function() {
 // called to get a container context per task. ditto all // from testService.
 // here instead our weird hijack work involves injecting our own constructed
 // container into the task context so it just picks it up and uses it.
-const testTask = (test) => () => new Promise((resolve, reject) => {
-  baseContainer.transacting((container) => {
-    task._container = container.with({ task: true });
-    const rollback = (f) => (x) => {
-      delete task._container;
-      return container.run(sql`rollback`).then(() => f(x));
-    };
-    return test(task._container).then(rollback(resolve), rollback(reject));
-  });//.catch(Promise.resolve.bind(Promise));
-});
+const testTask = (test) => function() {
+  return new Promise((resolve, reject) => {
+    baseContainer.transacting((container) => {
+      task._container = container.with({ task: true });
+      const rollback = (f) => (x) => {
+        delete task._container;
+        return container.run(sql`rollback`).then(() => f(x));
+      };
+      return test.call(this, task._container).then(rollback(resolve), rollback(reject));
+    });//.catch(Promise.resolve.bind(Promise));
+  });
+};
 
 // See testServiceFullTrx()
 // eslint-disable-next-line space-before-function-paren, func-names


### PR DESCRIPTION
Follow-up to #1402
Noticed while investigating #1403

Due to use of `function()` in the test wrappers, `this` was unbound from the real test functions.  This PR re-binds mocha's `this` to the test functions, allowing use of e.g. `this.timeout(...)` in individual tests.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Checked all the tests still pass.

#### Why is this the best possible solution? Were any other approaches considered?

No.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - it's test code only.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced