### PR TITLE
Add usage metrics for 2025.2 count ownerOnly datasets

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/forms/odk-analytics/submissions",
         "formId": "odk-analytics",
-        "version": "v2025.1.0_1"
+        "version": "v2025.2.0_1"
       },
       "s3blobStore": {}
     }

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -46,6 +46,7 @@ const metricsTemplate = {
     "max_entity_submission_delay": 0,
     "avg_entity_submission_delay": 0,
     "max_entity_branch_delay": 0,
+    "num_owner_only_datasets": 0,
     "num_xml_only_form_defs": 0,
     "num_blob_files": 0,
     "num_blob_files_on_s3": 0,

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -656,6 +656,10 @@ const measureMaxEntityBranchTime = () => ({ oneFirst }) => oneFirst(sql`
   ) AS subquery;
 `);
 
+const countOwnerOnlyDatasets = () => ({ oneFirst }) => oneFirst(sql`
+  SELECT COUNT(1) FROM datasets where "ownerOnly" = true;
+`);
+
 // Other
 const getProjectsWithDescriptions = () => ({ all }) => all(sql`
 select id as "projectId", length(trim(description)) as description_length from projects where coalesce(trim(description),'')!=''`);
@@ -864,11 +868,13 @@ const previewMetrics = () => (({ Analytics }) => runSequentially([
   Analytics.countSubmissionBacklogEvents,
   Analytics.measureEntityProcessingTime,
   Analytics.measureMaxEntityBranchTime,
+  Analytics.countOwnerOnlyDatasets,
   Analytics.projectMetrics
 ]).then(([db, encrypt, bigForm, admins, audits,
   archived, managers, viewers, collectors,
   caAttachments, caFailures, caRows, xmlDefs, blobFiles, resetFailedToPending,
   oeBranches, oeInterruptedBranches, oeBacklogEvents, oeProcessingTime, oeBranchTime,
+  ownerOnlyDatasets,
   projMetrics]) => {
   const metrics = clone(metricsTemplate);
   // system
@@ -919,6 +925,9 @@ const previewMetrics = () => (({ Analytics }) => runSequentially([
   metrics.system.num_blob_files = blobFiles.total_blobs;
   metrics.system.num_blob_files_on_s3 = blobFiles.uploaded_blobs;
   metrics.system.num_reset_failed_to_pending_count = resetFailedToPending;
+
+  // 2025.2.0 owner only entity lists/datasets
+  metrics.system.num_owner_only_datasets = ownerOnlyDatasets;
 
   return metrics;
 }));
@@ -982,5 +991,6 @@ module.exports = {
   countSubmissionBacklogEvents,
   measureEntityProcessingTime,
   measureElapsedEntityTime,
-  measureMaxEntityBranchTime
+  measureMaxEntityBranchTime,
+  countOwnerOnlyDatasets
 };


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1071

Introduces a new metric at the system level that counts datasets/entity lists with "ownerOnly" setting enabled:
* `num_owner_only_datasets`

Depends on merging https://github.com/getodk/central-backend/pull/1498 first
Only last commit in this PR is needed

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced