### PR TITLE
wip: fix API access to drafts through non-draft endpoints

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -594,10 +594,10 @@ const versionJoinCondition = (version, enketoId) => {
     )
   `;
   else if (version === '___') return versionJoinCondition('');
-  else if (version === Form.AnyVersion)       return sql`form_defs.id=coalesce(forms."currentDefId", forms."draftDefId")`;
-  else if (version === Form.DraftVersion)     return sql`form_defs.id=forms."draftDefId"`;
+  else if (version === Form.AnyVersion)       return sql`form_defs.id=coalesce(forms."currentDefId", forms."draftDefId")`; // eslint-disable-line no-multi-spaces
+  else if (version === Form.DraftVersion)     return sql`form_defs.id=forms."draftDefId"`; // eslint-disable-line no-multi-spaces
   else if (version === Form.PublishedVersion) return sql`form_defs.id=forms."currentDefId"`;
-  else if (version === Form.AllVersions)      return sql`form_defs."formId"=forms.id  and form_defs."publishedAt" is not null`;
+  else if (version === Form.AllVersions)      return sql`form_defs."formId"=forms.id  and form_defs."publishedAt" is not null`; // eslint-disable-line no-multi-spaces
   else return sql`form_defs."formId"=forms.id and form_defs.version=${version} and form_defs."publishedAt" is not null`;
 };
 /* eslint-enable indent */

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -581,8 +581,9 @@ order by coalesce(form_defs.name, forms."xmlFormId") asc`)
 
 // helper function to gate how form defs are joined to forms in _get
 /* eslint-disable indent */
-const versionJoinCondition = (version, enketoId) => (
-  (enketoId) ? sql`
+const versionJoinCondition = (version, enketoId) => {
+  if (version == null) throw new Error('Must request a specific version or version class');
+  else if (enketoId) return sql`
     form_defs."formId"=forms.id 
     AND (
       form_defs."enketoId" = ${enketoId} AND form_defs.id = forms."draftDefId"
@@ -590,14 +591,15 @@ const versionJoinCondition = (version, enketoId) => (
         ( forms."enketoId" = ${enketoId} OR forms."enketoOnceId" = ${enketoId} ) 
         AND form_defs.id = forms."currentDefId"
       )
-    )` :
-  (version === '___') ? versionJoinCondition('') :
-  (version == null) ? sql`form_defs.id=coalesce(forms."currentDefId", forms."draftDefId")` :
-  (version === Form.DraftVersion) ? sql`form_defs.id=forms."draftDefId"` :
-  (version === Form.PublishedVersion) ? sql`form_defs.id=forms."currentDefId"` :
-  (version === Form.AllVersions) ? sql`form_defs."formId"=forms.id and form_defs."publishedAt" is not null` :
-  sql`form_defs."formId"=forms.id and form_defs.version=${version} and form_defs."publishedAt" is not null`
-);
+    )
+  `;
+  else if (version === '___') return versionJoinCondition('');
+  else if (version === Form.AnyVersion)       return sql`form_defs.id=coalesce(forms."currentDefId", forms."draftDefId")`;
+  else if (version === Form.DraftVersion)     return sql`form_defs.id=forms."draftDefId"`;
+  else if (version === Form.PublishedVersion) return sql`form_defs.id=forms."currentDefId"`;
+  else if (version === Form.AllVersions)      return sql`form_defs."formId"=forms.id  and form_defs."publishedAt" is not null`;
+  else return sql`form_defs."formId"=forms.id and form_defs.version=${version} and form_defs."publishedAt" is not null`;
+};
 /* eslint-enable indent */
 
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -30,9 +30,15 @@ const excelMimeTypes = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 };
 
-const canReadForm = (auth, form) => (form.state === 'closed'
-  ? auth.canOrReject('form.read', form)
-  : auth.canOrReject(['open_form.read', 'form.read'], form));
+const canReadForm = (auth, form) => {
+  if (form.def.publishedAt == null) {
+    return auth.canOrReject('form.update', form);
+  } else if (form.state === 'closed') {
+    return auth.canOrReject('form.read', form);
+  } else {
+    return auth.canOrReject(['open_form.read', 'form.read'], form);
+  }
+};
 
 // Specify `auth` to limit entity access according to ownerOnly.
 const streamAttachment = async (container, attachment, auth, response) => {
@@ -295,6 +301,7 @@ module.exports = (service, endpoint) => {
     service.get(`${base}/manifest`, endpoint.openRosa(({ FormAttachments, Forms, env }, { auth, params, originalUrl }) =>
       getInstance(Forms, params)
         .then((form) => canReadForm(auth, form))
+        .then(ensureDef)
         .then((form) => FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id)
           .then((attachments) =>
             formManifest({ attachments,
@@ -325,7 +332,7 @@ module.exports = (service, endpoint) => {
 
   // the linter literally won't let me break this apart..
   formResource('/projects/:projectId/forms/:id', (Forms, params, withXml = false, options = QueryOptions.none) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, null, options)
+    Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, Form.PublishedVersion, options)
       .then(getOrNotFound));
   formResource('/projects/:projectId/forms/:id/versions/:version', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, params.version, options)

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -1086,6 +1086,19 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .set('X-OpenRosa-Version', '1.0')
             .expect(403))));
 
+      it.only('should not return a manifest if form is not published', testService((service) =>
+        service.login('alice', (asAlice) =>
+          asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.withAttachments)
+            .set('Content-Type', 'application/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+              .send('this is goodone.csv')
+              .expect(200))
+            .then(() => asAlice.get('/v1/projects/1/forms/withAttachments/manifest')
+              .set('X-OpenRosa-Version', '1.0')
+              .expect(404)))));
+
       it('should return no files if no attachments exist', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.get('/v1/projects/1/forms/simple/manifest')

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -1086,7 +1086,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .set('X-OpenRosa-Version', '1.0')
             .expect(403))));
 
-      it.only('should not return a manifest if form is not published', testService((service) =>
+      it('should not return a manifest if form is not published', testService((service) =>
         service.login('alice', (asAlice) =>
           asAlice.post('/v1/projects/1/forms')
             .send(testData.forms.withAttachments)


### PR DESCRIPTION
Closes getodk/central#1256

Restrict `/draft/` endpoints to draft form versions, and their corresponding endpoints _without_ `/draft/` to published form versions.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Updated all the tests.

#### Why is this the best possible solution? Were any other approaches considered?

An alternative would be to fix a subset of the `/draft`/not-`/draft` endpoints.

Some extras thrown in here:

* require `Form.<desired version>` in the `Form.get...()` query functions - this should make intentions and future uses clearer, and prevent draft/non-draft usage in future
* reverse order of `xml, version` args to `version, xml`, which allows for excluding the `xml`/`withXml` arg in most cases
* replacing boolean values for `xml`/`withXml` to make intent and API-misuse clearer

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Some users might be surprised that endpoints that would previously give them draft forms (when there was no published version) will no longer do so.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Potentially - will at least need a review of the current docs.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced