### PR TITLE
blobs: update contentType when duplicate uploaded

### DIFF
--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -23,7 +23,7 @@ const ensure = (blob) => ({ oneFirst }) => oneFirst(sql`
 with ensured as
 (insert into blobs (sha, md5, content, "contentType") values
     (${blob.sha}, ${blob.md5}, ${sql.binary(blob.content)}, ${blob.contentType || sql`DEFAULT`})
-  on conflict (sha) do update set sha = ${blob.sha}, "contentType" = ${blob.contentType || sql`DEFAULT`}
+  on conflict (sha) do update set sha = EXCLUDED.sha, "contentType" = EXCLUDED."contentType"
   returning id)
 select id from ensured`);
 

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -23,7 +23,7 @@ const ensure = (blob) => ({ oneFirst }) => oneFirst(sql`
 with ensured as
 (insert into blobs (sha, md5, content, "contentType") values
     (${blob.sha}, ${blob.md5}, ${sql.binary(blob.content)}, ${blob.contentType || sql`DEFAULT`})
-  on conflict (sha) do update set sha = ${blob.sha}
+  on conflict (sha) do update set sha = ${blob.sha}, "contentType" = ${blob.contentType || sql`DEFAULT`}
   returning id)
 select id from ensured`);
 

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -15,7 +15,7 @@ describe('blob query module', () => {
         .then(() => container.oneFirst(sql`select count(*) from blobs`))
         .then((count) => count.should.equal(1)))));
 
-  it.only('should handle blob collisions with different filenames', testService((service, container) =>
+  it('should handle blob collisions with different filenames', testService((service, container) =>
     // On one instance of the form, two files are uploaded
     // On another instance of the form (different id), one file is uploaded
     // and it creates another reference to one of the blobs with a different
@@ -55,7 +55,7 @@ describe('blob query module', () => {
         .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
           .expect(200)
           .then(({ headers, body }) => {
-            headers['content-type'].should.equal('video/mp4');
+            headers['content-type'].should.equal('audio/mp3');
             headers['content-disposition'].should.equal('attachment; filename="my_file1.mp4"; filename*=UTF-8\'\'my_file1.mp4');
             body.toString('utf8').should.equal('this is test file one');
           }))

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -15,7 +15,7 @@ describe('blob query module', () => {
         .then(() => container.oneFirst(sql`select count(*) from blobs`))
         .then((count) => count.should.equal(1)))));
 
-  it('should handle blob collisions with different filenames', testService((service, container) =>
+  it.only('should handle blob collisions with different filenames', testService((service, container) =>
     // On one instance of the form, two files are uploaded
     // On another instance of the form (different id), one file is uploaded
     // and it creates another reference to one of the blobs with a different
@@ -48,7 +48,7 @@ describe('blob query module', () => {
               .replace('<file1>my_file1.mp4</file1>', '<file1>my_file2.mp4</file1>')),
             { filename: 'data.xml' },
           )
-          .attach('my_file2.mp4', Buffer.from('this is test file one'), { filename: 'my_file2.mp4', contentType: 'text/plain' })
+          .attach('my_file2.mp4', Buffer.from('this is test file one'), { filename: 'my_file2.mp4', contentType: 'audio/mp3' })
           .expect(201))
         .then(() => container.oneFirst(sql`select count(*) from blobs`))
         .then((count) => count.should.equal(2))
@@ -62,7 +62,7 @@ describe('blob query module', () => {
         .then(() => asAlice.get('/v1/projects/1/forms/binaryType2/submissions/bone/attachments/my_file2.mp4')
           .expect(200)
           .then(({ headers, body }) => {
-            headers['content-type'].should.equal('video/mp4');
+            headers['content-type'].should.equal('audio/mp3');
             headers['content-disposition'].should.equal('attachment; filename="my_file2.mp4"; filename*=UTF-8\'\'my_file2.mp4');
             body.toString('utf8').should.equal('this is test file one');
           })))));

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -48,7 +48,7 @@ describe('blob query module', () => {
               .replace('<file1>my_file1.mp4</file1>', '<file1>my_file2.mp4</file1>')),
             { filename: 'data.xml' },
           )
-          .attach('my_file2.mp4', Buffer.from('this is test file one'), { filename: 'my_file2.mp4' })
+          .attach('my_file2.mp4', Buffer.from('this is test file one'), { filename: 'my_file2.mp4', contentType: 'text/plain' })
           .expect(201))
         .then(() => container.oneFirst(sql`select count(*) from blobs`))
         .then((count) => count.should.equal(2))


### PR DESCRIPTION
Ref getodk/central#751

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Modified duplicate blob test to a state which would have failed with previous `lib/` code, but now passes.

#### Why is this the best possible solution? Were any other approaches considered?

It's @matthew-white's approach **4** from getodk/central#751.

Approach **3** definitely feels more correct, but the approach in this PR has the following advantages:

1. it is definitely an improvement over the status quo
2. it is much simpler than approach **3**:
  * **3** requires changes to 5 database tables, which will be slow
  * **3** requires different `JOIN` semantics when fetching blobs

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It will change behaviour, but given #1356 it should be an improvement.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Not really?

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced