### PR TITLE
Fixes #1495: Truncate user-agent and deviceId

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -54,6 +54,7 @@ info:
     - Draft Submission can be created using draft token by adding `/test/{token}` to [Creating a draft Submission](/central-api-submission-management/#id1) endpoint.
     - [Dataset Metadata](/central-api-dataset-management/#dataset-metadata) now includes a new property, `lastUpdate`, which is the timestamp of the latest modification to the datasets or its entities.
     - After a file is uploaded for a Form Attachment via the POST endpoint, the response is now the updated Attachment.
+    - `userAgent` and `deviceId` longer than 255 characters will be truncated in [Submissions APIs](/central-api-submission-management)
 
     ## ODK Central v2024.3
 
@@ -13012,10 +13013,12 @@ components:
           description: The ID of the `Actor` (`App User`, `User`, or `Public Link`) that submitted this `Submission` version.
         deviceId:
           type: string
+          maxLength: 255
           example: imei:123456
           description: The self-identified `deviceId` of the device that submitted the `Submission` version.
         userAgent:
           type: string
+          maxLength: 255
           example: Enketo/3.0.4
           description: The self-identified `userAgent` of the device that submitted the `Submission` version.
         createdAt:

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -14,12 +14,11 @@ const { Actor, Form, Submission } = require('../frames');
 const { odataFilter, odataOrderBy, odataExcludeDeleted } = require('../../data/odata-filter');
 const { odataToColumnMap, odataSubTableToColumnMap } = require('../../data/submission');
 const { unjoiner, extender, sqlEquals, page, updater, QueryOptions, insertMany, markDeleted, markUndeleted, sqlInArray } = require('../../util/db');
-const { blankStringToNull, construct } = require('../../util/util');
+const { blankStringToNull, construct, truncateString, applyPipe } = require('../../util/util');
 const Problem = require('../../util/problem');
 const { streamEncBlobs } = require('../../util/blob');
 const { PURGE_DAY_RANGE } = require('../../util/constants');
 const Option = require('../../util/option');
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // SUBMISSION CREATE
@@ -32,8 +31,8 @@ const nextval = sql`nextval(pg_get_serial_sequence('submissions', 'id'))`;
 // creates both the submission and its initial submission def in one go.
 const createNew = (partial, form, deviceIdIn = null, userAgentIn = null) => ({ one, context }) => {
   const actorId = context.auth.actor.map((actor) => actor.id).orNull();
-  const deviceId = blankStringToNull(deviceIdIn);
-  const userAgent = blankStringToNull(userAgentIn);
+  const deviceId = applyPipe(deviceIdIn, truncateString(255), blankStringToNull);
+  const userAgent = applyPipe(userAgentIn, truncateString(255), blankStringToNull);
 
   return one(sql`
 with def as (${_defInsert(nextval, partial, form.def.id, actorId, true, deviceId, userAgent)}),
@@ -78,8 +77,8 @@ createNew.audit.logEvenIfAnonymous = true; // so that test submissions are fully
 
 const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn = null) => ({ one, context }) => {
   const actorId = context.auth.actor.map((actor) => actor.id).orNull();
-  const deviceId = blankStringToNull(deviceIdIn);
-  const userAgent = blankStringToNull(userAgentIn);
+  const deviceId = applyPipe(deviceIdIn, truncateString(255), blankStringToNull);
+  const userAgent = applyPipe(userAgentIn, truncateString(255), blankStringToNull);
 
   const _unjoiner = unjoiner(Submission, Submission.Def.into('currentVersion'));
 

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -9,6 +9,7 @@
 //
 // Contains generic util functions for manipulating strings, objects, and arrays.
 
+const { pipe } = require('ramda');
 const { inspect } = require('util');
 
 ////////////////////////////////////////
@@ -16,6 +17,7 @@ const { inspect } = require('util');
 
 const noop = () => {};
 const noargs = (f) => () => f();
+const applyPipe = (input, ...fns) => pipe(...fns)(input);
 
 
 ////////////////////////////////////////
@@ -26,6 +28,8 @@ const isBlank = (x) => (x === null) || (x === undefined) || (x === '');
 const isPresent = (x) => !isBlank(x);
 
 const blankStringToNull = (x) => ((x === '') ? null : x);
+
+const truncateString = length => str => (str ? str.substring(0, length) : str);
 
 // adds an underscore in front of leading illegal characters, and replaces contained
 // illegal characters with _
@@ -83,8 +87,8 @@ const construct = (Type) => (x, y) => new Type(x, y);
 const attachmentToDatasetName = (attachmentName) => attachmentName.replace(/\.csv$/i, '');
 
 module.exports = {
-  noop, noargs,
-  isBlank, isPresent, blankStringToNull, sanitizeOdataIdentifier,
+  noop, noargs, applyPipe,
+  isBlank, isPresent, blankStringToNull, truncateString, sanitizeOdataIdentifier,
   printPairs, omit, pickAll,
   base64ToUtf8, utf8ToBase64,
   construct, attachmentToDatasetName

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1147,6 +1147,25 @@ describe('api: /forms/:id/submissions', () => {
               body[0].userAgent.should.equal('central/test');
             })))));
 
+    const lengthyUserAgent = 'Enketo/7.5.1 Mozilla/5.0 (iPhone; CPU iPhone OS 18_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/22E252 [FBAN/FBIOS;FBAV/512.0.0.52.99;FBBV/731098301;FBDV/iPhone15,4;FBMD/iPhone;FBSN/iOS;FBSV/18.4.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5;FBRV/733464354;IABMV/1]';
+    const lengthyDeviceId = 'Lorem Ipsum: In ea cillum aliqua voluptate est non aute aute dolor. Non amet sit deserunt amet quis qui voluptate ad dolor magna do adipisicing. Laboris mollit anim exercitation anim Lorem ullamco culpa nulla sit qui. Occaecat laboris minim ea ut laboris mollit quis. Proident pariatur Lorem adipisicing nisi enim minim.';
+    it('should not fail if longer userAgent and deviceId is provided', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post(`/v1/projects/1/forms/simple/submissions?deviceID=${lengthyDeviceId}`)
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'text/xml')
+          .set('User-Agent', lengthyUserAgent)
+          .expect(200)
+          .then(({ body }) => {
+            body.deviceId.should.startWith('Lorem Ipsum');
+          })
+          .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/versions')
+            .expect(200)
+            .then(({ body }) => {
+              body[0].deviceId.should.startWith('Lorem Ipsum');
+              body[0].userAgent.should.startWith('Enketo/7.5.1');
+            })))));
+
     it('should accept a submission for an old form version', testService((service, { Submissions, one }) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms/simple/draft')


### PR DESCRIPTION
Closes #1495 

#### What has been done to verify that this works as intended?

All tests are passing

#### Why is this the best possible solution? Were any other approaches considered?

As mentioned in the issue, increasing the column width is not a reliable solution, we can't know the upper limit of user-agent or device ID

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Updated

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced