### PR TITLE
Auth.verbsOn(): deduplicate data returned from db

### DIFF
--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -59,17 +59,20 @@ const canAssignRole = (actor, role, actee) => ({ Auth }) =>
     return true;
   });
 
-const verbsOn = (actorId, actee) => ({ all }) => {
+const verbsOn = (actorId, actee) => ({ allFirst }) => {
   const acteeId = actee.acteeId || actee;
-  return all(sql`
-${_impliedActees(acteeId)}
-select verbs from roles
-inner join (select "roleId" from assignments
-  inner join implied on implied.id=assignments."acteeId"
-  where "actorId"=${actorId})
-  as assignments on assignments."roleId"=roles.id`)
-    // TODO: it miiiiight be possible to make postgres do this work?
-    .then(compose(uniq, flatten, map((r) => r.verbs)));
+
+  return allFirst(sql`
+    ${_impliedActees(acteeId)}
+    SELECT DISTINCT JSONB_ARRAY_ELEMENTS_TEXT(verbs)
+      FROM roles
+      INNER JOIN (
+        SELECT "roleId"
+          FROM assignments
+          INNER JOIN implied ON implied.id=assignments."acteeId"
+          WHERE "actorId"=${actorId}
+        ) AS assignments ON assignments."roleId"=roles.id
+  `);
 };
 
 

--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -8,7 +8,6 @@
 // except according to the terms contained in the LICENSE file.
 
 const { sql } = require('slonik');
-const { compose, uniq, flatten, map } = require('ramda');
 const { Actor, Session } = require('../frames');
 const { resolve, reject } = require('../../util/promise');
 const Option = require('../../util/option');

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -268,6 +268,7 @@ const queryFuncs = (db, obj) => {
     for (let i = 0; i < xs.length; i += 1) result[i] = f(xs[i]);
     return result;
   };
+  obj.allFirst = (s) => db.anyFirst(s);
 
   obj.stream = (s) => new Promise((resolve, reject1) => {
     db.stream(s, stream => {

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -391,7 +391,7 @@ describe('api: /projects', () => {
         .expect(200);
       project.verbs.should.be.an.Array();
       const { body: admin } = await asAlice.get('/v1/roles/admin').expect(200);
-      project.verbs.should.eql(admin.verbs);
+      project.verbs.should.eqlInAnyOrder(admin.verbs);
       project.verbs.should.containDeep([ 'user.password.invalidate', 'project.delete' ]);
     }));
 
@@ -403,7 +403,7 @@ describe('api: /projects', () => {
       project.verbs.should.be.an.Array();
       const { body: manager } = await asBob.get('/v1/roles/manager')
         .expect(200);
-      project.verbs.should.eql(manager.verbs);
+      project.verbs.should.eqlInAnyOrder(manager.verbs);
       project.verbs.should.containDeep([ 'assignment.create', 'project.delete', 'dataset.list' ]);
       project.verbs.should.not.containDeep([ 'project.create' ]);
     }));


### PR DESCRIPTION
Resolves TODO ref de-duplicating data on postgres side.

Noticed while working on #1502

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

All existing tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

The functional change is quite minimal.  There are unnecessary formatting changes included in this PR, which IMO make the whole thing more readable.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced