### PR TITLE
datasets: sort results in code

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -382,15 +382,22 @@ const _get = extender(Dataset)(Dataset.Extended)((fields, extend, options, publi
   `}
   WHERE ${sqlEquals(options.condition)}
     ${publishedOnly ? sql`AND "publishedAt" IS NOT NULL` : sql``}
-  ORDER BY name ASC
 `);
 
+// Sorting the datasets in code gives the PostgreSQL query planner a lot more
+// freedom.  This is OK if there aren't many datasets, and addresses poor
+// performance observed in testing.  Sorting is also unnecessary when calling
+// _get() for a maybeOne() request.
+const orderByName = (a, b) => (a.name > b.name ? 1 : -1);
+
 const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
-  _get(all, options, true, auth.actor.map((actor) => actor.id).orElse(-1));
+  _get(all, options, true, auth.actor.map((actor) => actor.id).orElse(-1))
+    .then(orderByName);
 
 // Get all published datasets for a specific project.
 const getList = (projectId, options = QueryOptions.none) => ({ all }) =>
-  _get(all, options.withCondition({ projectId }), true);
+  _get(all, options.withCondition({ projectId }), true)
+    .then(orderByName);
 
 // Get a dataset by it's project id and name. Commonly used in a resource.
 const get = (projectId, name, publishedOnly, extended = false) => ({ maybeOne }) => {


### PR DESCRIPTION
Sorting the datasets in code gives the PostgreSQL query planner a lot more freedom.

This is OK if there aren't many datasets, and addresses poor performance observed in testing.

Sorting is also unnecessary when calling _get() for a maybeOne() request.

Closes getodk/central#

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
