### PR TITLE
util: reduce confusion around without() fn

### DIFF
--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -19,7 +19,7 @@ const { parse, render } = require('mustache');
 const Problem = require('../util/problem');
 const { isTrue, urlPathname } = require('../util/http');
 const { PartialPipe } = require('../util/stream');
-const { sanitizeOdataIdentifier, without } = require('../util/util');
+const { sanitizeOdataIdentifier, omit } = require('../util/util');
 const { jsonDataFooter, extractOptions, nextUrlFor } = require('../util/odata');
 const { submissionToOData, systemFields } = require('../data/odata');
 const { SchemaStack } = require('../data/schema');
@@ -415,9 +415,9 @@ const rowStreamToOData = (fields, table, domain, originalUrl, query, inStream, t
         for (const field of data) {
 
           // if $select is there and parentId is not requested then remove it
-          let fieldRefined = options.metadata && !options.metadata[parentIdProperty] ? without([parentIdProperty], field) : field;
+          let fieldRefined = options.metadata && !options.metadata[parentIdProperty] ? omit([parentIdProperty], field) : field;
           // if $select is there and __id is not requested then remove it
-          fieldRefined = options.metadata && !options.metadata.__id ? without(['__id'], fieldRefined) : fieldRefined;
+          fieldRefined = options.metadata && !options.metadata.__id ? omit(['__id'], fieldRefined) : fieldRefined;
 
           if (added === doLimit) remainingItems += 1;
 
@@ -538,10 +538,10 @@ const singleRowToOData = (fields, row, domain, originalUrl, query) => {
 
 
     // if $select is there and parentId is not requested then remove it
-    let paredRefined = options.metadata && !options.metadata[filterField] ? pared.map(p => without([filterField], p)) : pared;
+    let paredRefined = options.metadata && !options.metadata[filterField] ? pared.map(p => omit([filterField], p)) : pared;
 
     // if $select is there and parentId is not requested then remove it
-    paredRefined = options.metadata && !options.metadata.__id ? paredRefined.map(p => without(['__id'], p)) : paredRefined;
+    paredRefined = options.metadata && !options.metadata.__id ? paredRefined.map(p => omit(['__id'], p)) : paredRefined;
 
     // and finally splice together and return our result:
     const dataContents = JSON.stringify(paredRefined);

--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { verifyPassword, isValidToken } = require('../util/crypto');
-const { isBlank, isPresent, noop, without } = require('../util/util');
+const { isBlank, isPresent, noop, omit } = require('../util/util');
 const { isTrue, urlDecode } = require('../util/http');
 const oidc = require('../util/oidc');
 const Problem = require('../util/problem');
@@ -129,7 +129,7 @@ const authHandler = ({ Sessions, Users, Auth }, context) => {
 
       // delete the token off the body so it doesn't mess with downstream
       // payload expectations.
-      return cxt.with({ body: without([ '__csrf' ], cxt.body) });
+      return cxt.with({ body: omit([ '__csrf' ], cxt.body) });
     });
   }
 };

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -45,9 +45,9 @@ const printPairs = (obj) => {
 };
 
 // Returns a new object with all the specified keys removed.
-// We define our own without() rather than use Ramda omit() due to omit()'s curious
+// We define our own omit() rather than use Ramda omit() due to R.omit()'s curious
 // habit of reifying prototype-inherited properties whilst omitting the given keys.
-const without = (keys, obj) => {
+const omit = (keys, obj) => {
   const result = Object.assign({}, obj);
   for (const key of keys)
     delete result[key];
@@ -85,7 +85,7 @@ const attachmentToDatasetName = (attachmentName) => attachmentName.replace(/\.cs
 module.exports = {
   noop, noargs,
   isBlank, isPresent, blankStringToNull, sanitizeOdataIdentifier,
-  printPairs, without, pickAll,
+  printPairs, omit, pickAll,
   base64ToUtf8, utf8ToBase64,
   construct, attachmentToDatasetName
 };

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -8,7 +8,7 @@ const { DateTime } = require('luxon');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
-const { without } = require(appRoot + '/lib/util/util');
+const { omit } = require(appRoot + '/lib/util/util');
 
 describe('api: /projects/:id/forms (create, read, update)', () => {
 
@@ -429,7 +429,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
           .expect(200);
         // This will make a published enketo token and a draft token even though the draft is not used
         global.enketo.callCount.should.equal(2);
-        without(['token'], global.enketo.createData).should.eql({
+        omit(['token'], global.enketo.createData).should.eql({
           openRosaUrl: `${env.domain}/v1/projects/1`,
           xmlFormId: 'simple2'
         });
@@ -493,7 +493,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
         global.enketo.callCount.should.equal(1);
         const { body } = await asAlice.get('/v1/projects/1/forms/simple2')
           .expect(200);
-        without(['token'], global.enketo.createData).should.eql({
+        omit(['token'], global.enketo.createData).should.eql({
           openRosaUrl: `${container.env.domain}/v1/projects/1`,
           xmlFormId: 'simple2'
         });

--- a/test/unit/util/util.js
+++ b/test/unit/util/util.js
@@ -24,15 +24,16 @@ describe('util/util', () => {
     });
   });
 
-  describe('without', () => {
-    const { without } = util;
+  describe('omit()', () => {
+    const { omit } = util;
+
     it('should remove the specified keys', () => {
-      without([ 'b', 'd' ], { a: 1, b: 2, c: 3, d: 4, e: 5 }).should.eql({ a: 1, c: 3, e: 5 });
+      omit([ 'b', 'd' ], { a: 1, b: 2, c: 3, d: 4, e: 5 }).should.eql({ a: 1, c: 3, e: 5 });
     });
 
     it('should actually remove the keys', () => {
       // eslint-disable-next-line no-prototype-builtins
-      without([ 'b' ], { a: 1, b: 2 }).hasOwnProperty('b').should.equal(false);
+      omit([ 'b' ], { a: 1, b: 2 }).hasOwnProperty('b').should.equal(false);
     });
 
     it('should not touch or reify prototype keys', () => {
@@ -40,13 +41,13 @@ describe('util/util', () => {
       const y = Object.create(x);
       y.c = 3;
 
-      without([ 'a' ], y).should.eql({ c: 3 });
+      omit([ 'a' ], y).should.eql({ c: 3 });
       y.a.should.equal(1);
     });
 
     it('should do nothing given no keys or no obj', () => {
-      without([], { a: 1 }).should.eql({ a: 1 });
-      without([ 'test' ]).should.eql({});
+      omit([], { a: 1 }).should.eql({ a: 1 });
+      omit([ 'test' ]).should.eql({});
     });
   });
 

--- a/test/util/enketo.js
+++ b/test/util/enketo.js
@@ -4,7 +4,7 @@
 const appRoot = require('app-root-path');
 const { call } = require('ramda');
 const Problem = require(appRoot + '/lib/util/problem');
-const { without } = require(appRoot + '/lib/util/util');
+const { omit } = require(appRoot + '/lib/util/util');
 
 const defaults = {
   // Properties that can be set to change the behavior of the mock. These
@@ -50,7 +50,7 @@ const request = () => {
   const options = { ...global.enketo };
 
   if (global.enketo.autoReset)
-    Object.assign(global.enketo, without(['callCount'], defaults));
+    Object.assign(global.enketo, omit(['callCount'], defaults));
 
   return new Promise((resolve, reject) => {
     const { wait } = options;


### PR DESCRIPTION
* rename util fn `without()` to `omit()`

This should reduce confusion between Ramda's `without()` function, for modifying arrays, and this repo's `omit()` function, which is a re-implementation of Ramda's `omit()` function, but with specific guarantees.

See:

* https://ramdajs.com/docs/#omit
* https://ramdajs.com/docs/#without

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Existing test suite passes.

#### Why is this the best possible solution? Were any other approaches considered?

This should prevent confusion between:

* `without()` imported from `ramda`
* `without()` imported from `./lib/util/util`
* `omit()` imported from `ramda`

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced