### PR TITLE
Allow data collectors/public links/app-users to upload attachment using rest endpoint

### DIFF
--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -480,45 +480,41 @@ module.exports = (service, endpoint) => {
 
     service.post(
       `${base}/:instanceId/attachments/:name`,
-      endpoint(({ Audits, Blobs, Forms, SubmissionAttachments, Submissions }, { params, headers, auth }, request) =>
-        Promise.all([
-          getForm(params, Forms)
-            .then(async (form) => {
-              const verbs = await auth.verbsOn(form);
-              if (!verbs.includes('submission.update') && !verbs.includes('submission.create')) {
-                throw Problem.user.insufficientRights();
-              }
-              return [form, verbs.includes('submission.update')];
-            })
-            .then(([form, canUpdateSubmissions]) => Submissions.getCurrentDefColsByIds(['id', 'submitterId'], form.projectId, form.xmlFormId, params.instanceId, draft)
-              .then(getOrNotFound)
-              .then(({ id: defId, submitterId }) => SubmissionAttachments.getBySubmissionDefIdAndName(defId, params.name) // just for audit logging
-                .then(getOrNotFound)
-                .then((oldAttachment) => [ form, canUpdateSubmissions, defId, submitterId, oldAttachment ]))),
-          Blob.fromStream(request, headers['content-type'] || defaultMimetypeFor(params.name)).then(Blobs.ensure)
-        ])
-          .then(([ [ form, canUpdateSubmissions, defId, submitterId, oldAttachment ], blobId ]) => {
-            // Authorization for the roles that can only submission.create: they can only upload
-            // attachment for their own submissions for which they haven't uploaded it before
-            const canUploadAttachment = auth.actor.isDefined() && auth.actor.get().id === submitterId && oldAttachment.blobId === null;
-            if (!canUpdateSubmissions && !canUploadAttachment) {
-              throw Problem.user.insufficientRights();
-            }
-            return Promise.all([
-              SubmissionAttachments.attach(defId, params.name, blobId),
-              Audits.log(auth.actor, 'submission.attachment.update', form, {
-                instanceId: params.instanceId,
-                submissionDefId: defId,
-                name: params.name,
-                oldBlobId: oldAttachment.blobId,
-                newBlobId: blobId
-              })
-            ]);
-          })
-          .then(([ wasSuccessful ]) => (wasSuccessful
-            ? success()
-            // should only be a Resolve[False] if everything worked but there wasn't a row to update.
-            : reject(Problem.user.notFound()))))
+      endpoint(async ({ Audits, Blobs, Forms, SubmissionAttachments, Submissions }, { params, headers, auth }, request) => {
+        const form = await getForm(params, Forms);
+        const verbs = await auth.verbsOn(form);
+        if (!verbs.includes('submission.update') && !verbs.includes('submission.create')) {
+          throw Problem.user.insufficientRights();
+        }
+        const canUpdateSubmissions = verbs.includes('submission.update');
+
+        const { id: defId, submitterId, root: isRootSubmissionDef } = await Submissions.getCurrentDefColsByIds(['id', 'submitterId', 'root'], form.projectId, form.xmlFormId, params.instanceId, draft)
+          .then(getOrNotFound);
+        const oldAttachment = await SubmissionAttachments.getBySubmissionDefIdAndName(defId, params.name)
+          .then(getOrNotFound);
+
+        // Authorization for the roles that can only submission.create: they can only upload
+        // attachment for their own submissions for which attachment is missing and the Submission
+        // is not edited by somebody
+        const canUploadAttachment = auth.actor.isDefined() && auth.actor.get().id === submitterId && oldAttachment.blobId === null && isRootSubmissionDef;
+        if (!canUpdateSubmissions && !canUploadAttachment) {
+          throw Problem.user.insufficientRights();
+        }
+
+        const blobId = await Blob.fromStream(request, headers['content-type'] || defaultMimetypeFor(params.name)).then(Blobs.ensure);
+
+        await SubmissionAttachments.attach(defId, params.name, blobId);
+
+        await Audits.log(auth.actor, 'submission.attachment.update', form, {
+          instanceId: params.instanceId,
+          submissionDefId: defId,
+          name: params.name,
+          oldBlobId: oldAttachment.blobId,
+          newBlobId: blobId
+        });
+
+        return success();
+      })
     );
 
     service.delete(

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -483,20 +483,24 @@ module.exports = (service, endpoint) => {
       endpoint(({ Audits, Blobs, Forms, SubmissionAttachments, Submissions }, { params, headers, auth }, request) =>
         Promise.all([
           getForm(params, Forms)
-            .then((form) => Submissions.getCurrentDefColsByIds(['id', 'submitterId'], form.projectId, form.xmlFormId, params.instanceId, draft)
+            .then(async (form) => {
+              const verbs = await auth.verbsOn(form);
+              if (!verbs.includes('submission.update') && !verbs.includes('submission.create')) {
+                throw Problem.user.insufficientRights();
+              }
+              return [form, verbs.includes('submission.update')];
+            })
+            .then(([form, canUpdateSubmissions]) => Submissions.getCurrentDefColsByIds(['id', 'submitterId'], form.projectId, form.xmlFormId, params.instanceId, draft)
               .then(getOrNotFound)
               .then(({ id: defId, submitterId }) => SubmissionAttachments.getBySubmissionDefIdAndName(defId, params.name) // just for audit logging
                 .then(getOrNotFound)
-                .then((oldAttachment) => [ form, defId, submitterId, oldAttachment ]))),
+                .then((oldAttachment) => [ form, canUpdateSubmissions, defId, submitterId, oldAttachment ]))),
           Blob.fromStream(request, headers['content-type'] || defaultMimetypeFor(params.name)).then(Blobs.ensure)
         ])
-          .then(async ([ [ form, defId, submitterId, oldAttachment ], blobId ]) => {
-            // if user has submission.update then they can upload attachment for any submission;
-            // but if user has only submission.create then they can upload attachment for their own
-            // submissions for which they haven't uploaded attachment before
-            const canUpdateSubmissions = await auth.can('submission.update', form);
-            const canCreateSubmissions = await auth.can('submission.create', form);
-            const canUploadAttachment = canCreateSubmissions && auth.actor.isDefined() && auth.actor.get().id === submitterId && oldAttachment.blobId === null;
+          .then(([ [ form, canUpdateSubmissions, defId, submitterId, oldAttachment ], blobId ]) => {
+            // Authorization for the roles that can only submission.create: they can only upload
+            // attachment for their own submissions for which they haven't uploaded it before
+            const canUploadAttachment = auth.actor.isDefined() && auth.actor.get().id === submitterId && oldAttachment.blobId === null;
             if (!canUpdateSubmissions && !canUploadAttachment) {
               throw Problem.user.insufficientRights();
             }

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -483,24 +483,34 @@ module.exports = (service, endpoint) => {
       endpoint(({ Audits, Blobs, Forms, SubmissionAttachments, Submissions }, { params, headers, auth }, request) =>
         Promise.all([
           getForm(params, Forms)
-            .then((form) => auth.canOrReject('submission.update', form))
-            .then((form) => Submissions.getCurrentDefColByIds('id', form.projectId, form.xmlFormId, params.instanceId, draft)
+            .then((form) => Submissions.getCurrentDefColsByIds(['id', 'submitterId'], form.projectId, form.xmlFormId, params.instanceId, draft)
               .then(getOrNotFound)
-              .then((defId) => SubmissionAttachments.getBySubmissionDefIdAndName(defId, params.name) // just for audit logging
+              .then(({ id: defId, submitterId }) => SubmissionAttachments.getBySubmissionDefIdAndName(defId, params.name) // just for audit logging
                 .then(getOrNotFound)
-                .then((oldAttachment) => [ form, defId, oldAttachment ]))),
+                .then((oldAttachment) => [ form, defId, submitterId, oldAttachment ]))),
           Blob.fromStream(request, headers['content-type'] || defaultMimetypeFor(params.name)).then(Blobs.ensure)
         ])
-          .then(([ [ form, defId, oldAttachment ], blobId ]) => Promise.all([
-            SubmissionAttachments.attach(defId, params.name, blobId),
-            Audits.log(auth.actor, 'submission.attachment.update', form, {
-              instanceId: params.instanceId,
-              submissionDefId: defId,
-              name: params.name,
-              oldBlobId: oldAttachment.blobId,
-              newBlobId: blobId
-            })
-          ]))
+          .then(async ([ [ form, defId, submitterId, oldAttachment ], blobId ]) => {
+            // if user has submission.update then they can upload attachment for any submission;
+            // but if user has only submission.create then they can upload attachment for their own
+            // submissions for which they haven't uploaded attachment before
+            const canUpdateSubmissions = await auth.can('submission.update', form);
+            const canCreateSubmissions = await auth.can('submission.create', form);
+            const canUploadAttachment = canCreateSubmissions && auth.actor.isDefined() && auth.actor.get().id === submitterId && oldAttachment.blobId === null;
+            if (!canUpdateSubmissions && !canUploadAttachment) {
+              throw Problem.user.insufficientRights();
+            }
+            return Promise.all([
+              SubmissionAttachments.attach(defId, params.name, blobId),
+              Audits.log(auth.actor, 'submission.attachment.update', form, {
+                instanceId: params.instanceId,
+                submissionDefId: defId,
+                name: params.name,
+                oldBlobId: oldAttachment.blobId,
+                newBlobId: blobId
+              })
+            ]);
+          })
           .then(([ wasSuccessful ]) => (wasSuccessful
             ? success()
             // should only be a Resolve[False] if everything worked but there wasn't a row to update.

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -4454,28 +4454,14 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
           .send('testimage')
           .expect(404))));
 
-    it('should reject if the user cannot update a submission', testService(async (service) => {
-      const asAlice = await service.login('alice');
+    it('should reject if the user cannot update a submission', testService((service) =>
+      service.login('chelsea', (asChelsea) =>
+        asChelsea.post('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
+          .set('Content-Type', 'image/jpeg')
+          .send('testimage')
+          .expect(403))));
 
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .set('Content-Type', 'application/xml')
-        .send(testData.forms.binaryType)
-        .expect(200);
-
-      await asAlice.post('/v1/projects/1/forms/binaryType/submissions')
-        .send(testData.instances.binaryType.both)
-        .set('Content-Type', 'text/xml')
-        .expect(200);
-
-      const asChelsea = await service.login('chelsea');
-
-      await asChelsea.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
-        .set('Content-Type', 'image/jpeg')
-        .send('testimage')
-        .expect(403);
-    }));
-
-    it('Data collector should attach the given file if user has only submission.create, submission is created by the same user and attachment is not previously uploaded', testService(async (service, { Users }) => {
+    it('Data collector should be able to attach the given file if Submission is created by the them and attachment is not previously uploaded', testService(async (service, { Users }) => {
       const asAlice = await service.login('alice');
 
       await asAlice.post('/v1/projects/1/forms?publish=true')

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -7,6 +7,8 @@ const { testService, testServiceFullTrx } = require('../setup');
 const testData = require('../../data/xml');
 const { httpZipResponseToFiles } = require('../../util/zip');
 const { map } = require('ramda');
+const { hashPassword } = require('../../../lib/util/crypto');
+const { User, Actor } = require(appRoot + '/lib/model/frames');
 const { Form } = require(appRoot + '/lib/model/frames');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
@@ -4473,7 +4475,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
         .expect(403);
     }));
 
-    it('should attach the given file if user has only submission.create, submission is created by the same user and attachment is not previously uploaded', testService(async (service) => {
+    it('Data collector should attach the given file if user has only submission.create, submission is created by the same user and attachment is not previously uploaded', testService(async (service, { Users }) => {
       const asAlice = await service.login('alice');
 
       await asAlice.post('/v1/projects/1/forms?publish=true')
@@ -4481,12 +4483,23 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
         .send(testData.forms.binaryType)
         .expect(200);
 
+      const password = await hashPassword('password4david');
+
+      await Users.create(new User({ email: 'david@getodk.org', password }, { actor: new Actor({ type: 'user', displayName: 'David' }) }));
+
       const asChelsea = await service.login('chelsea');
+      const asDavid = await service.login('david');
 
       const chelseaId = await asChelsea.get('/v1/users/current').expect(200)
         .then(({ body }) => body.id);
 
+      const davidId = await asDavid.get('/v1/users/current').expect(200)
+        .then(({ body }) => body.id);
+
       await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaId}`)
+        .expect(200);
+
+      await asAlice.post(`/v1/projects/1/assignments/formfill/${davidId}`)
         .expect(200);
 
       await asChelsea.post('/v1/projects/1/forms/binaryType/submissions')
@@ -4494,7 +4507,70 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
         .set('Content-Type', 'text/xml')
         .expect(200);
 
+      // David can't upload attachment for the Submission created by Chelsea
+      await asDavid.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(403);
+
       await asChelsea.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(200);
+
+      // Chelsea can't reupload attachment
+      await asChelsea.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(403);
+    }));
+
+    it('Public link should be able to upload attachment for the Submission', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.binaryType)
+        .expect(200);
+
+      const publicLinkToken = await asAlice.post('/v1/projects/1/forms/binaryType/public-links')
+        .send({ displayName: 'default' })
+        .expect(200)
+        .then(({ body }) => body.token);
+
+      await service.post(`/v1/projects/1/forms/binaryType/submissions?st=${publicLinkToken}`)
+        .send(testData.instances.binaryType.both)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      await service.post(`/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4?st=${publicLinkToken}`)
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(200);
+    }));
+
+    it('App user should be able to upload attachment for the Submission', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.binaryType)
+        .expect(200);
+
+      const appUser = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'default' })
+        .expect(200)
+        .then(({ body }) => body);
+
+      await asAlice.post(`/v1/projects/1/forms/binaryType/assignments/app-user/${appUser.id}`)
+        .expect(200);
+
+      await service.post(`/v1/key/${appUser.token}/projects/1/forms/binaryType/submissions`)
+        .send(testData.instances.binaryType.both)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      await service.post(`/v1/key/${appUser.token}/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4`)
         .set('Content-Type', 'image/jpeg')
         .send('testimage')
         .expect(200);

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -4452,12 +4452,53 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
           .send('testimage')
           .expect(404))));
 
-    it('should reject if the user cannot update a submission', testService((service) =>
-      service.login('chelsea', (asChelsea) =>
-        asChelsea.post('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
-          .set('Content-Type', 'image/jpeg')
-          .send('testimage')
-          .expect(403))));
+    it('should reject if the user cannot update a submission', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.binaryType)
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+        .send(testData.instances.binaryType.both)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      const asChelsea = await service.login('chelsea');
+
+      await asChelsea.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(403);
+    }));
+
+    it('should attach the given file if user has only submission.create, submission is created by the same user and attachment is not previously uploaded', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.binaryType)
+        .expect(200);
+
+      const asChelsea = await service.login('chelsea');
+
+      const chelseaId = await asChelsea.get('/v1/users/current').expect(200)
+        .then(({ body }) => body.id);
+
+      await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaId}`)
+        .expect(200);
+
+      await asChelsea.post('/v1/projects/1/forms/binaryType/submissions')
+        .send(testData.instances.binaryType.both)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      await asChelsea.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(200);
+    }));
 
     it('should reject if the attachment does not exist', testService((service) =>
       service.login('alice', (asAlice) =>

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -4535,6 +4535,30 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
         .expect(200);
     }));
 
+    it('Public link should not be able to upload attachment for others Submission', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.binaryType)
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+        .send(testData.instances.binaryType.both)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      const publicLinkToken = await asAlice.post('/v1/projects/1/forms/binaryType/public-links')
+        .send({ displayName: 'default' })
+        .expect(200)
+        .then(({ body }) => body.token);
+
+      await service.post(`/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4?st=${publicLinkToken}`)
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(403);
+    }));
+
     it('App user should be able to upload attachment for the Submission', testService(async (service) => {
       const asAlice = await service.login('alice');
 


### PR DESCRIPTION
Closes getodk/central#1166

#### What has been done to verify that this works as intended?

Manual verification + added an integration test

#### Why is this the best possible solution? Were any other approaches considered?

This implements what @lognaturel suggested during the summit. i.e. this allows users with permission to create submissions to upload corresponding attachments using REST API if attachment is not already there. I have added another condition that submission should have been created by the same user.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
