### PR TITLE
Sentry: document enabled integrations

### DIFF
--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -11,7 +11,7 @@
 // dependency container and feeds it to the service infrastructure.
 
 const config = require('config');
-require('../external/sentry').init(config.get('default.sentry.external'));
+require('../external/sentry').init(config.get('default.external.sentry'));
 const exit = require('express-graceful-exit');
 
 global.tap = (x) => { console.log(x); return x; }; // eslint-disable-line no-console

--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -10,9 +10,8 @@
 // This is the main entrypoint for the actual HTTP server. It sets up the
 // dependency container and feeds it to the service infrastructure.
 
-require('../external/sentry');
-
 const config = require('config');
+require('../external/sentry').init(config.get('default.sentry.external'));
 const exit = require('express-graceful-exit');
 
 global.tap = (x) => { console.log(x); return x; }; // eslint-disable-line no-console

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -122,10 +122,12 @@ const getInstance = () => {
 const init = ((config) => {
   if (_instance) throw new Error('Sentry already initialised.');
 
+  let Sentry;
+
   if (!config || !config.key || !config.project || !config.orgSubdomain) {
     // return a noop object that returns the hooks but does nothing.
     const noop = () => {};
-    return {
+    Sentry = {
       getCurrentScope: () => ({ setExtra: noop }),
       captureException(err) {
         process.stderr.write('attempted to log Sentry exception in development:\n');
@@ -143,38 +145,39 @@ const init = ((config) => {
         }
       },
     };
-  }
+  } else {
+    // otherwise initialize Sentry with some settings we want.
+    Sentry = require('@sentry/node');
+    Sentry.init({
+      dsn: `https://${config.key}@${config.orgSubdomain}.ingest.sentry.io/${config.project}`,
+      environment: process.env.SENTRY_ENVIRONMENT || 'production',
+      tracesSampleRate: Number(config.traceRate || 0),
+      beforeSend(event, hint) {
+        const sanitizedEvent = sanitizeEventRequest(event);
 
-  // otherwise initialize Sentry with some settings we want.
-  _instance = require('@sentry/node');
-  _instance.init({
-    dsn: `https://${config.key}@${config.orgSubdomain}.ingest.sentry.io/${config.project}`,
-    environment: process.env.SENTRY_ENVIRONMENT || 'production',
-    tracesSampleRate: Number(config.traceRate || 0),
-    beforeSend(event, hint) {
-      const sanitizedEvent = sanitizeEventRequest(event);
+        if (sanitizedEvent.extra && sanitizedEvent.extra.startTimestamp) { // just an extra safety check. this should be always true
+          sanitizedEvent.extra.duration = Date.now() - sanitizedEvent.extra.startTimestamp;
+        }
 
-      if (sanitizedEvent.extra && sanitizedEvent.extra.startTimestamp) { // just an extra safety check. this should be always true
-        sanitizedEvent.extra.duration = Date.now() - sanitizedEvent.extra.startTimestamp;
+        // only file the event if it is a bare exception or it is a true 500.x Problem.
+        const error = hint.originalException;
+        if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
+        if ((error.isProblem !== true) || (error.httpCode === 500)) return sanitizedEvent; // throw exceptions.
+        return null; // we have a user-space problem.
       }
+    });
 
-      // only file the event if it is a bare exception or it is a true 500.x Problem.
-      const error = hint.originalException;
-      if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
-      if ((error.isProblem !== true) || (error.httpCode === 500)) return sanitizedEvent; // throw exceptions.
-      return null; // we have a user-space problem.
+    const username = require('os').hostname();
+    Sentry.setUser({ username });
+
+    if (process.env.SENTRY_TAGS) {
+      const tags = JSON.parse(process.env.SENTRY_TAGS);
+      for (const [key, value] of Object.entries(tags))
+        Sentry.setTag(key, value);
     }
-  });
-
-  const username = require('os').hostname();
-  _instance.setUser({ username });
-
-  if (process.env.SENTRY_TAGS) {
-    const tags = JSON.parse(process.env.SENTRY_TAGS);
-    for (const [key, value] of Object.entries(tags))
-      _instance.setTag(key, value);
   }
 
+  _instance = Sentry;
   return _instance;
 });
 

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -25,7 +25,6 @@
 // Despite this, the `config` module must still be required first.
 
 const { inspect } = require('node:util');
-const config = require('config').get('default.external.sentry');
 
 // Endpoints where query strings are sensitive and should be removed
 const sensitiveEndpoints = [
@@ -115,7 +114,14 @@ const sanitizeEventRequest = (event) => {
   return event;
 };
 
-const Sentry = (() => {
+let _instance;
+const getInstance = () => {
+  if(!_instance) throw new Error('Sentry has not been initialised.');
+  return _instance;
+};
+const init = ((config) => {
+  if(_instance) throw new Error('Sentry already initialised.');
+
   if (!config || !config.key || !config.project || !config.orgSubdomain) {
     // return a noop object that returns the hooks but does nothing.
     const noop = () => {};
@@ -140,7 +146,7 @@ const Sentry = (() => {
   }
 
   // otherwise initialize Sentry with some settings we want.
-  const Sentry = require('@sentry/node'); // eslint-disable-line no-shadow
+  const Sentry = require('@sentry/node');
   Sentry.init({
     dsn: `https://${config.key}@${config.orgSubdomain}.ingest.sentry.io/${config.project}`,
     environment: process.env.SENTRY_ENVIRONMENT || 'production',
@@ -169,7 +175,7 @@ const Sentry = (() => {
       Sentry.setTag(key, value);
   }
 
-  return Sentry;
-})();
+  return (_instance = Sentry);
+});
 
-module.exports = { Sentry, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };
+module.exports = { init, getInstance, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -116,11 +116,11 @@ const sanitizeEventRequest = (event) => {
 
 let _instance;
 const getInstance = () => {
-  if(!_instance) throw new Error('Sentry has not been initialised.');
+  if (!_instance) throw new Error('Sentry has not been initialised.');
   return _instance;
 };
 const init = ((config) => {
-  if(_instance) throw new Error('Sentry already initialised.');
+  if (_instance) throw new Error('Sentry already initialised.');
 
   if (!config || !config.key || !config.project || !config.orgSubdomain) {
     // return a noop object that returns the hooks but does nothing.
@@ -146,8 +146,8 @@ const init = ((config) => {
   }
 
   // otherwise initialize Sentry with some settings we want.
-  const Sentry = require('@sentry/node');
-  Sentry.init({
+  _instance = require('@sentry/node');
+  _instance.init({
     dsn: `https://${config.key}@${config.orgSubdomain}.ingest.sentry.io/${config.project}`,
     environment: process.env.SENTRY_ENVIRONMENT || 'production',
     tracesSampleRate: Number(config.traceRate || 0),
@@ -167,15 +167,15 @@ const init = ((config) => {
   });
 
   const username = require('os').hostname();
-  Sentry.setUser({ username });
+  _instance.setUser({ username });
 
   if (process.env.SENTRY_TAGS) {
     const tags = JSON.parse(process.env.SENTRY_TAGS);
     for (const [key, value] of Object.entries(tags))
-      Sentry.setTag(key, value);
+      _instance.setTag(key, value);
   }
 
-  return (_instance = Sentry);
+  return _instance;
 });
 
 module.exports = { init, getInstance, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -182,4 +182,9 @@ const init = (config) => {
   return _instance;
 };
 
-module.exports = { init, _init, getInstance, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };
+// NOTE this does not check if the supplied config matches config used for previously-initialised instance.
+const getOrInit = (config) => {
+  return _instance || init(config);
+};
+
+module.exports = { init, _init, getInstance, getOrInit, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -183,8 +183,6 @@ const init = (config) => {
 };
 
 // NOTE this does not check if the supplied config matches config used for previously-initialised instance.
-const getOrInit = (config) => {
-  return _instance || init(config);
-};
+const getOrInit = (config) => _instance || init(config);
 
 module.exports = { init, _init, getInstance, getOrInit, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -119,15 +119,12 @@ const getInstance = () => {
   if (!_instance) throw new Error('Sentry has not been initialised.');
   return _instance;
 };
-const init = ((config) => {
-  if (_instance) throw new Error('Sentry already initialised.');
 
-  let Sentry;
-
+const _init = (config) => {
   if (!config || !config.key || !config.project || !config.orgSubdomain) {
     // return a noop object that returns the hooks but does nothing.
     const noop = () => {};
-    Sentry = {
+    return {
       getCurrentScope: () => ({ setExtra: noop }),
       captureException(err) {
         process.stderr.write('attempted to log Sentry exception in development:\n');
@@ -145,40 +142,44 @@ const init = ((config) => {
         }
       },
     };
-  } else {
-    // otherwise initialize Sentry with some settings we want.
-    Sentry = require('@sentry/node');
-    Sentry.init({
-      dsn: `https://${config.key}@${config.orgSubdomain}.ingest.sentry.io/${config.project}`,
-      environment: process.env.SENTRY_ENVIRONMENT || 'production',
-      tracesSampleRate: Number(config.traceRate || 0),
-      beforeSend(event, hint) {
-        const sanitizedEvent = sanitizeEventRequest(event);
-
-        if (sanitizedEvent.extra && sanitizedEvent.extra.startTimestamp) { // just an extra safety check. this should be always true
-          sanitizedEvent.extra.duration = Date.now() - sanitizedEvent.extra.startTimestamp;
-        }
-
-        // only file the event if it is a bare exception or it is a true 500.x Problem.
-        const error = hint.originalException;
-        if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
-        if ((error.isProblem !== true) || (error.httpCode === 500)) return sanitizedEvent; // throw exceptions.
-        return null; // we have a user-space problem.
-      }
-    });
-
-    const username = require('os').hostname();
-    Sentry.setUser({ username });
-
-    if (process.env.SENTRY_TAGS) {
-      const tags = JSON.parse(process.env.SENTRY_TAGS);
-      for (const [key, value] of Object.entries(tags))
-        Sentry.setTag(key, value);
-    }
   }
 
-  _instance = Sentry;
-  return _instance;
-});
+  // otherwise initialize Sentry with some settings we want.
+  const Sentry = require('@sentry/node');
+  Sentry.init({
+    dsn: `https://${config.key}@${config.orgSubdomain}.ingest.sentry.io/${config.project}`,
+    environment: process.env.SENTRY_ENVIRONMENT || 'production',
+    tracesSampleRate: Number(config.traceRate || 0),
+    beforeSend(event, hint) {
+      const sanitizedEvent = sanitizeEventRequest(event);
 
-module.exports = { init, getInstance, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };
+      if (sanitizedEvent.extra && sanitizedEvent.extra.startTimestamp) { // just an extra safety check. this should be always true
+        sanitizedEvent.extra.duration = Date.now() - sanitizedEvent.extra.startTimestamp;
+      }
+
+      // only file the event if it is a bare exception or it is a true 500.x Problem.
+      const error = hint.originalException;
+      if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
+      if ((error.isProblem !== true) || (error.httpCode === 500)) return sanitizedEvent; // throw exceptions.
+      return null; // we have a user-space problem.
+    }
+  });
+
+  const username = require('os').hostname();
+  Sentry.setUser({ username });
+
+  if (process.env.SENTRY_TAGS) {
+    const tags = JSON.parse(process.env.SENTRY_TAGS);
+    for (const [key, value] of Object.entries(tags))
+      Sentry.setTag(key, value);
+  }
+
+  return Sentry;
+};
+const init = (config) => {
+  if (_instance) throw new Error('Sentry already initialised.');
+  _instance = _init(config);
+  return _instance;
+};
+
+module.exports = { init, _init, getInstance, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -48,13 +48,14 @@ const sentry = require('../external/sentry');
 const task = {
   // not thread-safe! but we don't have threads..
   withContainer: (taskdef) => (...args) => {
+    const Sentry = sentry.getOrInit(config.get('default.external.sentry'));
+
     const needsContainer = (task._container == null);
     if (needsContainer) task._container = container.withDefaults({ db: slonikPool(config.get('default.database')), env, mail, task: true, odkAnalytics, s3 });
 
     const [, scriptPath] = process.argv;
     const { name } = Path.parse(scriptPath);
 
-    const Sentry = sentry.getInstance();
     return Sentry.startSpan(
       { op: 'task', name },
       async () => {

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -32,7 +32,7 @@ const { mailer } = require('../external/mail');
 const mail = mailer(mergeRight(config.get('default.email'), { env }));
 const odkAnalytics = require('../external/odk-analytics').init(config.get('default.external.analytics'));
 const s3 = require('../external/s3').init(config.get('default.external.s3blobStore'));
-const Sentry = require('../external/sentry').init(config.get('default.external.sentry'));
+const sentry = require('../external/sentry');
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -54,6 +54,7 @@ const task = {
     const [, scriptPath] = process.argv;
     const { name } = Path.parse(scriptPath);
 
+    const Sentry = sentry.getInstance();
     return Sentry.startSpan(
       { op: 'task', name },
       async () => {

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -32,7 +32,7 @@ const { mailer } = require('../external/mail');
 const mail = mailer(mergeRight(config.get('default.email'), { env }));
 const odkAnalytics = require('../external/odk-analytics').init(config.get('default.external.analytics'));
 const s3 = require('../external/s3').init(config.get('default.external.s3blobStore'));
-const { Sentry } = require('../external/sentry');
+const Sentry = require('../external/sentry').init(config.get('default.external.sentry'));
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/util/default-container.js
+++ b/lib/util/default-container.js
@@ -23,7 +23,7 @@ const { mailer } = require('../external/mail');
 const mail = mailer(mergeRight(config.get('default.email'), { env }));
 
 // get a sentry and configure errors.
-const { Sentry } = require('../external/sentry');
+const Sentry = require('../external/sentry').getInstance();
 Error.stackTrackLimit = 20;
 
 // get an xlsform client and a password module.

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -31,7 +31,7 @@ if (mailConfig.transport !== 'json')
 const xlsform = require(appRoot + '/test/util/xlsform');
 
 // set up our sentry mock.
-const Sentry = require(appRoot + '/ib/external/sentry').init(config.get('default.external.sentry'));
+const Sentry = require(appRoot + '/lib/external/sentry').init(config.get('default.external.sentry'));
 
 // set up our enketo mock.
 const { reset: resetEnketo, ...enketo } = require(appRoot + '/test/util/enketo');

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -31,7 +31,7 @@ if (mailConfig.transport !== 'json')
 const xlsform = require(appRoot + '/test/util/xlsform');
 
 // set up our sentry mock.
-const { Sentry } = require(appRoot + '/lib/external/sentry');
+const Sentry = require(appRoot + '/ib/external/sentry').init(config.get('default.external.sentry'));
 
 // set up our enketo mock.
 const { reset: resetEnketo, ...enketo } = require(appRoot + '/test/util/enketo');

--- a/test/unit/external/sentry.js
+++ b/test/unit/external/sentry.js
@@ -1,0 +1,67 @@
+const appRoot = require('app-root-path');
+const { init } = require(appRoot + '/lib/external/sentry');
+
+describe('sentry', () => {
+  it('should have expected integrations', () => {
+
+    // Note, this test may break for the following reasons:
+    //
+    // * Sentry does not have a documented way to check the enabled integrations,
+    //   so this test may break due to changing internals of the @sentry/node
+    //   module.
+    // * Sentry may change the default integrations.  In the case of new default
+    //   integrations, consider if they should be added to the expected list
+    //   below.  In the case of default integrations being removed, consider if
+    //   they should be re-enabled manually.
+
+    const config = {
+      project: 1,
+      key: 'abc-123',
+      orgSubdomain: 'example',
+    };
+
+    const integrations = init(config)
+      .getClient()
+      ._options
+      .integrations
+      .map(it => it.name)
+      .sort();
+
+    integrations.should.eql([
+      'Amqplib',
+      'ChildProcess',
+      'Connect',
+      'Console',
+      'Context',
+      'ContextLines',
+      'Express',
+      'Fastify',
+      'FunctionToString',
+      'GenericPool',
+      'Graphql',
+      'Hapi',
+      'Http',
+      'InboundFilters',
+      'Kafka',
+      'Koa',
+      'LinkedErrors',
+      'LocalVariablesAsync',
+      'LruMemoizer',
+      'Modules',
+      'Mongo',
+      'Mongoose',
+      'Mysql',
+      'Mysql2',
+      'NodeFetch',
+      'OnUncaughtException',
+      'OnUnhandledRejection',
+      'Postgres',
+      'Prisma',
+      'ProcessSession',
+      'Redis',
+      'RequestData',
+      'Tedious',
+      'VercelAI',
+    ]);
+  });
+});

--- a/test/unit/external/sentry.js
+++ b/test/unit/external/sentry.js
@@ -1,5 +1,5 @@
 const appRoot = require('app-root-path');
-const { init } = require(appRoot + '/lib/external/sentry');
+const { _init } = require(appRoot + '/lib/external/sentry');
 
 describe('sentry', () => {
   it('should have expected integrations', () => {
@@ -20,7 +20,7 @@ describe('sentry', () => {
       orgSubdomain: 'example',
     };
 
-    const integrations = init(config)
+    const integrations = _init(config)
       .getClient()
       ._options
       .integrations

--- a/test/unit/external/sentry.js
+++ b/test/unit/external/sentry.js
@@ -34,6 +34,7 @@ describe('sentry', () => {
       'Console',
       'Context',
       'ContextLines',
+      'Dedupe',
       'Express',
       'Fastify',
       'FunctionToString',


### PR DESCRIPTION
Sentry has a list of default integrations, which may change over time.

This commit adds a unit test to make enabled integrations explicit.

Also:

* make it explicit that the config module is loaded before sentry is initialised
* invert control of config for lib/external/sentry

Ref: https://github.com/getodk/central/issues/1191

This change will also lay the foundation for removing irrelevant Sentry integrations.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

An alternative approach would be to use `defaultIntegrations: false` per https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/#modifying-default-integrations, and then relisting all wanted integrations.  This would have the significant disadvantage of not automatically including _new_ default integrations which Sentry might add in future.  This would mean missing out on positive new integrations unless extra care is taken when reading changelogs (if they are accurate).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
