### PR TITLE
docs: fix dataset/.../integrity operationId

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -9957,7 +9957,7 @@ paths:
         This is the fully standards-compliant implementation of the Entities Integrity API as described in [OpenRosa spec proposal: support offline Entities](https://forum.getodk.org/t/openrosa-spec-proposal-support-offline-entities/48052).
 
         This returns the `deleted` flag of the Entities requested through `id` query parameter. If no `id` is provided then all Entities are return.
-      operationId: OpenRosa Form Manifest API
+      operationId: OpenRosa Dataset Integrity API
       parameters:
       - name: projectId
         in: path


### PR DESCRIPTION
The previous value seemed to be copy-pasted from a different operation.

Related: https://github.com/getodk/central/issues/1220

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Nothing - it's a text change though, so should be ok.

#### Why is this the best possible solution? Were any other approaches considered?

What is `operationId` for?  Is there any point in duplicating `summary` everywhere?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should make docs YAML more parseably by different OpenAPI tools.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

It actually does update the docs :ballot_box_with_check: 

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
