### PR TITLE
odata-filter: extract parse error handling

### DIFF
--- a/lib/data/odata-filter.js
+++ b/lib/data/odata-filter.js
@@ -11,7 +11,7 @@ const { sql } = require('slonik');
 const odataParser = require('odata-v4-parser');
 const Problem = require('../util/problem');
 
-const odataParse = expr => {
+const parseOdataExpr = expr => {
   try {
     return odataParser.filter(expr);
   } catch (ex) {
@@ -106,7 +106,7 @@ const odataFilter = (expr, odataToColumnMap) => {
     }
   };
 
-  return op(odataParse(expr));
+  return op(parseOdataExpr(expr));
 };
 
 // Returns sql expression to exclude deleted records if provided OData filter
@@ -144,7 +144,7 @@ const odataExcludeDeleted = (expr, odataToColumnMap) => {
     return false;
   };
 
-  if (!hasDeletedAtClause(odataParser(expr))) return filterOutDeletedRecordsExp;
+  if (!hasDeletedAtClause(parseOdataExpr(expr))) return filterOutDeletedRecordsExp;
 
   return sql`true`;
 };

--- a/lib/data/odata-filter.js
+++ b/lib/data/odata-filter.js
@@ -11,6 +11,14 @@ const { sql } = require('slonik');
 const odataParser = require('odata-v4-parser');
 const Problem = require('../util/problem');
 
+const odataParse = expr => {
+  try {
+    return odataParser.filter(expr);
+  } catch (ex) {
+    throw Problem.user.unparseableODataExpression({ reason: ex.message });
+  }
+};
+
 ////////////////////////////////////////
 // MAIN ENTRY POINT
 
@@ -98,13 +106,7 @@ const odataFilter = (expr, odataToColumnMap) => {
     }
   };
 
-
-
-  let ast; // still hate this.
-  try { ast = odataParser.filter(expr); } // eslint-disable-line brace-style
-  catch (ex) { throw Problem.user.unparseableODataExpression({ reason: ex.message }); }
-
-  return op(ast);
+  return op(odataParse(expr));
 };
 
 // Returns sql expression to exclude deleted records if provided OData filter
@@ -118,10 +120,6 @@ const odataExcludeDeleted = (expr, odataToColumnMap) => {
   const filterOutDeletedRecordsExp = sql`(${sql.identifier(deleteAtColumn.split('.'))} is null)`;
 
   if (expr == null) return filterOutDeletedRecordsExp;
-
-  let ast; // still hate this.
-  try { ast = odataParser.filter(expr); } // eslint-disable-line brace-style
-  catch (ex) { throw Problem.user.unparseableODataExpression({ reason: ex.message }); }
 
   const hasDeletedAtClause = (node) => {
     if (node.type === 'FirstMemberExpression' || node.type === 'RootExpression') {
@@ -146,7 +144,7 @@ const odataExcludeDeleted = (expr, odataToColumnMap) => {
     return false;
   };
 
-  if (!hasDeletedAtClause(ast)) return filterOutDeletedRecordsExp;
+  if (!hasDeletedAtClause(odataParser(expr))) return filterOutDeletedRecordsExp;
 
   return sql`true`;
 };


### PR DESCRIPTION
Stumbled on the abstract comment "still hate this" while wondering why there was extra whitespace added in https://github.com/getodk/central-backend/pull/1521/files#diff-90d20d47db15559988f3ded320c4c99215d0ec013538f2cbca18a0d5a2925833R101-R102.  I'm guessing the hate was for the `let` keyword, so this commit removes the `let`.

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Other approach considered was just to remove the comment, but I think this approach makes the intent of the code clearer.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
