### PR TITLE
Extract __entity and __label properties and property fields from entity forms

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -133,9 +133,45 @@ const getDatasets = (xml) =>
     const warnings = validateEntitySpecVersion(version);
 
     // Get the dataset name and actions from the <entity> tag attributes
-    const dataset = getNameAndActions(entityAttrs);
+    // Note: for the single dataset per form case, the path of the dataset in the form is base path
+    const dataset = { ...getNameAndActions(entityAttrs), path: '/' };
 
     return Option.of({ datasets: [ dataset ], warnings });
   });
 
-module.exports = { getDatasets, validateDatasetName, validatePropertyName };
+// Take parsed datasets and parsed form fields and match up fields
+// with their correct dataset based on path
+const matchFieldsWithDatasets = (datasets, fields) => {
+  // Create a map from dataset path to { dataset, fields: [] }
+  const resultMap = new Map(datasets.map(dataset => [dataset.path, { dataset, fields: [] }]));
+
+  // Sort dataset paths by length descending for specificity
+  const sortedPaths = [...datasets.map(ds => ds.path)].sort(
+    (a, b) => b.split('/').length - a.split('/').length
+  );
+
+  for (const field of fields) {
+    if (field.propertyName || field.path.includes('/meta/entity')) {
+      // Find the most specific dataset path that is a prefix of the field path
+      const matchedPath = sortedPaths.find(dsPath =>
+        field.path.startsWith(dsPath.endsWith('/') ? dsPath : dsPath + '/')
+        || field.path === dsPath
+      );
+      if (matchedPath) {
+        const datasetField = field.propertyName
+          ? field
+          : { ...field, propertyName: '__' + field.name, internal: true };
+        resultMap.get(matchedPath).fields.push(datasetField);
+      }
+    }
+  }
+
+  return Array.from(resultMap.values());
+};
+
+module.exports = {
+  getDatasets,
+  matchFieldsWithDatasets,
+  validateDatasetName,
+  validatePropertyName
+};

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -557,6 +557,7 @@ SELECT
 FROM datasets ds
   LEFT JOIN ds_properties p ON p."datasetId" = ds.id AND p."publishedAt" IS NOT NULL
 WHERE ds."publishedAt" IS NOT NULL
+AND p.name NOT LIKE '#_#_%' ESCAPE '#'
 GROUP BY ds.id, ds."projectId";
 `);
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -111,7 +111,7 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
   // Step 1: Filter to only fields with property name binds
   let dsPropertyFields = fields.filter((field) => (field.propertyName));
   // Step 2a: Check for invalid property names
-  if (dsPropertyFields.filter((field) => !validatePropertyName(field.propertyName)).length > 0)
+  if (dsPropertyFields.filter((field) => !field.internal && !validatePropertyName(field.propertyName)).length > 0)
     throw Problem.user.invalidEntityForm({ reason: 'Invalid entity property name.' });
 
   // Step 2b: Multiple fields trying to save to a single property (case-insensitive)
@@ -137,7 +137,8 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
     // Only consider updates that add new properties to the dataset
     const existingProperties = await Datasets.getProperties(existingDataset.get().id);
     const existingNames = existingProperties.map(f => f.name);
-    const newNames = dsPropertyFields.map(f => f.propertyName);
+    // Ignore system names like __entity and __label
+    const newNames = dsPropertyFields.map(f => f.propertyName).filter(p => !p.startsWith('__'));
     if (difference(newNames, existingNames).length > 0)
       await context.auth.canOrReject('dataset.update', { acteeId });
 
@@ -342,7 +343,8 @@ publishIfExists.audit = (properties) => (log) => {
     // In case of update, we don't want to log anything if no new property is published
     if (event === 'dataset.create' || (event === 'dataset.update' && datasets[acteeId].some(p => p.action === 'propertyAdded'))) {
       promiseArr.push(log(event, { acteeId }, {
-        properties: datasets[acteeId].filter(p => p.name).map(p => p.name)
+        // We only want to log named non-system properties
+        properties: datasets[acteeId].filter(p => p.name && !p.name.startsWith('__')).map(p => p.name)
       }));
     }
 
@@ -521,6 +523,7 @@ const getProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
   ` : sql``}
   WHERE ds_properties."datasetId" = ${datasetId}
     AND ds_properties."publishedAt" IS NOT NULL
+    AND ds_properties.name NOT LIKE '#_#_%' ESCAPE '#'
   ORDER BY ds_properties."publishedAt", form_fields.order, ds_properties.id
 `)
   .then((rows) => (includeForms
@@ -544,7 +547,7 @@ LEFT OUTER JOIN ds_property_fields ON
 LEFT OUTER JOIN ds_properties ON
   ds_properties."id" = ds_property_fields."dsPropertyId"
 WHERE form_defs."id" = ${formDefId}
-  AND (ds_properties."id" IS NOT NULL OR form_fields."path" LIKE '/meta/entity%')
+  AND (ds_properties."id" IS NOT NULL)
 ORDER BY form_fields."order"
 `)
   .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName })));
@@ -584,6 +587,7 @@ const _getFormSpecificProperties = (projectId, xmlFormId, forDraft) => sql`
     JOIN form f ON dpf."formDefId" = f."formDefId"
     JOIN form_fields ff ON f."schemaId" = ff."schemaId"
       AND dpf."path" = ff."path"
+    WHERE dp.name NOT LIKE '#_#_%' ESCAPE '#'
   )
   SELECT ds.name "datasetName", ds.id "datasetId", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew"
   FROM ds

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -12,7 +12,7 @@ const { map } = require('ramda');
 const { Frame, into } = require('../frame');
 const { Actor, Blob, Form } = require('../frames');
 const { getFormFields, merge, compare } = require('../../data/schema');
-const { getDatasets } = require('../../data/dataset');
+const { getDatasets, matchFieldsWithDatasets } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, sqlEquals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, timebound } = require('../../util/promise');
@@ -161,9 +161,10 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
 
   // Update datasets and properties, if defined
   if (parsedDatasets.isDefined()) {
+    const datasetsAndFields = matchFieldsWithDatasets(parsedDatasets.get().datasets, fields);
     await Promise.all(
-      parsedDatasets.get().datasets.map(ds =>
-        Datasets.createOrMerge(ds, savedForm, fields)
+      datasetsAndFields.map(ds =>
+        Datasets.createOrMerge(ds.dataset, savedForm, ds.fields)
       )
     );
   }
@@ -281,9 +282,10 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
 
   // Update datasets and properties, if defined
   if (parsedDatasets.isDefined()) {
+    const datasetsAndFields = matchFieldsWithDatasets(parsedDatasets.get().datasets, fields);
     await Promise.all(
-      parsedDatasets.get().datasets.map(ds =>
-        Datasets.createOrMerge(ds, new Form(form, { def: savedDef }), fields)
+      datasetsAndFields.map(ds =>
+        Datasets.createOrMerge(ds.dataset, new Form(form, { def: savedDef }), ds.fields)
       )
     );
     // Note: if publish=true, we are in the enabling encryption special case and won't

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4691,13 +4691,13 @@ describe('datasets and entities', () => {
         // there are expected to be
         // 2 defs of this form (published and new draft)
         // 6 form fields of original form (and new form): 3 entity related fields and 3 question fields
-        // ideally only 4 ds property fields, but 2 from deleted def are still there
+        // 12 ds property fields including system properties and those attached to deleted defs are still present
         await Promise.all([
           container.oneFirst(sql`select count(*) from form_defs as fd join forms as f on fd."formId" = f.id where f."xmlFormId"='simpleEntity'`),
           container.oneFirst(sql`select count(*) from form_fields as fs join forms as f on fs."formId" = f.id where f."xmlFormId"='simpleEntity'`),
           container.oneFirst(sql`select count(*) from ds_property_fields`),
         ])
-          .then((counts) => counts.should.eql([2, 6, 6]));
+          .then((counts) => counts.should.eql([2, 6, 12]));
 
       }));
     });


### PR DESCRIPTION
WIP for entities from repeats

Problem: Up until now, we assumed the one entity per form/submission was at the top level at `/data/meta/entity` so we didn't track a field for the entity block or label. We would just look up the entity and label fields by path. When we start tracking entities at different levels and from repeats, that's not going to keep working.

Solution: Use the existing `ds_properties` and `ds_property_fields` tables to explicitly track properties for the entity block and label. If we give these properties the property names '__entity' and '__label', we can identify them as system properties and not include them with the other properties but still make use of them behind the scenes. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
