### PR TITLE
forms/draft/get: fix permissions check

### DIFF
--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -31,10 +31,10 @@ const excelMimeTypes = {
 };
 
 const canReadForm = (auth, form) => {
-  if (form.state === 'closed') {
-    return auth.canOrReject('form.read', form);
-  } else if (form.def.publishedAt === null) {
+  if (form.def.publishedAt === null) {
     return auth.canOrReject('form.update', form);
+  } else if (form.state === 'closed') {
+    return auth.canOrReject('form.read', form);
   } else {
     return auth.canOrReject(['open_form.read', 'form.read'], form);
   }

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -30,9 +30,15 @@ const excelMimeTypes = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 };
 
-const canReadForm = (auth, form) => (form.state === 'closed'
-  ? auth.canOrReject('form.read', form)
-  : auth.canOrReject(['open_form.read', 'form.read'], form));
+const canReadForm = (auth, form) => {
+  if (form.state === 'closed') {
+    return auth.canOrReject('form.read', form);
+  } else if (form.def.publishedAt === null) {
+    return auth.canOrReject('form.update', form);
+  } else {
+    return auth.canOrReject(['open_form.read', 'form.read'], form);
+  }
+};
 
 const streamAttachment = async (container, attachment, response) => {
   const { s3, Blobs, Datasets, Entities } = container;

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -31,7 +31,7 @@ const excelMimeTypes = {
 };
 
 const canReadForm = (auth, form) => {
-  if (form.def.publishedAt === null) {
+  if (form.def.publishedAt == null) {
     return auth.canOrReject('form.update', form);
   } else if (form.state === 'closed') {
     return auth.canOrReject('form.read', form);

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -1418,7 +1418,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
         'pub-link',
         'viewer',
       ].forEach(role => {
-        it.only(`should reject if the user has role "${role}"`, testService((service) =>
+        it(`should reject if the user has role "${role}"`, testService((service) =>
           service.login('alice', (asAlice) =>
             asAlice.post('/v1/projects/1/forms/simple/draft')
               .send(testData.forms.simple)

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -1416,7 +1416,6 @@ describe('api: /projects/:id/forms (drafts)', () => {
         'formfill',
         'formview',
         'pub-link',
-        'pwreset',
         'viewer',
       ].forEach(role => {
         it.only(`should reject if the user has role "${role}"`, testService((service) =>

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -1401,7 +1401,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
               should.not.exist(body.details);
             }))));
 
-      it.only('should reject if the user does not have project-specific permissions', testService((service) =>
+      it('should reject if the user does not have project-specific permissions', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms/simple/draft')
             .send(testData.forms.simple)
@@ -1428,7 +1428,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 asChelsea.get('/v1/users/current')
                   .expect(200)
                   .then(({ body }) => body)
-                  .then((chelsea) => 
+                  .then((chelsea) =>
                     asAlice.post(`/v1/projects/1/assignments/${role}/${chelsea.id}`)
                       .expect(200))
                   .then(() => asChelsea.get('/v1/projects/1/forms/simple/draft')


### PR DESCRIPTION
<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

* role check as suggested by @matthew-white 
* maybe there's a neater way to check if a form is a draft?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Might affect users who were taking advantage of the lax permissions checks.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Should not.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced