### PR TITLE
frames/form: add isDaft() method

### DIFF
--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -64,6 +64,14 @@ class Form extends Frame.define(
   get xls() { return this.aux.xls || {}; } // TODO/SL sort of a hack but let's see how it goes.
   get xml() { return this.aux.xml?.xml; }
 
+  isDraft() {
+    // TODO remove these sanity checks before merging
+    if (this.def.id === this.draftDefId &&  this.def.publishedAt) throw new Error('This should not be true.');
+    if (this.def.id !== this.draftDefId && !this.def.publishedAt) throw new Error('Neither should this.');
+
+    return this.def.id === this.draftDefId;
+  }
+
   acceptsSubmissions() { return (this.state === 'open') || (this.state === 'closing'); }
 
   withManagedKey(key, suffix = generateVersionSuffix()) {
@@ -79,7 +87,7 @@ class Form extends Frame.define(
 
   _enketoIdForApi() {
     if (this.def == null) return null;
-    if (this.def.id === this.draftDefId) return this.def.enketoId;
+    if (this.isDraft()) return this.def.enketoId;
     if (this.def.id === this.currentDefId) return this.enketoId;
     return null;
   }

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -325,10 +325,10 @@ replaceDef.audit.logEvenIfAnonymous = true;
 // TODO: we need to make more explicit what .def actually represents throughout.
 // for now, enforce an extra check here just in case.
 const publish = (form, concurrentWithCreate = false) => async ({ Forms, Datasets, FormAttachments }) => {
-  if (form.draftDefId !== form.def.id) throw Problem.internal.unknown();
+  if (!form.isDraft()) throw Problem.internal.unknown();
 
   // dont use publish concurrentWithCreate on already published forms
-  if (concurrentWithCreate && form.publishedAt != null) throw Problem.internal.unknown({ error: 'Attempting to immediately publish a form' });
+  if (concurrentWithCreate && !form.isDraft()) throw Problem.internal.unknown({ error: 'Attempting to immediately publish a form' });
 
   // Try to push the form to Enketo if it hasn't been pushed already. If doing
   // so fails or is too slow, then the worker will try again later.

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -37,7 +37,7 @@ const createNew = (partial, form, deviceIdIn = null, userAgentIn = null) => ({ o
   return one(sql`
 with def as (${_defInsert(nextval, partial, form.def.id, actorId, true, deviceId, userAgent)}),
 ins as (insert into submissions (id, "formId", "instanceId", "submitterId", "deviceId", draft, "createdAt")
-  select def."submissionId", ${form.id}, ${partial.instanceId}, def."submitterId", ${deviceId}, ${form.def.publishedAt == null}, def."createdAt" from def
+  select def."submissionId", ${form.id}, ${partial.instanceId}, def."submitterId", ${deviceId}, ${form.isDraft()}, def."createdAt" from def
   returning submissions.*)
 select ins.*, def.id as "submissionDefId" from ins, def;`)
     .then(({ submissionDefId, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.

--- a/lib/worker/form.js
+++ b/lib/worker/form.js
@@ -14,7 +14,7 @@ const pushDraftToEnketo = ({ Forms }, event) =>
   Forms.getByActeeIdForUpdate(event.acteeId, undefined, Form.DraftVersion)
     .then((maybeForm) => maybeForm.map((form) => {
       // if there was no draft or this form isn't the draft anymore just bail.
-      if ((form.def.id == null) || (form.draftDefId !== form.def.id)) return;
+      if (form.def.id == null || !form.isDraft()) return;
 
       // if the enketoId was received during the request to create the draft, or
       // if it was carried forward from the previous draft, then bail.


### PR DESCRIPTION
Formalises the two functionally equivalent ways to check if a given Form frame represents the current draft of that form:

1. form.def.publishedAt === null
2. form.def.id === form.draftDefId

The first is probably more reliable, as if a future code change allowed a single form to have multiple drafts, it would continue to function correctly.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced