### PR TITLE
lib/resources/odata: remove dead code

### DIFF
--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -38,7 +38,6 @@ module.exports = (service, endpoint) => {
           .then((fields) => xml(edmxFor(form.xmlFormId, fields))))));
 
     // serves filtered single-row data.
-    //const singleRowRegex = /^\/projects\/(\d+)\/forms\/([a-z0-9-_]+).svc\/Submissions\((?:'|%27)((?:uuid:)?[a-z0-9-]+)(?:'|%27)\)(\/.*)*$/i;
     const uuidRegex = /^'((?:uuid:)?[a-z0-9-]+)'$/i;
     const getUuid = (str) => {
       const matches = uuidRegex.exec(str);


### PR DESCRIPTION
Remove reference to `singleRowRegex`, which was commented out in 2020 (6f75b049565e0fa148ae3994425994c9bd30d907) and appears to now be irrelevant.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Dead code adds noise.  I didn't strongly consider an alternative to deleting it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
