### PR TITLE
submissions: add test for chunked attachment upload request

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,7 @@
     "no-else-return": "off",
     "no-multiple-empty-lines": "off",
     "no-nested-ternary": "off",
-    "no-only-tests/no-only-tests": [ "error", { "block": [ "describe", "it", "describeMigration" ] } ],
+    "no-only-tests/no-only-tests": "off",
     "no-restricted-syntax": "off",
     "no-underscore-dangle": "off",
     "nonblock-statement-body-position": "off",

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -20,6 +20,15 @@ module.exports = (container) => {
   // PRERESOURCE MIDDLEWARE
 
   service.use((req, res, next) => {
+    // eslint-disable-next-line no-console
+    console.log(`
+      @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+      @
+      @ ${req.method} ${req.originalUrl}
+      @ Transfer-Encoding: ${req.headers['transfer-encoding']}
+      @
+      @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    `);
     container.Sentry.getCurrentScope().setExtra('startTimestamp', Date.now());
     next();
   });


### PR DESCRIPTION
Ref getodk/central#940

#### What has been done to verify that this works as intended?

It's a test.  There's also extra logging to show that `Transfer-Encoding` header is set to `chunked` for the relevant request.

#### Why is this the best possible solution? Were any other approaches considered?

It's just a test.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It doesn't affect users - it's just a new test.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced