### PR TITLE
Set PostgreSQL application name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 default: base
 
 NODE_CONFIG_ENV ?= test
+export PGAPPNAME ?= odkcentral
 
 node_modules: package.json
 	npm install


### PR DESCRIPTION
Related: getodk/central#1202

Uses the [PGAPPNAME](https://www.postgresql.org/docs/14/libpq-envars.html#id-1.7.3.22.3.4.12.1.1) environment variable that makes libpq set the [application_name](https://www.postgresql.org/docs/14/libpq-connect.html#LIBPQ-CONNECT-APPLICATION-NAME) connection parameter. This makes us show up as `odkcentral` in the application name show up in the `application_name` column of the `pg_stat_activity` view, and in error messages.

#### What has been done to verify that this works as intended?

Manual testing.

#### Why is this the best possible solution? Were any other approaches considered?

Not applicable.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

If the user already had a `PGAPPNAME` env var set, then we roll with that. No regression risk as far as I can see.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Not applicable.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
