### PR TITLE
http/preprocessors: simplify authBySessionToken() signature

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -8,7 +8,7 @@
 // except according to the terms contained in the LICENSE file.
 
 const { verifyPassword, isValidToken } = require('../util/crypto');
-const { isBlank, isPresent, noop, omit } = require('../util/util');
+const { isBlank, isPresent, omit } = require('../util/util');
 const { isTrue, urlDecode } = require('../util/http');
 const oidc = require('../util/oidc');
 const Problem = require('../util/problem');
@@ -26,9 +26,9 @@ const emptyAuthInjector = ({ Auth }, context) => context.with({ auth: Auth.by(nu
 //
 // TODO?: repetitive, but deduping it makes it even harder to understand.
 const authHandler = ({ Sessions, Users, Auth }, context) => {
-  const authBySessionToken = (token, onFailure = noop) => Sessions.getByBearerToken(token)
+  const authBySessionToken = (token) => Sessions.getByBearerToken(token)
     .then((session) => {
-      if (session.isEmpty()) return onFailure();
+      if (session.isEmpty()) throw Problem.user.authenticationFailed();
       return context.with({ auth: Auth.by(session.get()) });
     });
 
@@ -63,7 +63,7 @@ const authHandler = ({ Sessions, Users, Auth }, context) => {
   // Standard Bearer token auth:
   } else if (isPresent(authHeader) && authHeader.startsWith('Bearer ')) {
     // auth by the bearer token we found:
-    return authBySessionToken(authHeader.substring(7), () => reject(Problem.user.authenticationFailed()));
+    return authBySessionToken(authHeader.substring(7));
 
   // Basic Auth, which is allowed under certain circumstances:
   } else if (isPresent(authHeader) && authHeader.startsWith('Basic ')) {
@@ -108,7 +108,7 @@ const authHandler = ({ Sessions, Users, Auth }, context) => {
     if (token == null)
       return reject(Problem.user.authenticationFailed());
     // actually try to authenticate with it. reject on failure.
-    const maybeSession = authBySessionToken(token, () => reject(Problem.user.authenticationFailed()));
+    const maybeSession = authBySessionToken(token);
 
     // Following code is for the CSRF protection.
     // Rules:


### PR DESCRIPTION
Second arg was always called with the same, defined value.

Follow on from https://github.com/getodk/central-backend/pull/1488

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

* could keep as-is, but the extra indirection seems harder to follow than necessary
* could maintain `return reject(...)` instead of `throw`?  `throw` seems more idiomatic

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
