### PR TITLE
Allow entities-version 2025.1 and refactor to prepare to parse multiple datasets

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -82,20 +82,46 @@ const validatePropertyName = (name) => {
 };
 
 /*
-getDataset() parses form XML for dataset-related information on the <entity>
-tag:
+Extracts the dataset name and actions from an <entity> block.
+*/
+const getNameAndActions = (entityAttrs) => {
+  const strippedAttrs = Object.create(null);
+  for (const [name, value] of Object.entries(entityAttrs.get()))
+    strippedAttrs[stripNamespacesFromPath(name)] = value;
+
+  // check that dataset name is valid
+  const datasetName = strippedAttrs.dataset?.trim();
+  if (datasetName == null)
+    throw Problem.user.invalidEntityForm({ reason: 'Dataset name is missing.' });
+  if (!validateDatasetName(datasetName))
+    throw Problem.user.invalidEntityForm({ reason: 'Invalid dataset name.' });
+
+  // Entity actions permitted by the form def
+  const actions = [];
+  const { create, update } = strippedAttrs;
+  if (create != null) actions.push('create');
+  if (update != null) actions.push('update');
+  if (actions.length === 0)
+    throw Problem.user.invalidEntityForm({ reason: 'The form must specify at least one entity action, for example, create or update.' });
+
+  return { name: datasetName, actions };
+};
+
+/*
+getDatasets() parses form XML for dataset-related information on the <entity>
+tag and returns a list of datasets, each one including:
 
   - The dataset name
   - The entity actions permitted by the form def
 
-getDataset() also does some validation, including of:
+getDatasets() also does some validation, including of:
 
   - The version of the entities spec
   - The dataset name
 
 Like with getFormFields() in schema.js, we assume the form is otherwise valid.
 */
-const getDataset = (xml) =>
+const getDatasets = (xml) =>
   traverseXml(xml, [
     findOne(root('html'), node('head'), node('model'))(attr('entities-version')),
     findOne(root('html'), node('head'), node('model'), node('instance'), node(), node('meta'), node('entity'))(attr())
@@ -106,26 +132,10 @@ const getDataset = (xml) =>
     // Validate the entity spec version
     const warnings = validateEntitySpecVersion(version);
 
-    const strippedAttrs = Object.create(null);
-    for (const [name, value] of Object.entries(entityAttrs.get()))
-      strippedAttrs[stripNamespacesFromPath(name)] = value;
+    // Get the dataset name and actions from the <entity> tag attributes
+    const dataset = getNameAndActions(entityAttrs);
 
-    // check that dataset name is valid
-    const datasetName = strippedAttrs.dataset?.trim();
-    if (datasetName == null)
-      throw Problem.user.invalidEntityForm({ reason: 'Dataset name is missing.' });
-    if (!validateDatasetName(datasetName))
-      throw Problem.user.invalidEntityForm({ reason: 'Invalid dataset name.' });
-
-    // Entity actions permitted by the form def
-    const actions = [];
-    const { create, update } = strippedAttrs;
-    if (create != null) actions.push('create');
-    if (update != null) actions.push('update');
-    if (actions.length === 0)
-      throw Problem.user.invalidEntityForm({ reason: 'The form must specify at least one entity action, for example, create or update.' });
-
-    return Option.of({ name: datasetName, actions, warnings });
+    return Option.of({ datasets: [ dataset ], warnings });
   });
 
-module.exports = { getDataset, validateDatasetName, validatePropertyName };
+module.exports = { getDatasets, validateDatasetName, validatePropertyName };

--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -20,6 +20,32 @@ const Problem = require('../util/problem');
 const { traverseXml, findOne, root, node, attr, stripNamespacesFromPath } = require('../util/xml');
 
 /*
+Validates the entities-version spec
+https://getodk.github.io/xforms-spec/entities.html
+
+- 2022.1: entity creation
+- 2023.1: entity updates
+- 2024.1: offline entities
+- 2025.1: entities from repeats
+*/
+const validateEntitySpecVersion = (version) => {
+  if (version.isEmpty())
+    throw Problem.user.invalidEntityForm({ reason: 'Entities specification version is missing.' });
+  else if (!semverSatisfies(version.get(), '2022.1.0 - 2025.1.x'))
+    throw Problem.user.invalidEntityForm({ reason: `Entities specification version [${version.get()}] is not supported.` });
+
+  const warnings = semverSatisfies(version.get(), '>=2024.1.x')
+    ? null
+    : [{
+      type: 'oldEntityVersion',
+      details: { version: version.get() },
+      reason: `Entities specification version [${version.get()}] is not compatible with Offline Entities. Please use version 2024.1.0 or later.`
+    }];
+
+  return warnings;
+};
+
+/*
 Validates a dataset name:
 
   - valid xml identifier
@@ -77,18 +103,8 @@ const getDataset = (xml) =>
     if (entityAttrs.isEmpty())
       return Option.none();
 
-    if (version.isEmpty())
-      throw Problem.user.invalidEntityForm({ reason: 'Entities specification version is missing.' });
-    else if (!semverSatisfies(version.get(), '2022.1.0 - 2024.1.x'))
-      throw Problem.user.invalidEntityForm({ reason: `Entities specification version [${version.get()}] is not supported.` });
-
-    const warnings = semverSatisfies(version.get(), '>=2024.1.x')
-      ? null
-      : [{
-        type: 'oldEntityVersion',
-        details: { version: version.get() },
-        reason: `Entities specification version [${version.get()}] is not compatible with Offline Entities. Please use version 2024.1.0 or later.`
-      }];
+    // Validate the entity spec version
+    const warnings = validateEntitySpecVersion(version);
 
     const strippedAttrs = Object.create(null);
     for (const [name, value] of Object.entries(entityAttrs.get()))

--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -22,6 +22,7 @@ const ptr = last; // just rename to make it more relevant to our context.
 const hparser = require('htmlparser2');
 const parse = require('csv-parse/lib/sync');
 const { decodeXML } = require('entities');
+const semverSatisfies = require('semver/functions/satisfies');
 const Option = require('../util/option');
 const Problem = require('../util/problem');
 const { sanitizeOdataIdentifier } = require('../util/util');
@@ -52,7 +53,7 @@ const saveToAttr = (binding) => Object.keys(binding).find((k) => stripNamespaces
 //   envelope root. these are important so we preserve namespaces while matching bindings.
 // * bindingPath adds to joinedPath the envelope root.
 // * the actual saved field.path subtracts from joinedPath namespaces.
-const _recurseFormFields = (instance, bindings, repeats, selectMultiples, envelope = instance.name, basePath = [], orderStart = 0) => {
+const _recurseFormFields = (instance, bindings, repeats, selectMultiples, rejectEntityRepeats, envelope = instance.name, basePath = [], orderStart = 0) => {
   const fields = [];
   const processedRepeats = new Set();
   let order = orderStart;
@@ -83,7 +84,7 @@ const _recurseFormFields = (instance, bindings, repeats, selectMultiples, envelo
         field.type = binding.type || 'unknown'; // binding should have a type.
         const prop = saveToAttr(binding);
         if (prop) {
-          if (Array.from(repeats).find((repeat) => bindingPath.startsWith(repeat)))
+          if (rejectEntityRepeats && Array.from(repeats).find((repeat) => bindingPath.startsWith(repeat)))
             throw Problem.user.invalidEntityForm({ reason: 'Currently, entities cannot be populated from fields in repeat groups.' });
           field.propertyName = binding[prop];
         }
@@ -113,7 +114,7 @@ const _recurseFormFields = (instance, bindings, repeats, selectMultiples, envelo
       field.selectMultiple = true;
 
     if (((field.type === 'repeat') || (field.type === 'structure')) && (tag.children != null)) {
-      const children = _recurseFormFields(tag, bindings, repeats, selectMultiples, envelope, path, order);
+      const children = _recurseFormFields(tag, bindings, repeats, selectMultiples, rejectEntityRepeats, envelope, path, order);
       fields.push(...children);
       order += children.length;
     }
@@ -152,10 +153,14 @@ const getFormFields = (xml) => {
     modelNode(findOne(root(), node('instance'), node())(tree())),
     modelNode(findAll(root(), and(node('bind'), hasAttr('type')))(attr())),
     bodyNode(findAll(node('repeat'))(attr('nodeset'))),
-    bodyNode(findAll(node('select'))(oneOf(attr('nodeset'), attr('ref'))))
-  ]).then(([ instance, bindings, repeats, selectMultiples ]) =>
-    _recurseFormFields(instance.get(), getList(bindings),
-      new Set(stripNamespacesFromPaths(getList(repeats))), new Set(stripNamespacesFromPaths(getList(selectMultiples)))));
+    bodyNode(findAll(node('select'))(oneOf(attr('nodeset'), attr('ref')))),
+    findOne(root('html'), node('head'), node('model'))(attr('entities-version')),
+  ]).then(([ instance, bindings, repeats, selectMultiples, entitiesVersion ]) => {
+    const rejectEntityRepeats = entitiesVersion.isEmpty() || semverSatisfies(entitiesVersion.get(), '<2025.1.0');
+    return _recurseFormFields(instance.get(), getList(bindings),
+      new Set(stripNamespacesFromPaths(getList(repeats))), new Set(stripNamespacesFromPaths(getList(selectMultiples))),
+      rejectEntityRepeats);
+  });
 };
 
 

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -12,7 +12,7 @@ const { map } = require('ramda');
 const { Frame, into } = require('../frame');
 const { Actor, Blob, Form } = require('../frames');
 const { getFormFields, merge, compare } = require('../../data/schema');
-const { getDataset } = require('../../data/dataset');
+const { getDatasets } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, sqlEquals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, timebound } = require('../../util/promise');
@@ -89,7 +89,7 @@ const pushFormToEnketo = ({ projectId, xmlFormId, acteeId }, bound = undefined) 
 
 const _parseFormXml = (partial) => Promise.all([
   getFormFields(partial.xml),
-  (partial.aux.key.isDefined() ? resolve(Option.none()) : getDataset(partial.xml)) // Don't parse dataset schema if Form has encryption key
+  (partial.aux.key.isDefined() ? resolve(Option.none()) : getDatasets(partial.xml)) // Don't parse dataset schema if Form has encryption key
 ]);
 
 const _insertFormFields = (fields, formId, schemaId) => async ({ run }) => {
@@ -127,14 +127,14 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form XML for fields and entity/dataset definitions
-  const [fields, parsedDataset] = await _parseFormXml(partial);
+  const [fields, parsedDatasets] = await _parseFormXml(partial);
 
   // Check that meta field (group containing instanceId and name) exists
   await Forms.checkMeta(fields);
 
   // Check for xmlFormId collisions with previously deleted forms
   await Forms.checkDeletedForms(partial.xmlFormId, project.id);
-  await Forms.checkDatasetWarnings(parsedDataset);
+  await Forms.checkDatasetWarnings(parsedDatasets);
   await Forms.rejectIfWarnings();
 
   // Provision Actee for form
@@ -160,8 +160,12 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
   await FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets);
 
   // Update datasets and properties, if defined
-  if (parsedDataset.isDefined()) {
-    await Datasets.createOrMerge(parsedDataset.get(), savedForm, fields);
+  if (parsedDatasets.isDefined()) {
+    await Promise.all(
+      parsedDatasets.get().datasets.map(ds =>
+        Datasets.createOrMerge(ds, savedForm, fields)
+      )
+    );
   }
 
   // Return new draft Form frame with Form.Def
@@ -216,7 +220,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   const keyId = await partial.aux.key.map(Keys.ensure).orElse(resolve(null));
 
   // Parse form fields and dataset/entity definition from form XML
-  const [fields, parsedDataset] = await _parseFormXml(partial);
+  const [fields, parsedDatasets] = await _parseFormXml(partial);
 
   // Compute the intermediate schema ID
   let schemaId;
@@ -276,8 +280,12 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   await FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish);
 
   // Update datasets and properties, if defined
-  if (parsedDataset.isDefined()) {
-    await Datasets.createOrMerge(parsedDataset.get(), new Form(form, { def: savedDef }), fields);
+  if (parsedDatasets.isDefined()) {
+    await Promise.all(
+      parsedDatasets.get().datasets.map(ds =>
+        Datasets.createOrMerge(ds, new Form(form, { def: savedDef }), fields)
+      )
+    );
     // Note: if publish=true, we are in the enabling encryption special case and won't
     // do dataset operations. Dataset publishing will happen only through Forms.publish().
   }

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -32,11 +32,16 @@ describe('parsing dataset from entity block', () => {
         .replace('2024.1.0', '2024.1.123'))
         .should.be.fulfilled());
 
+    it('should validate any version that starts with 2025.1.', () =>
+      getDataset(testData.forms.offlineEntity
+        .replace('2024.1.0', '2025.1.123'))
+        .should.be.fulfilled());
+
     it('should reject probable future version', () =>
       getDataset(testData.forms.simpleEntity2022
-        .replace('2022.1.0', '2025.1.0'))
+        .replace('2022.1.0', '2026.1.0'))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
-          message: 'The entity definition within the form is invalid. Entities specification version [2025.1.0] is not supported.' }));
+          message: 'The entity definition within the form is invalid. Entities specification version [2026.1.0] is not supported.' }));
 
     it('should complain if version is wrong', () =>
       getDataset(testData.forms.simpleEntity2022

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -1,56 +1,56 @@
 const appRoot = require('app-root-path');
 const should = require('should');
 const { getFormFields } = require(appRoot + '/lib/data/schema');
-const { getDataset, validateDatasetName, validatePropertyName } = require(appRoot + '/lib/data/dataset');
+const { getDatasets, validateDatasetName, validatePropertyName } = require(appRoot + '/lib/data/dataset');
 const testData = require(appRoot + '/test/data/xml');
 const Problem = require(appRoot + '/lib/util/problem');
 const Option = require(appRoot + '/lib/util/option');
 
 describe('parsing dataset from entity block', () => {
   it('should run but find no dataset on non-entity forms', () =>
-    getDataset(testData.forms.simple).then((res) =>
+    getDatasets(testData.forms.simple).then((res) =>
       res.should.equal(Option.none())));
 
   describe('versioning', () => {
     it('should validate any version that starts with 2022.1.', () =>
-      getDataset(testData.forms.simpleEntity2022
+      getDatasets(testData.forms.simpleEntity2022
         .replace('2022.1.0', '2022.1.123'))
         .should.be.fulfilled());
 
     it('should validate a version between major releases, e.g. 2023.2.0', () =>
-      getDataset(testData.forms.updateEntity2023
+      getDatasets(testData.forms.updateEntity2023
         .replace('2023.1.0', '2023.2.0'))
         .should.be.fulfilled());
 
     it('should validate any version that starts with 2023.1.', () =>
-      getDataset(testData.forms.updateEntity2023
+      getDatasets(testData.forms.updateEntity2023
         .replace('2023.1.0', '2023.1.123'))
         .should.be.fulfilled());
 
     it('should validate any version that starts with 2024.1.', () =>
-      getDataset(testData.forms.offlineEntity
+      getDatasets(testData.forms.offlineEntity
         .replace('2024.1.0', '2024.1.123'))
         .should.be.fulfilled());
 
     it('should validate any version that starts with 2025.1.', () =>
-      getDataset(testData.forms.offlineEntity
+      getDatasets(testData.forms.offlineEntity
         .replace('2024.1.0', '2025.1.123'))
         .should.be.fulfilled());
 
     it('should reject probable future version', () =>
-      getDataset(testData.forms.simpleEntity2022
+      getDatasets(testData.forms.simpleEntity2022
         .replace('2022.1.0', '2026.1.0'))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
           message: 'The entity definition within the form is invalid. Entities specification version [2026.1.0] is not supported.' }));
 
     it('should complain if version is wrong', () =>
-      getDataset(testData.forms.simpleEntity2022
+      getDatasets(testData.forms.simpleEntity2022
         .replace('entities-version="2022.1.0"', 'entities-version="bad-version"'))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
           message: 'The entity definition within the form is invalid. Entities specification version [bad-version] is not supported.' }));
 
     it('should complain if version is missing', () =>
-      getDataset(testData.forms.simpleEntity2022
+      getDatasets(testData.forms.simpleEntity2022
         .replace('entities-version="2022.1.0"', ''))
         .should.be.rejectedWith(Problem, { problemCode: 400.25,
           message: 'The entity definition within the form is invalid. Entities specification version is missing.' }));
@@ -77,8 +77,8 @@ describe('parsing dataset from entity block', () => {
           </model>
         </h:head>
       </h:html>`;
-      return getDataset(xml).then((res) =>
-        res.get().name.should.eql('foo'));
+      return getDatasets(xml).then((res) =>
+        res.get().datasets[0].name.should.eql('foo'));
     });
 
     it('should retrieve the name of a dataset with namespace prefix on dataset attribute ', () => {
@@ -101,8 +101,8 @@ describe('parsing dataset from entity block', () => {
           </model>
         </h:head>
       </h:html>`;
-      return getDataset(xml).then((res) =>
-        res.get().name.should.eql('foo'));
+      return getDatasets(xml).then((res) =>
+        res.get().datasets[0].name.should.eql('foo'));
     });
 
     it('should find dataset name even if other fields are in meta block before entity block', () => {
@@ -129,8 +129,8 @@ describe('parsing dataset from entity block', () => {
                 </model>
           </h:head>
       </h:html>`;
-      return getDataset(xml).then((res) =>
-        res.get().name.should.eql('bar'));
+      return getDatasets(xml).then((res) =>
+        res.get().datasets[0].name.should.eql('bar'));
     });
 
     it('should return rejected promise if dataset name is missing', () => {
@@ -153,7 +153,7 @@ describe('parsing dataset from entity block', () => {
           </model>
         </h:head>
       </h:html>`;
-      return getDataset(xml).should.be.rejectedWith(Problem, {
+      return getDatasets(xml).should.be.rejectedWith(Problem, {
         // Problem.user.invalidEntityForm
         problemCode: 400.25,
         message: 'The entity definition within the form is invalid. Dataset name is missing.'
@@ -180,7 +180,7 @@ describe('parsing dataset from entity block', () => {
           </model>
         </h:head>
       </h:html>`;
-      return getDataset(xml).should.be.rejectedWith(Problem, {
+      return getDatasets(xml).should.be.rejectedWith(Problem, {
         // Problem.user.invalidEntityForm
         problemCode: 400.25,
         message: 'The entity definition within the form is invalid. Invalid dataset name.'
@@ -207,7 +207,7 @@ describe('parsing dataset from entity block', () => {
           </model>
         </h:head>
       </h:html>`;
-      return getDataset(xml).should.be.rejectedWith(Problem, {
+      return getDatasets(xml).should.be.rejectedWith(Problem, {
         problemCode: 400.25,
         message: 'The entity definition within the form is invalid. Dataset name is missing.'
       });
@@ -216,29 +216,29 @@ describe('parsing dataset from entity block', () => {
 
   describe('parsing entity actions', () => {
     it('should return create for a create form', async () => {
-      const result = await getDataset(testData.forms.simpleEntity);
-      result.get().actions.should.eql(['create']);
+      const result = await getDatasets(testData.forms.simpleEntity);
+      result.get().datasets[0].actions.should.eql(['create']);
     });
 
     it('should return update for an update form', async () => {
-      const result = await getDataset(testData.forms.updateEntity);
-      result.get().actions.should.eql(['update']);
+      const result = await getDatasets(testData.forms.updateEntity);
+      result.get().datasets[0].actions.should.eql(['update']);
     });
 
     it('should return create and update for a form that can do both', async () => {
-      const result = await getDataset(testData.forms.updateEntity
+      const result = await getDatasets(testData.forms.updateEntity
         .replace('update=""', 'create="" update=""'));
-      result.get().actions.should.eql(['create', 'update']);
+      result.get().datasets[0].actions.should.eql(['create', 'update']);
     });
 
     it('should strip namespaces from action attributes', async () => {
-      const result = await getDataset(testData.forms.updateEntity
+      const result = await getDatasets(testData.forms.updateEntity
         .replace('update=""', 'entities:create="" entities:update=""'));
-      result.get().actions.should.eql(['create', 'update']);
+      result.get().datasets[0].actions.should.eql(['create', 'update']);
     });
 
     it('should reject for an entity form without an action', () => {
-      const promise = getDataset(testData.forms.simpleEntity
+      const promise = getDatasets(testData.forms.simpleEntity
         .replace('create=""', ''));
       return promise.should.be.rejectedWith(Problem, {
         problemCode: 400.25,
@@ -329,14 +329,14 @@ describe('parsing dataset from entity block', () => {
 
 describe('dataset name validation', () => {
   it('should have name be case sensitive', () =>
-    getDataset(testData.forms.simpleEntity
+    getDatasets(testData.forms.simpleEntity
       .replace('people', 'PeopleWithACapitalP')).then((res) =>
-      res.get().name.should.eql('PeopleWithACapitalP')));
+      res.get().datasets[0].name.should.eql('PeopleWithACapitalP')));
 
   it('should strip whitespace from name', () =>
-    getDataset(testData.forms.simpleEntity
+    getDatasets(testData.forms.simpleEntity
       .replace('people', '   people ')).then((res) =>
-      res.get().name.should.eql('people')));
+      res.get().datasets[0].name.should.eql('people')));
 
   it('should reject empty name', () => {
     validateDatasetName('').should.equal(false);
@@ -346,7 +346,7 @@ describe('dataset name validation', () => {
     const name = '   ';
     validateDatasetName(name).should.equal(false);
     const xml = testData.forms.simpleEntity.replace('people', name);
-    return getDataset(xml).should.be.rejectedWith(Problem, {
+    return getDatasets(xml).should.be.rejectedWith(Problem, {
       problemCode: 400.25,
       message: 'The entity definition within the form is invalid. Invalid dataset name.'
     });


### PR DESCRIPTION
Part one of working towards https://github.com/getodk/central/issues/1020

This PR
- allows the version 2025.1.0 entities-version spec
- no longer has an error about entity binds in repeats if the version is 2025.1 or greater
- refactors the code to expect an array of datasets in the XML parsing even though the code is still limited to finding only one dataset

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced