### PR TITLE
Forms: make conflation of published/draft explicit

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -581,8 +581,9 @@ order by coalesce(form_defs.name, forms."xmlFormId") asc`)
 
 // helper function to gate how form defs are joined to forms in _get
 /* eslint-disable indent */
-const versionJoinCondition = (version, enketoId) => (
-  (enketoId) ? sql`
+const versionJoinCondition = (version, enketoId) => {
+  if (version == null) throw new Error('Must request a specific version or version class');
+  else if (enketoId) return sql`
     form_defs."formId"=forms.id 
     AND (
       form_defs."enketoId" = ${enketoId} AND form_defs.id = forms."draftDefId"
@@ -590,14 +591,15 @@ const versionJoinCondition = (version, enketoId) => (
         ( forms."enketoId" = ${enketoId} OR forms."enketoOnceId" = ${enketoId} ) 
         AND form_defs.id = forms."currentDefId"
       )
-    )` :
-  (version === '___') ? versionJoinCondition('') :
-  (version == null) ? sql`form_defs.id=coalesce(forms."currentDefId", forms."draftDefId")` :
-  (version === Form.DraftVersion) ? sql`form_defs.id=forms."draftDefId"` :
-  (version === Form.PublishedVersion) ? sql`form_defs.id=forms."currentDefId"` :
-  (version === Form.AllVersions) ? sql`form_defs."formId"=forms.id and form_defs."publishedAt" is not null` :
-  sql`form_defs."formId"=forms.id and form_defs.version=${version} and form_defs."publishedAt" is not null`
-);
+    )
+  `;
+  else if (version === '___') return versionJoinCondition('');
+  else if (version === Form.AnyVersion)       return sql`form_defs.id=coalesce(forms."currentDefId", forms."draftDefId")`; // eslint-disable-line no-multi-spaces
+  else if (version === Form.DraftVersion)     return sql`form_defs.id=forms."draftDefId"`; // eslint-disable-line no-multi-spaces
+  else if (version === Form.PublishedVersion) return sql`form_defs.id=forms."currentDefId"`;
+  else if (version === Form.AllVersions)      return sql`form_defs."formId"=forms.id  and form_defs."publishedAt" is not null`; // eslint-disable-line no-multi-spaces
+  else return sql`form_defs."formId"=forms.id and form_defs.version=${version} and form_defs."publishedAt" is not null`;
+};
 /* eslint-enable indent */
 
 


### PR DESCRIPTION
Current `master` allows requests for forms through query functions to implicitly conflate form drafts and published versions.

This leads to surprising behaviours in the API like:

* #1404
* TODO others?

Affected functions: pretty much all form querying functions.

Closes #

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced