### PR TITLE
UserPreferences: ensure "null" and NULL are handled distinctly

### DIFF
--- a/test/integration/api/user-preferences.js
+++ b/test/integration/api/user-preferences.js
@@ -23,6 +23,26 @@ describe('api: user-preferences', () => {
       });
   }));
 
+  it('can store the string "null", distinct from NULL value', testService(async (service) => {
+    const asAlice = await service.login('alice');
+
+    await asAlice.put('/v1/user-preferences/site/let-us-store-a-string-whose-content-is-null')
+      .send({ propertyValue: 'null' })
+      .expect(200);
+
+    await asAlice.get('/v1/users/current')
+      .set('X-Extended-Metadata', 'true')
+      .expect(200)
+      .then(({ body }) => {
+        body.preferences.should.eql({
+          site: {
+            'let-us-store-a-string-whose-content-is-null': 'null',
+          },
+          projects: {
+          },
+        });
+      });
+  }));
 
   it('can store a JS null propertyValue', testService(async (service) => {
     const asAlice = await service.login('alice');


### PR DESCRIPTION
Test added while trying to understand special `null` handling at https://github.com/getodk/central-backend/blob/bf49b89d1b22d2cc6989f2c4eba7a9c739d347e9/lib/model/query/user-preferences.js#L68-L73

Closes #1423

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added a new test.

#### Why is this the best possible solution? Were any other approaches considered?

Seems quite direct, but open to other options.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is just a new test - should not affect users except for preventing future regressions.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced