### PR TITLE
Return form attachment after POST, not { success: true }

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -52,10 +52,8 @@ info:
     **Changed**:
     - `webformsEnabled` boolean flag is added to [Forms](/central-api-form-management) APIs that enables use of ODK Web Forms instead of Enketo.
     - Draft Submission can be created using draft token by adding `/test/{token}` to [Creating a draft Submission](/central-api-submission-management/#id1) endpoint.
-
-    **Changed**:
     - [Dataset Metadata](/central-api-dataset-management/#dataset-metadata) now includes a new property, `lastUpdate`, which is the timestamp of the latest modification to the datasets or its entities.
-
+    - After a file is uploaded for a Form Attachment via the POST endpoint, the response is now the updated Attachment.
 
     ## ODK Central v2024.3
 
@@ -4575,7 +4573,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Success'
+                $ref: '#/components/schemas/FormAttachment'
         403:
           description: Forbidden
           content:

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -16,7 +16,7 @@ const { map, mergeRight } = require('ramda');
 const { expectedFormAttachments } = require('../../data/schema');
 const { Frame, into } = require('../frame');
 const { Blob, Form } = require('../frames');
-const { unjoiner, insertMany } = require('../../util/db');
+const { QueryOptions, unjoiner, insertMany, sqlEquals } = require('../../util/db');
 const { ignoringResult, resolve } = require('../../util/promise');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
@@ -119,18 +119,10 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
 ////////////////////////////////////////////////////////////////////////////////
 // UPDATING
 
-// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
-const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
-
 const update = (_, fa, blobId, datasetId = null) => ({ one }) => one(sql`
-  with updated_attachments as (
-    update form_attachments set "blobId"=${blobId}, "datasetId"=${datasetId}, "updatedAt"=clock_timestamp()
-      where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}
-      returning *
-  )
-  select ${_unjoinMd5.fields} from updated_attachments as form_attachments
-  left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id`)
-  .then(_unjoinMd5);
+  update form_attachments set "blobId"=${blobId}, "datasetId"=${datasetId}, "updatedAt"=clock_timestamp()
+    where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}
+    returning *`).then(construct(Form.Attachment));
 update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attachment.update', form,
   { formDefId: form.draftDefId, name: fa.name, oldBlobId: fa.blobId, newBlobId: blobId, oldDatasetId: fa.datasetId, newDatasetId: datasetId });
 
@@ -138,17 +130,20 @@ update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attach
 ////////////////////////////////////////////////////////////////////////////////
 // GETTERS
 
+// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
+const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
 
-const getAllByFormDefId = (formDefId) => ({ all }) =>
-  all(sql`select ${_unjoinMd5.fields} from form_attachments
+const _get = (exec, options) =>
+  exec(sql`select ${_unjoinMd5.fields} from form_attachments
   left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
-  where "formDefId"=${formDefId} order by name asc`)
+  where ${sqlEquals(options.condition)} order by name asc`)
     .then(map(_unjoinMd5));
 
-// Does not need to be joined with blobs table due to how it is used
-const getByFormDefIdAndName = (formDefId, name) => ({ maybeOne }) => maybeOne(sql`
-select * from form_attachments where "formDefId"=${formDefId} and "name"=${name}`)
-  .then(map(construct(Form.Attachment)));
+const getAllByFormDefId = (formDefId) => ({ all }) =>
+  _get(all, QueryOptions.none.withCondition({ formDefId }));
+
+const getByFormDefIdAndName = (formDefId, name) => ({ maybeOne }) =>
+  _get(maybeOne, QueryOptions.none.withCondition({ formDefId, name }));
 
 // This function decides on the OpenRosa hash (functionally equivalent to an http Etag)
 // It uses the blob md5 directly if it exists.
@@ -166,13 +161,9 @@ const _chooseOpenRosaHash = (attachment) => async ({ Datasets }) => {
   return attachment.with({ openRosaHash: null });
 };
 
-const getAllByFormDefIdForOpenRosa = (formDefId) => ({ all, FormAttachments }) => all(sql`
-select ${_unjoinMd5.fields} from form_attachments
-  left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
-  where "formDefId"=${formDefId}`)
-  .then(map(_unjoinMd5))
-  .then((attachments) => Promise.all(attachments.map(FormAttachments._chooseOpenRosaHash)));
-
+const getAllByFormDefIdForOpenRosa = (formDefId) => ({ FormAttachments }) =>
+  FormAttachments.getAllByFormDefId(formDefId)
+    .then((attachments) => Promise.all(attachments.map(FormAttachments._chooseOpenRosaHash)));
 
 module.exports = {
   createNew, createVersion,

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -117,12 +117,20 @@ const createVersion = (xml, form, savedDef, itemsets, publish = false) => ({ Blo
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// CRUD
+// UPDATING
+
+// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
+const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
 
 const update = (_, fa, blobId, datasetId = null) => ({ one }) => one(sql`
-  update form_attachments set "blobId"=${blobId}, "datasetId"=${datasetId}, "updatedAt"=clock_timestamp()
-    where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}
-    returning *`).then(construct(Form.Attachment));
+  with updated_attachments as (
+    update form_attachments set "blobId"=${blobId}, "datasetId"=${datasetId}, "updatedAt"=clock_timestamp()
+      where "formId"=${fa.formId} and "formDefId"=${fa.formDefId} and name=${fa.name}
+      returning *
+  )
+  select ${_unjoinMd5.fields} from updated_attachments as form_attachments
+  left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id`)
+  .then(_unjoinMd5);
 update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attachment.update', form,
   { formDefId: form.draftDefId, name: fa.name, oldBlobId: fa.blobId, newBlobId: blobId, oldDatasetId: fa.datasetId, newDatasetId: datasetId });
 
@@ -130,8 +138,6 @@ update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attach
 ////////////////////////////////////////////////////////////////////////////////
 // GETTERS
 
-// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
-const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
 
 const getAllByFormDefId = (formDefId) => ({ all }) =>
   all(sql`select ${_unjoinMd5.fields} from form_attachments

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -165,6 +165,7 @@ const getAllByFormDefIdForOpenRosa = (formDefId) => ({ FormAttachments }) =>
   FormAttachments.getAllByFormDefId(formDefId)
     .then((attachments) => Promise.all(attachments.map(FormAttachments._chooseOpenRosaHash)));
 
+
 module.exports = {
   createNew, createVersion,
   update,

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -223,6 +223,12 @@ module.exports = (service, endpoint) => {
       ])
         .then(([dataset, attachment]) => (attachment.type !== 'file' && body.dataset ?
           Problem.user.datasetLinkNotAllowed() :
+          // Unlike the POST endpoint for uploading a file, we do not need to
+          // use FormAttachments.getByFormDefIdAndName() to re-fetch the
+          // attachment after updating it. Compared to the return value from
+          // FormAttachments.update(), getByFormDefIdAndName() just joins in the
+          // blob hash. But we're setting blobId to `null` here, so we know
+          // already that there is no blob hash.
           FormAttachments.update(form, attachment, null, body.dataset ? dataset.id : null))))));
 
 
@@ -381,7 +387,11 @@ module.exports = (service, endpoint) => {
         Blob.fromStream(request, headers['content-type'] || defaultMimetypeFor(params.name)).then((blob) => Blobs.ensure(blob)),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
       ])
-        .then(([ blobId, attachment ]) => FormAttachments.update(form, attachment, blobId, null)))));
+        .then(([ blobId, attachment ]) => FormAttachments.update(form, attachment, blobId, null))
+        // Use FormAttachments.getByFormDefIdAndName() to re-fetch the form
+        // attachment in order to join in the blob hash.
+        .then(() => FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name))
+        .then(getOrNotFound))));
 
   service.delete('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ FormAttachments, Forms }, { params, auth }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -381,8 +381,7 @@ module.exports = (service, endpoint) => {
         Blob.fromStream(request, headers['content-type'] || defaultMimetypeFor(params.name)).then((blob) => Blobs.ensure(blob)),
         FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name).then(getOrNotFound)
       ])
-        .then(([ blobId, attachment ]) => FormAttachments.update(form, attachment, blobId, null))
-        .then(success))));
+        .then(([ blobId, attachment ]) => FormAttachments.update(form, attachment, blobId, null)))));
 
   service.delete('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ FormAttachments, Forms }, { params, auth }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -348,10 +348,11 @@ should.Assertion.add('eqlInAnyOrder', function(expectedUnsorted) {
   actualSorted.should.eql(expectedSorted);
 });
 
-should.Assertion.add('subsetOf', function(subset) {
+should.Assertion.add('subsetOf', function(array) {
   this.params = { operator: 'to be a subset of' };
+
   this.obj.should.be.an.Array();
-  for (const x of this.obj) subset.should.containEql(x);
+  for (const x of this.obj) array.should.containEql(x);
 });
 
 should.Assertion.add('Dataset', function assertDataset() {

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -216,14 +216,16 @@ should.Assertion.add('ExtendedForm', function() {
 should.Assertion.add('FormAttachment', function() {
   this.params = { operator: 'to be a Form Attachment' };
 
-  Object.keys(this.obj).should.eqlInAnyOrder([ 'name', 'type', 'blobExists', 'datasetExists', 'exists', 'updatedAt' ]);
+  Object.keys(this.obj).should.be.a.subsetOf([ 'name', 'type', 'blobExists', 'datasetExists', 'exists', 'hash', 'updatedAt' ]);
   this.obj.name.should.be.a.String();
   this.obj.type.should.be.a.String();
-  const { blobExists, datasetExists, exists } = this.obj;
+  const { blobExists, datasetExists, exists, hash } = this.obj;
   blobExists.should.be.a.Boolean();
   datasetExists.should.be.a.Boolean();
   (blobExists && datasetExists).should.be.false();
   exists.should.equal(blobExists || datasetExists);
+  (hash != null).should.equal(blobExists);
+  if (hash != null) hash.should.be.an.md5Sum();
   if (this.obj.updatedAt != null) this.obj.updatedAt.should.be.an.isoDate();
 });
 
@@ -344,6 +346,12 @@ should.Assertion.add('eqlInAnyOrder', function(expectedUnsorted) {
   const actualSorted = [ ...this.obj ].sort();
   const expectedSorted = [ ...expectedUnsorted ].sort();
   actualSorted.should.eql(expectedSorted);
+});
+
+should.Assertion.add('subsetOf', function(subset) {
+  this.params = { operator: 'to be a subset of' };
+  this.obj.should.be.an.Array();
+  for (const x of this.obj) subset.should.containEql(x);
 });
 
 should.Assertion.add('Dataset', function assertDataset() {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1966,13 +1966,17 @@ describe('datasets and entities', () => {
         await asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
           .send({ dataset: true })
           .expect(200)
-          .then(({ body }) => omit(['updatedAt'], body).should.be.eql({
-            name: 'goodone.csv',
-            type: 'file',
-            exists: true,
-            blobExists: false,
-            datasetExists: true
-          }));
+          .then(({ body }) => {
+            body.should.be.a.FormAttachment();
+            omit(['updatedAt'], body).should.be.eql({
+              name: 'goodone.csv',
+              type: 'file',
+              exists: true,
+              blobExists: false,
+              datasetExists: true,
+              hash: null
+            });
+          });
 
         // Publish form with dataset as attachment
         await asAlice.post('/v1/projects/1/forms/withAttachments/draft/publish?version=newversion')
@@ -1982,6 +1986,7 @@ describe('datasets and entities', () => {
         await asAlice.get('/v1/projects/1/forms/withAttachments/attachments')
           .expect(200)
           .then(({ body }) => {
+            body[0].should.be.a.FormAttachment();
             body[0].name.should.equal('goodone.csv');
             body[0].datasetExists.should.equal(true);
             body[0].updatedAt.should.be.a.recentIsoDate();
@@ -2048,6 +2053,7 @@ describe('datasets and entities', () => {
         await asAlice.get('/v1/projects/1/forms/withAttachments/draft/attachments')
           .expect(200)
           .then(({ body }) => {
+            body[0].should.be.a.FormAttachment();
             body[0].name.should.equal('goodone.csv');
             body[0].exists.should.equal(true);
             body[0].datasetExists.should.equal(false);
@@ -2068,6 +2074,7 @@ describe('datasets and entities', () => {
         await asAlice.get('/v1/projects/1/forms/withAttachments/draft/attachments')
           .expect(200)
           .then(({ body }) => {
+            body[0].should.be.a.FormAttachment();
             body[0].name.should.equal('goodone.csv');
             body[0].exists.should.equal(true);
             body[0].datasetExists.should.equal(true);
@@ -2146,6 +2153,7 @@ describe('datasets and entities', () => {
             .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/attachments')
               .expect(200)
               .then(({ body }) => {
+                body[0].should.be.a.FormAttachment();
                 body[0].name.should.equal('goodone.csv');
                 body[0].datasetExists.should.equal(false);
                 body[0].updatedAt.should.be.a.recentIsoDate();
@@ -2358,6 +2366,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].datasetExists.should.be.true();
             });
@@ -2376,6 +2385,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.false();
@@ -2401,6 +2411,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.true();
@@ -2446,6 +2457,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.false();
               body[0].blobExists.should.be.false();
@@ -2469,6 +2481,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/draft/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.false();
@@ -2481,6 +2494,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.false();
@@ -2506,6 +2520,7 @@ describe('datasets and entities', () => {
           // because the form was uploaded before the dataset was created, this will be null
           await asAlice.get('/v1/projects/1/forms/updateEntity/draft/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.false();
               body[0].blobExists.should.be.false();
@@ -2520,6 +2535,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.true();
               body[0].blobExists.should.be.false();
@@ -2587,6 +2603,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.csv');
               body[0].exists.should.be.false();
               body[0].blobExists.should.be.false();
@@ -2632,6 +2649,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.CSV');
               body[0].exists.should.be.false();
               body[0].blobExists.should.be.false();
@@ -2677,6 +2695,7 @@ describe('datasets and entities', () => {
 
           await asAlice.get('/v1/projects/1/forms/updateEntity/draft/attachments')
             .then(({ body }) => {
+              body[0].should.be.a.FormAttachment();
               body[0].name.should.equal('people.CSV');
               body[0].exists.should.be.false();
               body[0].blobExists.should.be.false();

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1973,8 +1973,7 @@ describe('datasets and entities', () => {
               type: 'file',
               exists: true,
               blobExists: false,
-              datasetExists: true,
-              hash: null
+              datasetExists: true
             });
           });
 

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -2000,7 +2000,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                   .set('Content-Type', 'text/csv')
                   .expect(403))))));
 
-        it('should accept the file with a success result', testService((service) =>
+        it('should accept the file', testService((service) =>
           service.login('alice', (asAlice) =>
             asAlice.post('/v1/projects/1/forms')
               .send(testData.forms.withAttachments)
@@ -2011,7 +2011,14 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 .set('Content-Type', 'text/csv')
                 .expect(200)
                 .then(({ body }) => {
-                  body.should.eql({ success: true });
+                  body.should.be.a.FormAttachment();
+                  body.should.containEql({
+                    name: 'goodone.csv',
+                    type: 'file',
+                    blobExists: true,
+                    hash: '2241de57bbec8144c8ad387e69b3a3ba'
+                  });
+                  body.updatedAt.should.be.a.recentIsoDate();
                 })))));
 
         it('should accept xml type files', testService((service) =>
@@ -2025,7 +2032,8 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 .set('Content-Type', 'text/xml')
                 .expect(200)
                 .then(({ body }) => {
-                  body.should.eql({ success: true });
+                  body.should.be.a.FormAttachment();
+                  body.name.should.equal('goodone.csv');
                 }))
               .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
                 .expect(200)


### PR DESCRIPTION
This PR makes a change to the POST endpoint for uploading a file for a form attachment. Right now, that endpoint returns `{ success: true }`. However, Frontend would benefit from receiving the updated form attachment (the metadata about the form attachment, not the blob). This PR makes a change along those lines, returning the updated form attachment rather than `{ success: true }`.

Even today, Frontend would benefit from receiving the updated form attachment. After a successful request to the POST endpoint, Frontend wants to update the `updatedAt` timestamp that's shown in the form attachments table. Since it doesn't know the true `updatedAt` timestamp, it just uses the current timestamp after the response is received, which should be pretty close to the true timestamp. You can see the code for that [here](https://github.com/getodk/central-frontend/blob/edb862ce6d9a1860fb34e3dd0dcec596882a0694/src/components/form-attachment/list.vue#L270-L272).

The real motivation for this PR is getodk/central#728. Specifically, this PR is needed for the Frontend PR getodk/central-frontend#1172. After a file is uploaded in Frontend, we want to adjust the count of changed attachments that's shown in the tag for the Attachments section. We do that by comparing the old and new hashes for the attachment. Backend knows the hash of the uploaded file, and by returning the updated form attachment, it can pass that information back to Frontend.

Frontend could calculate the new hash itself, but it doesn't seem like the easiest thing to do in the browser, especially without reading the entire file into memory. Backend knows the new hash, and it's easy enough for Backend to return it to Frontend.

We're a little inconsistent in our POST endpoints in what we return. I think usually we just return `{ success: true }`. However, sometimes we return the new resource, e.g., for POST /v1/projects/:id/forms. This POST endpoint for uploading a file is interesting in that in some ways, it's more so updating an existing form attachment rather than creating a new resource. In that way, the endpoint is sort of similar to a PATCH endpoint. For PATCH endpoints, I think we usually return the updated resource. In other words, even though we're changing the response that's returned from the endpoint, I think we're still being consistent with how other endpoints work (both POST endpoints and PATCH).

#### What has been done to verify that this works as intended?

Updated existing tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The schema of the response has changed. However, the response before was just `{ success: true }`: there wasn't any concrete/useful information returned. I doubt that anyone is using that specific response. However, I've updated the API docs to mention this change to the API.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced