### PR TITLE
Audits.getLatestByAction(): include id in ordering

### DIFF
--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -64,7 +64,7 @@ const actionCondition = (action) => {
 
 // used entirely by tests only:
 const getLatestByAction = (action) => ({ maybeOne }) =>
-  maybeOne(sql`select * from audits where action=${action} order by "loggedAt", id desc limit 1`)
+  maybeOne(sql`select * from audits where action=${action} order by "loggedAt" desc, id desc limit 1`)
     .then(map(construct(Audit)));
 
 


### PR DESCRIPTION
This relates to recent work on `log-upgrade`.

As in other cases where searching for the latest audit, it's important to do a secondary ordering by ID to avoid duplicate audits.

Closes #1563

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

It might be helpful to enforce this somehow, but there are no obvious avenues currently.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should fix a very infrequent bug.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
