### PR TITLE
http/preprocessors: use getOrReject() idiomatically

### DIFF
--- a/lib/http/preprocessors.js
+++ b/lib/http/preprocessors.js
@@ -27,10 +27,8 @@ const emptyAuthInjector = ({ Auth }, context) => context.with({ auth: Auth.by(nu
 // TODO?: repetitive, but deduping it makes it even harder to understand.
 const authHandler = ({ Sessions, Users, Auth }, context) => {
   const authBySessionToken = (token) => Sessions.getByBearerToken(token)
-    .then((session) => {
-      if (session.isEmpty()) throw Problem.user.authenticationFailed();
-      return context.with({ auth: Auth.by(session.get()) });
-    });
+    .then(getOrReject(Problem.user.authenticationFailed()))
+    .then(session => context.with({ auth: Auth.by(session) }));
 
   const authHeader = context.headers.authorization;
 


### PR DESCRIPTION
Clean up `Option` handling in `authBySessionToken()`.

Related:

* https://github.com/getodk/central-backend/pull/1587
* https://github.com/getodk/central-backend/pull/1582

Closes getodk/central#

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Clearer?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
