### PR TITLE
submissions: add test for chunked requests with attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-plugin-import": "~2.25",
         "eslint-plugin-no-only-tests": "~3.1",
         "fetch-cookie": "^2.1.0",
+        "form-data": "^4.0.2",
         "http-proxy-middleware": "^2.0.6",
         "lodash": "^4.17.21",
         "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-import": "~2.25",
     "eslint-plugin-no-only-tests": "~3.1",
     "fetch-cookie": "^2.1.0",
+    "form-data": "^4.0.2",
     "http-proxy-middleware": "^2.0.6",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",


### PR DESCRIPTION
Ref https://github.com/getodk/central/issues/940

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Ran the test without `pipe()` call, and observed that transfer is not chunked, and the test failed.

#### Why is this the best possible solution? Were any other approaches considered?

It could be done more explicitly with lower-level libs, e.g. `node:http`.  That would make the code more different from existing tests for similar endpoints.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced