### PR TITLE
resources/forms: remove outdated comment

### DIFF
--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -325,10 +325,10 @@ module.exports = (service, endpoint) => {
     }));
   };
 
-  // the linter literally won't let me break this apart..
   formResource('/projects/:projectId/forms/:id', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, null, options)
       .then(getOrNotFound));
+
   formResource('/projects/:projectId/forms/:id/versions/:version', (Forms, params, withXml = false, options = QueryOptions.none) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.id, withXml, params.version, options)
       .then(getOrNotFound)


### PR DESCRIPTION
This comment was introduced in 4c9fbf9f0036b7320cfafeaad0a8aca4e24b23b6, when the proceeding lines read:

	formResource('/projects/:projectId/forms/:id', (Form, params, withXml = false, options = QueryOptions.none) =>
	  ((withXml === true) ? Form.getWithXmlByProjectAndXmlFormId : Form.getByProjectAndXmlFormId)(params.projectId, params.id, options)
	    .then(getOrNotFound));

The comment no longer seems relevant to the code that follows it, which is now much simpler than it was originally.

This commit also adds a newline, breaking apart two resource definitions, in keeping with the rest of the file.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

It's a comment.

#### Why is this the best possible solution? Were any other approaches considered?

It's a comment.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's a comment.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

It's a comment.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced