### PR TITLE
Don't return actorId from /v1/sessions/restore

### DIFF
--- a/lib/resources/sessions.js
+++ b/lib/resources/sessions.js
@@ -9,12 +9,12 @@
 
 const { verifyPassword } = require('../util/crypto');
 const Problem = require('../util/problem');
-const { isBlank, noargs, omit } = require('../util/util');
+const { isBlank, noargs } = require('../util/util');
 const { getOrReject, rejectIf } = require('../util/promise');
 const { success } = require('../util/http');
 const { SESSION_COOKIE, createUserSession } = require('../http/sessions');
 const oidc = require('../util/oidc');
-const { partial } = require('ramda');
+const { pick } = require('ramda');
 
 module.exports = (service, endpoint) => {
 
@@ -44,7 +44,7 @@ module.exports = (service, endpoint) => {
 
   service.get('/sessions/restore', endpoint((_, { auth }) =>
     auth.session
-      .map(partial(omit, [['token', 'csrf']]))
+      .map(pick(['createdAt', 'expiresAt']))
       .orElse(Problem.user.notFound())));
 
   const logOut = (Sessions, auth, session) =>

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -143,10 +143,11 @@ should.Assertion.add('ExtendedSubmissionDef', function() {
 should.Assertion.add('Session', function() {
   this.params = { operator: 'to be a Session' };
 
-  Object.keys(this.obj).should.containDeep([ 'expiresAt', 'createdAt', 'token' ]);
+  Object.keys(this.obj).should.eqlInAnyOrder([ 'expiresAt', 'createdAt', 'token', 'csrf' ]);
   this.obj.expiresAt.should.be.an.isoDate();
   this.obj.createdAt.should.be.an.isoDate();
   this.obj.token.should.be.a.token();
+  this.obj.csrf.should.be.a.token();
 });
 
 should.Assertion.add('FieldKey', function() {

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -145,6 +145,7 @@ describe('api: /sessions', () => {
           .set('Cookie', 'session=' + token)
           .expect(200)
           .then((restore) => {
+            Object.keys(restore.body).should.eqlInAnyOrder(['createdAt', 'expiresAt']);
             restore.body.expiresAt.should.be.an.isoDate();
             restore.body.createdAt.should.be.an.isoDate();
             should(restore.body.token).be.undefined();


### PR DESCRIPTION
This is a follow-up PR to #1472. I noticed that /v1/sessions/restore was returning `actorId` in addition to `expiresAt` and `createdAt`. `actorId` isn't a readable field on the `Session` frame, and I don't think we want to return it from this endpoint.

#### What has been done to verify that this works as intended?

I updated a test.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced