### PR TITLE
set PostgreSQL error message language on connection initialization

### DIFF
--- a/lib/external/slonik.js
+++ b/lib/external/slonik.js
@@ -7,24 +7,43 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const { createPool, createDateTypeParser, createBigintTypeParser, createIntervalTypeParser, createNumericTypeParser } = require('slonik');
+const { createPool, createDateTypeParser, createBigintTypeParser, createIntervalTypeParser, createNumericTypeParser, sql } = require('slonik');
 const { connectionString } = require('../util/db');
 
 const timestampTypeParser = { name: 'timestamp', parse: (x) => new Date(x) };
 const timestamptzTypeParser = { name: 'timestamptz', parse: (x) => new Date(x) };
 
-const slonikPool = (config) => createPool(connectionString(config), {
-  captureStackTrace: false,
-  maximumPoolSize: config.maximumPoolSize ?? 10,
-  typeParsers: [
-    createDateTypeParser(),
-    createBigintTypeParser(),
-    createIntervalTypeParser(),
-    createNumericTypeParser(),
-    timestampTypeParser,
-    timestamptzTypeParser
-  ]
-});
+// We depend on C.UTF-8 for error message parsing. See https://github.com/getodk/central/issues/1199
+// Unless we set this, the server's LC_MESSAGES locale is applied.
+// The override via the POSTGRESQL_MESSAGES_LOCALE env var is used for testing.
+const DEFAULT_MESSAGES_LOCALE = 'C.UTF-8';
+
+const slonikPool = (config, lcMessages) => {
+  const POSTGRESQL_MESSAGES_LOCALE = lcMessages || process.env.ODK_POSTGRESQL_MESSAGES_LOCALE || DEFAULT_MESSAGES_LOCALE;
+  const POSTGRESQL_SET_MESSAGES_LOCALE = sql`SELECT set_config('lc_messages', ${POSTGRESQL_MESSAGES_LOCALE}, FALSE)`;
+
+  return createPool(connectionString(config), {
+    captureStackTrace: false,
+    maximumPoolSize: config.maximumPoolSize ?? 10,
+    typeParsers: [
+      createDateTypeParser(),
+      createBigintTypeParser(),
+      createIntervalTypeParser(),
+      createNumericTypeParser(),
+      timestampTypeParser,
+      timestamptzTypeParser
+    ],
+    resetConnection: async (connection) => {
+      await connection.query(sql`DISCARD ALL`);
+      await connection.query(POSTGRESQL_MESSAGES_LOCALE);
+    },
+    interceptors: [{
+      afterPoolConnection: async (_connectionContext, connection) => {
+        await connection.query(POSTGRESQL_SET_MESSAGES_LOCALE);
+      },
+    }],
+  });
+};
 
 module.exports = { slonikPool };
 

--- a/test/integration/other/slonik.js
+++ b/test/integration/other/slonik.js
@@ -1,6 +1,6 @@
 const should = require('should');
 const { sql } = require('slonik');
-const { testContainer } = require('../setup');
+const { testContainer, createPool } = require('../setup');
 
 describe('slonik', () => {
   describe('query()', () => {
@@ -31,5 +31,19 @@ describe('slonik', () => {
       should(caught).be.an.Error();
       caught.message.should.eql('Unexpected value expression.');
     }));
+  });
+
+  describe('connection initialization', () => {
+
+    it('should have configurable LC_MESSAGES locale', testContainer(async () => {
+      const testLocale = 'it_IT.UTF-8';
+      const pool = createPool(testLocale); // when not available, falls back to C.UTF-8, but the DB sessions setting should get this value nonetheless
+      try {
+        (await pool.oneFirst(sql`SELECT current_setting('lc_messages')`)).should.equal(testLocale);
+      } finally {
+        await pool.end();
+      }
+    }));
+
   });
 });

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -16,7 +16,8 @@ const { knexConnect } = require(appRoot + '/lib/model/knex-migrator');
 
 // slonik connection pool
 const { slonikPool } = require(appRoot + '/lib/external/slonik');
-const db = slonikPool(config.get('test.database'));
+const createPool = (lcMessages) => slonikPool(config.get('test.database'), lcMessages);
+const db = createPool();
 
 // set up our mailer.
 const env = config.get('default.env');
@@ -232,4 +233,4 @@ const withClosedForm = (f) => async (service) => {
   return f(service);
 };
 
-module.exports = { testService, testServiceFullTrx, testContainer, testContainerFullTrx, testTask, testTaskFullTrx, withClosedForm };
+module.exports = { testService, testServiceFullTrx, testContainer, testContainerFullTrx, testTask, testTaskFullTrx, withClosedForm, createPool };


### PR DESCRIPTION
Fixes: getodk/central#1199

#### What has been done to verify that this works as intended?

Testing. Also added an automated test.

#### Why is this the best possible solution? Were any other approaches considered?

Other approaches considered: setting the lc_messages setting on the database rather than the connection. But setting it on the connection is less invasive and more robust (can't be changed behind our back).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users may notice that they can now use ODK with external databases (not launched through our docker compose setup, which happens to have the messages locale that we depend on) which gave mysterious errors before if those servers were running with a non-english locale.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
