### PR TITLE
Disable new issues in repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links: 
   - name: "Report an issue"
     about: "For when Central is behaving in an unexpected way"


### PR DESCRIPTION
All open issues in this repo have been transferred to the `central` repo. That's where all new issues should be filed. This PR turns off the ability to file new issues in this repo.

#### What has been done to verify that this works as intended?

I'll check it after merging the PR.

#### Why is this the best possible solution? Were any other approaches considered?

I thought about getting rid of the contact links, but I feel like they might still be helpful for ODK users.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
