### PR TITLE
lib/resources: standardise usage of xmlFormId in path params

### DIFF
--- a/lib/resources/assignments.js
+++ b/lib/resources/assignments.js
@@ -92,8 +92,8 @@ module.exports = (service, endpoint) => {
   assignmentsResource('/projects/:id', ({ Projects }, params) =>
     Projects.getById(params.id).then(getOrNotFound));
 
-  assignmentsResource('/projects/:projectId/forms/:id', ({ Forms }, params) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id).then(getOrNotFound));
+  assignmentsResource('/projects/:projectId/forms/:xmlFormId', ({ Forms }, params) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId).then(getOrNotFound));
 
 };
 

--- a/lib/resources/comments.js
+++ b/lib/resources/comments.js
@@ -11,25 +11,25 @@ const { Comment } = require('../model/frames');
 const { getOrNotFound } = require('../util/promise');
 
 module.exports = (service, endpoint) => {
-  service.get('/projects/:projectId/forms/:formId/submissions/:id/comments', endpoint(({ Comments, Forms, Submissions }, { auth, params, queryOptions }) =>
-    Submissions.getByIds(params.projectId, params.formId, params.id, false)
+  service.get('/projects/:projectId/forms/:xmlFormId/submissions/:id/comments', endpoint(({ Comments, Forms, Submissions }, { auth, params, queryOptions }) =>
+    Submissions.getByIds(params.projectId, params.xmlFormId, params.id, false)
       .then(getOrNotFound)
       .then((submission) => Promise.all([
         // TODO: until we have a better sense of what comments will be and where,
         // just keep it simple. if you can read the submission you can comment on it.
-        Forms.getByProjectAndXmlFormId(params.projectId, params.formId)
+        Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId)
           .then(getOrNotFound)
           .then(auth.canOrReject('submission.read')),
         Comments.getBySubmissionId(submission.id, queryOptions)
       ]))
       .then(([ , comments ]) => comments)));
 
-  service.post('/projects/:projectId/forms/:formId/submissions/:id/comments', endpoint(({ Comments, Forms, Submissions }, { auth, params, body }) =>
-    Submissions.getByIds(params.projectId, params.formId, params.id, false)
+  service.post('/projects/:projectId/forms/:xmlFormId/submissions/:id/comments', endpoint(({ Comments, Forms, Submissions }, { auth, params, body }) =>
+    Submissions.getByIds(params.projectId, params.xmlFormId, params.id, false)
       .then(getOrNotFound)
       .then((submission) => Promise.all([
         // TODO: same temporary permissions shortcut as above.
-        Forms.getByProjectAndXmlFormId(params.projectId, params.formId)
+        Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId)
           .then(getOrNotFound)
           .then(auth.canOrReject('submission.read')),
         Comments.create(auth.actor.map((actor) => actor.id).orNull(),

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -120,14 +120,14 @@ module.exports = (service, endpoint) => {
           : newForm)))));
 
   // can POST empty body to copy the current def to draft.
-  service.post('/projects/:projectId/forms/:id/draft', endpoint(({ Forms, Keys, Projects, Submissions }, { params, auth }, request) =>
+  service.post('/projects/:projectId/forms/:xmlFormId/draft', endpoint(({ Forms, Keys, Projects, Submissions }, { params, auth }, request) =>
     Promise.all([
       Projects.getById(params.projectId).then(getOrNotFound),
-      Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion).then(getOrNotFound)
+      Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion).then(getOrNotFound)
     ])
       .then(([ project, form ]) => auth.canOrReject('form.update', form)
         .then(() => ((request.is('*/*') === false) // false only if no request body.
-          ? Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.PublishedVersion)
+          ? Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, true, Form.PublishedVersion)
             .then(getOrNotFound)
             .then((published) => ((published.xml == null)
               ? reject(Problem.user.missingParameter({ field: 'xml' }))
@@ -142,8 +142,8 @@ module.exports = (service, endpoint) => {
         .then(() => Forms.clearUnneededDrafts(form))) // remove drafts made obsolete by new draft
       .then(success)));
 
-  service.post('/projects/:projectId/forms/:id/draft/publish', endpoint(({ Forms, Submissions }, { params, auth, query }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.DraftVersion)
+  service.post('/projects/:projectId/forms/:xmlFormId/draft/publish', endpoint(({ Forms, Submissions }, { params, auth, query }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, true, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then(ensureDef)
@@ -159,7 +159,7 @@ module.exports = (service, endpoint) => {
           // copy forward xlsx reference since no real change was made
           .then((partial) => partial.withAux('xls', { xlsBlobId: form.def.xlsBlobId }))
           .then((partial) => Forms.createVersion(partial, form, false, true))
-          .then(() => Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion))
+          .then(() => Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion))
           .then(getOrNotFound)
         : resolve(form)))
       .then(((form) => Promise.all([ Forms.publish(form), Submissions.deleteDraftSubmissions(form.id) ])))
@@ -171,9 +171,9 @@ module.exports = (service, endpoint) => {
   // form verbs for authorization.
   // We are not considering a separate 'dataset.update' verb right now because it seems weird to mix the
   // ability/inability to alter a dataset with the ability to modify forms -- they should just be the same.
-  service.get('/projects/:projectId/forms/:id/draft/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
+  service.get('/projects/:projectId/forms/:xmlFormId/draft/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
     Promise.all([
-      Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion),
+      Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion),
       Projects.getById(params.projectId)
     ])
       .then(([form, project]) =>
@@ -189,11 +189,11 @@ module.exports = (service, endpoint) => {
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId
         ? [] // return empty array if encryption is enabled
-        : Datasets.getDiff(params.projectId, params.id, true)))));
+        : Datasets.getDiff(params.projectId, params.xmlFormId, true)))));
 
-  service.get('/projects/:projectId/forms/:id/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
+  service.get('/projects/:projectId/forms/:xmlFormId/dataset-diff', endpoint(({ Forms, Datasets, Projects }, { params, auth }) =>
     Promise.all([
-      Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.PublishedVersion),
+      Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.PublishedVersion),
       Projects.getById(params.projectId)
     ])
       .then(([form, project]) =>
@@ -209,10 +209,10 @@ module.exports = (service, endpoint) => {
       .then(([form]) => ensureDef(form))
       .then((form) => (form.aux.def.keyId
         ? [] // return empty array if encryption is enabled
-        : Datasets.getDiff(params.projectId, params.id, false)))));
+        : Datasets.getDiff(params.projectId, params.xmlFormId, false)))));
 
-  service.patch('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Datasets, FormAttachments, Forms }, { auth, params, body }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+  service.patch('/projects/:projectId/forms/:xmlFormId/draft/attachments/:name', endpoint(({ Datasets, FormAttachments, Forms }, { auth, params, body }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then((form) => Promise.all([
@@ -232,8 +232,8 @@ module.exports = (service, endpoint) => {
           FormAttachments.update(form, attachment, null, body.dataset ? dataset.id : null))))));
 
 
-  service.delete('/projects/:projectId/forms/:id/draft', endpoint(({ Audits, Forms, Submissions }, { params, auth }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id)
+  service.delete('/projects/:projectId/forms/:xmlFormId/draft', endpoint(({ Audits, Forms, Submissions }, { params, auth }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then(rejectIf(((form) => form.currentDefId == null), noargs(Problem.user.noPublishedVersion)))
@@ -316,16 +316,16 @@ module.exports = (service, endpoint) => {
   };
 
   // the linter literally won't let me break this apart..
-  formResource('/projects/:projectId/forms/:id', (Forms, params, withXml = false, options = QueryOptions.none) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, null, options)
+  formResource('/projects/:projectId/forms/:xmlFormId', (Forms, params, withXml = false, options = QueryOptions.none) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, withXml, null, options)
       .then(getOrNotFound));
-  formResource('/projects/:projectId/forms/:id/versions/:version', (Forms, params, withXml = false, options = QueryOptions.none) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, params.version, options)
+  formResource('/projects/:projectId/forms/:xmlFormId/versions/:version', (Forms, params, withXml = false, options = QueryOptions.none) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, withXml, params.version, options)
       .then(getOrNotFound)
       .then(ensureDef));
 
-  formResource('/projects/:projectId/forms/:id/draft', (Forms, params, withXml = false, options = QueryOptions.none) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, Form.DraftVersion, options)
+  formResource('/projects/:projectId/forms/:xmlFormId/draft', (Forms, params, withXml = false, options = QueryOptions.none) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, withXml, Form.DraftVersion, options)
       .then(getOrNotFound)
       .then(ensureDef));
 
@@ -337,17 +337,17 @@ module.exports = (service, endpoint) => {
   ////////////////////////////////////////
   // PRIMARY-FORM SPECIFIC ENDPOINTS
 
-  service.patch('/projects/:projectId/forms/:id', endpoint(({ Forms }, { auth, params, body }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id)
+  service.patch('/projects/:projectId/forms/:xmlFormId', endpoint(({ Forms }, { auth, params, body }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then((form) => Forms.update(form, Form.fromApi(body)))
       // TODO: sucks to have to re-request but this shouldn't be a perf-critical path.
-      .then(() => Forms.getByProjectAndXmlFormId(params.projectId, params.id))
+      .then(() => Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId))
       .then(getOrNotFound)));
 
-  service.delete('/projects/:projectId/forms/:id', endpoint(({ Forms }, { auth, params }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id)
+  service.delete('/projects/:projectId/forms/:xmlFormId', endpoint(({ Forms }, { auth, params }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.delete', form))
       .then(Forms.del)
@@ -357,8 +357,8 @@ module.exports = (service, endpoint) => {
   ////////////////////////////////////////
   // VERSIONS LISTING
 
-  service.get('/projects/:projectId/forms/:id/versions', endpoint(({ Forms }, { auth, params, queryOptions }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id)
+  service.get('/projects/:projectId/forms/:xmlFormId/versions', endpoint(({ Forms }, { auth, params, queryOptions }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId)
       .then(getOrNotFound)
       .then((form) => canReadForm(auth, form))
       .then((form) => Forms.getVersions(form.id, queryOptions))));
@@ -368,8 +368,8 @@ module.exports = (service, endpoint) => {
   // RESTORE / UNDELETE
 
   // Instead of the xmlFormId, this endpoint uses the numeric form id in the database
-  service.post('/projects/:projectId/forms/:id/restore', endpoint(({ Forms }, { auth, params }) =>
-    Forms.getByProjectAndNumericId(params.projectId, params.id, false, null, QueryOptions.none, true)
+  service.post('/projects/:projectId/forms/:formId/restore', endpoint(({ Forms }, { auth, params }) =>
+    Forms.getByProjectAndNumericId(params.projectId, params.formId, false, null, QueryOptions.none, true)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.restore', form))
       .then(Forms.restore)
@@ -379,8 +379,8 @@ module.exports = (service, endpoint) => {
   ////////////////////////////////////////
   // DRAFT ATTACHMENT R/W ENDPOINTS
 
-  service.post('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ Blobs, FormAttachments, Forms }, { auth, headers, params }, request) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+  service.post('/projects/:projectId/forms/:xmlFormId/draft/attachments/:name', endpoint(({ Blobs, FormAttachments, Forms }, { auth, headers, params }, request) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then((form) => Promise.all([
@@ -393,8 +393,8 @@ module.exports = (service, endpoint) => {
         .then(() => FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name))
         .then(getOrNotFound))));
 
-  service.delete('/projects/:projectId/forms/:id/draft/attachments/:name', endpoint(({ FormAttachments, Forms }, { params, auth }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+  service.delete('/projects/:projectId/forms/:xmlFormId/draft/attachments/:name', endpoint(({ FormAttachments, Forms }, { params, auth }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('form.update', form))
       .then((form) => FormAttachments.getByFormDefIdAndName(form.draftDefId, params.name)
@@ -418,8 +418,8 @@ module.exports = (service, endpoint) => {
     noargs(Problem.user.notFound)
   );
 
-  service.get('/test/:key/projects/:projectId/forms/:id/draft/formList', endpoint.openRosa(({ Forms, FormAttachments, env }, { params, originalUrl }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+  service.get('/test/:key/projects/:projectId/forms/:xmlFormId/draft/formList', endpoint.openRosa(({ Forms, FormAttachments, env }, { params, originalUrl }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))
@@ -433,8 +433,8 @@ module.exports = (service, endpoint) => {
             draft: true, forms: [ form.withAux('openRosa', { hasAttachments }) ], basePath: path.resolve(originalUrl, '../../../..'), domain: env.domain
           })))));
 
-  service.get('/test/:key/projects/:projectId/forms/:id/draft/manifest', endpoint.openRosa(({ FormAttachments, Forms, env }, { params, originalUrl }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+  service.get('/test/:key/projects/:projectId/forms/:xmlFormId/draft/manifest', endpoint.openRosa(({ FormAttachments, Forms, env }, { params, originalUrl }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))
@@ -442,16 +442,16 @@ module.exports = (service, endpoint) => {
         .then((attachments) =>
           formManifest({ attachments, basePath: path.resolve(originalUrl, '..'), domain: env.domain })))));
 
-  service.get('/test/:key/projects/:projectId/forms/:id/draft.xml', endpoint(({ Forms }, { params }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, true, Form.DraftVersion)
+  service.get('/test/:key/projects/:projectId/forms/:xmlFormId/draft.xml', endpoint(({ Forms }, { params }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, true, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))
       .then((form) => xml(form.xml))));
 
-  service.get('/test/:key/projects/:projectId/forms/:id/draft/attachments/:name', endpoint((container, { params }, request, response) => {
+  service.get('/test/:key/projects/:projectId/forms/:xmlFormId/draft/attachments/:name', endpoint((container, { params }, request, response) => {
     const { FormAttachments, Forms } = container;
-    return Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+    return Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -78,14 +78,14 @@ module.exports = (service, endpoint) => {
   ////////////////////////////////////////////////////////////////////////////////
   // REIFY ODATA RESOURCES
 
-  odataResource('/projects/:projectId/forms/:id.svc', false, (Forms, auth, params) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.PublishedVersion)
+  odataResource('/projects/:projectId/forms/:xmlFormId.svc', false, (Forms, auth, params) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.PublishedVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then((form) => auth.canOrReject('submission.read', form)));
 
-  odataResource('/projects/:projectId/forms/:id/draft.svc', true, (Forms, auth, params) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, false, Form.DraftVersion)
+  odataResource('/projects/:projectId/forms/:xmlFormId/draft.svc', true, (Forms, auth, params) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef)
       .then((form) => auth.canOrReject('submission.read', form)));

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -206,7 +206,7 @@ module.exports = (service, endpoint) => {
         .then((partial) => getForm(params, Forms, partial.def.version)
           .then((form) => auth.canOrReject('submission.create', form))
           .then((form) => {
-            if (partial.xmlFormId !== params.formId)
+            if (partial.xmlFormId !== params.xmlFormId)
               return reject(Problem.user.unexpectedValue({ field: 'form id', value: partial.xmlFormId, reason: 'did not match the form ID in the URL' }));
 
             return Promise.all([
@@ -220,18 +220,18 @@ module.exports = (service, endpoint) => {
 
     service.put(`${base}/submissions/:instanceId`, endpoint(({ Forms, Submissions, SubmissionAttachments }, { params, auth, query, userAgent }, request) =>
       Submission.fromXml(request).then((partial) => {
-        if (partial.xmlFormId !== params.formId)
+        if (partial.xmlFormId !== params.xmlFormId)
           return reject(Problem.user.unexpectedValue({ field: 'form id', value: partial.xmlFormId, reason: 'did not match the form ID in the URL' }));
         const deprecatedId = partial.deprecatedId.orElseGet(() => { throw Problem.user.expectedDeprecation(); });
         return Promise.all([
           // TODO/PERF: a bespoke query here could save some round-trips
-          Submissions.getCurrentDefColsByIds(['instanceId', 'submissionId'], params.projectId, params.formId, params.instanceId, draft)
+          Submissions.getCurrentDefColsByIds(['instanceId', 'submissionId'], params.projectId, params.xmlFormId, params.instanceId, draft)
             .then(getOrNotFound)
             .then(rejectIf(((current) => current.instanceId !== deprecatedId),
               () => Problem.user.deprecatingOldSubmission(({ deprecatedId })))),
           getForm(params, Forms, partial.def.version)
             .then((form) => auth.canOrReject('submission.create', form)),
-          Submissions.getByIds(params.projectId, params.formId, params.instanceId, draft)
+          Submissions.getByIds(params.projectId, params.xmlFormId, params.instanceId, draft)
             .then(getOrNotFound) // this request exists just to check existence and fail the whole request.
         ])
           .then(([ deprecated, form ]) => Promise.all([
@@ -245,8 +245,8 @@ module.exports = (service, endpoint) => {
       })));
   };
 
-  restSubmission('/projects/:projectId/forms/:formId', false, ({ projectId, formId }, Forms, version) =>
-    Forms.getByProjectAndXmlFormId(projectId, formId, false, version) // TODO: okay so this is exactly the same as the func above..
+  restSubmission('/projects/:projectId/forms/:xmlFormId', false, ({ projectId, xmlFormId }, Forms, version) =>
+    Forms.getByProjectAndXmlFormId(projectId, xmlFormId, false, version) // TODO: okay so this is exactly the same as the func above..
       .then(getOrNotFound)
       // This replaces ensureDef(form). If the form was found with the project ID and form ID
       // constraints but the def was not found, that suggest the problem was with the version.
@@ -256,8 +256,8 @@ module.exports = (service, endpoint) => {
         () => Problem.user.notAcceptingSubmissions()
       )));
 
-  restSubmission('/projects/:projectId/forms/:formId/draft', true, ({ projectId, formId }, Forms) =>
-    Forms.getByProjectAndXmlFormId(projectId, formId, false, Form.DraftVersion)
+  restSubmission('/projects/:projectId/forms/:xmlFormId/draft', true, ({ projectId, xmlFormId }, Forms) =>
+    Forms.getByProjectAndXmlFormId(projectId, xmlFormId, false, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef));
 
@@ -267,14 +267,14 @@ module.exports = (service, endpoint) => {
   );
 
   // Create Submission using draftToken
-  service.post(`/test/:key/projects/:projectId/forms/:formId/draft/submissions`, endpoint(({ Forms, Submissions, SubmissionAttachments }, { params, query, userAgent }, request) =>
+  service.post(`/test/:key/projects/:projectId/forms/:xmlFormId/draft/submissions`, endpoint(({ Forms, Submissions, SubmissionAttachments }, { params, query, userAgent }, request) =>
     Submission.fromXml(request)
-      .then((partial) => Forms.getByProjectAndXmlFormId(params.projectId, params.formId, false, Form.DraftVersion)
+      .then((partial) => Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false, Form.DraftVersion)
         .then(getOrNotFound)
         .then(ensureDef)
         .then(checkFormToken(params.key))
         .then((form) => {
-          if (partial.xmlFormId !== params.formId)
+          if (partial.xmlFormId !== params.xmlFormId)
             return reject(Problem.user.unexpectedValue({ field: 'form id', value: partial.xmlFormId, reason: 'did not match the form ID in the URL' }));
 
           return Promise.all([
@@ -289,8 +289,8 @@ module.exports = (service, endpoint) => {
   ////////////////////////////////////////////////////////////////////////////////
   // SUBMISSION EDIT / UPDATE
 
-  service.get('/projects/:projectId/forms/:formId/submissions/:instanceId/edit', endpoint(({ Forms, Submissions, SubmissionAttachments, enketo, env }, { params, auth }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.formId, false)
+  service.get('/projects/:projectId/forms/:xmlFormId/submissions/:instanceId/edit', endpoint(({ Forms, Submissions, SubmissionAttachments, enketo, env }, { params, auth }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false)
       .then(getOrNotFound)
       .then(auth.canOrReject('submission.update'))
       // we could theoretically wire up the pushFormToEnketo routine here, under a manual
@@ -298,7 +298,7 @@ module.exports = (service, endpoint) => {
       // reject if we haven't pushed to enketo for .. some probably bad unrelated reason.
       .then(rejectIf(((form) => form.enketoId == null), noargs(Problem.user.enketoNotReady)))
       .then(rejectIf(((form) => form.state !== 'open'), noargs(Problem.user.editingClosingOrClosed)))
-      .then((form) => Submissions.getCurrentDefByIds(params.projectId, params.formId, params.instanceId, false)
+      .then((form) => Submissions.getCurrentDefByIds(params.projectId, params.xmlFormId, params.instanceId, false)
         .then(getOrNotFound)
         .then((def) => SubmissionAttachments.getCurrentForSubmissionId(form.id, def.submissionId, false)
           .then((attachments) => (form.webformsEnabled ? `${env.domain}/projects/${form.projectId}/forms/${form.xmlFormId}/submissions/${params.instanceId}/edit` : enketo.edit(
@@ -307,24 +307,24 @@ module.exports = (service, endpoint) => {
           ))))
         .then(redirect(302)))));
 
-  service.patch('/projects/:projectId/forms/:formId/submissions/:instanceId', endpoint(({ Forms, Submissions }, { params, auth, body }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.formId, false)
+  service.patch('/projects/:projectId/forms/:xmlFormId/submissions/:instanceId', endpoint(({ Forms, Submissions }, { params, auth, body }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false)
       .then(getOrNotFound)
       .then(auth.canOrReject('submission.update'))
-      .then((form) => Submissions.getByIdsWithDef(params.projectId, params.formId, params.instanceId, false)
+      .then((form) => Submissions.getByIdsWithDef(params.projectId, params.xmlFormId, params.instanceId, false)
         .then(getOrNotFound)
         .then((submission) => Submissions.update(form, submission, Submission.fromApi(body))))));
 
-  service.delete('/projects/:projectId/forms/:formId/submissions/:instanceId', endpoint(async ({ Forms, Submissions }, { params, auth }) => {
-    const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.formId, false).then(getOrNotFound);
+  service.delete('/projects/:projectId/forms/:xmlFormId/submissions/:instanceId', endpoint(async ({ Forms, Submissions }, { params, auth }) => {
+    const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false).then(getOrNotFound);
     await auth.canOrReject('submission.delete', form);
-    const submission = await Submissions.getByIdsWithDef(params.projectId, params.formId, params.instanceId, false).then(getOrNotFound);
+    const submission = await Submissions.getByIdsWithDef(params.projectId, params.xmlFormId, params.instanceId, false).then(getOrNotFound);
     await Submissions.del(submission, form);
     return success();
   }));
 
-  service.post('/projects/:projectId/forms/:formId/submissions/:instanceId/restore', endpoint(async ({ Forms, Submissions }, { params, auth }) => {
-    const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.formId, false).then(getOrNotFound);
+  service.post('/projects/:projectId/forms/:xmlFormId/submissions/:instanceId/restore', endpoint(async ({ Forms, Submissions }, { params, auth }) => {
+    const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, false).then(getOrNotFound);
     await auth.canOrReject('submission.restore', form);
     const submission = await Submissions.getDeleted(params.projectId, form.id, params.instanceId).then(getOrNotFound);
     await Submissions.restore(submission, form);
@@ -434,7 +434,7 @@ module.exports = (service, endpoint) => {
     service.get(`${base}/:instanceId/audits`, endpoint(({ Audits, Forms, Submissions }, { params, auth, queryOptions }) =>
       getForm(params, Forms)
         .then(auth.canOrReject('submission.read')) // TODO: this could be split to audit.read on form
-        .then(() => Submissions.getByIds(params.projectId, params.formId, params.instanceId, draft))
+        .then(() => Submissions.getByIds(params.projectId, params.xmlFormId, params.instanceId, draft))
         .then(getOrNotFound)
         .then((submission) => Audits.getBySubmissionId(submission.id, queryOptions))));
 
@@ -442,7 +442,7 @@ module.exports = (service, endpoint) => {
     const getOrRedirect = (Forms, Submissions, { params, auth, originalUrl, queryOptions }) =>
       Promise.all([
         getForm(params, Forms),
-        Submissions.getByIds(params.projectId, params.formId, params.instanceId, draft, queryOptions)
+        Submissions.getByIds(params.projectId, params.xmlFormId, params.instanceId, draft, queryOptions)
       ])
         .then(([ form, maybeSub ]) => Promise.all([
           auth.canOrReject('submission.read', form),
@@ -457,7 +457,7 @@ module.exports = (service, endpoint) => {
 
     service.get(`${base}/:instanceId.xml`, endpoint(({ Forms, Submissions }, context) =>
       getOrRedirect(Forms, Submissions, context)
-        .then(() => Submissions.getCurrentDefColByIds('xml', context.params.projectId, context.params.formId, context.params.instanceId, draft))
+        .then(() => Submissions.getCurrentDefColByIds('xml', context.params.projectId, context.params.xmlFormId, context.params.instanceId, draft))
         .then(getOrNotFound)
         .then((defXml) => xml(defXml))));
 
@@ -528,7 +528,7 @@ module.exports = (service, endpoint) => {
         .then(auth.canOrReject('submission.read'))
         .then((form) => Promise.all([
           Submissions.getDefsByFormAndLogicalId(form.id, params.rootId, draft, queryOptions),
-          Submissions.getByIds(params.projectId, params.formId, params.rootId, draft)
+          Submissions.getByIds(params.projectId, params.xmlFormId, params.rootId, draft)
             .then(getOrNotFound)
         ]))
         .then(([ versions ]) => versions)));
@@ -537,7 +537,7 @@ module.exports = (service, endpoint) => {
       getForm(params, Forms)
         .then(auth.canOrReject('submission.read'))
         .then((form) => Promise.all([
-          Submissions.getByIds(params.projectId, params.formId, params.rootId, draft)
+          Submissions.getByIds(params.projectId, params.xmlFormId, params.rootId, draft)
             .then(getOrNotFound),
           Submissions.getAnyDefByFormAndInstanceId(form.id, params.instanceId, draft, queryOptions)
             .then(getOrNotFound)
@@ -573,19 +573,19 @@ module.exports = (service, endpoint) => {
         .then((form) => Promise.all([
           Forms.getStructuralFields(form.def.id),
           Submissions.getDefsByFormAndLogicalId(form.id, params.rootId, draft),
-          Submissions.getByIds(params.projectId, params.formId, params.rootId, draft)
+          Submissions.getByIds(params.projectId, params.xmlFormId, params.rootId, draft)
             .then(getOrNotFound)
         ]))
         .then(([ structurals, versions ]) => diffSubmissions(structurals, versions))));
   };
 
   // reify for draft/nondraft
-  dataOutputs('/projects/:projectId/forms/:formId/submissions', false, (params, Forms) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.formId)
+  dataOutputs('/projects/:projectId/forms/:xmlFormId/submissions', false, (params, Forms) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId)
       .then(getOrNotFound));
 
-  dataOutputs('/projects/:projectId/forms/:formId/draft/submissions', true, (params, Forms) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.formId, undefined, Form.DraftVersion)
+  dataOutputs('/projects/:projectId/forms/:xmlFormId/draft/submissions', true, (params, Forms) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, undefined, Form.DraftVersion)
       .then(getOrNotFound)
       .then(ensureDef));
 };


### PR DESCRIPTION
This makes intent more explicit, and makes it easit to locate uses of xmlFormId in path params.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced