### PR TITLE
Sentry: document enabled integrations

### DIFF
--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -115,7 +115,7 @@ const sanitizeEventRequest = (event) => {
   return event;
 };
 
-const Sentry = (() => {
+const _init = (config) => { // eslint-disable-line no-shadow
   if (!config || !config.key || !config.project || !config.orgSubdomain) {
     // return a noop object that returns the hooks but does nothing.
     const noop = () => {};
@@ -171,6 +171,7 @@ const Sentry = (() => {
   }
 
   return Sentry;
-})();
+};
+const Sentry = _init(config);
 
-module.exports = { Sentry, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };
+module.exports = { Sentry, _init, sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl };

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -31,7 +31,7 @@ if (mailConfig.transport !== 'json')
 const xlsform = require(appRoot + '/test/util/xlsform');
 
 // set up our sentry mock.
-const { Sentry } = require(appRoot + '/lib/external/sentry');
+const Sentry = require(appRoot + '/lib/external/sentry').init(config.get('default.external.sentry'));
 
 // set up our enketo mock.
 const { reset: resetEnketo, ...enketo } = require(appRoot + '/test/util/enketo');

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -31,7 +31,7 @@ if (mailConfig.transport !== 'json')
 const xlsform = require(appRoot + '/test/util/xlsform');
 
 // set up our sentry mock.
-const Sentry = require(appRoot + '/lib/external/sentry').init(config.get('default.external.sentry'));
+const { Sentry } = require(appRoot + '/lib/external/sentry');
 
 // set up our enketo mock.
 const { reset: resetEnketo, ...enketo } = require(appRoot + '/test/util/enketo');

--- a/test/unit/external/sentry.js
+++ b/test/unit/external/sentry.js
@@ -1,0 +1,68 @@
+const appRoot = require('app-root-path');
+const { _init } = require(appRoot + '/lib/external/sentry');
+
+describe('sentry', () => {
+  it('should have expected integrations', () => {
+
+    // Note, this test may break for the following reasons:
+    //
+    // * Sentry does not have a documented way to check the enabled integrations,
+    //   so this test may break due to changing internals of the @sentry/node
+    //   module.
+    // * Sentry may change the default integrations.  In the case of new default
+    //   integrations, consider if they should be added to the expected list
+    //   below.  In the case of default integrations being removed, consider if
+    //   they should be re-enabled manually.
+
+    const config = {
+      project: 1,
+      key: 'abc-123',
+      orgSubdomain: 'example',
+    };
+
+    const integrations = _init(config)
+      .getClient()
+      ._options
+      .integrations
+      .map(it => it.name)
+      .sort();
+
+    integrations.should.eql([
+      'Amqplib',
+      'ChildProcess',
+      'Connect',
+      'Console',
+      'Context',
+      'ContextLines',
+      'Dedupe',
+      'Express',
+      'Fastify',
+      'FunctionToString',
+      'GenericPool',
+      'Graphql',
+      'Hapi',
+      'Http',
+      'InboundFilters',
+      'Kafka',
+      'Koa',
+      'LinkedErrors',
+      'LocalVariablesAsync',
+      'LruMemoizer',
+      'Modules',
+      'Mongo',
+      'Mongoose',
+      'Mysql',
+      'Mysql2',
+      'NodeFetch',
+      'OnUncaughtException',
+      'OnUnhandledRejection',
+      'Postgres',
+      'Prisma',
+      'ProcessSession',
+      'Redis',
+      'RequestData',
+      'Tedious',
+      'VercelAI',
+    ]);
+  });
+});


### PR DESCRIPTION
Sentry has a list of default integrations, which may change over time.

This commit adds a unit test to make enabled integrations explicit.

Ref: https://github.com/getodk/central/issues/1191

This change will also lay the foundation for removing irrelevant Sentry integrations.

#### What has been done to verify that this works as intended?

CI, `make run`.

#### Why is this the best possible solution? Were any other approaches considered?

Alternative to https://github.com/getodk/central-backend/pull/1562, responding to comments there.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not affect users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
