### PR TITLE
purge: s3: delete uploaded blobs in batches

### DIFF
--- a/lib/external/s3.js
+++ b/lib/external/s3.js
@@ -102,8 +102,8 @@ const init = (config) => {
     return `${objectPrefix??''}blob-${id}-${sha}`;
   };
 
-  function deleteObjFor(blob) {
-    return minioClient.removeObject(bucketName, objectNameFor(blob));
+  function deleteObjsFor(blobs) {
+    return minioClient.removeObjects(bucketName, blobs.map(blob => objectNameFor(blob)));
   }
 
   async function getContentFor(blob) {
@@ -164,7 +164,7 @@ const init = (config) => {
 
   return {
     enabled: true,
-    deleteObjFor:   guarded(deleteObjFor),  // eslint-disable-line key-spacing, no-multi-spaces
+    deleteObjsFor:  guarded(deleteObjsFor), // eslint-disable-line key-spacing, no-multi-spaces
     getContentFor:  guarded(getContentFor), // eslint-disable-line key-spacing
     uploadFromBlob: guarded(uploadFromBlob),
     urlForBlob:     guarded(urlForBlob),    // eslint-disable-line key-spacing, no-multi-spaces

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -95,10 +95,14 @@ const _getOnePending = () => ({ maybeOne }) => maybeOne(sql`
 `).then(map(construct(Blob)));
 
 const unattachedClause = sql`
-  WHERE b.id NOT IN (SELECT "blobId"    FROM client_audits)
-    AND b.id NOT IN (SELECT "blobId"    FROM submission_attachments WHERE "blobId"    IS NOT NULL)
-    AND b.id NOT IN (SELECT "blobId"    FROM form_attachments       WHERE "blobId"    IS NOT NULL)
-    AND b.id NOT IN (SELECT "xlsBlobId" FROM form_defs              WHERE "xlsBlobId" IS NOT NULL)
+  LEFT JOIN client_audits          AS ca ON ca."blobId" = b.id
+  LEFT JOIN submission_attachments AS sa ON sa."blobId" = b.id
+  LEFT JOIN form_attachments       AS fa ON fa."blobId" = b.id
+  LEFT JOIN form_defs              AS fd ON fd."xlsBlobId" = b.id
+  WHERE ca."blobId" IS NULL
+    AND sa."blobId" IS NULL
+    AND fa."blobId" IS NULL
+    AND fd."xlsBlobId" IS NULL
 `;
 
 const _purgeAllUnattached = () => ({ all }) => all(sql`

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -116,14 +116,14 @@ const _purgeUnattachedNotUploaded = () => ({ all }) => all(sql`
       AND blobs.id = b.id
 `);
 
-const _purgeOneUnattachedUploaded = () => ({ maybeOne }) => maybeOne(sql`
+const _purgeUnattachedUploadedBatch = () => ({ all }) => all(sql`
   DELETE FROM blobs
-    WHERE id = (
+    WHERE id IN (
       SELECT b.id
         FROM blobs AS b
         ${unattachedClause}
           AND b.s3_status = 'uploaded'
-        LIMIT 1
+        LIMIT 100
     )
     RETURNING blobs.id, blobs.sha
 `);
@@ -134,13 +134,13 @@ const purgeUnattached = () => async ({ s3, Blobs }) => {
   await Blobs._purgeUnattachedNotUploaded();
 
   while (true) { // eslint-disable-line no-constant-condition
-    const maybeBlob = await Blobs._purgeOneUnattachedUploaded(); // eslint-disable-line no-await-in-loop
-    if (isEmpty(maybeBlob)) return;
+    const blobs = await Blobs._purgeUnattachedUploadedBatch(); // eslint-disable-line no-await-in-loop
+    if (!blobs.length) return;
 
     // If delete is interrupted or failed, this may leave an orphaned object in
     // the S3 bucket.  This should be identifiable by comparing object names
     // with blob IDs available in postgres.
-    await s3.deleteObjFor(maybeBlob.get()); // eslint-disable-line no-await-in-loop
+    await s3.deleteObjsFor(blobs); // eslint-disable-line no-await-in-loop
   }
 };
 
@@ -196,6 +196,6 @@ module.exports = {
   ensure, getById, purgeUnattached,
   _getOnePending, _markAsFailed, _markAsUploaded,
   s3CountByStatus, s3SetFailedToPending, s3UploadPending,
-  _purgeAllUnattached, _purgeOneUnattachedUploaded, _purgeUnattachedNotUploaded,
+  _purgeAllUnattached, _purgeUnattachedUploadedBatch, _purgeUnattachedNotUploaded,
 };
 

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -95,10 +95,10 @@ const _getOnePending = () => ({ maybeOne }) => maybeOne(sql`
 `).then(map(construct(Blob)));
 
 const unattachedClause = sql`
-  WHERE b.id NOT IN (SELECT "blobId" FROM client_audits)
-    AND b.id NOT IN (SELECT "blobId" FROM submission_attachments)
-    AND b.id NOT IN (SELECT "blobId" FROM form_attachments)
-    AND b.id NOT IN (SELECT "xlsBlobId" FROM form_defs)
+  WHERE b.id NOT IN (SELECT "blobId"    FROM client_audits)
+    AND b.id NOT IN (SELECT "blobId"    FROM submission_attachments WHERE "blobId"    IS NOT NULL)
+    AND b.id NOT IN (SELECT "blobId"    FROM form_attachments       WHERE "blobId"    IS NOT NULL)
+    AND b.id NOT IN (SELECT "xlsBlobId" FROM form_defs              WHERE "xlsBlobId" IS NOT NULL)
 `;
 
 const _purgeAllUnattached = () => ({ all }) => all(sql`

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -95,14 +95,10 @@ const _getOnePending = () => ({ maybeOne }) => maybeOne(sql`
 `).then(map(construct(Blob)));
 
 const unattachedClause = sql`
-  LEFT JOIN client_audits          AS ca ON ca."blobId" = b.id
-  LEFT JOIN submission_attachments AS sa ON sa."blobId" = b.id
-  LEFT JOIN form_attachments       AS fa ON fa."blobId" = b.id
-  LEFT JOIN form_defs              AS fd ON fd."xlsBlobId" = b.id
-  WHERE ca."blobId" IS NULL
-    AND sa."blobId" IS NULL
-    AND fa."blobId" IS NULL
-    AND fd."xlsBlobId" IS NULL
+  WHERE b.id NOT IN (SELECT "blobId" FROM client_audits)
+    AND b.id NOT IN (SELECT "blobId" FROM submission_attachments)
+    AND b.id NOT IN (SELECT "blobId" FROM form_attachments)
+    AND b.id NOT IN (SELECT "xlsBlobId" FROM form_defs)
 `;
 
 const _purgeAllUnattached = () => ({ all }) => all(sql`

--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -324,14 +324,12 @@ describe('task: purge deleted resources (forms, submissions and entities)', () =
       global.s3.enableMock();
     });
 
-    // eslint-disable-next-line prefer-arrow-callback
     it('should purge in a reasonable amount of time @slow', testTask(async function({ all }) {
       // On a dev laptop, the following measurements were made:
       //
       // legacy implementation:   25s
       // current implementation: 2.5s
 
-      // Enable when checking other implementations:
       this.timeout(5_000);
 
       // given

--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -1,9 +1,11 @@
+const crypto = require('node:crypto');
 const appRoot = require('app-root-path');
 const assert = require('node:assert');
 const { isEmpty } = require('ramda');
 const { sql } = require('slonik');
 const { testTask } = require('../setup');
 const { purgeTask } = require(appRoot + '/lib/task/purge');
+const { Blob } = require(appRoot + '/lib/model/frames');
 
 // The basics of this task are tested here, including returning the message
 // of purged forms, but the full functionality is more thoroughly tested in
@@ -310,5 +312,50 @@ describe('task: purge deleted resources (forms, submissions and entities)', () =
             message.should.equal('Forms purged: 1, Submissions purged: 0, Entities purged: 0');
           }))));
   });
+
+  describe('with s3 blob storage', () => {
+    // The Postgres query planner can end up doing some crazy things when trying
+    // to identify unattached blobs.  This test seems to expose that behaviour,
+    // although real-world performance will still need to be monitored.
+    //
+    // See: https://github.com/getodk/central-backend/issues/1443
+
+    beforeEach(() => {
+      global.s3.enableMock();
+    });
+
+    // eslint-disable-next-line prefer-arrow-callback
+    it('should purge in a reasonable amount of time', testTask(async function({ all }) {
+      // On a dev laptop, the following measurements were made:
+      //
+      // legacy implementation:   25s
+      // current implementation: 400ms
+
+      // Enable when checking other implementations:
+      //this.timeout(0);
+
+      // given
+      const blobs = [];
+      for (let i=0; i<10_000; ++i) { // eslint-disable-line no-plusplus
+        const blob = Blob.fromBuffer(crypto.randomBytes(100));
+        const { sha, md5 } = blob;
+        blobs.push({ sha, md5, content: null, contentType: 'text/plain', s3_status: 'uploaded' });
+      }
+      const dbBlobs = await all(sql`
+        INSERT INTO blobs (sha, md5, content, "contentType", s3_status)
+          SELECT sha, md5, content, "contentType", s3_status
+            FROM JSON_POPULATE_RECORDSET(NULL::blobs, ${JSON.stringify(blobs)})
+          RETURNING id, sha
+      `);
+      global.s3.mockExistingBlobs(dbBlobs);
+
+      // when
+      await purgeTask({ mode: 'forms', force: false, formId: 1 });
+
+      // then
+      // it has not timed out
+    }));
+  });
+
 });
 

--- a/test/integration/task/purge.js
+++ b/test/integration/task/purge.js
@@ -325,14 +325,14 @@ describe('task: purge deleted resources (forms, submissions and entities)', () =
     });
 
     // eslint-disable-next-line prefer-arrow-callback
-    it('should purge in a reasonable amount of time', testTask(async function({ all }) {
+    it('should purge in a reasonable amount of time @slow', testTask(async function({ all }) {
       // On a dev laptop, the following measurements were made:
       //
       // legacy implementation:   25s
-      // current implementation: 400ms
+      // current implementation: 2.5s
 
       // Enable when checking other implementations:
-      //this.timeout(0);
+      this.timeout(5_000);
 
       // given
       const blobs = [];
@@ -353,7 +353,7 @@ describe('task: purge deleted resources (forms, submissions and entities)', () =
       await purgeTask({ mode: 'forms', force: false, formId: 1 });
 
       // then
-      // it has not timed out
+      // it has not timed out or thrown
     }));
   });
 

--- a/test/util/s3.js
+++ b/test/util/s3.js
@@ -20,6 +20,10 @@ class S3mock {
     this.uploads = { attempted: 0, successful: 0, deleted: 0 };
   }
 
+  mockExistingBlobs(blobs) {
+    for (const { id, sha } of blobs) this.s3bucket.set(keyFrom(id, sha), 'i should never be read');
+  }
+
   // MOCKED FUNCTIONS
   // ================
   // These functions should be marked `async` to correspond with the function

--- a/test/util/s3.js
+++ b/test/util/s3.js
@@ -21,7 +21,7 @@ class S3mock {
   }
 
   mockExistingBlobs(blobs) {
-    for (const { id, sha } of blobs) this.s3bucket.set(keyFrom(id, sha), 'i should never be read');
+    for (const { id, sha, content } of blobs) this.s3bucket.set(keyFrom(id, sha), content);
   }
 
   // MOCKED FUNCTIONS

--- a/test/util/s3.js
+++ b/test/util/s3.js
@@ -77,14 +77,17 @@ class S3mock {
     return `s3://mock/${md5}/${sha}/${filename}?contentType=${contentType}`;
   }
 
-  async deleteObjFor({ id, sha }) {
+  async deleteObjsFor(blobs) {
     if (!this.enabled) throw new Error('S3 mock has not been enabled, so this function should not be called.');
 
-    const key = keyFrom(id, sha);
-    if (!this.s3bucket.has(key)) throw new Error('Blob not found.');
-    this.s3bucket.delete(key);
-    // eslint-disable-next-line no-plusplus
-    ++this.uploads.deleted;
+    const keys = blobs.map(({ id, sha }) => keyFrom(id, sha));
+    if (!keys.every(key => this.s3bucket.has(key))) throw new Error('One or more blobs not found in store.');
+
+    for (const key of keys) {
+      this.s3bucket.delete(key);
+      // eslint-disable-next-line no-plusplus
+      ++this.uploads.deleted;
+    }
   }
 }
 


### PR DESCRIPTION
This significantly improves performance (about 3x locally).

Closes #1443

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

* did a lot of benchmarking and staring at query plans
* added a test
* realised that to make significant improvements over the current approach, this is the simplest option

Note that the current test doesn't even rely on any data being in the joined tables

#### Why is this the best possible solution? Were any other approaches considered?

A few other options, e.g.

* adding indexes.  This PR is much less invasive, and shouldn't have side effects
* changing the `unattachedClause` clause
  * to avoid `NULL` checks.  This looks like it could potentially 100x performance (or 30x over this PR), but would probably need a placeholder row in the `Blobs` table (e.g. w/ id = -1), and then add NOT NULL constraints to all `blobId` FK columns[1]
  * in other ways, none of which had significant improvements.  The nicest alternative syntax was:

```sql
WHERE NOT EXISTS (SELECT 1 FROM client_audits AS ca WHERE ca."blobId" = b.id)
  AND NOT EXISTS (SELECT 1 FROM submission_attachments AS sa WHERE sa."blobId" = b.id)
  AND NOT EXISTS (SELECT 1 FROM form_attachments AS fa WHERE fa."blobId" = b.id)
  AND NOT EXISTS (SELECT 1 FROM form_defs AS fd WHERE fd."xlsBlobId" = b.id)
```

### Avoiding `NULL` checks [1]

```sql
WHERE b.id NOT IN (SELECT "blobId" FROM client_audits)
  AND b.id NOT IN (SELECT "blobId" FROM submission_attachments)
  AND b.id NOT IN (SELECT "blobId" FROM form_attachments)
  AND b.id NOT IN (SELECT "xlsBlobId" FROM form_defs)
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Hopefully significantly better performance in production systems.  Hard to know without testing on realistic datasets.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced