### PR TITLE
Fixes: Return 404 if submission or attachment info is missing when uploading an attachment

### DIFF
--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -483,7 +483,6 @@ module.exports = (service, endpoint) => {
       endpoint(({ Audits, Blobs, Forms, SubmissionAttachments, Submissions }, { params, headers, auth }, request) =>
         Promise.all([
           getForm(params, Forms)
-            .then((form) => auth.canOrReject('submission.update', form))
             .then((form) => Submissions.getCurrentDefColByIds('id', form.projectId, form.xmlFormId, params.instanceId, draft)
               .then(getOrNotFound)
               .then((defId) => SubmissionAttachments.getBySubmissionDefIdAndName(defId, params.name) // just for audit logging
@@ -491,16 +490,22 @@ module.exports = (service, endpoint) => {
                 .then((oldAttachment) => [ form, defId, oldAttachment ]))),
           Blob.fromStream(request, headers['content-type'] || defaultMimetypeFor(params.name)).then(Blobs.ensure)
         ])
-          .then(([ [ form, defId, oldAttachment ], blobId ]) => Promise.all([
-            SubmissionAttachments.attach(defId, params.name, blobId),
-            Audits.log(auth.actor, 'submission.attachment.update', form, {
-              instanceId: params.instanceId,
-              submissionDefId: defId,
-              name: params.name,
-              oldBlobId: oldAttachment.blobId,
-              newBlobId: blobId
-            })
-          ]))
+          .then(async ([ [ form, defId, oldAttachment ], blobId ]) => {
+            const canUpdateSubmissions = await auth.can('submission.update', form);
+            if (!canUpdateSubmissions) {
+              throw Problem.user.insufficientRights();
+            }
+            return Promise.all([
+              SubmissionAttachments.attach(defId, params.name, blobId),
+              Audits.log(auth.actor, 'submission.attachment.update', form, {
+                instanceId: params.instanceId,
+                submissionDefId: defId,
+                name: params.name,
+                oldBlobId: oldAttachment.blobId,
+                newBlobId: blobId
+              })
+            ]);
+          })
           .then(([ wasSuccessful ]) => (wasSuccessful
             ? success()
             // should only be a Resolve[False] if everything worked but there wasn't a row to update.

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -4452,12 +4452,42 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
           .send('testimage')
           .expect(404))));
 
-    it('should reject if the user cannot update a submission', testService((service) =>
-      service.login('chelsea', (asChelsea) =>
-        asChelsea.post('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
-          .set('Content-Type', 'image/jpeg')
-          .send('testimage')
-          .expect(403))));
+    it('should return notfound if the attachment does not exist in the submission', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms/simple/submissions')
+        .send(testData.instances.simple.one)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      const asChelsea = await service.login('chelsea');
+
+      await asChelsea.post('/v1/projects/1/forms/simple/submissions/one/attachments/my_file1.mp4')
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(404);
+    }));
+
+    it('should reject if the user cannot update a submission', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.binaryType)
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+        .send(testData.instances.binaryType.both)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      const asChelsea = await service.login('chelsea');
+
+      await asChelsea.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+        .set('Content-Type', 'image/jpeg')
+        .send('testimage')
+        .expect(403);
+    }));
 
     it('should reject if the attachment does not exist', testService((service) =>
       service.login('alice', (asAlice) =>


### PR DESCRIPTION
Prerequisite for https://github.com/getodk/central/issues/1166

#### What has been done to verify that this works as intended?

Added and updated tests

#### Why is this the best possible solution? Were any other approaches considered?

It breaks the change in two part, makes easier to review and come back to it if required in future.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
