### PR TITLE
tests: do not use getOrNotFound()

### DIFF
--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4,7 +4,6 @@ const { testService, testServiceFullTrx } = require('../setup');
 const testData = require('../../data/xml');
 const config = require('config');
 const { Form } = require('../../../lib/model/frames');
-const { getOrNotFound } = require('../../../lib/util/promise');
 const should = require('should');
 const { sql } = require('slonik');
 const { QueryOptions } = require('../../../lib/util/db');
@@ -2057,8 +2056,8 @@ describe('datasets and entities', () => {
 
         // For bookkeeping later
         // Get blob id of original CSV file
-        const form = await Forms.getByProjectAndXmlFormId(1, 'withAttachments', false, Form.DraftVersion).then(getOrNotFound);
-        const attachment = await FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodone.csv').then(getOrNotFound);
+        const form = await Forms.getByProjectAndXmlFormId(1, 'withAttachments', false, Form.DraftVersion).then((o) => o.get());
+        const attachment = await FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodone.csv').then((o) => o.get());
 
         // Update attachment to link to dataset instead of csv file
         await asAlice.patch('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
@@ -2077,8 +2076,8 @@ describe('datasets and entities', () => {
           });
 
         // Check bookkeeping
-        const dataset = await Datasets.get(1, 'goodone').then(getOrNotFound);
-        const audit = await Audits.getLatestByAction('form.attachment.update').then(getOrNotFound);
+        const dataset = await Datasets.get(1, 'goodone').then((o) => o.get());
+        const audit = await Audits.getLatestByAction('form.attachment.update').then((o) => o.get());
         audit.details.should.be.eql({
           formDefId: form.draftDefId,
           name: 'goodone.csv',
@@ -2714,10 +2713,10 @@ describe('datasets and entities', () => {
               .set('Content-Type', 'text/csv')
               .expect(200))
             .then(() => Promise.all([
-              Forms.getByProjectAndXmlFormId(1, 'withAttachments', false, Form.DraftVersion).then(getOrNotFound),
-              Datasets.get(1, 'goodone').then(getOrNotFound)
+              Forms.getByProjectAndXmlFormId(1, 'withAttachments', false, Form.DraftVersion).then((o) => o.get()),
+              Datasets.get(1, 'goodone').then((o) => o.get())
             ]))
-            .then(([form, dataset]) => FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodone.csv').then(getOrNotFound)
+            .then(([form, dataset]) => FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodone.csv').then((o) => o.get())
               .then((attachment) => FormAttachments.update(form, attachment, 1, dataset.id)
                 .catch(error => {
                   error.constraint.should.be.equal('check_blobId_or_datasetId_is_null');
@@ -2732,10 +2731,10 @@ describe('datasets and entities', () => {
             .then(() => asAlice.post('/v1/projects/1/forms?publish=true')
               .send(testData.forms.simpleEntity))
             .then(() => Promise.all([
-              Forms.getByProjectAndXmlFormId(1, 'withAttachments', false, Form.DraftVersion).then(getOrNotFound),
-              Datasets.get(1, 'people').then(getOrNotFound)
+              Forms.getByProjectAndXmlFormId(1, 'withAttachments', false, Form.DraftVersion).then((o) => o.get()),
+              Datasets.get(1, 'people').then((o) => o.get())
             ]))
-            .then(([form, dataset]) => FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodtwo.mp3').then(getOrNotFound)
+            .then(([form, dataset]) => FormAttachments.getByFormDefIdAndName(form.draftDefId, 'goodtwo.mp3').then((o) => o.get())
               .then((attachment) => FormAttachments.update(form, attachment, null, dataset.id)
                 .catch(error => {
                   error.constraint.should.be.equal('check_datasetId_is_null_for_non_file');

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -8,7 +8,6 @@ const { getById, createVersion } = require('../../../lib/model/query/entities');
 const { log } = require('../../../lib/model/query/audits');
 const Option = require('../../../lib/util/option');
 const { Entity } = require('../../../lib/model/frames');
-const { getOrNotFound } = require('../../../lib/util/promise');
 
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
@@ -2009,7 +2008,7 @@ describe('Entities API', () => {
 
       await exhaust(container);
 
-      const dataset = await container.Datasets.get(1, 'people', true).then(getOrNotFound);
+      const dataset = await container.Datasets.get(1, 'people', true).then((o) => o.get());
       const actorId = await container.oneFirst(sql`SELECT id FROM actors WHERE "displayName" = 'Alice'`);
 
       let secondTxWaiting = false;
@@ -2021,7 +2020,7 @@ describe('Entities API', () => {
 
         const logger = (action, actee, details) => log(containerTx1.context.auth.actor, action, actee, details);
 
-        const entity = await getById(dataset.id, '12345678-1234-4123-8234-123456789abc', QueryOptions.forUpdate)(containerTx1).then(getOrNotFound);
+        const entity = await getById(dataset.id, '12345678-1234-4123-8234-123456789abc', QueryOptions.forUpdate)(containerTx1).then((o) => o.get());
 
         entityLocked = true;
         console.log('Tx1: entity fetched');
@@ -2068,7 +2067,7 @@ describe('Entities API', () => {
 
         console.log('Tx2: looks like 1st tx has locked the row');
 
-        const promise = getById(dataset.id, '12345678-1234-4123-8234-123456789abc', QueryOptions.forUpdate)(containerTx2).then(getOrNotFound)
+        const promise = getById(dataset.id, '12345678-1234-4123-8234-123456789abc', QueryOptions.forUpdate)(containerTx2).then((o) => o.get())
           .then(async (entity) => {
             console.log('Tx2: entity fetched');
 

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -1,6 +1,5 @@
 const appRoot = require('app-root-path');
 const should = require('should');
-const { getOrNotFound } = require(appRoot + '/lib/util/promise');
 const { testService } = require('../setup');
 
 describe('api: /users', () => {
@@ -129,7 +128,7 @@ describe('api: /users', () => {
                   .send({ email: 'david@getodk.org', password: '' })
                   .expect(400),
                 Users.getByEmail('david@getodk.org')
-                  .then(getOrNotFound)
+                  .then((o) => o.get())
                   .then(({ password }) => { should.not.exist(password); })
               ])))));
 

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -1,4 +1,3 @@
-const appRoot = require('app-root-path');
 const should = require('should');
 const { testService } = require('../setup');
 

--- a/test/integration/task/account.js
+++ b/test/integration/task/account.js
@@ -2,7 +2,6 @@ const appRoot = require('app-root-path');
 const should = require('should');
 const { testTask } = require('../setup');
 const { verifyPassword } = require(appRoot + '/lib/util/crypto');
-const { getOrNotFound } = require(appRoot + '/lib/util/promise');
 const { createUser, promoteUser, setUserPassword } = require(appRoot + '/lib/task/account');
 const { User } = require(appRoot + '/lib/model/frames');
 
@@ -39,14 +38,14 @@ describe('task: accounts', () => {
     it('should set the password if given', testTask(({ Users }) =>
       createUser('testuser@getodk.org', 'aoeuidhtns')
         .then(() => Users.getByEmail('testuser@getodk.org'))
-        .then(getOrNotFound)
+        .then((o) => o.get())
         .then((user) => verifyPassword('aoeuidhtns', user.password))
         .then((verified) => verified.should.equal(true))));
 
     it('should not verify a null password', testTask(({ Users }) =>
       createUser('testuser@getodk.org', null)
         .then(() => Users.getByEmail('testuser@getodk.org'))
-        .then(getOrNotFound)
+        .then((o) => o.get())
         .then((user) => verifyPassword(null, user.password))
         .then((verified) => verified.should.equal(false))));
 
@@ -65,7 +64,7 @@ describe('task: accounts', () => {
           allowed.should.equal(false);
           return promoteUser('testuser@getodk.org')
             .then(() => Users.getByEmail('testuser@getodk.org')
-              .then(getOrNotFound)
+              .then((o) => o.get())
               .then((user) => Auth.can(user.actor, 'user.create', User.species))
               // eslint-disable-next-line no-shadow
               .then((allowed) => allowed.should.equal(true)));
@@ -90,7 +89,7 @@ describe('task: accounts', () => {
       Users.create(User.fromApi({ email: 'testuser@getodk.org', displayName: 'test user' }))
         .then(() => setUserPassword('testuser@getodk.org', 'aoeuidhtns'))
         .then(() => Users.getByEmail('testuser@getodk.org'))
-        .then(getOrNotFound)
+        .then((o) => o.get())
         .then((user) => verifyPassword('aoeuidhtns', user.password))
         .then((verified) => verified.should.equal(true))));
 

--- a/test/integration/task/config.js
+++ b/test/integration/task/config.js
@@ -22,7 +22,7 @@ describe('task: config', () => {
     it('should save configuration by key', testTask(({ Configs }) =>
       setConfiguration('testConfig', { set: 'data' })
         .then(() => Configs.get('testConfig'))
-        .then(getOrNotFound)
+        .then((o) => o.get())
         .then((config) => config.value.should.eql({ set: 'data' }))));
   });
 });

--- a/test/integration/task/config.js
+++ b/test/integration/task/config.js
@@ -1,6 +1,5 @@
 const appRoot = require('app-root-path');
 const { testTask } = require('../setup');
-const { getOrNotFound } = require(appRoot + '/lib/util/promise');
 const { getConfiguration, setConfiguration } = require(appRoot + '/lib/task/config');
 
 describe('task: config', () => {


### PR DESCRIPTION
Replace getOrNotFound uses with `(o) => o.get()`

In API code `getOrNotFound()` makes sense, as it generates a `Problem` which is converted to an HTTP 404 response.

In test code, the `Problem` is not required, and while the code may look neater, it obscures stacktraces and makes test failures harder to understand.

Closes https://github.com/getodk/central/issues/1162

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced