### PR TITLE
Add cache headers to responses

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -58,6 +58,21 @@ module.exports = (container) => {
   const cookieParser = require('cookie-parser');
   service.use(cookieParser());
 
+  service.use((req, res, next) => {
+    if (req.path.startsWith('/sessions/')) {
+      // Do not allow any caching for single-use endpoints.
+      res.set('Cache-Control', 'no-store');
+    } else {
+      // For authorised content, allow private caching but require revalidation
+      // on every use.
+      res.set('Cache-Control', 'private, max-age=0');
+      // Even in a private cache, only re-use cached values if the client
+      // provides matching auth headers.
+      res.set('Vary', 'Authorization, Cookie');
+    }
+    next();
+  });
+
 
   ////////////////////////////////////////////////////////////////////////////////
   // PREPROCESSORS

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "streamtest": "~1.2",
         "supertest": "^6.3.3",
         "tmp": "~0.2",
+        "undici": "^7.5.0",
         "xml2js": "^0.5.0"
       },
       "engines": {
@@ -11089,6 +11090,16 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
       "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
     },
+    "node_modules/undici": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.5.0.tgz",
+      "integrity": "sha512-NFQG741e8mJ0fLQk90xKxFdaSM7z4+IQpAgsFI36bCDY9Z2+aXXZjVy2uUksMouWfMI9+w5ejOq5zYYTBCQJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -19896,6 +19907,12 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
       "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+    },
+    "undici": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.5.0.tgz",
+      "integrity": "sha512-NFQG741e8mJ0fLQk90xKxFdaSM7z4+IQpAgsFI36bCDY9Z2+aXXZjVy2uUksMouWfMI9+w5ejOq5zYYTBCQJDQ==",
+      "dev": true
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "streamtest": "~1.2",
     "supertest": "^6.3.3",
     "tmp": "~0.2",
+    "undici": "^7.5.0",
     "xml2js": "^0.5.0"
   }
 }

--- a/test/e2e/standard/test.js
+++ b/test/e2e/standard/test.js
@@ -17,24 +17,253 @@ const serverUrl = 'http://localhost:8383';
 const userEmail = 'x@example.com';
 const userPassword = 'secret1234';
 
+describe('Cache headers', () => {
+  const undici = require('undici');
+
+  let api;
+  let projectId = ':projectId';
+  let xmlFormId = ':xmlFormId';
+  let xmlFormVersion = ':xmlFormVersion';
+
+  before(async () => {
+    // given
+    api = await apiClient(SUITE_NAME, { serverUrl, userEmail, userPassword });
+    projectId = await createProject(api);
+    // and
+    const form = await uploadForm(api, projectId, 'test-form.xml');
+    xmlFormId = form.xmlFormId;
+    xmlFormVersion = form.version;
+    // and
+    await uploadSubmission(api, projectId, xmlFormId, xmlFormVersion, 'cache-test-submission');
+  });
+
+  describe('private paths', () => {
+    // TODO write test version with cookie (and/or with session header?)
+    [
+      () => `${serverUrl}/v1/projects/${projectId}`,
+      () => `${serverUrl}/v1/projects/${projectId}/forms/${encodeURIComponent(xmlFormId)}`,
+      () => `${serverUrl}/v1/projects/${projectId}/forms/${encodeURIComponent(xmlFormId)}.svc/Submissions('cache-test-submission')`,
+    ].forEach(url => {
+      testTable(`
+        inputs                                              || expected outputs
+        with cache | has session | has etag | after max-age || response status | date
+        -----------|-------------|----------|---------------||-----------------|---------------
+                ❌ |          ❌ |       ❌ |            ❌ || 403             | N/A
+                ❌ |          ❌ |       ❌ |            ✅ || 403             | N/A
+                ❌ |          ❌ |       ✅ |            ❌ || 403             | N/A
+                ❌ |          ❌ |       ✅ |            ✅ || 403             | N/A
+                ❌ |          ✅ |       ❌ |            ❌ || 200             | race-condition
+                ❌ |          ✅ |       ❌ |            ✅ || 200             | changed
+                ❌ |          ✅ |       ✅ |            ❌ || 304             | race-condition
+                ❌ |          ✅ |       ✅ |            ✅ || 304             | changed
+            shared |          ❌ |       ❌ |            ❌ || 403             | N/A
+            shared |          ❌ |       ❌ |            ✅ || 403             | N/A
+            shared |          ❌ |       ✅ |            ❌ || 403             | N/A
+            shared |          ❌ |       ✅ |            ✅ || 403             | N/A
+            shared |          ✅ |       ❌ |            ❌ || 200             | race-condition
+            shared |          ✅ |       ❌ |            ✅ || 200             | changed
+            shared |          ✅ |       ✅ |            ❌ || 304             | race-condition
+            shared |          ✅ |       ✅ |            ✅ || 304             | changed
+           private |          ❌ |       ❌ |            ❌ || 403             | N/A
+           private |          ❌ |       ❌ |            ✅ || 403             | N/A
+           private |          ❌ |       ✅ |            ❌ || 403             | N/A
+           private |          ❌ |       ✅ |            ✅ || 403             | N/A
+           private |          ✅ |       ❌ |            ❌ || 200             | same
+           private |          ✅ |       ❌ |            ✅ || 200             | same
+           private |          ✅ |       ✅ |            ❌ || 200             | same
+           private |          ✅ |       ✅ |            ✅ || 200             | same
+      `)
+        .forEach(args => testSecondRequest(url, args,
+          [ 'Cache-Control', 'private, max-age=0' ],
+          [ 'Expires',        undefined ],
+          [ 'Vary',          'Authorization, Cookie' ],
+        ));
+      });
+  });
+
+  describe('single-use paths', () => {
+    [
+      () => `${serverUrl}/v1/sessions/restore`,
+    ].forEach(url => {
+      testTable(`
+        inputs                                              || expected outputs
+        with cache | has session | has etag | after max-age || response status | date
+        -----------|-------------|----------|---------------||-----------------|---------------
+                ❌ |          ❌ |       ❌ |            ❌ || 404             | N/A
+                ❌ |          ❌ |       ❌ |            ✅ || 404             | N/A
+                ❌ |          ❌ |       ✅ |            ❌ || 404             | N/A
+                ❌ |          ❌ |       ✅ |            ✅ || 404             | N/A
+                ❌ |          ✅ |       ❌ |            ❌ || 200             | race-condition
+                ❌ |          ✅ |       ❌ |            ✅ || 200             | changed
+                ❌ |          ✅ |       ✅ |            ❌ || 304             | race-condition
+                ❌ |          ✅ |       ✅ |            ✅ || 304             | changed
+            shared |          ❌ |       ❌ |            ❌ || 404             | N/A
+            shared |          ❌ |       ❌ |            ✅ || 404             | N/A
+            shared |          ❌ |       ✅ |            ❌ || 404             | N/A
+            shared |          ❌ |       ✅ |            ✅ || 404             | N/A
+            shared |          ✅ |       ❌ |            ❌ || 200             | race-condition
+            shared |          ✅ |       ❌ |            ✅ || 200             | changed
+            shared |          ✅ |       ✅ |            ❌ || 304             | race-condition
+            shared |          ✅ |       ✅ |            ✅ || 304             | changed
+           private |          ❌ |       ❌ |            ❌ || 404             | N/A
+           private |          ❌ |       ❌ |            ✅ || 404             | N/A
+           private |          ❌ |       ✅ |            ❌ || 404             | N/A
+           private |          ❌ |       ✅ |            ✅ || 404             | N/A
+           private |          ✅ |       ❌ |            ❌ || 200             | race-condition
+           private |          ✅ |       ❌ |            ✅ || 200             | changed
+           private |          ✅ |       ✅ |            ❌ || 304             | race-condition
+           private |          ✅ |       ✅ |            ✅ || 304             | changed
+      `)
+        .forEach(args => testSecondRequest(url, args,
+          [ 'Cache-Control', 'no-store' ],
+          [ 'Expires',        undefined ],
+          [ 'Vary',           undefined ],
+        ));
+    });
+  });
+
+  function testTable(tableString) {
+    const lines = tableString.split('\n');
+    const idxHeaderEnd = lines.findIndex(line => line.match(/^\s*-+(\|+-+)+\s*$/));
+    return lines
+      .map(line => line.replace(/\/\/.*/, '')) // remove comments starting with //
+      .filter((line, idx) => line.trim() && idx > idxHeaderEnd)
+      .map(line => line
+        .trim()
+        .split(/\s*\|+\s*/)
+        .map(str => {
+          if (str === '✅') return true;
+          if (str === '❌') return false;
+          return str;
+        }));
+  }
+
+  function testSecondRequest(url, [ cache, useSession, useEtag, useSleep, expectedStatus, dateExpectation ], ...expectedHeaders) {
+    if(!useSession) {
+      scenario('without session',     withBearerToken, withoutAuth);
+    } else {
+      scenario('with bearer token',   withBearerToken, withBearerToken);
+
+      scenario('with session cookie', withCookie,      withCookie);
+    }
+
+    function withoutAuth(opts) {
+      return opts;
+    }
+
+    function withBearerToken(opts={}) {
+      return {
+        ...opts,
+        headers: { ...opts.headers, authorization:`Bearer ${api.getSessionToken()}` },
+      };
+    }
+
+    function withCookie(opts={}) {
+      return {
+        ...opts,
+        headers: {
+          ...opts.headers,
+          cookie: `session=${api.getSessionToken()}`,
+          'x-forwarded-proto': 'https', // see lib/http/preprocessors.js
+        },
+      };
+    }
+
+    function scenario(authType, withFirstAuth, withSecondAuth) {
+      return it(`should return ${expectedStatus} ${authType} and ${JSON.stringify({ cache, useSession, useEtag, useSleep })}`, async function() {
+        this.timeout(2000);
+
+        // Testing with cacheByDefault: MAX_SAFE_INTEGER is appropriate for
+        // testing privacy & integrity of cached data.  There may be a more
+        // appropriate value if looking to test real-world browser behaviour.
+        const dispatcher = (() => {
+          switch (cache) {
+            case 'private': return new undici.Agent().compose(undici.interceptors.cache({
+              cacheByDefault: Number.MAX_SAFE_INTEGER, // aggressively cache everything
+              methods: [ 'GET' ],
+              type: 'private',
+            }));
+            case 'shared': return new undici.Agent().compose(undici.interceptors.cache({
+              cacheByDefault: Number.MAX_SAFE_INTEGER, // aggressively cache everything
+              methods: [ 'GET' ],
+              type: 'shared',
+            }));
+            case false: return;
+            default: throw new Error(`Unrecognised cache option '${cache}'`);
+          }
+        })();
+
+        // Note that undici has had various historical issues with case-sensitivity
+        // of header names.  With this in mind, it's generally safest to follow the
+        // undici style of using lower-case header names.
+        const baseOpts = {
+          dispatcher,
+          // Base caching headers are set to work around "helpful" fetch behaviour.
+          // These overrides may make these tests behave less like browsers, which
+          // may be of significance if trying to tune real-world client behaviour
+          // for e.g. odk-central-frontend users.
+          // See: https://github.com/nodejs/undici/issues/1930
+          headers: {
+            'cache-control': 'max-stale=3600',
+            'pragma':        '', // eslint-disable-line quote-props
+          },
+        };
+
+        const withEtagFrom = (res, opts={}) => ({ ...opts, headers: { ...opts.headers, 'if-none-match': res.headers.get('ETag') } });
+
+        // given
+        const opts1 = withFirstAuth(baseOpts);
+        const res1 = await undici.fetch(url(), opts1);
+        assert.equal(res1.ok, true, `Expected OK response status, but got ${res1.status}`);
+        // and
+        let opts2 = baseOpts;
+        if (useEtag)    opts2 = withEtagFrom(res1, opts2);
+        if (useSession) opts2 = withSecondAuth(opts2);
+
+        // when
+        if (useSleep) await sleep(1000);
+        const res2 = await undici.fetch(url(), opts2);
+
+        // then
+        assert.equal(res2.status, Number(expectedStatus), `Expected response status ${expectedStatus}, but got ${res2.status}`);
+        switch(dateExpectation) {
+          case 'same':       assert.equal(res2.headers.get('date'), res1.headers.get('date')); break;
+          case 'changed': assert.notEqual(res2.headers.get('date'), res1.headers.get('date')); break;
+          case 'N/A': /* not important - no assertion made about date values; the behaviour is undefined */ break;
+          case 'race-condition': /* date may or may not have changed, depending on if the clock ticked between requests */ break;
+          default: throw new Error(`Unrecognised value for dateExpectation: '${dateExpectation}'`);
+        }
+        // and
+        expectedHeaders.forEach(([ name, expectedValue ]) => {
+          assert.deepEqual(res1.headers.get(name), expectedValue, `Unexpected value for header ${name} of response 1`);
+          assert.deepEqual(res2.headers.get(name), expectedValue, `Unexpected value for header ${name} of response 2`);
+        });
+      });
+    }
+  }
+});
+
 describe('#1157 - Backend crash when opening hostile-named submission detail', () => {
   let api, projectId, xmlFormId, xmlFormVersion; // eslint-disable-line one-var, one-var-declaration-per-line
 
   it('should handle weird submission instanceId gracefully', async () => {
     // given
     api = await apiClient(SUITE_NAME, { serverUrl, userEmail, userPassword });
-    projectId = await createProject();
-    await uploadForm('test-form.xml');
+    projectId = await createProject(api);
+    // and
+    const form = await uploadForm(api, projectId, 'test-form.xml');
+    xmlFormId = form.xmlFormId;
+    xmlFormVersion = form.version;
     // and
     const goodSubmissionId = 'good-id';
-    await uploadSubmission(goodSubmissionId);
+    await uploadSubmission(api, projectId, xmlFormId, xmlFormVersion, goodSubmissionId);
 
     // expect 200:
     await api.apiGet(`projects/${projectId}/forms/${encodeURIComponent(xmlFormId)}.svc/Submissions('${goodSubmissionId}')`);
 
     // given
     const badSubmissionId = 'bad-id:';
-    await uploadSubmission(badSubmissionId);
+    await uploadSubmission(api, projectId, xmlFormId, xmlFormVersion, badSubmissionId);
     // when
     await assert.rejects(
       () => api.apiGet(`projects/${projectId}/forms/${encodeURIComponent(xmlFormId)}.svc/Submissions('${badSubmissionId}')?%24select=__id%2C__system%2Cmeta`),
@@ -54,31 +283,33 @@ describe('#1157 - Backend crash when opening hostile-named submission detail', (
     assert.strictEqual(rootRes.status, 404);
     assert.strictEqual(await rootRes.text(), '{"message":"Expected an API version (eg /v1) at the start of the request URL.","code":404.2}');
   });
-
-  async function createProject() {
-    const project = await api.apiPostJson(
-      'projects',
-      { name:`standard-test-${new Date().toISOString().replace(/\..*/, '')}` },
-    );
-    return project.id;
-  }
-
-  async function uploadForm(xmlFilePath) {
-    const res = await api.apiPostFile(`projects/${projectId}/forms?publish=true`, xmlFilePath);
-    xmlFormId = res.xmlFormId;
-    xmlFormVersion = res.version;
-  }
-
-  function uploadSubmission(submissionId) {
-    const xmlTemplate = fs.readFileSync('submission.xml', { encoding: 'utf8' });
-    const formXml = xmlTemplate
-      .replace('{{submissionId}}', submissionId)
-      .replace('{{formId}}', xmlFormId)
-      .replace('{{formVersion}}', xmlFormVersion);
-
-    return api.apiPostFile(`projects/${projectId}/forms/${encodeURIComponent(xmlFormId)}/submissions?deviceID=testid`, {
-      body: formXml,
-      mimeType: 'application/xml',
-    });
-  }
 });
+
+async function createProject(api) {
+  const project = await api.apiPostJson(
+    'projects',
+    { name:`standard-test-${new Date().toISOString().replace(/\..*/, '')}` },
+  );
+  return project.id;
+}
+
+function uploadForm(api, projectId, xmlFilePath) {
+  return api.apiPostFile(`projects/${projectId}/forms?publish=true`, xmlFilePath);
+}
+
+function uploadSubmission(api, projectId, xmlFormId, xmlFormVersion, submissionId) {
+  const xmlTemplate = fs.readFileSync('submission.xml', { encoding: 'utf8' });
+  const formXml = xmlTemplate
+    .replace('{{submissionId}}', submissionId)
+    .replace('{{formId}}', xmlFormId)
+    .replace('{{formVersion}}', xmlFormVersion);
+
+  return api.apiPostFile(`projects/${projectId}/forms/${encodeURIComponent(xmlFormId)}/submissions?deviceID=testid`, {
+    body: formXml,
+    mimeType: 'application/xml',
+  });
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms)); // eslint-disable-line no-promise-executor-return
+}

--- a/test/e2e/util/api.js
+++ b/test/e2e/util/api.js
@@ -23,6 +23,7 @@ async function apiClient(suiteName, { serverUrl, userEmail, userPassword, logPat
     apiPostAndDump,
     apiPost,
     apiFetch,
+    getSessionToken: () => bearerToken,
   };
 
   async function apiGet(path, headers) {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/662

#### What has been done to verify that this works as intended?

Added tests.

#### Why is this the best possible solution? Were any other approaches considered?

It seems simple.

An alternative approach was tried in https://github.com/getodk/central-backend/pull/1390, but it was decided that content should be cached for less time.

This PR also adds more extensive tests which were not present in #1390.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should prevent future caching surprises.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No?  "cache" is not currently mentioned in docs/

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced