### PR TITLE
query/submissions: reduce JOINS by 1 for SELECTs

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -179,8 +179,7 @@ const _get = extender(Submission, Submission.Def.into('currentVersion'))(Actor.i
     join submission_defs on submissions.id = submission_defs."submissionId" and root
   ) submissions
   join submission_defs on submissions.id = submission_defs."submissionId" and submission_defs.current
-  join forms on forms."xmlFormId"=${xmlFormId} and forms.id=submissions."formId"
-  join projects on projects.id=${projectId} and projects.id=forms."projectId"
+  join forms on forms."xmlFormId"=${xmlFormId} and forms.id=submissions."formId" and forms."projectId"=${projectId}
   ${extend|| sql`
     left outer join actors on actors.id=submissions."submitterId"
     left outer join actors current_version_actors on current_version_actors.id=submission_defs."submitterId"


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

CI.

Additional possibilities:

* profile the change
* analyse query plans on some production databases

This change seems obviously more efficient, so further analysis has not been performed.

#### Why is this the best possible solution? Were any other approaches considered?

Simple change, obvious impact.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Submissions fetching is very common, so this might provide noticeable performance improvements.

There is a chance for regression if `options.condition` ever references some column of `projects`.  I cannot see any code where this occurs; if it happens in prod, the error should trigger alerting.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
