### PR TITLE
Fixes: exclude entity.restore and entity.purge from nonverbose audits endpoint

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -899,6 +899,8 @@ tags:
     * `entity.update.version` when an Entity is updated.
     * `entity.update.resolve` when an Entity conflict is resolved.
     * `entity.delete` when an Entity is deleted.
+    * `entity.restore` when a deleted Entity is restored.
+    * `entity.purge` when a deleted Entity is purged (ppermanently deleted).
     * `config.set` when a system configuration is set.
     * `analytics` when a Usage Report is attempted.
     * `blobs.s3.upload` when blobs are moved from the database to external storage.

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -38,7 +38,7 @@ const actionCondition = (action) => {
     // The backup action was logged by a backup script that has been removed.
     // Even though the script has been removed, the audit log entries it logged
     // have not, so we should continue to exclude those.
-    return sql`action not in ('entity.create', 'entity.bulk.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete', 'submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'submission.backlog.hold', 'submission.backlog.reprocess', 'submission.backlog.force', 'submission.delete', 'submission.restore', 'backup', 'analytics')`;
+    return sql`action not in ('entity.create', 'entity.bulk.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete', 'entity.restore', 'entity.purge', 'submission.create', 'submission.update', 'submission.update.version', 'submission.attachment.update', 'submission.backlog.hold', 'submission.backlog.reprocess', 'submission.backlog.force', 'submission.delete', 'submission.restore', 'backup', 'analytics')`;
   else if (action === 'user')
     return sql`action in ('user.create', 'user.update', 'user.delete', 'user.assignment.create', 'user.assignment.delete', 'user.session.create')`;
   else if (action === 'field_key')
@@ -54,7 +54,7 @@ const actionCondition = (action) => {
   else if (action === 'dataset')
     return sql`action in ('dataset.create', 'dataset.update')`;
   else if (action === 'entity')
-    return sql`action in ('entity.create', 'entity.bulk.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete')`;
+    return sql`action in ('entity.create', 'entity.bulk.create', 'entity.error', 'entity.update.version', 'entity.update.resolve', 'entity.delete', 'entity.restore', 'entity.purge')`;
 
   return sql`action=${action}`;
 };

--- a/test/integration/api/audits.js
+++ b/test/integration/api/audits.js
@@ -406,11 +406,20 @@ describe('/audits', () => {
           body.success.should.be.true();
         });
 
+      await asAlice.post('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/restore')
+        .expect(200);
+      await asAlice.delete('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+        .expect(200);
+      await container.Entities.purge(true);
+
       await asAlice.get('/v1/audits?action=entity')
         .expect(200)
         .then(({ body }) => {
-          body.length.should.equal(6);
+          body.length.should.equal(9);
           body.map(a => a.action).should.eql([
+            'entity.purge',
+            'entity.delete',
+            'entity.restore',
             'entity.delete',
             'entity.update.resolve',
             'entity.update.version',
@@ -614,6 +623,11 @@ describe('/audits', () => {
         .then(({ body }) => {
           body.success.should.be.true();
         });
+      await asAlice.post('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc/restore')
+        .expect(200);
+      await asAlice.delete('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
+        .expect(200);
+      await container.Entities.purge(true);
       await asAlice.post('/v1/projects/1/datasets/people/entities')
         .send({
           source: {


### PR DESCRIPTION
### Change:

`entity.restore` and `entity.purge` should be excluded for `action=nonverbose` audits API and should be added for `action=entity`

#### What has been done to verify that this works as intended?

Updated the existing tests

#### Why is this the best possible solution? Were any other approaches considered?

NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Updated.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced