### PR TITLE
Stop using legacy url.parse()

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -9,7 +9,7 @@
 //
 // Helper functions that relate to the HTTP/service layer of the application.
 
-const { parse, URL } = require('url');
+const { URL } = require('url');
 const { map, tryCatch } = require('ramda');
 const { isBlank } = require('./util');
 const Option = require('./option');
@@ -24,7 +24,7 @@ const isTrue = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() 
 const isFalse = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() === 'false'));
 
 // Returns just the pathname of the URL, omitting querystring and other non-path decoration.
-const urlPathname = (x) => parse(x).pathname;
+const urlPathname = (x) => URL.parse(x).pathname;
 
 const urlDecode = tryCatch(map(Option.of, decodeURIComponent), Option.none);
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -24,7 +24,10 @@ const isTrue = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() 
 const isFalse = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() === 'false'));
 
 // Returns just the pathname of the URL, omitting querystring and other non-path decoration.
-const urlPathname = (x) => new URL(x, 'http://example.test').pathname;
+const urlPathname = (url) => {
+  if (typeof url !== 'string') throw new Error(`The "url" argument must be of type string.`);
+  return new URL(url, 'http://example.test').pathname;
+};
 
 const urlDecode = tryCatch(map(Option.of, decodeURIComponent), Option.none);
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -24,7 +24,7 @@ const isTrue = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() 
 const isFalse = (x) => (!isBlank(x) && typeof x === 'string' && (x.toLowerCase() === 'false'));
 
 // Returns just the pathname of the URL, omitting querystring and other non-path decoration.
-const urlPathname = (x) => URL.parse(x).pathname;
+const urlPathname = (x) => new URL(x, 'http://example.test').pathname;
 
 const urlDecode = tryCatch(map(Option.of, decodeURIComponent), Option.none);
 


### PR DESCRIPTION
`url.parse()` was deprecated in node v18.13 and v19+:

> Stability: 0 - Deprecated: Use the WHATWG URL API instead.

See: https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost

Noticed while trying to upgrade `supertest` to the latest release.

#### What has been done to verify that this works as intended?

Existing test suite.

#### Why is this the best possible solution? Were any other approaches considered?

Recommended by node.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not affect users.

Risks: `url.parse()`, `URL.parse()` and `new URL(...)` behave differently for invalid URLs.  I've introduced some validation for more consistency:

```js
[
  undefined,
  null,
  '',
  'asdf',
  'http://example.test/some/path/to/a-file.php.exe?q=asdf&2+2=5#frag',
].map(u => {
  let p1, p2;
  try { p1 = url.parse(u).pathname                     } catch(err) { p1=err.message }
  try { p2 = require('./lib/util/http').urlPathname(u) } catch(err) { p2=err.message }
  return [ p1 === p2, u, p1, p2 ];
})
[
  [
    false,
    undefined,
    'The "url" argument must be of type string. Received undefined',
    'The "url" argument must be of type string.'
  ],
  [
    false,
    null,
    'The "url" argument must be of type string. Received null',
    'The "url" argument must be of type string.'
  ],
  [ false, '', null, '/' ],
  [ false, 'asdf', 'asdf', '/asdf' ],
  [
    true,
    'http://example.test/some/path/to/a-file.php.exe?q=asdf&2+2=5#frag',
    '/some/path/to/a-file.php.exe',
    '/some/path/to/a-file.php.exe'
  ]
]
```

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced