### PR TITLE
model/query/submissions: avoid RETURNING * where possible

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -86,8 +86,6 @@ const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn
   const deviceId = applyPipe(deviceIdIn, truncateString(255), blankStringToNull);
   const userAgent = applyPipe(userAgentIn, truncateString(255), blankStringToNull);
 
-  const _unjoiner = unjoiner(Submission, Submission.Def.into('currentVersion'));
-
   // we already do transactions but it just feels nice to have the cte do it all at once.
   return one(sql`
 with logical as (update submissions set "reviewState"='edited', "updatedAt"=clock_timestamp()
@@ -97,13 +95,50 @@ with logical as (update submissions set "reviewState"='edited', "updatedAt"=cloc
 , def as (
   ${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, deviceId, userAgent)}
 )
-select ${_unjoiner.fields} from (
+select "submissions"."id" as "id"
+     , "submissions"."formId" as "submissions!formId"
+     , "submissions"."instanceId" as "submissions!instanceId"
+     , "submissions"."submitterId" as "submissions!submitterId"
+     , "submissions"."deviceId" as "submissions!deviceId"
+     , "submissions"."createdAt" as "submissions!createdAt"
+     , "submissions"."updatedAt" as "submissions!updatedAt"
+     , "submissions"."reviewState" as "submissions!reviewState"
+     , "submissions"."userAgent" as "submissions!userAgent"
+     , "submissions"."draft" as "submissions!draft"
+     , "submissions"."deletedAt" as "submissions!deletedAt"
+     , "submission_defs"."id" as "submissionDefId"
+     , "submission_defs"."createdAt" as "submission_defs!createdAt"
+from (
   select logical.*, upd."userAgent" from logical
   join upd on logical.id = upd."submissionId" and root
 ) submissions
 join def submission_defs on submissions.id = submission_defs."submissionId"
 `)
-    .then(_unjoiner);
+    .then(({ submissionDefId, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
+      new Submission(submissionData, {
+        def: new Submission.Def({
+          id: submissionDefId,
+          submissionId: submissionData.id,
+          formDefId: form.def.id,
+          submitterId: submissionData.submitterId,
+          localKey: partial.def.localKey,
+          encDataAttachmentName: partial.def.encDataAttachmentName,
+          signature: partial.def.signature,
+          createdAt: submissionData.createdAt,
+          userAgent
+        }),
+        currentVersion: new Submission.Def({
+          id: submissionDefId,
+          instanceId: partial.instanceId,
+          createdAt: submissionData.createdAt,
+          deviceId,
+          userAgent,
+          instanceName: partial.def.instanceName,
+          current: true,
+          submitterId: submissionData.submitterId
+        }),
+        xml: new Submission.Xml({ xml: partial.xml })
+      }));
 };
 
 createVersion.audit = (submission, partial, deprecated, form) => (log) =>

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -96,18 +96,18 @@ with logical as (update submissions set "reviewState"='edited', "updatedAt"=cloc
   ${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, deviceId, userAgent)}
 )
 select "submissions"."id" as "id"
-     , "submissions"."formId" as "submissions!formId"
-     , "submissions"."instanceId" as "submissions!instanceId"
-     , "submissions"."submitterId" as "submissions!submitterId"
-     , "submissions"."deviceId" as "submissions!deviceId"
-     , "submissions"."createdAt" as "submissions!createdAt"
-     , "submissions"."updatedAt" as "submissions!updatedAt"
-     , "submissions"."reviewState" as "submissions!reviewState"
-     , "submissions"."userAgent" as "submissions!userAgent"
-     , "submissions"."draft" as "submissions!draft"
-     , "submissions"."deletedAt" as "submissions!deletedAt"
+     , "submissions"."formId" as "formId"
+     , "submissions"."instanceId" as "instanceId"
+     , "submissions"."submitterId" as "submitterId"
+     , "submissions"."deviceId" as "deviceId"
+     , "submissions"."createdAt" as "createdAt"
+     , "submissions"."updatedAt" as "updatedAt"
+     , "submissions"."reviewState" as "reviewState"
+     , "submissions"."userAgent" as "userAgent"
+     , "submissions"."draft" as "draft"
+     , "submissions"."deletedAt" as "deletedAt"
      , "submission_defs"."id" as "submissionDefId"
-     , "submission_defs"."createdAt" as "submission_defs!createdAt"
+     , "submission_defs"."createdAt" as "submissionCreatedAt"
 from (
   select logical.*, upd."userAgent" from logical
   join upd on logical.id = upd."submissionId" and root
@@ -116,26 +116,15 @@ join def submission_defs on submissions.id = submission_defs."submissionId"
 `)
     .then(({ submissionDefId, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
       new Submission(submissionData, {
-        def: new Submission.Def({
-          id: submissionDefId,
-          submissionId: submissionData.id,
-          formDefId: form.def.id,
-          submitterId: submissionData.submitterId,
-          localKey: partial.def.localKey,
-          encDataAttachmentName: partial.def.encDataAttachmentName,
-          signature: partial.def.signature,
-          createdAt: submissionData.createdAt,
-          userAgent
-        }),
         currentVersion: new Submission.Def({
           id: submissionDefId,
           instanceId: partial.instanceId,
-          createdAt: submissionData.createdAt,
+          createdAt: submissionData.submissionCreatedAt,
           deviceId,
           userAgent,
           instanceName: partial.def.instanceName,
           current: true,
-          submitterId: submissionData.submitterId
+          submitterId: submissionData.submitterId,
         }),
         xml: new Submission.Xml({ xml: partial.xml })
       }));

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -23,9 +23,16 @@ const Option = require('../../util/option');
 ////////////////////////////////////////////////////////////////////////////////
 // SUBMISSION CREATE
 
+const withoutProvided = ({ fields }, ...providedFields) => sql.join(fields.filter(it => !providedFields.includes(it)).map(k => sql.identifier([k])), sql`,`);
+
+const _defInsertReturnFields = withoutProvided(
+  Submission.Def,
+  'xml', 'formDefId', 'instanceId', 'instanceName', 'submitterId', 'localKey',
+  'encDataAttachmentName', 'signature', 'root', 'current', 'deviceId', 'userAgent',
+);
 const _defInsert = (id, partial, formDefId, actorId, root, deviceId, userAgent) => sql`insert into submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
   values (${id}, ${sql.binary(partial.xml)}, ${formDefId}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), ${root}, true, ${deviceId}, ${userAgent})
-  returning *`;
+  returning ${_defInsertReturnFields}`;
 const nextval = sql`nextval(pg_get_serial_sequence('submissions', 'id'))`;
 
 // creates both the submission and its initial submission def in one go.
@@ -37,7 +44,7 @@ const createNew = (partial, form, deviceIdIn = null, userAgentIn = null) => ({ o
   return one(sql`
 with def as (${_defInsert(nextval, partial, form.def.id, actorId, true, deviceId, userAgent)}),
 ins as (insert into submissions (id, "formId", "instanceId", "submitterId", "deviceId", draft, "createdAt")
-  select def."submissionId", ${form.id}, ${partial.instanceId}, def."submitterId", ${deviceId}, ${form.def.publishedAt == null}, def."createdAt" from def
+  select def."submissionId", ${form.id}, ${partial.instanceId}, ${actorId}, ${deviceId}, ${form.def.publishedAt == null}, def."createdAt" from def
   returning submissions.*)
 select ins.*, def.id as "submissionDefId" from ins, def;`)
     .then(({ submissionDefId, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -130,7 +130,7 @@ module.exports = (service, endpoint) => {
                     Forms.getBinaryFields(form.def.id),
                     SubmissionAttachments.getForFormAndInstanceId(form.id, deprecatedId, draft)
                   ]).then(([ saved, binaryFields, deprecatedAtts ]) =>
-                    SubmissionAttachments.create(saved.aux.currentVersion.with({ def: saved.aux.currentVersion }), form, binaryFields, files, deprecatedAtts))))
+                    SubmissionAttachments.create(saved.aux.currentVersion.with({ def: saved.aux.currentVersion, xml: partial.xml }), form, binaryFields, files, deprecatedAtts))))
 
               // ((no deprecatedId given))
               : Submissions.getAnyDefByFormAndInstanceId(form.id, partial.instanceId, draft)

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -240,7 +240,7 @@ module.exports = (service, endpoint) => {
             SubmissionAttachments.getForFormAndInstanceId(form.id, deprecatedId, draft),
           ])
             .then(([ submission, binaryFields, deprecatedAtt ]) =>
-              SubmissionAttachments.create(submission.aux.currentVersion.with({ def: submission.aux.currentVersion }), form, binaryFields, undefined, deprecatedAtt)
+              SubmissionAttachments.create(submission.aux.currentVersion.with({ def: submission.aux.currentVersion, xml: partial.xml }), form, binaryFields, undefined, deprecatedAtt)
                 .then(always(submission))));
       })));
   };


### PR DESCRIPTION
`INSERT...RETURNING *` is a very convenient SQL structure, but it's often used to return values which are already available to the calling code. When this happens, there is unnecessary overhead to database communications.

There is risk to introducing this change, as:

1. new columns may be added to an `INSERT`/`UPDATE` statement without noticing that they might also be excluded from the generated list of `RETURNING` columns
2. a `BEFORE INSERT` trigger might change supplied values when returned
3. supplied value might be coerced into a different type when returned

Related: getodk/central#1170

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
