### PR TITLE
Include user, change-reason in client_audits export

### DIFF
--- a/lib/data/client-audits.js
+++ b/lib/data/client-audits.js
@@ -14,7 +14,7 @@ const sanitize = require('sanitize-filename');
 const { PartialPipe } = require('../util/stream');
 const { zipPart } = require('../util/zip');
 
-const headers = [ 'event', 'node', 'start', 'end', 'latitude', 'longitude', 'accuracy', 'old-value', 'new-value' ];
+const headers = [ 'event', 'node', 'start', 'end', 'latitude', 'longitude', 'accuracy', 'old-value', 'new-value', 'user', 'change-reason' ];
 
 // used by parseClientAudits below.
 const parseOptions = { bom: true, trim: true, skip_empty_lines: true, relax_column_count: true, relax: true };

--- a/lib/model/migrations/20250415-01-client-audit-remainder.js
+++ b/lib/model/migrations/20250415-01-client-audit-remainder.js
@@ -1,0 +1,34 @@
+// Copyright 2025 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`
+    ALTER TABLE client_audits
+      ADD COLUMN "user" TEXT,
+      ADD COLUMN "change-reason" TEXT
+  `);
+
+  await db.raw(`
+    UPDATE client_audits
+    SET 
+      "user" = remainder->>'user',
+      "change-reason" = remainder->>'change-reason'
+    WHERE remainder IS NOT NULL;
+  `);
+};
+
+const down = async (db) => {
+  await db.raw(`
+    ALTER TABLE client_audits
+      DROP COLUMN "user",
+      DROP COLUMN "change-reason"
+  `);
+};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20250415-01-client-audit-remainder.js
+++ b/lib/model/migrations/20250415-01-client-audit-remainder.js
@@ -26,6 +26,21 @@ const up = async (db) => {
 
 const down = async (db) => {
   await db.raw(`
+    UPDATE client_audits
+    SET
+      remainder = jsonb_set(
+        jsonb_set(
+          COALESCE(remainder, '{}'),
+          '{user}',
+          to_jsonb("user")
+        ),
+        '{change-reason}',
+        to_jsonb("change-reason")
+      )
+    WHERE "user" IS NOT NULL OR "change-reason" IS NOT NULL
+  `);
+
+  await db.raw(`
     ALTER TABLE client_audits
       DROP COLUMN "user",
       DROP COLUMN "change-reason"

--- a/lib/model/migrations/20250415-01-client-audit-remainder.js
+++ b/lib/model/migrations/20250415-01-client-audit-remainder.js
@@ -18,7 +18,8 @@ const up = async (db) => {
     UPDATE client_audits
     SET 
       "user" = remainder->>'user',
-      "change-reason" = remainder->>'change-reason'
+      "change-reason" = remainder->>'change-reason',
+      remainder = remainder - 'user' - 'change-reason'
     WHERE remainder IS NOT NULL;
   `);
 };

--- a/test/data/audit4.csv
+++ b/test/data/audit4.csv
@@ -1,0 +1,5 @@
+event,node,start,end,latitude,longitude,unknown-column,old-value,new-value,user,change-reason
+l,/data/l,2000-01-01T00:04,2000-01-01T00:05,-1,-2,y,aa,bb,user,reason1
+m,/data/m,2000-01-01T00:05,2000-01-01T00:06,-3,-4,z,cc,dd,user,
+n,/data/n,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,reason2
+

--- a/test/db-migrations/.eslintrc.js
+++ b/test/db-migrations/.eslintrc.js
@@ -5,4 +5,7 @@ module.exports = {
     log: false,
     sql: false,
   },
+  rules: {
+    'no-multi-spaces': 'off',
+  },
 };

--- a/test/db-migrations/20250113-01-disable-nullable-blob-content-types.spec.js
+++ b/test/db-migrations/20250113-01-disable-nullable-blob-content-types.spec.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const { hash, randomBytes } = require('node:crypto');
 
 const { // eslint-disable-line object-curly-newline
   assertTableContents,
@@ -7,15 +6,9 @@ const { // eslint-disable-line object-curly-newline
   rowsExistFor,
 } = require('./utils'); // eslint-disable-line object-curly-newline
 
-describeMigration('20250113-01-disable-nullable-blob-content-types', ({ runMigrationBeingTested }) => {
-  const aBlobWith = props => {
-    const randomContent = randomBytes(100);
-    const md5 = hash('md5',  randomContent); // eslint-disable-line no-multi-spaces
-    const sha = hash('sha1', randomContent);
-    return { md5, sha, ...props };
-  };
-  const aBlob = () => aBlobWith({});
+const { aBlob, aBlobWith } = require('./fixtures');
 
+describeMigration('20250113-01-disable-nullable-blob-content-types', ({ runMigrationBeingTested }) => {
   const blob1 = aBlobWith({ contentType: null });
   const blob2 = aBlobWith({ contentType: 'text/plain' });
 

--- a/test/db-migrations/20250415-01-client-audit-remainder.spec.js
+++ b/test/db-migrations/20250415-01-client-audit-remainder.spec.js
@@ -1,0 +1,82 @@
+const { hash, randomBytes } = require('node:crypto');
+
+const { // eslint-disable-line object-curly-newline
+  assertTableSchema,
+  assertTableContents,
+  describeMigration,
+} = require('./utils'); // eslint-disable-line object-curly-newline
+
+describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTested }) => {
+  const aBlobWith = props => {
+    const randomContent = randomBytes(100);
+    const md5 = hash('md5',  randomContent); // eslint-disable-line no-multi-spaces
+    const sha = hash('sha1', randomContent);
+    return { md5, sha, ...props };
+  };
+  const aBlob = () => aBlobWith({});
+
+  before(async () => {
+    await assertTableSchema('client_audits',
+      { column_name: 'blobId',        is_nullable: 'NO', data_type: 'integer' }, // eslint-disable-line no-multi-spaces
+      { column_name: 'event',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'node',          is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'start',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'end',           is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'latitude',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'longitude',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'accuracy',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'old-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'new-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'remainder',     is_nullable: 'YES', data_type: 'jsonb' },  // eslint-disable-line no-multi-spaces
+    );
+
+    const { md5, sha } = aBlob();
+
+    const blobId = await db.oneFirst(sql`
+      INSERT INTO blobs (md5, sha, "contentType")
+      VALUES(${md5}, ${sha}, DEFAULT)
+      RETURNING id
+    `);
+
+    await db.oneFirst(sql`
+      INSERT INTO client_audits (
+      "blobId",
+      remainder
+      )
+      VALUES (
+      ${blobId},
+      '{"user": "test-user", "change-reason": "test-reason", "unknown-value": "test-unknown"}'::jsonb
+      )
+      returning "blobId"
+    `);
+
+    await runMigrationBeingTested();
+  });
+
+  it('should add columns to client audit table', async () => {
+    await assertTableSchema('client_audits',
+      { column_name: 'blobId',        is_nullable: 'NO', data_type: 'integer' }, // eslint-disable-line no-multi-spaces
+      { column_name: 'event',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'node',          is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'start',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'end',           is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'latitude',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'longitude',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'accuracy',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'old-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'new-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'remainder',     is_nullable: 'YES', data_type: 'jsonb' },  // eslint-disable-line no-multi-spaces
+      { column_name: 'user',          is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'change-reason', is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+    );
+  });
+
+  it('should move value from remainder to new columns', async () => {
+    await assertTableContents('client_audits', {
+      'user': 'test-user', // eslint-disable-line quote-props
+      'change-reason': 'test-reason',
+      'remainder': { 'unknown-value': 'test-unknown' } // eslint-disable-line quote-props
+    }
+    );
+  });
+});

--- a/test/db-migrations/20250415-01-client-audit-remainder.spec.js
+++ b/test/db-migrations/20250415-01-client-audit-remainder.spec.js
@@ -1,25 +1,20 @@
-const { // eslint-disable-line object-curly-newline
-  assertTableSchema,
-  assertTableContents,
-  describeMigration,
-} = require('./utils'); // eslint-disable-line object-curly-newline
-
+const { assertTableSchema, assertTableContents, describeMigration } = require('./utils');
 const { aBlob } = require('./fixtures');
 
 describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTested }) => {
   before(async () => {
     await assertTableSchema('client_audits',
-      { column_name: 'blobId',        is_nullable: 'NO', data_type: 'integer' }, // eslint-disable-line no-multi-spaces
-      { column_name: 'event',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'node',          is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'start',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'end',           is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'latitude',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'longitude',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'accuracy',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'old-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'new-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'remainder',     is_nullable: 'YES', data_type: 'jsonb' },  // eslint-disable-line no-multi-spaces
+      { column_name: 'blobId', is_nullable: 'NO', data_type: 'integer' },
+      { column_name: 'event', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'node', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'start', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'end', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'latitude', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'longitude', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'accuracy', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'old-value', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'new-value', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'remainder', is_nullable: 'YES', data_type: 'jsonb' }
     );
 
     const { md5, sha } = aBlob();
@@ -32,42 +27,41 @@ describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTest
 
     await db.any(sql`
       INSERT INTO client_audits (
-      "blobId",
-      remainder
+        "blobId",
+        remainder
       )
       VALUES (
-      ${blobId},
-      '{"user": "test-user", "change-reason": "test-reason", "unknown-value": "test-unknown"}'::jsonb
+        ${blobId},
+        '{"user": "test-user", "change-reason": "test-reason", "unknown-value": "test-unknown"}'::jsonb
       )
     `);
 
     await runMigrationBeingTested();
   });
 
-  it.only('should add columns to client audit table', async () => {
+  it('should add columns to client audit table', async () => {
     await assertTableSchema('client_audits',
-      { column_name: 'blobId',        is_nullable: 'NO', data_type: 'integer' }, // eslint-disable-line no-multi-spaces
-      { column_name: 'event',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'node',          is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'start',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'end',           is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'latitude',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'longitude',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'accuracy',      is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'old-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'new-value',     is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'remainder',     is_nullable: 'YES', data_type: 'jsonb' },  // eslint-disable-line no-multi-spaces
-      { column_name: 'user',          is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
-      { column_name: 'change-reason', is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
+      { column_name: 'blobId', is_nullable: 'NO', data_type: 'integer' },
+      { column_name: 'event', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'node', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'start', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'end', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'latitude', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'longitude', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'accuracy', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'old-value', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'new-value', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'remainder', is_nullable: 'YES', data_type: 'jsonb' },
+      { column_name: 'user', is_nullable: 'YES', data_type: 'text' },
+      { column_name: 'change-reason', is_nullable: 'YES', data_type: 'text' }
     );
   });
 
-  it.only('should move value from remainder to new columns', async () => {
+  it('should move value from remainder to new columns', async () => {
     await assertTableContents('client_audits', {
-      'user': 'test-user', // eslint-disable-line quote-props
+      user: 'test-user',
       'change-reason': 'test-reason',
-      'remainder': { 'unknown-value': 'test-unknown' } // eslint-disable-line quote-props
-    }
-    );
+      remainder: { 'unknown-value': 'test-unknown' }
+    });
   });
 });

--- a/test/db-migrations/20250415-01-client-audit-remainder.spec.js
+++ b/test/db-migrations/20250415-01-client-audit-remainder.spec.js
@@ -1,20 +1,12 @@
-const { hash, randomBytes } = require('node:crypto');
-
 const { // eslint-disable-line object-curly-newline
   assertTableSchema,
   assertTableContents,
   describeMigration,
 } = require('./utils'); // eslint-disable-line object-curly-newline
 
-describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTested }) => {
-  const aBlobWith = props => {
-    const randomContent = randomBytes(100);
-    const md5 = hash('md5',  randomContent); // eslint-disable-line no-multi-spaces
-    const sha = hash('sha1', randomContent);
-    return { md5, sha, ...props };
-  };
-  const aBlob = () => aBlobWith({});
+const { aBlob } = require('./fixtures');
 
+describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTested }) => {
   before(async () => {
     await assertTableSchema('client_audits',
       { column_name: 'blobId',        is_nullable: 'NO', data_type: 'integer' }, // eslint-disable-line no-multi-spaces
@@ -38,7 +30,7 @@ describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTest
       RETURNING id
     `);
 
-    await db.oneFirst(sql`
+    await db.any(sql`
       INSERT INTO client_audits (
       "blobId",
       remainder
@@ -47,13 +39,12 @@ describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTest
       ${blobId},
       '{"user": "test-user", "change-reason": "test-reason", "unknown-value": "test-unknown"}'::jsonb
       )
-      returning "blobId"
     `);
 
     await runMigrationBeingTested();
   });
 
-  it('should add columns to client audit table', async () => {
+  it.only('should add columns to client audit table', async () => {
     await assertTableSchema('client_audits',
       { column_name: 'blobId',        is_nullable: 'NO', data_type: 'integer' }, // eslint-disable-line no-multi-spaces
       { column_name: 'event',         is_nullable: 'YES', data_type: 'text' },   // eslint-disable-line no-multi-spaces
@@ -71,7 +62,7 @@ describeMigration('20250415-01-client-audit-remainder', ({ runMigrationBeingTest
     );
   });
 
-  it('should move value from remainder to new columns', async () => {
+  it.only('should move value from remainder to new columns', async () => {
     await assertTableContents('client_audits', {
       'user': 'test-user', // eslint-disable-line quote-props
       'change-reason': 'test-reason',

--- a/test/db-migrations/fixtures.js
+++ b/test/db-migrations/fixtures.js
@@ -1,0 +1,14 @@
+const { hash, randomBytes } = require('node:crypto');
+
+const aBlobWith = props => {
+  const randomContent = randomBytes(100);
+  const md5 = hash('md5',  randomContent); // eslint-disable-line no-multi-spaces
+  const sha = hash('sha1', randomContent);
+  return { md5, sha, ...props };
+};
+const aBlob = () => aBlobWith({});
+
+module.exports = {
+  aBlob,
+  aBlobWith
+};

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -2263,15 +2263,15 @@ describe('api: /forms/:id/submissions', () => {
                 'audits - audit.csv'
               ]);
 
-              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
-two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
+two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
             }))
           .then(() => container.oneFirst(sql`select count(*) from client_audits`)
@@ -2300,15 +2300,15 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                 'audits - audit.csv'
               ]);
 
-              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
-two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
+two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
             })))));
 
@@ -2341,15 +2341,15 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                 'audits - audit.csv'
               ]);
 
-              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
-two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
+two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
             }))
           .then(() => {
@@ -2382,6 +2382,49 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
             .catch(err => err.message.should.equal('aborted'))));
     }));
 
+    it('should return additional user and change-reason columns of client audit log', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.clientAudits)
+        .expect(200);
+
+      // The client audit for this submission contains user and change-reason columns
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .attach('audit.csv', createReadStream(appRoot + '/test/data/audit4.csv'), { filename: 'audit.csv' })
+        .attach('xml_submission_file', Buffer.from(testData.instances.clientAudits.one), { filename: 'data.xml' })
+        .expect(201);
+
+      // The client audit for this submission does not contain user and change-reason columns
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .attach('log.csv', createReadStream(appRoot + '/test/data/audit2.csv'), { filename: 'log.csv' })
+        .attach('xml_submission_file', Buffer.from(testData.instances.clientAudits.two), { filename: 'data.xml' })
+        .expect(201);
+
+      const expected = `instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,l,/data/l,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,user,reason1
+one,m,/data/m,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,user,
+one,n,/data/n,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,reason2
+two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
+`;
+
+      // Constructed ad-hoc
+      await httpZipResponseToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
+        .then((res) => res.files.get('audits - audit.csv').should.equal(expected));
+
+      // Run worker to process client audits
+      await exhaust(container);
+
+      // Constructed from worker-processed client audit log
+      await httpZipResponseToFiles(asAlice.get('/v1/projects/1/forms/audits/submissions.csv.zip'))
+        .then((res) => res.files.get('audits - audit.csv').should.equal(expected));
+    }));
+
     it('should return consolidated client audit log filtered by user', testService((service) =>
       service.login('alice', (asAlice) =>
         service.login('bob', (asBob) =>
@@ -2406,12 +2449,12 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                   'audits - audit.csv'
                 ]);
 
-                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
+                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
 `);
 
               }))))));
@@ -2442,12 +2485,12 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
                 'audits - audit.csv'
               ]);
 
-              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
+              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
 `);
 
             })))));
@@ -2477,10 +2520,10 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
                   'audits - audit.csv'
                 ]);
 
-                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-one,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+one,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
 
               }))))));
@@ -2509,10 +2552,10 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                   'audits - audit.csv'
                 ]);
 
-                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-one,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+one,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
 
               }))))));
@@ -2537,12 +2580,12 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                   'audits - audit.csv'
                 ]);
 
-                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
+                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
 `);
               }))))));
 
@@ -2566,12 +2609,12 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
                   'audits - audit.csv'
                 ]);
 
-                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,"g""g",
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
+                result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,"g""g",,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
 `);
               }))))));
 
@@ -2604,10 +2647,10 @@ one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
                     'audits - audit.csv'
                   ]);
 
-                  result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-one,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+                  result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+one,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
                 }))))));
     });

--- a/test/integration/other/encryption.js
+++ b/test/integration/other/encryption.js
@@ -480,15 +480,15 @@ describe('managed encryption', () => {
                 'audits - audit.csv'
               ]);
 
-              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
-two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
+two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
             })))));
 
@@ -522,15 +522,15 @@ two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
                 'audits - audit.csv'
               ]);
 
-              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
-two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb
-two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd
-two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff
+              result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
+two,f,/data/f,2000-01-01T00:04,2000-01-01T00:05,-1,-2,,aa,bb,,
+two,g,/data/g,2000-01-01T00:05,2000-01-01T00:06,-3,-4,,cc,dd,,
+two,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 `);
             })));
     }));

--- a/test/integration/other/submission-purging.js
+++ b/test/integration/other/submission-purging.js
@@ -455,12 +455,12 @@ describe('query module submission purge', () => {
         'audits - audit.csv'
       ]);
 
-      result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value
-one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb
-one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd
-one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff
-one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,
-one,e,/data/e,2000-01-01T00:11,,,,,hh,ii
+      result.files.get('audits - audit.csv').should.equal(`instance ID,event,node,start,end,latitude,longitude,accuracy,old-value,new-value,user,change-reason
+one,a,/data/a,2000-01-01T00:01,2000-01-01T00:02,1,2,3,aa,bb,,
+one,b,/data/b,2000-01-01T00:02,2000-01-01T00:03,4,5,6,cc,dd,,
+one,c,/data/c,2000-01-01T00:03,2000-01-01T00:04,7,8,9,ee,ff,,
+one,d,/data/d,2000-01-01T00:10,,10,11,12,gg,,,
+one,e,/data/e,2000-01-01T00:11,,,,,hh,ii,,
 `);
     }));
   });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/654

As discussed in the issue, the values for `user` and `change-reason` were luckily captured in the jsonb `remainder` column of the `client_audits` table. 

This PR migrates/copies the values from that column to two new columns in the `client_audits` table and adds `user` and `change-reason` as expected client audit headers to be included in the audit export.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I've added a new test for the behavior, created a database migration test, and tried it with some real data.

#### Why is this the best possible solution? Were any other approaches considered?

Straightforward solution based on discussion in issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Exposes `user` and `change-reason` in consolidated client audits export when these parameters are set in the xlsform: `identify-user=true track-changes-reasons=on-form-edit` 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

I'm not sure client audits are mentioned in the API docs.


#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced