### PR TITLE
Return approvalEntityList in Form attachment manifest

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -42,6 +42,11 @@ info:
 
     ## ODK Central v2025.1
 
+    **Changed**:
+    - [Form attachment manifest API](/central-api-openrosa-endpoints/#openrosa-form-manifest-api) returns `type="approvalEntityList"` in the `mediaFile` element for the Datasets that require Submission approval to create Entities.
+    
+    ## ODK Central v2025.1
+
     **Added**:
     - [RESTORE](/central-api-entity-management/#restoring-a-deleted-entity) endpoint for Entities.
     - Entities that have been soft-deleted for 30 days will automatically be purged. 
@@ -9855,7 +9860,7 @@ paths:
 
         [Offline Entities support](https://forum.getodk.org/t/openrosa-spec-proposal-support-offline-entities/48052):
 
-        * If an attachment is linked to a Dataset, then `type="entityList"` attribute is added to the `mediaFile` element.
+        * If an attachment is linked to a Dataset, then `type="entityList"` attribute is added to the `mediaFile` element. If the Dataset requires approval of Submission to create new Entity then `type="approvalEntityList"` is added instead.
 
         * `integrityUrl` is also returned for the attachments that are linked to a Dataset.
       operationId: OpenRosa Form Manifest API

--- a/lib/formats/openrosa.js
+++ b/lib/formats/openrosa.js
@@ -63,7 +63,7 @@ const formManifestTemplate = template(200, `<?xml version="1.0" encoding="UTF-8"
   <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
   {{#attachments}}
     {{#hasSource}}
-    <mediaFile{{#isDataset}} type="entityList"{{/isDataset}}>
+    <mediaFile{{#isDataset}} type="{{datasetType}}"{{/isDataset}}>
       <filename>{{name}}</filename>
       <hash>md5:{{openRosaHash}}</hash>
       <downloadUrl>{{{domain}}}{{{basePath}}}/attachments/{{urlName}}</downloadUrl>
@@ -82,6 +82,7 @@ const formManifest = (data) => formManifestTemplate(mergeRight(data, {
       hasSource: attachment.blobId || attachment.datasetId,
       urlName: encodeURIComponent(attachment.name),
       isDataset: attachment.datasetId != null,
+      datasetType: attachment.datasetType,
       integrityUrl: attachment.datasetId ?
         `${data.domain}${data.projectPath}/datasets/${encodeURIComponent(attachmentToDatasetName(attachment.name))}/integrity`
         : null

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -656,8 +656,9 @@ const getUnprocessedSubmissions = (datasetId) => ({ all }) =>
   all(_unprocessedSubmissions(datasetId, sql`audits.*`))
     .then(map(construct(Audit)));
 
-// Used in the openRosa form attachment manifest.
-// Also to return lastUpdate field for `GET /datasets/:name`
+// To return lastUpdate field for `GET /datasets/:name`
+// Similar query is in form-attachments.js, if the logic lastUpdateTimestamp is changed here then it
+// probably needs to be changed there.
 const getLastUpdateTimestamp = (datasetId) => ({ maybeOne }) =>
   maybeOne(sql`
   SELECT "loggedAt" FROM audits

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -143,8 +143,8 @@ const _unjoin = (datasetMetadata = false) => {
 
 const _get = (exec, options) => {
   const unjoin = _unjoin(options.datasetMetadata);
-  return exec(sql`select ${unjoin.fields} from form_attachments
-    left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
+  return exec(sql`SELECT ${unjoin.fields} FROM form_attachments
+    LEFT OUTER JOIN (SELECT id, md5 FROM blobs) AS blobs ON form_attachments."blobId"=blobs.id
     ${!options.datasetMetadata ? sql`` : sql`
       LEFT OUTER JOIN datasets ON datasets.id = form_attachments."datasetId"
       LEFT OUTER JOIN (
@@ -153,7 +153,7 @@ const _get = (exec, options) => {
         GROUP BY datasets.id
       ) audits ON audits.id = datasets.id
     `}
-    where ${sqlEquals(options.condition)} order by form_attachments.name asc`)
+    WHERE ${sqlEquals(options.condition)} ORDER BY form_attachments.name ASC`)
     .then(map(unjoin));
 };
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -130,17 +130,35 @@ update.audit = (form, fa, blobId, datasetId = null) => (log) => log('form.attach
 ////////////////////////////////////////////////////////////////////////////////
 // GETTERS
 
-// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
-const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
+// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame.
+// Also adds dataset metadata if datasetMetadata is true,
+// (similar query Datasets.getLastUpdateTimestamp)
+const _unjoin = (datasetMetadata = false) => {
+  const frames = [Form.Attachment, Frame.define(into('blob'), 'md5')];
+  if (datasetMetadata) {
+    frames.push(Frame.define(into('dataset'), 'approvalRequired', 'lastUpdateTimestamp'));
+  }
+  return unjoiner(...frames);
+};
 
-const _get = (exec, options) =>
-  exec(sql`select ${_unjoinMd5.fields} from form_attachments
-  left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
-  where ${sqlEquals(options.condition)} order by name asc`)
-    .then(map(_unjoinMd5));
+const _get = (exec, options) => {
+  const unjoin = _unjoin(options.datasetMetadata);
+  return exec(sql`select ${unjoin.fields} from form_attachments
+    left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
+    ${!options.datasetMetadata ? sql`` : sql`
+      LEFT OUTER JOIN datasets ON datasets.id = form_attachments."datasetId"
+      LEFT OUTER JOIN (
+        SELECT datasets.id, MAX("loggedAt") "lastUpdateTimestamp" FROM audits
+        JOIN datasets ON audits."acteeId" = datasets."acteeId"
+        GROUP BY datasets.id
+      ) audits ON audits.id = datasets.id
+    `}
+    where ${sqlEquals(options.condition)} order by form_attachments.name asc`)
+    .then(map(unjoin));
+};
 
-const getAllByFormDefId = (formDefId) => ({ all }) =>
-  _get(all, QueryOptions.none.withCondition({ formDefId }));
+const getAllByFormDefId = (formDefId, options = QueryOptions.none) => ({ all }) =>
+  _get(all, options.withCondition({ formDefId }));
 
 const getByFormDefIdAndName = (formDefId, name) => ({ maybeOne }) =>
   _get(maybeOne, QueryOptions.none.withCondition({ formDefId, name }));
@@ -150,20 +168,23 @@ const getByFormDefIdAndName = (formDefId, name) => ({ maybeOne }) =>
 // If the attachment is actually an entity list, it looks up the last modified time
 // in the database, which is computed from the latest dataset/entity audit timestamp.
 // It is dynamic because it can change when a dataset's data is updated.
-const _chooseOpenRosaHash = (attachment) => async ({ Datasets }) => {
+const _chooseOpenRosaHash = (attachment) => {
   if (attachment.blobId) return attachment.with({ openRosaHash: attachment.aux.blob.md5 });
 
   if (attachment.datasetId) {
-    const lastTimestamp = await Datasets.getLastUpdateTimestamp(attachment.datasetId);
-    return attachment.with({ openRosaHash: md5sum(lastTimestamp ? lastTimestamp.toISOString() : '1970-01-01') });
+    const lastTimestamp = attachment.aux.dataset.lastUpdateTimestamp;
+    return attachment.with({
+      openRosaHash: md5sum(lastTimestamp ? lastTimestamp.toISOString() : '1970-01-01'),
+      datasetType: attachment.aux.dataset.approvalRequired ? 'approvalEntityList' : 'entityList'
+    });
   }
 
   return attachment.with({ openRosaHash: null });
 };
 
 const getAllByFormDefIdForOpenRosa = (formDefId) => ({ FormAttachments }) =>
-  FormAttachments.getAllByFormDefId(formDefId)
-    .then((attachments) => Promise.all(attachments.map(FormAttachments._chooseOpenRosaHash)));
+  FormAttachments.getAllByFormDefId(formDefId, new QueryOptions({ datasetMetadata: true }))
+    .then((attachments) => attachments.map(_chooseOpenRosaHash));
 
 
 module.exports = {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -3006,7 +3006,7 @@ describe('datasets and entities', () => {
 
       }));
 
-      it('should return md5 of last Entity timestamp in the manifest', testService(async (service) => {
+      it('should return approvalEntityList as the type attribute of mediaFile for datasets that require approval', testService(async (service) => {
         const asAlice = await service.login('alice');
 
         await asAlice.post('/v1/projects/1/datasets')

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -3006,6 +3006,41 @@ describe('datasets and entities', () => {
 
       }));
 
+      it('should return md5 of last Entity timestamp in the manifest', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people', approvalRequired: true })
+          .expect(200);
+
+        const result = await asAlice.get('/v1/projects/1/datasets/people/entities.csv')
+          .expect(200);
+
+        const etag = result.get('ETag');
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.withAttachments.replace(/goodone/g, 'people'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/forms/withAttachments/manifest')
+          .set('X-OpenRosa-Version', '1.0')
+          .expect(200)
+          .then(({ text }) => {
+            const domain = config.get('default.env.domain');
+            text.should.be.eql(`<?xml version="1.0" encoding="UTF-8"?>
+  <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    <mediaFile type="approvalEntityList">
+      <filename>people.csv</filename>
+      <hash>md5:${etag.replace(/"/g, '')}</hash>
+      <downloadUrl>${domain}/v1/projects/1/forms/withAttachments/attachments/people.csv</downloadUrl>
+      <integrityUrl>${domain}/v1/projects/1/datasets/people/integrity</integrityUrl>
+    </mediaFile>
+  </manifest>`);
+          });
+
+      }));
+
       it('should return 304 content not changed if ETag matches', testService(async (service, container) => {
         const asAlice = await service.login('alice');
 


### PR DESCRIPTION
Closes getodk/central#685

#### What has been done to verify that this works as intended?

Added a test.

#### Why is this the best possible solution? Were any other approaches considered?

I could have modified `getLastUpdateTimestamp()` to return `approvalRequired` fields as well but that function is consumed by `Datasets.getMetadata` as well where approval required is already available. But the real reason I didn't go that route is the renaming the function, what could I have called the it (getLastUpdateTimestampAndApprovalRequired?) 🙃

The change in this PR modifies the `FormAttachments._get()` in a way that additional database queries for each dataset are no longer required, saving us multiple database round-trips.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced