### PR TITLE
fixes getodk/central#1100: add --no-acl flag for db restore

### DIFF
--- a/lib/task/db.js
+++ b/lib/task/db.js
@@ -55,7 +55,7 @@ const pgrestore = async (directory, namespace = 'default') => {
   });
 
   // actually do the restore:
-  const invokeRestore = `pg_restore -e -j 4 -F d -C -c -h ${dbConfig.host} -U ${dbConfig.user} -d template1 ${directory}`;
+  const invokeRestore = `pg_restore --no-acl -e -j 4 -F d -C -c -h ${dbConfig.host} -U ${dbConfig.user} -d template1 ${directory}`;
   await promisify(exec)(invokeRestore, { env });
 
   // now we have to allow connections again:


### PR DESCRIPTION
Closes getodk/central#1100

#### What has been done to verify that this works as intended?

Verified the change on dev environment to double check, previously same change was applied on test env during regression testing of the last release.

#### Why is this the best possible solution? Were any other approaches considered?

It solves the problem. I have opt not to include `--no-owner` because in our case we have single user and assumption is that the backup is created with `/v1/backup` API; any deviation or different/complex infrastructure created by end-user would be managed by themselves.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced