### PR TITLE
Usage metric: count webforms enabled

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/forms/odk-analytics/submissions",
         "formId": "odk-analytics",
-        "version": "v2024.3.0_1"
+        "version": "v2025.1.0_1"
       },
       "s3blobStore": {}
     }

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -101,6 +101,7 @@ const metricsTemplate = {
           "recent": 0,
           "total": 0
         },
+        "num_forms_webforms_enabled": 0,
         "num_reused_form_ids": 0,
         "num_open_forms": {
           "recent": 0,

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -219,16 +219,15 @@ group by f."projectId";`);
 
 // Forms
 const countForms = () => ({ all }) => all(sql`
-select p."id" as "projectId", count(f."id") as total, count(recentSubs."activeForm") as recent
+select f."projectId" as "projectId", count(f."id") as total, count(recentSubs."activeForm") as recent
 from forms as f
-join projects as p on p."id" = f."projectId"
 left join (
   select "formId" as "activeForm"
   from submissions
   where "createdAt" >= ${_cutoffDate}
   group by "formId"
   ) as recentSubs on recentSubs."activeForm" = f."id"
-group by p."id"`);
+group by f."projectId"`);
 
 const countFormFieldTypes = () => ({ all }) => all(sql`
 select fs."projectId",
@@ -309,6 +308,13 @@ left join (
   group by "formId"
   ) as recentSubs on recentSubs."activeForm" = f."id"
 group by (p."id", f."state")`);
+
+
+const countFormsWebformsEnabled = () => ({ all }) => all(sql`
+  select f."projectId" as "projectId", count(f."id") as total
+  from forms as f
+  where f."webformsEnabled" is true
+  group by f."projectId"`);
 
 // This query checks the audit log for 'form.delete' actions
 // and joins with two sources: purged actees and soft-deleted forms
@@ -662,6 +668,7 @@ const projectMetrics = () => (({ Analytics }) => runSequentially([
   Analytics.countFormFieldTypes,
   Analytics.countFormsEncrypted,
   Analytics.countFormsInStates,
+  Analytics.countFormsWebformsEnabled,
   Analytics.countReusedFormIds,
   Analytics.countSubmissions,
   Analytics.countSubmissionReviewStates,
@@ -673,7 +680,7 @@ const projectMetrics = () => (({ Analytics }) => runSequentially([
   Analytics.getDatasetEvents,
   Analytics.getDatasetProperties
 ]).then(([ userRoles, appUsers, deviceIds, pubLinks,
-  forms, formGeoRepeats, formsEncrypt, formStates, reusedIds,
+  forms, formGeoRepeats, formsEncrypt, formStates, webforms, reusedIds,
   subs, subStates, subEdited, subComments, subUsers,
   projWithDesc, datasets, datasetEvents, datasetProperties ]) => {
   const projects = {};
@@ -737,6 +744,11 @@ const projectMetrics = () => (({ Analytics }) => runSequentially([
     };
     const project = _getProject(projects, row.projectId);
     project.forms[stateToField[row.state]] = { total: row.total, recent: row.recent };
+  }
+
+  for (const row of webforms) {
+    const project = _getProject(projects, row.projectId);
+    project.forms.num_forms_webforms_enabled = row.total;
   }
 
   for (const row of reusedIds) {
@@ -944,6 +956,7 @@ module.exports = {
   countFormsEncrypted,
   countFormFieldTypes,
   countFormsInStates,
+  countFormsWebformsEnabled,
   countPublicLinks,
   countReusedFormIds,
   countSubmissions,


### PR DESCRIPTION
Backend part of https://github.com/getodk/central/issues/861

Count number of forms in each project that have webforms enabled.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced