### PR TITLE
allow overriding of default session lifetime through config setting

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -33,7 +33,8 @@
         "version": "v2025.2.0_1"
       },
       "s3blobStore": {}
-    }
+    },
+    "sessionLifetime": 86400
   },
   "test": {
     "database": {

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -663,7 +663,7 @@ tags:
   description: |-
     This is the authentication method used by the ODK Central Frontend packaged with Central Backend. Only `User`s can authenticate this way. It consists mostly of two steps:
 
-    1. **Logging in**: presenting an Email Address and a Password for verification, after which a new `Session` is created. Associated with the Session is an expiration and a bearer token. Sessions expire 24 hours after they are created.
+    1. **Logging in**: presenting an Email Address and a Password for verification, after which a new `Session` is created. Associated with the Session is an expiration and a bearer token. By default, sessions will expire 24 hours after they are created. This can be changed through the `default.sessionLifetime` configuration setting.
     2. **Using the session**: each request to the API needs a header attached to it: `Authorization: Bearer {token}`. This authenticates that particular request as belonging to the Session we created by logging in.
 
     You might notice that Step 2 greatly resembles how OAuth 2.0 works. This was an intentional first step towards OAuth support, and should make the forward migration of your code easier down the road.

--- a/lib/model/query/sessions.js
+++ b/lib/model/query/sessions.js
@@ -14,18 +14,29 @@ const { generateToken, isValidToken } = require('../../util/crypto');
 const { unjoiner } = require('../../util/db');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
+const config = require('config');
 
-const aDayFromNow = () => {
-  const date = new Date();
-  date.setDate(date.getDate() + 1);
-  return date;
+const create = (actor, expiresAt) => ({ one }) => {
+  const expirySqlFragment = (expiresAt instanceof Date ? sql`${expiresAt.toISOString()}` : sql`statement_timestamp() + ${config.default.sessionLifetime + ' s'}::interval`);
+  return one(sql`
+      INSERT INTO sessions (
+        "actorId",
+        token,
+        csrf,
+        "createdAt",
+        "expiresAt"
+      )
+      VALUES (
+        ${actor.id},
+        ${generateToken()},
+        ${generateToken()},
+        statement_timestamp(),
+        ${expirySqlFragment}
+      )
+      RETURNING *
+    `)
+    .then(construct(Session));
 };
-
-const create = (actor, expiresAt = aDayFromNow()) => ({ one }) => one(sql`
-insert into sessions ("actorId", token, csrf, "createdAt", "expiresAt")
-values (${actor.id}, ${generateToken()}, ${generateToken()}, clock_timestamp(), ${expiresAt.toISOString()})
-returning *`)
-  .then(construct(Session));
 
 const _unjoiner = unjoiner(Session, Actor);
 const getByBearerToken = (token) => ({ maybeOne }) => (isValidToken(token) ? maybeOne(sql`


### PR DESCRIPTION
Allow overriding of default session lifetime through a config setting.

Fixes getodk/central#1212

#### Notes
- The previous way the default expiry duration manifested itself in the database (as `"expiresAt" - "createdAt"`) was jittery. That was because the the expiration timestamp itself was created as a `Date` object JS-side based on _its_ wall clock time, and some indeterminate time later the creation timestamp would be set by the database based on _its_ wall clock time. Thus the interval between those would be a little bit off from the lifetime default says it should be. This also fixes that, one less surprise.
- The function signature for `sessions.create` expects a timestamp for the expiry, whereas I think specifying a definite expiry is the exceptional use case. I susped (haven't verified) that in the common case the caller would only actually care that the expiry is a certain time _offset_ from the now into the future (or past, for all I care), and should not concern itself with what time it is right now (resulting in messing around with Date objects at every call site). So it should just have to pass an offset (eg number of seconds) if the default doesn't suffice. That function signature, eg with an `expiresIn` integer parameter rather than the `expiresAt` date parameter would then also have allowed specifying our default (either the hardcoded one, or begotten from the env) as a default value for the parameter. It would make things a bit cleaner but I want to keep this PR small & simple and I don't want to go on a refactoring binge right now ;-)


#### What has been done to verify that this works as intended?

Manual verification.

#### Why is this the best possible solution? Were any other approaches considered?

Previous iterations of this PR featured additional overriding via environment variables. I've removed that for now, because I don't really like the hoops one has to jump through [to get it done with node-config](https://github.com/node-config/node-config/wiki/Environment-Variables#custom-environment-variables), and an even earlier iteration's ad-hoc reading of an env var was, well, too ad-hoc.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes. Documentation updated.

#### Before submitting this PR, please make sure you have:

- [X] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [X] verified that any code from external sources are properly credited in comments or that everything is internally sourced
