### PR TITLE
auth.can(): simplify SQL

### DIFF
--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -40,12 +40,11 @@ const can = (actor, verbs, actee) => ({ oneFirst }) => {
 
   return oneFirst(sql`
 ${_impliedActees(acteeId)}
-select count(*) from assignments
+select count(*)>0 from assignments
 inner join implied on implied.id=assignments."acteeId"
 inner join (select id from roles where ${_verbClause(verbsSet)}) as role on role.id=assignments."roleId"
 where "actorId"=${actor.id}
-limit 1`)
-    .then((count) => count > 0);
+  `);
 };
 
 const canAssignRole = (actor, role, actee) => ({ Auth }) =>

--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -19,9 +19,7 @@ with recursive implied(id) as (
   (select unnest(ARRAY[ parent, species ]) from actees
     join implied on implied.id=actees.id))`;
 
-const _verbClause = (verbs) => sql.join(Array.from(verbs).map(v => sql`verbs ? ${v}`), sql` or `);
-
-const can = (actor, verbs, actee) => ({ oneFirst }) => {
+const can = (actor, verbs, actee) => () => {
   const acteeId = actee.acteeId || actee;
 
   const verbsSet = new Set(typeof verbs === 'string' ? [verbs] : verbs);
@@ -37,13 +35,7 @@ const can = (actor, verbs, actee) => ({ oneFirst }) => {
       return resolve(true);
   }
 
-  return oneFirst(sql`
-${_impliedActees(acteeId)}
-select count(*)>0 from assignments
-inner join implied on implied.id=assignments."acteeId"
-inner join (select id from roles where ${_verbClause(verbsSet)}) as role on role.id=assignments."roleId"
-where "actorId"=${actor.id}
-  `);
+  return Promise.resolve(true);
 };
 
 const canAssignRole = (actor, role, actee) => ({ Auth }) =>

--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -35,7 +35,7 @@ const can = (actor, verbs, actee) => () => {
       return resolve(true);
   }
 
-  return Promise.resolve(true);
+  return Promise.resolve(false);
 };
 
 const canAssignRole = (actor, role, actee) => ({ Auth }) =>

--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -44,9 +44,7 @@ const can = (actor, verbs, actee) => ({ oneFirst }) => {
         FROM assignments
         INNER JOIN implied ON implied.id=assignments."acteeId"
         INNER JOIN (
-          SELECT id
-            FROM roles
-            WHERE ${_verbClause(verbsSet)}
+          SELECT id FROM roles WHERE ${_verbClause(verbsSet)}
         ) AS role ON role.id=assignments."roleId"
         WHERE "actorId"=${actor.id}
     )

--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -42,8 +42,12 @@ const can = (actor, verbs, actee) => ({ oneFirst }) => {
     SELECT EXISTS (
       SELECT 1
         FROM assignments
-        INNER JOIN implied ON implied.id = assignments."acteeId"
-        INNER JOIN roles   ON roles.id   = assignments."roleId"
+        INNER JOIN implied ON implied.id=assignments."acteeId"
+        INNER JOIN (
+          SELECT id
+            FROM roles
+            WHERE ${_verbClause(verbsSet)}
+        ) AS role ON role.id=assignments."roleId"
         WHERE "actorId"=${actor.id}
     )
   `);

--- a/lib/model/query/auth.js
+++ b/lib/model/query/auth.js
@@ -19,7 +19,9 @@ with recursive implied(id) as (
   (select unnest(ARRAY[ parent, species ]) from actees
     join implied on implied.id=actees.id))`;
 
-const can = (actor, verbs, actee) => () => {
+const _verbClause = (verbs) => sql.join(Array.from(verbs).map(v => sql`verbs ? ${v}`), sql` or `);
+
+const can = (actor, verbs, actee) => ({ oneFirst }) => {
   const acteeId = actee.acteeId || actee;
 
   const verbsSet = new Set(typeof verbs === 'string' ? [verbs] : verbs);
@@ -35,7 +37,16 @@ const can = (actor, verbs, actee) => () => {
       return resolve(true);
   }
 
-  return Promise.resolve(false);
+  return oneFirst(sql`
+    ${_impliedActees(acteeId)}
+    SELECT EXISTS (
+      SELECT 1
+        FROM assignments
+        INNER JOIN implied ON implied.id = assignments."acteeId"
+        INNER JOIN roles   ON roles.id   = assignments."roleId"
+        WHERE "actorId"=${actor.id}
+    )
+  `);
 };
 
 const canAssignRole = (actor, role, actee) => ({ Auth }) =>


### PR DESCRIPTION
Current code seems odd.

Noted while working on #1502

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

- [x] existing tests pass

#### Why is this the best possible solution? Were any other approaches considered?

This introduces some formatting change which IMO improve readability.  A simpler changeset could be achieved by maintaining existing formatting.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Potential for breaking existing authZ, but test coverage should ensure it's fine.  Also reading the code, it seems low-risk.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced