### PR TITLE
stderr.write(): add newline suffix consistently

### DIFF
--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -109,8 +109,7 @@ const init = (config) => {
       },
       captureException(err) {
         process.stderr.write('attempted to log Sentry exception in development:\n');
-        process.stderr.write(inspect(err));
-        process.stderr.write('\n');
+        process.stderr.write(inspect(err) + '\n');
       },
       configureScope: noop
     };

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -246,7 +246,7 @@ const defaultErrorWriter = (error, request, response) => {
     writeProblemJson(response, error);
   } else {
     debugger; // trip debugger if attached.
-    process.stderr.write(inspect(error));
+    process.stderr.write(inspect(error) + '\n');
     response.status(500).type('application/json').send({
       message: 'Internal Server Error',
     });

--- a/lib/model/migrations/20180727-03-add-form-attachments-table.js
+++ b/lib/model/migrations/20180727-03-add-form-attachments-table.js
@@ -31,7 +31,7 @@ const up = (knex) =>
       Promise.all(forms.map((form) => expectedFormAttachments(form.xml)
         .then((expected) => {
           if (uniq(pluck('name', expected)).length < expected.length) {
-            process.stderr.write(`WARNING: a form ${form.xmlFormId} contains an attachment filename collision. It will not correctly support form attachments.`);
+            process.stderr.write(`WARNING: a form ${form.xmlFormId} contains an attachment filename collision. It will not correctly support form attachments.\n`);
             return Promise.resolve();
           }
           return knex.insert(Object.assign({ formId: form.id }, expected))

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -583,7 +583,7 @@ const postgresErrorToProblem = (x) => {
   }
 
   debugger; // automatically trip the debugger if it's attached.
-  process.stderr.write(inspect(error));
+  process.stderr.write(inspect(error) + '\n');
   return reject(error);
 };
 


### PR DESCRIPTION
Noted while investigating #1403.

Some logging is not followed by a newline character, so it is concatenated with the next output to `stderr`.

This commit adds newline characters to calls to `process.stderr.write()` where missing, and standardises their inclusion.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Run locally; tests in CI.

#### Why is this the best possible solution? Were any other approaches considered?

Introduced in f3e85630a3985fbcb03cd84cfbe1384a1f39017d, it's unclear why `process.stderr.write()` is used in preference to `console.error()`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change for users, unless they're parsing stderr for e.g. monitoring.  This change would probably make parsing more reliable.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

I don't think stderr output is currently documented.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced