### PR TITLE
test/db-migrations: don't break on non-JS files in migrations dir

### DIFF
--- a/test/db-migrations/migrator.js
+++ b/test/db-migrations/migrator.js
@@ -68,6 +68,7 @@ function moveMigrationsToHoldingPen() {
 
 function moveAll(src, tgt) {
   fs.readdirSync(src)
+    .filter(f => f.endsWith('.js'))
     .forEach(f => fs.renameSync(`${src}/${f}`, `${tgt}/${f}`));
 }
 


### PR DESCRIPTION
This allows non-JS files in lib/model/migrations, e.g. `.eslintrc.json`.

Encountered while working on https://github.com/getodk/central-backend/pull/1363

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests still pass (¬:

#### Why is this the best possible solution? Were any other approaches considered?

Just a simple fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No - it's in test code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No - it's in test code.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced