### PR TITLE
Improve search/filter performance.

### DIFF
--- a/lib/data/odata-filter.js
+++ b/lib/data/odata-filter.js
@@ -37,6 +37,23 @@ const odataFilter = (expr, odataToColumnMap) => {
   };
   const booleanOp = sqlQuery => sql`(${sqlQuery})`; // always use parens to ensure the original AST op precedence.
 
+  // We can't pass `${left} IS NOT DISTINCT FROM ${right}` when one of the operand is null because
+  // ${null} is transformed into `NULL::<type>` and then postgresql can't use index if available.
+  const equality = (node) => {
+    const left = op(node.value.left); // eslint-disable-line no-use-before-define
+    const right = op(node.value.right); // eslint-disable-line no-use-before-define
+
+    if (left === null && right === null) {
+      return booleanOp(sql`TRUE`);
+    } else if (left === null) {
+      return booleanOp(sql`NULL IS ${right}`);
+    } else if (right === null) {
+      return booleanOp(sql`${left} IS NULL`);
+    } else {
+      return booleanOp(sql`${left} IS NOT DISTINCT FROM ${right}`);
+    }
+  };
+
   const op = (node) => {
     if (node.type === 'FirstMemberExpression' || node.type === 'RootExpression') {
       if (odataToColumnMap.has(node.raw)) {
@@ -54,9 +71,9 @@ const odataFilter = (expr, odataToColumnMap) => {
     } else if (node.type === 'MethodCallExpression') {
       return methodCall(node);
     } else if (node.type === 'EqualsExpression') {
-      return booleanOp(sql`${op(node.value.left)} is not distinct from ${op(node.value.right)}`);
+      return equality(node);
     } else if (node.type === 'NotEqualsExpression') {
-      return booleanOp(sql`${op(node.value.left)} is distinct from ${op(node.value.right)}`);
+      return booleanOp(sql`NOT ${equality(node)}`);
     } else if (node.type === 'LesserThanExpression') {
       return booleanOp(sql`${op(node.value.left)} < ${op(node.value.right)}`);
     } else if (node.type === 'LesserOrEqualsExpression') {
@@ -80,6 +97,8 @@ const odataFilter = (expr, odataToColumnMap) => {
       throw Problem.internal.unsupportedODataExpression({ at: node.position, type: node.type, text: node.raw });
     }
   };
+
+
 
   let ast; // still hate this.
   try { ast = odataParser.filter(expr); } // eslint-disable-line brace-style


### PR DESCRIPTION
Change: If an operand of equality operator is null then transform it into IS NULL so that index can be used if available

#### What has been done to verify that this works as intended?

Verified performance improvement locally: without this change I get results in ~1500 and with the change I get it in <100ms. I have around 40K entities in a dataset locally.
Previously I had deployed this patch to staging and observed significant performance improvement. 15sec without the change and ~100ms with the change.

#### Why is this the best possible solution? Were any other approaches considered?

The approach is result of quite a bit of research and discussion with the team. Slack thread: https://getodk.slack.com/archives/C01TKJ7TG7J/p1749070387516389

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I don't see any risk of regression in this change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
