### PR TITLE
http/preprocessors: eliminate confusing variable

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -108,32 +108,32 @@ const authHandler = ({ Sessions, Users, Auth }, context) => {
     const token = context.cookies[SESSION_COOKIE];
     if (token == null)
       return reject(Problem.user.authenticationFailed());
-    // actually try to authenticate with it. reject on failure.
-    const maybeSession = authBySessionToken(token);
 
-    // Following code is for the CSRF protection.
-    // Rules:
-    // 1 - If it is a non-POST request then we allow it.
-    // 2 - If it is a POST request then we require it to have either a custom header
-    //     `x-requested-with` with the value of `XMLHttpRequest` or the body should contain `__csrf`
-    //     token
-    if (context.method !== 'POST') return maybeSession;
+    // actually try to authenticate with it
+    return authBySessionToken(token)
+      .then((cxt) => { // we have to use cxt rather than context for the linter
+        // Following code is for the CSRF protection.
+        // Rules:
+        // 1 - If it is a non-POST request then we allow it.
+        // 2 - If it is a POST request then we require it to have either a custom header
+        //     `x-requested-with` with the value of `XMLHttpRequest` or the body should contain `__csrf`
+        //     token
+        if (context.method !== 'POST') return cxt;
 
-    if (context.headers['x-requested-with'] === 'XMLHttpRequest') {
-      return maybeSession;
-    }
+        if (context.headers['x-requested-with'] === 'XMLHttpRequest') {
+          return cxt;
+        }
 
-    // if POST run authentication as usual but we'll have to check CSRF afterwards.
-    return maybeSession.then((cxt) => { // we have to use cxt rather than context for the linter
-      const csrf = urlDecode(cxt.body.__csrf);
-      if (csrf.isEmpty() || isBlank(csrf.get()) || (cxt.auth.session.get().csrf !== csrf.get())) {
-        return reject(Problem.user.authenticationFailed());
-      }
+        // if POST run authentication as usual but we'll have to check CSRF afterwards.
+        const csrf = urlDecode(cxt.body.__csrf);
+        if (csrf.isEmpty() || isBlank(csrf.get()) || (cxt.auth.session.get().csrf !== csrf.get())) {
+          return reject(Problem.user.authenticationFailed());
+        }
 
-      // delete the token off the body so it doesn't mess with downstream
-      // payload expectations.
-      return cxt.with({ body: omit([ '__csrf' ], cxt.body) });
-    });
+        // delete the token off the body so it doesn't mess with downstream
+        // payload expectations.
+        return cxt.with({ body: omit([ '__csrf' ], cxt.body) });
+      });
   } else {
     // Authentication not provided by any means
     return reject(Problem.user.authenticationFailed());


### PR DESCRIPTION
Variable `maybeSession` was not maybe a session - it was a promise which resolves to a session.

This PR restructures the related code to eliminate the confusing variable and make control flow easier to follow.

Closes getodk/central#

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
