### PR TITLE
Change dataset-diff form verb from update to read

### DIFF
--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -168,17 +168,7 @@ module.exports = (service, endpoint) => {
   // Entity/Dataset-specific endpoint that is used to show how publishing
   // a form will change any datasets mentioned in the form.
   // Even though there are dataset-related permissions, we will use a combination of dataset access and
-  // form modification verbs for authorization. Though form.update and dataset.list will likely be part
-  // of the same role, we want to use the combined authorization strength. One scenario where they are
-  // different is if a user has been assigned a higher auth role on a specific form but not a project,
-  // which can be done through the API: projects/.../forms/.../assignments
-  //
-  // e.g.
-  // Someone can list all datasets but can't read forms so they shouldn't be able to get info about the form
-  // through this endpoint.
-  // Or they can modify forms but not access datasets so they shouldn't be able to get info about the datasets
-  // through this endpoint.
-  //
+  // form verbs for authorization.
   // We are not considering a separate 'dataset.update' verb right now because it seems weird to mix the
   // ability/inability to alter a dataset with the ability to modify forms -- they should just be the same.
   service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
@@ -193,7 +183,7 @@ module.exports = (service, endpoint) => {
         ]))
       .then(([form, project]) =>
         Promise.all([
-          auth.canOrReject('form.update', form),
+          canReadForm(auth, form),
           auth.canOrReject('dataset.list', project)
         ]))
       .then(([form]) => ensureDef(form))
@@ -213,7 +203,7 @@ module.exports = (service, endpoint) => {
         ]))
       .then(([form, project]) =>
         Promise.all([
-          auth.canOrReject('form.read', form),
+          canReadForm(auth, form),
           auth.canOrReject('dataset.list', project)
         ]))
       .then(([form]) => ensureDef(form))

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -213,7 +213,7 @@ module.exports = (service, endpoint) => {
         ]))
       .then(([form, project]) =>
         Promise.all([
-          auth.canOrReject('form.update', form),
+          auth.canOrReject('form.read', form),
           auth.canOrReject('dataset.list', project)
         ]))
       .then(([form]) => ensureDef(form))


### PR DESCRIPTION
Backend change of issue https://github.com/getodk/central/issues/897

The verbs on `/projects/:projectId/forms/:id/dataset-diff` have changed to `form.read` and `dataset.list` so that project viewers are able to get the list of datasets related to a published form.

The verbs on `/projects/:projectId/forms/:id/draft/dataset-diff` are still the same (`form.update` and `dataset.list`) and I think this makes sense because project viewers can't see draft forms so they don't need to see this kind of information.



<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced