### PR TITLE
analytics: fix audit fetching

### DIFF
--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -944,7 +944,7 @@ const ANALYTICS_SCHEDULE = config.has('default.taskSchedule.analytics')
 // recent attempt, then it is time for a new report to be sent.
 const getLatestAudit = () => ({ maybeOne }) => maybeOne(sql`select * from audits
   where action='analytics' and current_date - "loggedAt"::date < ${ANALYTICS_SCHEDULE}
-  order by "loggedAt" desc limit 1`);
+  order by "loggedAt", id desc limit 1`);
 
 module.exports = {
   archivedProjects,

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -944,7 +944,7 @@ const ANALYTICS_SCHEDULE = config.has('default.taskSchedule.analytics')
 // recent attempt, then it is time for a new report to be sent.
 const getLatestAudit = () => ({ maybeOne }) => maybeOne(sql`select * from audits
   where action='analytics' and current_date - "loggedAt"::date < ${ANALYTICS_SCHEDULE}
-  order by "loggedAt", id desc limit 1`);
+  order by "loggedAt" desc, id desc limit 1`);
 
 module.exports = {
   archivedProjects,


### PR DESCRIPTION
As in other cases where searching for the latest audit, it's important to do a secondary ordering by ID to avoid duplicate audits.

Related: #1564

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

It might be helpful to enforce this somehow, but there are no obvious avenues currently.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should fix a very infrequent bug.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
