### PR TITLE
test/entities-purging: whitespace

### DIFF
--- a/test/integration/other/entities-purging.js
+++ b/test/integration/other/entities-purging.js
@@ -180,13 +180,13 @@ describe('query module entities purge', () => {
     const PROVIDE_ALL = 'Must specify projectId and datasetName to purge a specify entity.';
     const PROVIDE_PROJECT_ID = 'Must specify projectId to purge all entities of a dataset/entity-list.';
     const cases = [
-      { description: ' when entityUuid specified without projectId and datasetName',
+      { description: 'when entityUuid specified without projectId and datasetName',
         projectId: false, datasetName: false, entityUuid: true, expectedError: PROVIDE_ALL },
-      { description: ' when entityUuid specified without projectId',
+      { description: 'when entityUuid specified without projectId',
         projectId: false, datasetName: true, entityUuid: true, expectedError: PROVIDE_ALL },
-      { description: ' when entityUuid specified without datasetName',
+      { description: 'when entityUuid specified without datasetName',
         projectId: true, datasetName: false, entityUuid: true, expectedError: PROVIDE_ALL },
-      { description: ' when datasetName specified without projectId',
+      { description: 'when datasetName specified without projectId',
         projectId: false, datasetName: true, entityUuid: false, expectedError: PROVIDE_PROJECT_ID },
     ];
     cases.forEach(c =>


### PR DESCRIPTION
Noted while working on #1437.

Previous test descriptions were causing double spaces to be inserted in test names.

Before:

```
✔ should throw an error  when entityUuid specified without projectId and datasetName (273ms)
✔ should throw an error  when entityUuid specified without projectId (105ms)
✔ should throw an error  when entityUuid specified without datasetName (97ms)
✔ should throw an error  when datasetName specified without projectId (89ms
```

After:

```
✔ should throw an error when entityUuid specified without projectId and datasetName (273ms)
✔ should throw an error when entityUuid specified without projectId (105ms)
✔ should throw an error when entityUuid specified without datasetName (97ms)
✔ should throw an error when datasetName specified without projectId (89ms
```

#### What has been done to verify that this works as intended?

It's a change to test titles - the test report was checked.

#### Why is this the best possible solution? Were any other approaches considered?

No.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced