### PR TITLE
Standardise responses for invalid user email

### DIFF
--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -8,11 +8,12 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { map } = require('ramda');
+const { compose, is, map, not } = require('ramda');
 const { Actor, User } = require('../frames');
 const { hashPassword } = require('../../util/crypto');
 const { unjoiner, page, sqlEquals, QueryOptions } = require('../../util/db');
-const { rejectUnless } = require('../../util/promise');
+const Problem = require('../../util/problem');
+const { rejectIf, resolve } = require('../../util/promise');
 
 const create = (user) => ({ Actors }) => Actors.createSubtype(user);
 create.audit = (user) => (log) => log('user.create', user.actor, { data: user });
@@ -74,7 +75,7 @@ ${page(options)}`;
 const getAll = (options) => ({ all }) => all(_getSql(options)).then(map(_unjoin));
 
 const getByEmail = (email, options = QueryOptions.none) => ({ maybeOne }) =>
-  rejectUnless('string')({ email })
+  resolve(rejectIf(compose(not, is(String)), () => Problem.user.invalidDataTypeOfParameter({ field: 'email', expected: 'string' }))(email))
     .then(() => maybeOne(_getSql(options.withCondition({ email }))).then(map(_unjoin)));
 
 const getByActorId = (actorId, options = QueryOptions.none) => ({ maybeOne }) =>

--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -12,6 +12,7 @@ const { map } = require('ramda');
 const { Actor, User } = require('../frames');
 const { hashPassword } = require('../../util/crypto');
 const { unjoiner, page, sqlEquals, QueryOptions } = require('../../util/db');
+const { rejectUnless } = require('../../util/promise');
 
 const create = (user) => ({ Actors }) => Actors.createSubtype(user);
 create.audit = (user) => (log) => log('user.create', user.actor, { data: user });
@@ -73,7 +74,8 @@ ${page(options)}`;
 const getAll = (options) => ({ all }) => all(_getSql(options)).then(map(_unjoin));
 
 const getByEmail = (email, options = QueryOptions.none) => ({ maybeOne }) =>
-  maybeOne(_getSql(options.withCondition({ email }))).then(map(_unjoin));
+  rejectUnless('string')({ email })
+    .then(() => maybeOne(_getSql(options.withCondition({ email }))).then(map(_unjoin)));
 
 const getByActorId = (actorId, options = QueryOptions.none) => ({ maybeOne }) =>
   maybeOne(_getSql(options.withCondition({ actorId }))).then(map(_unjoin));

--- a/lib/util/promise.js
+++ b/lib/util/promise.js
@@ -62,6 +62,17 @@ const ignoringResult = (f) => (x) => f(x).then(() => x);
 // helpful for using pipeline()
 const rejectIfError = (rej) => (err) => { if (err != null) rej(err); };
 
+const rejectUnless = (expected) => (propObj) => {
+  const [ [ field, value ], ...tooManyKeys ] = Object.entries(propObj);
+
+  if (!field || tooManyKeys.length) throw new Error('propObj must have exactly one key');
+
+  // eslint-disable-next-line valid-typeof
+  if (typeof value !== expected) throw Problem.user.invalidDataTypeOfParameter({ field, expected });
+
+  return resolve();
+};
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // MISC
@@ -95,7 +106,7 @@ module.exports = {
   reject, resolve,
   timebound,
   getOrElse, getOrReject, getOrNotFound, rejectIf, ignoringResult,
-  rejectIfError,
+  rejectIfError, rejectUnless,
   block, runSequentially
 };
 

--- a/lib/util/promise.js
+++ b/lib/util/promise.js
@@ -62,17 +62,6 @@ const ignoringResult = (f) => (x) => f(x).then(() => x);
 // helpful for using pipeline()
 const rejectIfError = (rej) => (err) => { if (err != null) rej(err); };
 
-const rejectUnless = (expected) => (propObj) => {
-  const [ [ field, value ], ...tooManyKeys ] = Object.entries(propObj);
-
-  if (!field || tooManyKeys.length) throw new Error('propObj must have exactly one key');
-
-  // eslint-disable-next-line valid-typeof
-  if (typeof value !== expected) throw Problem.user.invalidDataTypeOfParameter({ field, expected });
-
-  return resolve();
-};
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // MISC
@@ -106,7 +95,7 @@ module.exports = {
   reject, resolve,
   timebound,
   getOrElse, getOrReject, getOrNotFound, rejectIf, ignoringResult,
-  rejectIfError, rejectUnless,
+  rejectIfError,
   block, runSequentially
 };
 

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -103,6 +103,22 @@ describe('api: /sessions', () => {
           .then(({ body }) => body.message.should.equal(expectedError))));
     });
 
+    [
+      [ 'undefined',      undefined, 400, 'Required parameters missing. Expected (email, password), got (email: undefined, password: \'n/a\').' ], // eslint-disable-line no-multi-spaces
+      [ 'null',           null,      400, 'Required parameters missing. Expected (email, password), got (email: null, password: \'n/a\').' ], // eslint-disable-line no-multi-spaces
+      [ 'empty string',   '',        400, 'Required parameters missing. Expected (email, password), got (email: \'\', password: \'n/a\').' ], // eslint-disable-line no-multi-spaces
+      [ 'invalid email',  'letmein', 401, 'Could not authenticate with the provided credentials.' ], // eslint-disable-line no-multi-spaces
+      [ 'number',         123,       400, 'Invalid input data type: expected (email) to be (string)' ], // eslint-disable-line no-multi-spaces
+      [ 'array',          [],        400, 'Invalid input data type: expected (email) to be (string)' ], // eslint-disable-line no-multi-spaces
+      [ 'object',         {},        400, 'Invalid input data type: expected (email) to be (string)' ], // eslint-disable-line no-multi-spaces
+    ].forEach(([ description, email, expectedStatus, expectedError ]) => {
+      it(`should return a ${expectedStatus} for invalid email (${description})`, testService((service) =>
+        service.post('/v1/sessions')
+          .send({ email, password: 'n/a' })
+          .expect(expectedStatus)
+          .then(({ body }) => body.message.should.equal(expectedError))));
+    });
+
     it('should return a 401 if the email is wrong', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'winnifred@getodk.org', password: 'winnifred' })


### PR DESCRIPTION
Closes #1430

#### What has been done to verify that this works as intended?

* existing tests
* new tests

#### Why is this the best possible solution? Were any other approaches considered?

Validation of the `email` type could be performed closer to the API.  In that case, validations should be added in more places.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should reduce number of 500 errors.  Users are unlikely to be relying on this status code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

500 errors should not be documented, so no documentation update is expected.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced