### PR TITLE
Part A: Backport some ideas for multi-entities to the single entity scenario

### DIFF
--- a/lib/data/dataset.js
+++ b/lib/data/dataset.js
@@ -81,6 +81,20 @@ const validatePropertyName = (name) => {
   return (match !== null);
 };
 
+const prepareFieldsForDataset = (fields) => {
+  // Validate user-provided property names before processing
+  if (fields.some((field) => field.propertyName && !validatePropertyName(field.propertyName)))
+    throw Problem.user.invalidEntityForm({ reason: 'Invalid entity property name.' });
+
+  // Augment fields with __entity and __label propertyNames
+  // and then only keep fields with either user-provided or system propertyName
+  return fields.map(field =>
+    (field.path.startsWith('/meta/entity')
+      ? { ...field, propertyName: `__${field.name}` }
+      : field)
+  ).filter(field => field.propertyName);
+};
+
 /*
 Extracts the dataset name and actions from an <entity> block.
 */
@@ -138,4 +152,4 @@ const getDatasets = (xml) =>
     return Option.of({ datasets: [ dataset ], warnings });
   });
 
-module.exports = { getDatasets, validateDatasetName, validatePropertyName };
+module.exports = { getDatasets, validateDatasetName, validatePropertyName, prepareFieldsForDataset };

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -17,7 +17,7 @@ const { Transform } = require('stream');
 const uuid = require('uuid').v4;
 const { PartialPipe } = require('../util/stream');
 const Problem = require('../util/problem');
-const { submissionXmlToFieldStream } = require('./submission');
+const { submissionXmlToFieldData } = require('./submission');
 const { nextUrlFor, getServiceRoot, jsonDataFooter, extractPaging } = require('../util/odata');
 const { sanitizeOdataIdentifier, blankStringToNull, isBlank } = require('../util/util');
 
@@ -101,11 +101,12 @@ const extractTrunkVersionFromSubmission = (entity) => {
 // 1. this is expecting the entityFields to be filled in with propertyName attributes
 // 2. the "meta/entity" structural field should be included to get necessary
 //    entity node attributes like dataset name.
-const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) => {
+const parseSubmissionXml = (entityFields, xml) => {
+  const data = submissionXmlToFieldData(entityFields, xml);
+
   const entity = { system: Object.create(null), data: Object.create(null) };
-  const stream = submissionXmlToFieldStream(entityFields, xml, true, true);
-  stream.on('error', reject);
-  stream.on('data', ({ field, text }) => {
+
+  for (const { field, text } of data) {
     if (field.name === 'entity') {
       entity.system.dataset = field.attrs.dataset;
       entity.system.id = field.attrs.id;
@@ -114,19 +115,15 @@ const parseSubmissionXml = (entityFields, xml) => new Promise((resolve, reject) 
       entity.system.baseVersion = field.attrs.baseVersion;
       entity.system.trunkVersion = field.attrs.trunkVersion;
       entity.system.branchId = field.attrs.branchId;
-    } else if (field.path.indexOf('/meta/entity') === 0)
+    } else if (field.path.indexOf('/meta/entity') === 0) {
       entity.system[field.name] = text;
-    else if (field.propertyName != null)
+    } else if (field.propertyName != null) {
       entity.data[field.propertyName] = text;
-  });
-  stream.on('end', () => {
-    try {
-      resolve(entity);
-    } catch (err) {
-      reject(err);
     }
-  });
-});
+  }
+
+  return entity;
+};
 
 // Can be used to parse new entities and entity updates from
 // request data in the form of JSON.

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -98,6 +98,47 @@ const getSelectMultipleResponses = (selectMultipleFields, xml) => new Promise((r
 });
 
 
+const submissionXmlToFieldData = (fields, xml, includeStructuralAttrs = true, includeEmptyNodes = true) => {
+  const stack = new SchemaStack(fields, true);
+
+  const data = [];
+
+  let textBuffer = '';
+  const parser = new hparser.Parser({
+    onopentag: (tagName, attrs) => {
+      textBuffer = '';
+
+      const field = stack.push(tagName);
+
+      if (field != null) {
+        textBuffer = '';
+        if (includeStructuralAttrs &&
+          (typeof field.isStructural === 'function' && field.isStructural()) &&
+          Object.keys(attrs).length !== 0)
+          data.push({ field: { ...field, attrs }, text: null });
+      }
+    },
+    ontext: (text) => {
+      textBuffer += text;
+    },
+    onclosetag: () => {
+      const field = stack.pop();
+
+      if (textBuffer !== '' || includeEmptyNodes) {
+        if ((field != null) && !field.isStructural()) // don't output useless whitespace
+          data.push({ field, text: textBuffer });
+        textBuffer = '';
+      }
+    }
+  }, { xmlMode: true, decodeEntities: true });
+
+  parser.write(xml);
+  parser.end();
+
+  return data;
+};
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // SUBMISSION DIFFING
 //
@@ -356,7 +397,7 @@ const odataToColumnMap = new Map(filterableFields.concat(filterableFields.map(f 
 const odataSubTableToColumnMap = new Map(filterableFields.map(f => ([`$root/Submissions/${f[0]}`, f[1]])));
 
 module.exports = {
-  submissionXmlToFieldStream,
+  submissionXmlToFieldData, submissionXmlToFieldStream,
   getSelectMultipleResponses,
   _hashedTree, _diffObj, _diffArray,
   diffSubmissions, odataToColumnMap, odataSubTableToColumnMap,

--- a/lib/model/migrations/20250904-01-rm-entity-def-sources-index.js
+++ b/lib/model/migrations/20250904-01-rm-entity-def-sources-index.js
@@ -1,0 +1,26 @@
+// Copyright 2025 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+// make index no longer unique
+
+const up = async (db) => {
+  await db.raw(`
+    DROP INDEX idx_fk_entity_def_sources_submissionDefId;
+    CREATE INDEX idx_fk_entity_def_sources_submissionDefId        ON "entity_def_sources" ("submissionDefId");
+  `);
+};
+
+const down = async (db) => {
+  await db.raw(`
+    DROP INDEX idx_fk_entity_def_sources_submissionDefId;
+    CREATE UNIQUE INDEX idx_fk_entity_def_sources_submissionDefId        ON "entity_def_sources" ("submissionDefId");
+  `);
+};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20250904-02-insert-entity-label-ds-properties.js
+++ b/lib/model/migrations/20250904-02-insert-entity-label-ds-properties.js
@@ -1,0 +1,70 @@
+// Copyright 2025 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`
+-- Insert __entity property for every dataset, with publishedAt
+INSERT INTO ds_properties (name, "datasetId", "publishedAt")
+SELECT DISTINCT
+  '__entity',
+  dfd."datasetId",
+  ds."publishedAt"
+FROM dataset_form_defs dfd
+JOIN datasets ds ON ds.id = dfd."datasetId"
+WHERE NOT EXISTS (
+  SELECT 1 FROM ds_properties dp
+  WHERE dp.name = '__entity' AND dp."datasetId" = dfd."datasetId"
+);
+  `);
+
+  await db.raw(`
+-- Insert __label property for every dataset, with publishedAt
+INSERT INTO ds_properties (name, "datasetId", "publishedAt")
+SELECT DISTINCT
+  '__label',
+  dfd."datasetId",
+  ds."publishedAt"
+FROM dataset_form_defs dfd
+JOIN datasets ds ON ds.id = dfd."datasetId"
+WHERE NOT EXISTS (
+  SELECT 1 FROM ds_properties dp
+  WHERE dp.name = '__label' AND dp."datasetId" = dfd."datasetId"
+);
+  `);
+
+  await db.raw(`
+-- Insert ds_property_fields for __entity (references path directly)
+INSERT INTO ds_property_fields ("dsPropertyId", "formDefId", path)
+SELECT dp.id, dfd."formDefId", '/meta/entity'
+FROM dataset_form_defs dfd
+JOIN ds_properties dp ON dp.name = '__entity' AND dp."datasetId" = dfd."datasetId"
+WHERE NOT EXISTS (
+  SELECT 1 FROM ds_property_fields dpf
+  WHERE dpf."dsPropertyId" = dp.id AND dpf."formDefId" = dfd."formDefId" AND dpf.path = '/meta/entity'
+);
+  `);
+
+  await db.raw(`
+-- Insert ds_property_fields for __label (references path directly)
+INSERT INTO ds_property_fields ("dsPropertyId", "formDefId", path)
+SELECT dp.id, dfd."formDefId", '/meta/entity/label'
+FROM dataset_form_defs dfd
+JOIN ds_properties dp ON dp.name = '__label' AND dp."datasetId" = dfd."datasetId"
+WHERE NOT EXISTS (
+  SELECT 1 FROM ds_property_fields dpf
+  WHERE dpf."dsPropertyId" = dp.id AND dpf."formDefId" = dfd."formDefId" AND dpf.path = '/meta/entity/label'
+);
+  `);
+};
+
+const down = async (db) => {
+  await db.raw('');
+};
+
+module.exports = { up, down };

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -627,6 +627,7 @@ SELECT
   MAX("processed"-"loggedAt") as max_wait,
   AVG("processed"-"loggedAt") as avg_wait
 FROM entity_def_sources
+JOIN entity_defs on entity_def_sources.id = entity_defs."sourceId"
 JOIN audits ON audits.id = "auditId"
 WHERE action = 'submission.create'
 `);

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -557,6 +557,7 @@ SELECT
 FROM datasets ds
   LEFT JOIN ds_properties p ON p."datasetId" = ds.id AND p."publishedAt" IS NOT NULL
 WHERE ds."publishedAt" IS NOT NULL
+AND p.name NOT LIKE '#_#_%' ESCAPE '#'
 GROUP BY ds.id, ds."projectId";
 `);
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -10,7 +10,6 @@
 const { sql } = require('slonik');
 const { extender, insert, QueryOptions, sqlEquals, unjoiner, updater } = require('../../util/db');
 const { Dataset, Form, Audit } = require('../frames');
-const { validatePropertyName } = require('../../data/dataset');
 const { difference, isEmpty, isNil, either, reduceBy, groupBy, uniqWith, equals, map, pipe, values, any, prop, toLower, sortBy } = require('ramda');
 
 const Problem = require('../../util/problem');
@@ -83,6 +82,7 @@ SELECT "action", "id" FROM ds
 // * form (a Form frame or object containing projectId, formDefId, and schemaId)
 // * array of field objects and property names that were parsed from the form xml
 //   (form fields do not need any extra IDs of the form, form def, or schema.)
+//   These fields have been pre-processed for the dataset.
 const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Actees, Datasets, Projects }) => {
   const { projectId } = form;
   const { id: formDefId, schemaId } = form.def;
@@ -107,21 +107,14 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
       .then((actee) => (actee.id));
   const partial = new Dataset({ name, projectId, acteeId }, { formDefId });
 
-  // Prepare dataset properties from form fields:
-  // Step 1: Filter to only fields with property name binds
-  let dsPropertyFields = fields.filter((field) => (field.propertyName));
-  // Step 2a: Check for invalid property names
-  if (dsPropertyFields.filter((field) => !validatePropertyName(field.propertyName)).length > 0)
-    throw Problem.user.invalidEntityForm({ reason: 'Invalid entity property name.' });
-
-  // Step 2b: Multiple fields trying to save to a single property (case-insensitive)
+  // Step 2: Check for multiple fields trying to save to a single property (case-insensitive)
   const hasDuplicateProperties = pipe(groupBy(pipe(prop('propertyName'), toLower)), values, any(g => g.length > 1));
-  if (hasDuplicateProperties(dsPropertyFields)) {
+  if (hasDuplicateProperties(fields)) {
     throw Problem.user.invalidEntityForm({ reason: 'Multiple Form Fields cannot be saved to a single property.' });
   }
 
   // Step 3: Build Form Field frames to handle dataset property field insertion
-  dsPropertyFields = dsPropertyFields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId, formDefId }));
+  const dsPropertyFields = fields.map((field) => new Form.Field(field, { propertyName: field.propertyName, schemaId, formDefId }));
 
   // Insert or update: update dataset, dataset properties, and links to fields and current form
   // result contains action (created or updated) and the id of the dataset.
@@ -137,7 +130,7 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
     // Only consider updates that add new properties to the dataset
     const existingProperties = await Datasets.getProperties(existingDataset.get().id);
     const existingNames = existingProperties.map(f => f.name);
-    const newNames = dsPropertyFields.map(f => f.propertyName);
+    const newNames = dsPropertyFields.map(f => f.propertyName).filter(p => !p.startsWith('__'));
     if (difference(newNames, existingNames).length > 0)
       await context.auth.canOrReject('dataset.update', { acteeId });
 
@@ -342,7 +335,8 @@ publishIfExists.audit = (properties) => (log) => {
     // In case of update, we don't want to log anything if no new property is published
     if (event === 'dataset.create' || (event === 'dataset.update' && datasets[acteeId].some(p => p.action === 'propertyAdded'))) {
       promiseArr.push(log(event, { acteeId }, {
-        properties: datasets[acteeId].filter(p => p.name).map(p => p.name)
+        // We only want to log named non-system properties
+        properties: datasets[acteeId].filter(p => p.name && !p.name.startsWith('__')).map(p => p.name)
       }));
     }
 
@@ -507,9 +501,10 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
 // Dataset.Property will be duplicated for each form that writes that
 // property in the dataset. Expect Dataset.Property to have NULL 'xmlFormId'
 // if any form had created the property but was later deleted/purged.
-const getProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
+const getProperties = (datasetId, includeForms = false, includeInternal = false) => ({ all }) => all(sql`
   SELECT
       ds_properties.* ${includeForms ? sql`, form_defs."name" as "formName", forms."xmlFormId"` : sql``}
+       ${includeInternal ? sql`, ds_property_fields."path"` : sql``}
   FROM
     ds_properties
   LEFT OUTER JOIN ds_property_fields ON
@@ -528,6 +523,7 @@ const getProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
   ` : sql``}
   WHERE ds_properties."datasetId" = ${datasetId}
     AND ds_properties."publishedAt" IS NOT NULL
+    ${includeInternal ? sql`` : sql`AND ds_properties.name NOT LIKE '#_#_%' ESCAPE '#'`}
   ORDER BY ds_properties."publishedAt", form_fields.order, ds_properties.id
 `)
   .then((rows) => (includeForms
@@ -538,20 +534,18 @@ const getProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
 // This it used by the submission XML parser to create an entity from a submission.
 const getFieldsByFormDefId = (formDefId) => ({ all }) => all(sql`
 SELECT
-  form_fields.*, ds_properties."name" as "propertyName"
+  form_fields.*, ds_properties."name" as "propertyName", ds_properties."datasetId"
 FROM
   form_fields
 JOIN form_schemas fs ON fs.id = form_fields."schemaId"
 JOIN form_defs ON fs.id = form_defs."schemaId"
-JOIN dataset_form_defs ON
-  dataset_form_defs."formDefId" = form_defs."id"
 LEFT OUTER JOIN ds_property_fields ON
   ds_property_fields."formDefId" = form_defs."id"
     AND ds_property_fields."path" = form_fields."path"
 LEFT OUTER JOIN ds_properties ON
   ds_properties."id" = ds_property_fields."dsPropertyId"
 WHERE form_defs."id" = ${formDefId}
-  AND (ds_properties."id" IS NOT NULL OR form_fields."path" LIKE '/meta/entity%')
+  AND (ds_properties."id" IS NOT NULL)
 ORDER BY form_fields."order"
 `)
   .then((fields) => fields.map((field) => new Form.Field(field, { propertyName: field.propertyName })));
@@ -591,6 +585,7 @@ const _getFormSpecificProperties = (projectId, xmlFormId, forDraft) => sql`
     JOIN form f ON dpf."formDefId" = f."formDefId"
     JOIN form_fields ff ON f."schemaId" = ff."schemaId"
       AND dpf."path" = ff."path"
+    WHERE dp.name NOT LIKE '#_#_%' ESCAPE '#'
   )
   SELECT ds.name "datasetName", ds.id "datasetId", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew"
   FROM ds

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -401,8 +401,8 @@ const _updateEntity = (sourceId, dataset, entityData, submissionDef, event, forc
       entityId: entity.id,
       entityDefId: entity.aux.currentVersion.id,
       entity: { uuid: entity.uuid, dataset: dataset.name },
-      submissionDef: submissionDef.submissionId,
-      submissionId: submissionDef.id
+      submissionId: submissionDef.submissionId,
+      submissionDefId: submissionDef.id
     });
   return entity;
 };
@@ -567,7 +567,6 @@ const _processEntityData = (sourceId, entityData, event, form, submissionDef, fo
   // workers attempted to concurrently process two different submissions that
   // affect the same entity. See https://github.com/getodk/central/issues/705
   await _lockEntity(run, normalizeUuid(entityData.system.id));
-
 
   let maybeEntity = null;
   // Try update before create (if both are specified)

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -250,7 +250,7 @@ const _lockEntity = (exec, uuid) => {
 ////////////////////////////////////////////////////////////////////////////////
 // WRAPPER FUNCTIONS FOR CREATING AND UPDATING ENTITIES
 
-const _createEntity = (sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing) => async ({ Audits, Entities }) => {
+const _createEntity = (sourceId, dataset, entityData, submissionDef, event, forceOutOfOrderProcessing) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
   // an approval event, then don't create an entity
   if ((dataset.approvalRequired && event.details.reviewState !== 'approved') ||
@@ -282,8 +282,8 @@ const _createEntity = (sourceId, dataset, entityData, submissionId, submissionDe
       entityId: entity.id, // Added in v2023.3 and backfilled
       entityDefId: entity.aux.currentVersion.id, // Added in v2023.3 and backfilled
       entity: { uuid: entity.uuid, dataset: dataset.name },
-      submissionId,
-      submissionDefId
+      submissionId: submissionDef.submissionId,
+      submissionDefId: submissionDef.id
     });
   return entity;
 };
@@ -291,7 +291,7 @@ const _createEntity = (sourceId, dataset, entityData, submissionId, submissionDe
 // Extra flags
 // - forceOutOfOrderProcessing: entity was in backlog and was force-processed, which affects base version calculation
 // - createSubAsUpdate: submission was meant to *create* entity (and should be parsed as such) but is applied as an update
-const _updateEntity = (sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, createSubAsUpdate = false) => async ({ Audits, Entities }) => {
+const _updateEntity = (sourceId, dataset, entityData, submissionDef, event, forceOutOfOrderProcessing, createSubAsUpdate = false) => async ({ Audits, Entities }) => {
   if (!(event.action === 'submission.create'
     || event.action === 'submission.update.version'
     || event.action === 'submission.backlog.reprocess'))
@@ -401,8 +401,8 @@ const _updateEntity = (sourceId, dataset, entityData, submissionId, submissionDe
       entityId: entity.id,
       entityDefId: entity.aux.currentVersion.id,
       entity: { uuid: entity.uuid, dataset: dataset.name },
-      submissionId,
-      submissionDefId
+      submissionDef: submissionDef.submissionId,
+      submissionId: submissionDef.id
     });
   return entity;
 };
@@ -559,7 +559,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
   // Try update before create (if both are specified)
   if (entityData.system.update === '1' || entityData.system.update === 'true')
     try {
-      maybeEntity = await Entities._updateEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing);
+      maybeEntity = await Entities._updateEntity(sourceId, dataset, entityData, submissionDef, event, forceOutOfOrderProcessing);
     } catch (err) {
       const attemptCreate = (entityData.system.create === '1' || entityData.system.create === 'true') || forceOutOfOrderProcessing;
       // The two types of errors for which we attempt to create after a failed update:
@@ -567,14 +567,14 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
       // 2. baseVersion is empty and failed to parse in the update case
       // This second one is a special case related to issue c#727
       if ((err.problemCode === 404.8 || (err.problemCode === 400.2 && err.problemDetails.field === 'baseVersion')) && attemptCreate) {
-        maybeEntity = await Entities._createEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
+        maybeEntity = await Entities._createEntity(sourceId, dataset, entityData, submissionDef, event, forceOutOfOrderProcessing);
       } else {
         throw (err);
       }
     }
   else if (entityData.system.create === '1' || entityData.system.create === 'true') {
     try {
-      maybeEntity = await Entities._createEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
+      maybeEntity = await Entities._createEntity(sourceId, dataset, entityData, submissionDef, event, forceOutOfOrderProcessing);
     } catch (err) {
       // There was a problem creating the entity
       // If it is a uuid collision, check if the entity was created via an update
@@ -582,7 +582,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
       if (err.problemCode === 409.3 && err.problemDetails?.fields[0] === 'uuid') {
         const rootDef = await Entities.getDef(dataset.id, entityData.system.id, new QueryOptions().withCondition({ root: true })).then(o => o.orNull());
         if (rootDef && rootDef.aux.source.forceProcessed) {
-          maybeEntity = await Entities._updateEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, true);
+          maybeEntity = await Entities._updateEntity(sourceId, dataset, entityData, submissionDef, event, forceOutOfOrderProcessing, true);
         } else {
           throw (err);
         }

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -480,7 +480,7 @@ const _getFormDefActions = (oneFirst, datasetId, formDefId) => oneFirst(sql`
 
 // Main submission event processing function, which runs within a transaction
 // so any errors can be rolled back and logged as an entity processing error.
-const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms, oneFirst, run }) => {
+const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entities, Submissions, Forms }) => {
   const { submissionId, submissionDefId } = event.details;
   const forceOutOfOrderProcessing = parentEvent?.details?.force === true;
 
@@ -522,6 +522,28 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
 
   const entityData = await parseSubmissionXml(fields, submissionDef.xml);
 
+  // Create source object from this submission
+  const sourceDetails = {
+    submission: {
+      instanceId: submissionDef.instanceId,
+    },
+    ...parentEvent ? { parentEventId: parentEvent.id } : {}
+  };
+  const sourceId = await Entities.createOrUpdateSource(sourceDetails, submissionDefId, event.id, forceOutOfOrderProcessing);
+
+  await Entities._processEntityData(sourceId, entityData, event, form, submissionDef, forceOutOfOrderProcessing);
+
+  return null;
+};
+
+// Once entityData has been extracted from the submission XML, examine that data
+// including dataset name, actions, id, baseVersions, trunkVersions, data, etc.
+// to determine whether to create or update an entity, or handle a processing error.
+//
+// At this point in the code, we should be working with a single entity.
+// If there is an error with the entity, it should throw an error, which should
+// also block the processing of any other entities found in the same submission.
+const _processEntityData = (sourceId, entityData, event, form, submissionDef, forceOutOfOrderProcessing) => async ({ Datasets, Entities, oneFirst, run }) => {
   // We have to look up the dataset based on the name in the XML
   if (!entityData.system.dataset || entityData.system.dataset.trim() === '') {
     throw Problem.user.missingParameter({ field: 'dataset' });
@@ -546,14 +568,6 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
   // affect the same entity. See https://github.com/getodk/central/issues/705
   await _lockEntity(run, normalizeUuid(entityData.system.id));
 
-  // Create source object from this submission
-  const sourceDetails = {
-    submission: {
-      instanceId: submissionDef.instanceId,
-    },
-    ...parentEvent ? { parentEventId: parentEvent.id } : {}
-  };
-  const sourceId = await Entities.createOrUpdateSource(sourceDetails, submissionDefId, event.id, forceOutOfOrderProcessing);
 
   let maybeEntity = null;
   // Try update before create (if both are specified)
@@ -606,8 +620,6 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
       await Entities.logBacklogEvent('reprocess', event, nextSubmissionId, nextSubmissionDefId);
     }
   }
-
-  return null;
 };
 
 const processSubmissionEvent = (event, parentEvent) => (container) =>
@@ -1045,7 +1057,7 @@ order by actors."displayName" asc`)
   .then(map(construct(Actor)));
 
 module.exports = {
-  createNew, _processSubmissionEvent,
+  createNew, _processSubmissionEvent, _processEntityData,
   createOrUpdateSource, updateSourceDetails,
   createMany,
   _createEntity, _updateEntity,

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -39,13 +39,26 @@ const _isPurgedOrDeletedUuid = (oneFirst, uuid) => oneFirst(sql`
 /////////////////////////////////////////////////////////////////////////////////
 // ENTITY DEF SOURCES
 
-const createSource = (details = null, subDefId = null, eventId = null, forceProcessed = false) => ({ one }) => {
+const createOrUpdateSource = (details = null, subDefId = null, eventId = null, forceProcessed = false) => ({ one }) => {
   const type = (subDefId) ? 'submission' : 'api';
-  return one(sql`insert into entity_def_sources ("type", "submissionDefId", "auditId", "details", "forceProcessed")
-  values (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)}, ${forceProcessed})
-  returning id`)
-    .then((row) => row.id);
+  return one(sql`
+    INSERT INTO entity_def_sources ("type", "submissionDefId", "auditId", "details", "forceProcessed")
+    VALUES (${type}, ${subDefId}, ${eventId}, ${JSON.stringify(details)}, ${forceProcessed})
+    ON CONFLICT ("auditId") DO UPDATE
+      SET
+        "forceProcessed" = ${forceProcessed},
+        details = entity_def_sources.details || ${JSON.stringify(details)}::jsonb
+    RETURNING id
+  `).then((row) => row.id);
 };
+
+const updateSourceDetails = (sourceId, details) => ({ one }) =>
+  one(sql`
+    UPDATE entity_def_sources
+    SET details = details || ${JSON.stringify(details)}::jsonb
+    WHERE id = ${sourceId}
+    RETURNING *
+  `);
 
 ////////////////////////////////////////////////////////////////////////////////
 // ENTITY CREATE
@@ -237,7 +250,7 @@ const _lockEntity = (exec, uuid) => {
 ////////////////////////////////////////////////////////////////////////////////
 // WRAPPER FUNCTIONS FOR CREATING AND UPDATING ENTITIES
 
-const _createEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing) => async ({ Audits, Entities }) => {
+const _createEntity = (sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing) => async ({ Audits, Entities }) => {
   // If dataset requires approval on submission to create an entity and this event is not
   // an approval event, then don't create an entity
   if ((dataset.approvalRequired && event.details.reviewState !== 'approved') ||
@@ -262,8 +275,6 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
   if (maybeEntity.isDefined())
     throw Problem.user.uniquenessViolation({ fields: ['uuid'], values: [partial.uuid] });
 
-  const sourceDetails = { submission: { instanceId: submissionDef.instanceId }, parentEventId: parentEvent ? parentEvent.id : undefined };
-  const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id, forceOutOfOrderProcessing);
   const entity = await Entities.createNew(dataset, partial, submissionDef, sourceId);
 
   await Audits.log({ id: event.actorId }, 'entity.create', { acteeId: dataset.acteeId },
@@ -280,7 +291,7 @@ const _createEntity = (dataset, entityData, submissionId, submissionDef, submiss
 // Extra flags
 // - forceOutOfOrderProcessing: entity was in backlog and was force-processed, which affects base version calculation
 // - createSubAsUpdate: submission was meant to *create* entity (and should be parsed as such) but is applied as an update
-const _updateEntity = (dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, createSubAsUpdate = false) => async ({ Audits, Entities }) => {
+const _updateEntity = (sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, createSubAsUpdate = false) => async ({ Audits, Entities }) => {
   if (!(event.action === 'submission.create'
     || event.action === 'submission.update.version'
     || event.action === 'submission.backlog.reprocess'))
@@ -361,19 +372,10 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       conflict = ConflictType.SOFT;
     }
   }
-
   // merge data
   const mergedData = mergeRight(serverEntity.aux.currentVersion.data, clientEntity.def.data);
   const mergedLabel = clientEntity.def.label ?? serverEntity.aux.currentVersion.label;
 
-  // make some kind of source object
-  const sourceDetails = {
-    submission: {
-      instanceId: submissionDef.instanceId,
-    },
-    ...createSubAsUpdate ? { action: 'create' } : {}
-  };
-  const sourceId = await Entities.createSource(sourceDetails, submissionDefId, event.id, forceOutOfOrderProcessing);
   const partial = new Entity.Partial(serverEntity.with({ conflict }), {
     def: new Entity.Def({
       data: mergedData,
@@ -385,6 +387,10 @@ const _updateEntity = (dataset, entityData, submissionId, submissionDef, submiss
       conflictingProperties
     })
   });
+
+  // If this was a create submission applied as a create, update or augment source details with { action: 'create' }
+  if (createSubAsUpdate)
+    await Entities.updateSourceDetails(sourceId, { action: 'create' });
 
   // Assign new version (increment latest server version)
   const version = serverEntity.aux.currentVersion.version + 1;
@@ -540,11 +546,20 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
   // affect the same entity. See https://github.com/getodk/central/issues/705
   await _lockEntity(run, normalizeUuid(entityData.system.id));
 
+  // Create source object from this submission
+  const sourceDetails = {
+    submission: {
+      instanceId: submissionDef.instanceId,
+    },
+    ...parentEvent ? { parentEventId: parentEvent.id } : {}
+  };
+  const sourceId = await Entities.createOrUpdateSource(sourceDetails, submissionDefId, event.id, forceOutOfOrderProcessing);
+
   let maybeEntity = null;
   // Try update before create (if both are specified)
   if (entityData.system.update === '1' || entityData.system.update === 'true')
     try {
-      maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing);
+      maybeEntity = await Entities._updateEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing);
     } catch (err) {
       const attemptCreate = (entityData.system.create === '1' || entityData.system.create === 'true') || forceOutOfOrderProcessing;
       // The two types of errors for which we attempt to create after a failed update:
@@ -552,14 +567,14 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
       // 2. baseVersion is empty and failed to parse in the update case
       // This second one is a special case related to issue c#727
       if ((err.problemCode === 404.8 || (err.problemCode === 400.2 && err.problemDetails.field === 'baseVersion')) && attemptCreate) {
-        maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
+        maybeEntity = await Entities._createEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
       } else {
         throw (err);
       }
     }
   else if (entityData.system.create === '1' || entityData.system.create === 'true') {
     try {
-      maybeEntity = await Entities._createEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
+      maybeEntity = await Entities._createEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, parentEvent, forceOutOfOrderProcessing);
     } catch (err) {
       // There was a problem creating the entity
       // If it is a uuid collision, check if the entity was created via an update
@@ -567,7 +582,7 @@ const _processSubmissionEvent = (event, parentEvent) => async ({ Datasets, Entit
       if (err.problemCode === 409.3 && err.problemDetails?.fields[0] === 'uuid') {
         const rootDef = await Entities.getDef(dataset.id, entityData.system.id, new QueryOptions().withCondition({ root: true })).then(o => o.orNull());
         if (rootDef && rootDef.aux.source.forceProcessed) {
-          maybeEntity = await Entities._updateEntity(dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, true);
+          maybeEntity = await Entities._updateEntity(sourceId, dataset, entityData, submissionId, submissionDef, submissionDefId, event, forceOutOfOrderProcessing, true);
         } else {
           throw (err);
         }
@@ -1031,7 +1046,7 @@ order by actors."displayName" asc`)
 
 module.exports = {
   createNew, _processSubmissionEvent,
-  createSource,
+  createOrUpdateSource, updateSourceDetails,
   createMany,
   _createEntity, _updateEntity,
   _computeBaseVersion, _interruptedBranch,

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -12,7 +12,7 @@ const { map } = require('ramda');
 const { Frame, into } = require('../frame');
 const { Actor, Blob, Form } = require('../frames');
 const { getFormFields, merge, compare } = require('../../data/schema');
-const { getDatasets } = require('../../data/dataset');
+const { getDatasets, prepareFieldsForDataset } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
 const { unjoiner, extender, updater, sqlEquals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, timebound } = require('../../util/promise');
@@ -163,7 +163,7 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
   if (parsedDatasets.isDefined()) {
     await Promise.all(
       parsedDatasets.get().datasets.map(ds =>
-        Datasets.createOrMerge(ds, savedForm, fields)
+        Datasets.createOrMerge(ds, savedForm, prepareFieldsForDataset(fields))
       )
     );
   }
@@ -283,7 +283,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   if (parsedDatasets.isDefined()) {
     await Promise.all(
       parsedDatasets.get().datasets.map(ds =>
-        Datasets.createOrMerge(ds, new Form(form, { def: savedDef }), fields)
+        Datasets.createOrMerge(ds, new Form(form, { def: savedDef }), prepareFieldsForDataset(fields))
       )
     );
     // Note: if publish=true, we are in the enabling encryption special case and won't

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -102,7 +102,7 @@ module.exports = (service, endpoint) => {
     if (!entities) {
       // not a bulk operation
       const partial = await Entity.fromJson(body, properties, dataset);
-      const sourceId = await Entities.createSource();
+      const sourceId = await Entities.createOrUpdateSource();
       const entity = await Entities.createNew(dataset, partial, null, sourceId, userAgent);
       // Entities.createNew doesn't return enough information for a full response so re-fetch.
       return Entities.getById(dataset.id, entity.uuid).then(getOrNotFound);
@@ -116,7 +116,7 @@ module.exports = (service, endpoint) => {
 
       const partials = body.entities.map(e => Entity.fromJson(e, properties, dataset));
 
-      const sourceId = await Entities.createSource(extractBulkSource(source, partials.length, userAgent));
+      const sourceId = await Entities.createOrUpdateSource(extractBulkSource(source, partials.length, userAgent));
 
       await Entities.createMany(dataset, partials, sourceId, userAgent);
       return success();
@@ -152,7 +152,7 @@ module.exports = (service, endpoint) => {
     const properties = await Datasets.getProperties(dataset.id);
     const partial = Entity.fromJson(body, properties, dataset, entity);
 
-    const sourceId = await Entities.createSource();
+    const sourceId = await Entities.createOrUpdateSource();
 
     const updatedEntity = await Entities.createVersion(dataset, partial, null, serverEntityVersion + 1, sourceId, serverEntityVersion, userAgent);
 

--- a/test/db-migrations/20250904-02-insert-entity-label-ds-properties.spec.js
+++ b/test/db-migrations/20250904-02-insert-entity-label-ds-properties.spec.js
@@ -1,0 +1,451 @@
+const assert = require('node:assert/strict');
+const { assertQueryContents, describeMigration } = require('./utils');
+
+describeMigration('20250904-02-insert-entity-label-ds-properties', ({ runMigrationBeingTested }) => {
+  before(async () => {
+    // The purpose of this migration is to add __entity and __label dataset properties for all existing datasets.
+    // These were implicit before, but in the future when we have multiple entities per form, we need to keep better
+    // track of where each entity came from in each form definition.
+
+    // These insert statements are pretty gross. They are built from partial dumps of a real fresh Central database
+    // in which I uploaded a bunch of different forms with different dataset situations. The inserts seem to capture
+    // enough of the relationships around forms, projects, actees, schemas, etc. to satisfy the database constraints
+    // and the migration.
+
+    // Insert the actee for the project
+    await db.any(sql`
+      INSERT INTO actees (id, species, parent, "purgedAt", "purgedName", details)
+      VALUES ('8c03476a-a4f0-444a-97a1-850c5303e968', 'project', NULL, NULL, NULL, NULL)
+    `);
+
+    // Insert the project
+    await db.any(sql`
+      INSERT INTO projects (id, name, "acteeId", "createdAt", "updatedAt", "deletedAt", archived, "keyId", description)
+      VALUES (1, 'test', '8c03476a-a4f0-444a-97a1-850c5303e968', NOW(), NULL, NULL, NULL, NULL, NULL)
+    `);
+
+    // Insert the forms and datasets
+    await db.any(sql`
+      INSERT INTO actees (id, species, parent, "purgedAt", "purgedName", details)
+      VALUES 
+        ('074466d8-7494-493b-a383-b14b727ee4a4', 'form', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('0a4a6413-a781-4386-b69e-8a39d491f41b', 'form', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('09144439-3dc3-4fa8-8c06-c46643542c85', 'dataset', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('2374d161-027f-4437-8067-05452079d975', 'form', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('7555d579-e452-4b6c-b564-cd18a9284ddc', 'dataset', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('77bb257a-0a92-4d56-9de3-4aa6e8e73cb7', 'form', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('e3f430b9-0a0f-4c2f-86c8-1791e966e992', 'dataset', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('6c3258b1-d01e-4c68-891d-6ecb2df58e49', 'form', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('500a4944-45d3-4929-9367-859474042f46', 'dataset', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('bde4df10-66a0-41f5-ae16-538ff2174cda', 'form', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL),
+        ('34d9b126-6171-496f-895f-ebcbb28e859e', 'dataset', '8c03476a-a4f0-444a-97a1-850c5303e968', NULL, NULL, NULL)
+    `);
+
+    // Insert form schemas
+    await db.any(sql`
+      INSERT INTO form_schemas (id)
+      VALUES (1), (2), (3), (5), (7), (8), (10)
+    `);
+
+    // Insert forms and form defs (sql written by claude)
+    await db.any(sql`
+      WITH inserted_forms AS (
+        INSERT INTO forms (
+          id, "xmlFormId", "createdAt", "updatedAt", "deletedAt", "acteeId", 
+          state, "projectId", "currentDefId", "draftDefId", "enketoId", 
+          "enketoOnceId", "webformsEnabled"
+        )
+        VALUES 
+          (1, 'form1', '2025-07-15 17:46:08.971+00', '2025-07-15 17:46:12.282+00', NULL, '074466d8-7494-493b-a383-b14b727ee4a4', 'open', 1, NULL, NULL, NULL, NULL, false),
+          (2, 'form2_ds_no_props', '2025-07-15 17:46:19.176+00', '2025-07-15 17:48:04.807+00', NULL, '0a4a6413-a781-4386-b69e-8a39d491f41b', 'open', 1, NULL, NULL, NULL, NULL, false),
+          (3, 'form2_ds_no_props_draft', '2025-07-15 17:48:37.857+00', NULL, NULL, '2374d161-027f-4437-8067-05452079d975', 'open', 1, NULL, NULL, NULL, NULL, false),
+          (4, 'form4_ds_regular', '2025-07-15 17:49:55.766+00', '2025-07-15 17:50:40.953+00', NULL, '77bb257a-0a92-4d56-9de3-4aa6e8e73cb7', 'open', 1, NULL, NULL, NULL, NULL, false),
+          (5, 'form4_ds_regular_draft', '2025-07-15 17:51:24.348+00', '2025-07-15 17:51:46.603+00', NULL, '6c3258b1-d01e-4c68-891d-6ecb2df58e49', 'open', 1, NULL, NULL, NULL, NULL, false),
+          (6, 'form6_ds_props_versions', '2025-07-15 17:54:52.203+00', '2025-07-15 17:56:50.463+00', NULL, 'bde4df10-66a0-41f5-ae16-538ff2174cda', 'open', 1, NULL, NULL, NULL, NULL, false)
+        RETURNING id
+      ),
+      inserted_form_defs AS (
+        INSERT INTO form_defs (
+          id, "formId", xml, hash, sha, sha256, version, "createdAt", "keyId", 
+          "xlsBlobId", "publishedAt", "draftToken", "enketoId", name, "schemaId"
+        )
+        VALUES 
+          (1, 1, '<xml></xml>', 'hash1', 'sha1', 'sha256_1', 'v1', NOW(), NULL, NULL, NOW(), NULL, NULL, 'form1', 1),
+          (2, 2, '<xml></xml>', 'hash2', 'sha2', 'sha256_2', 'v1', NOW(), NULL, NULL, NOW(), NULL, NULL, 'form2_ds_no_props', 2),
+          (3, 3, '<xml></xml>', 'hash3', 'sha3', 'sha256_3', 'v1', NOW(), NULL, NULL, NULL, 'draft_token_3', NULL, 'form2_ds_no_props_draft', 3),
+          (5, 4, '<xml></xml>', 'hash5', 'sha5', 'sha256_5', 'v1', NOW(), NULL, NULL, NOW(), NULL, NULL, 'form4_ds_regular', 5),
+          (7, 5, '<xml></xml>', 'hash7', 'sha7', 'sha256_7', 'v1', NOW(), NULL, NULL, NULL, 'draft_token_7', NULL, 'form4_ds_regular_draft', 7),
+          (8, 6, '<xml></xml>', 'hash8', 'sha8', 'sha256_8', 'v1', NOW(), NULL, NULL, NOW(), NULL, NULL, 'form6_ds_props_versions', 8),
+          (10, 6, '<xml></xml>', 'hash10', 'sha10', 'sha256_10', 'v2', NOW(), NULL, NULL, NOW(), NULL, NULL, 'form6_ds_props_versions', 10),
+          (12, 6, '<xml></xml>', 'hash12', 'sha12', 'sha256_12', 'v3', NOW(), NULL, NULL, NULL, 'draft_token_12', NULL, 'form6_ds_props_versions', 10)
+        RETURNING id
+      )
+      UPDATE forms SET 
+        "currentDefId" = CASE 
+          WHEN id = 1 THEN 1
+          WHEN id = 2 THEN 2  
+          WHEN id = 4 THEN 5
+          WHEN id = 6 THEN 10
+          ELSE "currentDefId"
+        END,
+        "draftDefId" = CASE
+          WHEN id = 3 THEN 3
+          WHEN id = 5 THEN 7
+          WHEN id = 6 THEN 12
+          ELSE "draftDefId"
+        END
+    `);
+
+    // Insert datasets
+    await db.any(sql`
+      INSERT INTO datasets (
+        id, name, "acteeId", "createdAt", "projectId", "publishedAt", 
+        "approvalRequired", "ownerOnly"
+      )
+      VALUES 
+        (1, 'ds_no_props', '09144439-3dc3-4fa8-8c06-c46643542c85', NOW(), 1, NOW(), false, false),
+        (2, 'ds_no_props_draft', '7555d579-e452-4b6c-b564-cd18a9284ddc', NOW(), 1, NULL, false, false),
+        (3, 'ds_props', 'e3f430b9-0a0f-4c2f-86c8-1791e966e992', NOW(), 1, NOW(), false, false),
+        (6, 'ds_props_draft', '500a4944-45d3-4929-9367-859474042f46', NOW(), 1, NULL, false, false),
+        (7, 'ds_props_versions', '34d9b126-6171-496f-895f-ebcbb28e859e', NOW(), 1, NOW(), false, false)
+    `);
+
+    // Insert dataset form defs
+    await db.any(sql`
+      INSERT INTO dataset_form_defs ("datasetId", "formDefId", actions)
+      VALUES 
+        (1, 2, '["create"]'),
+        (2, 3, '["create"]'),
+        (3, 5, '["create"]'),
+        (6, 7, '["create"]'),
+        (7, 8, '["create"]'),
+        (7, 10, '["create"]'),
+        (7, 12, '["create"]')
+    `);
+
+    // Insert properties and ds_property_fields
+    // everything else has hardcoded autoincrement keys, but since we're inserting more properties,
+    // i had the property computed as part of the insert statement.
+    await db.any(sql`
+      WITH inserted_properties AS (
+        INSERT INTO ds_properties (name, "datasetId", "publishedAt")
+        VALUES 
+          ('age', 3, NOW()),
+          ('color', 3, NULL),
+          ('color', 6, NULL),
+          ('height', 7, NOW()),
+          ('petals', 7, NOW()),
+          ('api_prop', 7, NOW()),
+          ('thorns', 7, NOW()),
+          ('leaves', 7, NULL)
+        RETURNING id, name, "datasetId"
+      )
+      INSERT INTO ds_property_fields ("dsPropertyId", "formDefId", path)
+      SELECT 
+        p.id,
+        f.form_def_id,
+        f.path
+      FROM inserted_properties p
+      JOIN (VALUES 
+        ('age', 3, 5, '/age'),
+        ('color', 3, 6, '/color'),
+        ('color', 6, 7, '/color'),
+        ('petals', 7, 8, '/petals'),
+        ('height', 7, 8, '/height'),
+        ('petals', 7, 9, '/petals'),
+        ('height', 7, 9, '/height'),
+        ('petals', 7, 10, '/petals'),
+        ('thorns', 7, 10, '/thorns'),
+        ('thorns', 7, 11, '/thorns'),
+        ('petals', 7, 11, '/petals'),
+        ('leaves', 7, 12, '/leaves'),
+        ('thorns', 7, 12, '/thorns'),
+        ('petals', 7, 12, '/petals')
+      ) AS f(prop_name, dataset_id, form_def_id, path) 
+      ON p.name = f.prop_name AND p."datasetId" = f.dataset_id
+    `);
+
+    await runMigrationBeingTested();
+  });
+
+  it('should not add properties for forms that do not include datasets', async () => {
+    const { rows: actual } = await db.query(sql`
+      SELECT dpf."dsPropertyId", dpf."formDefId", dpf.path
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      WHERE fd."formId" = 1;`);
+
+    assert.strictEqual(actual.length, 0, 'row count mismatch');
+  });
+
+  it('should add __entity and __label properties for published form with dataset but no properties', async () => {
+    const q = sql`
+      SELECT dpf."formDefId", dpf.path, dp.name, dp."datasetId", (dp."publishedAt" IS NOT NULL) AS published
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      JOIN ds_properties dp ON dpf."dsPropertyId" = dp.id
+      WHERE fd."formId" = 2
+      ORDER BY dp.name;`;
+
+    await assertQueryContents(q,
+      {
+        formDefId: 2,
+        path: '/meta/entity',
+        name: '__entity',
+        datasetId: 1,
+        published: true
+      },
+      {
+        formDefId: 2,
+        path: '/meta/entity/label',
+        name: '__label',
+        datasetId: 1,
+        published: true
+      }
+    );
+  });
+
+  it('should add __entity and __label properties for unpublished form with unpublished dataset but no properties', async () => {
+    const q = sql`
+      SELECT dpf."formDefId", dpf.path, dp.name, dp."datasetId", (dp."publishedAt" IS NOT NULL) AS published
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      JOIN ds_properties dp ON dpf."dsPropertyId" = dp.id
+      WHERE fd."formId" = 3
+      ORDER BY dp.name;`;
+
+    await assertQueryContents(q,
+      {
+        formDefId: 3,
+        path: '/meta/entity',
+        name: '__entity',
+        datasetId: 2,
+        published: false
+      },
+      {
+        formDefId: 3,
+        path: '/meta/entity/label',
+        name: '__label',
+        datasetId: 2,
+        published: false
+      }
+    );
+  });
+
+  it('should add __entity and __label properties for published form with published dataset with existing properties', async () => {
+    const q = sql`
+      SELECT dpf."formDefId", dpf.path, dp.name, dp."datasetId", (dp."publishedAt" IS NOT NULL) AS published
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      JOIN ds_properties dp ON dpf."dsPropertyId" = dp.id
+      WHERE fd."formId" = 4
+      ORDER BY dp.name;`;
+
+    await assertQueryContents(q,
+      {
+        formDefId: 5,
+        path: '/age',
+        name: 'age',
+        datasetId: 3,
+        published: true
+      },
+      {
+        formDefId: 5,
+        path: '/meta/entity',
+        name: '__entity',
+        datasetId: 3,
+        published: true
+      },
+      {
+        formDefId: 5,
+        path: '/meta/entity/label',
+        name: '__label',
+        datasetId: 3,
+        published: true
+      }
+    );
+  });
+
+  it('should add __entity and __label properties for unpublished form with unpublished dataset and properties', async () => {
+    const q = sql`
+      SELECT dpf."formDefId", dpf.path, dp.name, dp."datasetId", (dp."publishedAt" IS NOT NULL) AS published
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      JOIN ds_properties dp ON dpf."dsPropertyId" = dp.id
+      WHERE fd."formId" = 5
+      ORDER BY dp.name;`;
+
+    await assertQueryContents(q,
+      {
+        formDefId: 7,
+        path: '/color',
+        name: 'color',
+        datasetId: 6,
+        published: false
+      },
+      {
+        formDefId: 7,
+        path: '/meta/entity',
+        name: '__entity',
+        datasetId: 6,
+        published: false
+      },
+      {
+        formDefId: 7,
+        path: '/meta/entity/label',
+        name: '__label',
+        datasetId: 6,
+        published: false
+      }
+    );
+  });
+
+  it('should work for published form with draft version', async () => {
+    const q0 = sql`
+      SELECT name, "datasetId", ("publishedAt" IS NOT NULL) AS published
+      FROM ds_properties
+      WHERE "datasetId" = 7`;
+
+    await assertQueryContents(q0,
+      {
+        name: '__entity',
+        published: true
+      },
+      {
+        name: '__label',
+        published: true
+      },
+      {
+        name: 'height',
+        published: true
+      },
+      {
+        name: 'petals',
+        published: true
+      },
+      {
+        name: 'thorns',
+        published: true
+      },
+      {
+        name: 'api_prop',
+        published: true
+      },
+      {
+        name: 'leaves',
+        published: false
+      },
+    );
+
+    const q1 = sql`
+      SELECT dpf.path, dp.name, dp."datasetId", (dp."publishedAt" IS NOT NULL) AS published
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      JOIN ds_properties dp ON dpf."dsPropertyId" = dp.id
+      WHERE fd."formId" = 6 and fd.id = 8
+      ORDER BY dp.name;`;
+
+    await assertQueryContents(q1,
+      {
+        path: '/height',
+        name: 'height',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/petals',
+        name: 'petals',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/meta/entity',
+        name: '__entity',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/meta/entity/label',
+        name: '__label',
+        datasetId: 7,
+        published: true
+      }
+    );
+
+    const q2 = sql`
+      SELECT dpf.path, dp.name, dp."datasetId", (dp."publishedAt" IS NOT NULL) AS published
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      JOIN ds_properties dp ON dpf."dsPropertyId" = dp.id
+      WHERE fd."formId" = 6 and fd.id = 10
+      ORDER BY dp.name;`;
+
+    await assertQueryContents(q2,
+      {
+        path: '/thorns',
+        name: 'thorns',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/petals',
+        name: 'petals',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/meta/entity',
+        name: '__entity',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/meta/entity/label',
+        name: '__label',
+        datasetId: 7,
+        published: true
+      }
+    );
+
+    const q3 = sql`
+      SELECT dpf.path, dp.name, dp."datasetId", (dp."publishedAt" IS NOT NULL) AS published
+      FROM ds_property_fields dpf
+      JOIN form_defs fd ON dpf."formDefId" = fd.id
+      JOIN ds_properties dp ON dpf."dsPropertyId" = dp.id
+      WHERE fd."formId" = 6 and fd.id = 12
+      ORDER BY dp.name;`;
+
+    await assertQueryContents(q3,
+      {
+        path: '/leaves',
+        name: 'leaves',
+        datasetId: 7,
+        published: false
+      },
+      {
+        path: '/thorns',
+        name: 'thorns',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/petals',
+        name: 'petals',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/meta/entity',
+        name: '__entity',
+        datasetId: 7,
+        published: true
+      },
+      {
+        path: '/meta/entity/label',
+        name: '__label',
+        datasetId: 7,
+        published: true
+      }
+    );
+  });
+});

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4690,13 +4690,13 @@ describe('datasets and entities', () => {
         // there are expected to be
         // 2 defs of this form (published and new draft)
         // 6 form fields of original form (and new form): 3 entity related fields and 3 question fields
-        // ideally only 4 ds property fields, but 2 from deleted def are still there
+        // 12 ds property fields including system properties and those attached to deleted defs are still present
         await Promise.all([
           container.oneFirst(sql`select count(*) from form_defs as fd join forms as f on fd."formId" = f.id where f."xmlFormId"='simpleEntity'`),
           container.oneFirst(sql`select count(*) from form_fields as fs join forms as f on fs."formId" = f.id where f."xmlFormId"='simpleEntity'`),
           container.oneFirst(sql`select count(*) from ds_property_fields`),
         ])
-          .then((counts) => counts.should.eql([2, 6, 6]));
+          .then((counts) => counts.should.eql([2, 6, 12]));
 
       }));
     });

--- a/test/unit/data/dataset.js
+++ b/test/unit/data/dataset.js
@@ -1,5 +1,6 @@
 const appRoot = require('app-root-path');
 const should = require('should');
+const { prepareFieldsForDataset } = require('../../../lib/data/dataset');
 const { getFormFields } = require(appRoot + '/lib/data/schema');
 const { getDatasets, validateDatasetName, validatePropertyName } = require(appRoot + '/lib/data/dataset');
 const testData = require(appRoot + '/test/data/xml');
@@ -480,5 +481,41 @@ describe('property name validation', () => {
 
   it('should reject name with unicode', () => {
     validatePropertyName('unicode÷divide').should.equal(false);
+  });
+});
+
+describe('prepare fields for dataset', () => {
+  it('should add __entity and __label properties to certain fields', async () => {
+    const fields = await getFormFields(testData.forms.simpleEntity);
+    prepareFieldsForDataset(fields).should.eql([
+      {
+        name: 'name',
+        order: 0,
+        path: '/name',
+        propertyName: 'first_name',
+        type: 'string'
+      },
+      {
+        name: 'age',
+        order: 1,
+        path: '/age',
+        propertyName: 'age',
+        type: 'int'
+      },
+      {
+        name: 'entity',
+        order: 4,
+        path: '/meta/entity',
+        propertyName: '__entity',
+        type: 'structure'
+      },
+      {
+        name: 'label',
+        order: 5,
+        path: '/meta/entity/label',
+        propertyName: '__label',
+        type: 'unknown'
+      }
+    ]);
   });
 });

--- a/test/unit/data/submission.js
+++ b/test/unit/data/submission.js
@@ -2,7 +2,7 @@ const should = require('should');
 const appRoot = require('app-root-path');
 const { filter } = require('ramda');
 const { toObjects } = require('streamtest').v2;
-const { submissionXmlToFieldStream, getSelectMultipleResponses, _hashedTree, _diffObj, _diffArray, diffSubmissions, _symbols } = require(appRoot + '/lib/data/submission');
+const { submissionXmlToFieldData, submissionXmlToFieldStream, getSelectMultipleResponses, _hashedTree, _diffObj, _diffArray, diffSubmissions, _symbols } = require(appRoot + '/lib/data/submission');
 const { fieldsFor, MockField } = require(appRoot + '/test/util/schema');
 const testData = require(appRoot + '/test/data/xml');
 
@@ -234,6 +234,65 @@ describe('submission field streamer', () => {
           { field: new MockField({ order: 2, name: 'hometown', path: '/location/hometown', type: 'string', propertyName: 'hometown' }), text: '' },
         ]);
       }));
+    });
+
+    it('should parse submission xml by fields without stream', async () => {
+      const fields = await fieldsFor(testData.forms.simpleEntity);
+      const data = await submissionXmlToFieldData(fields, testData.instances.simpleEntity.one);
+      data.should.eql([
+        {
+          field: new MockField({
+            order: 4,
+            name: 'entity',
+            path: '/meta/entity',
+            type: 'structure',
+            attrs: {
+              create: '1',
+              dataset: 'people',
+              id: 'uuid:12345678-1234-4123-8234-123456789abc'
+            }
+          }),
+          text: null
+        },
+        {
+          field: new MockField({
+            order: 5,
+            name: 'label',
+            path: '/meta/entity/label',
+            type: 'unknown'
+          }),
+          text: 'Alice (88)'
+        },
+        {
+          field: new MockField({
+            order: 0,
+            name: 'name',
+            path: '/name',
+            type: 'string',
+            propertyName: 'first_name'
+          }),
+          text: 'Alice'
+        },
+        {
+          field: new MockField({
+            order: 1,
+            name: 'age',
+            path: '/age',
+            type: 'int',
+            propertyName: 'age'
+          }),
+          text: '88'
+        },
+        {
+          field: new MockField({
+            order: 2,
+            name: 'hometown',
+            path: '/hometown',
+            type: 'string'
+          }),
+          text: 'Chicago'
+        }
+      ]);
     });
   });
 });


### PR DESCRIPTION
Related to https://github.com/getodk/central/issues/1306

Backporting some ideas for multi-entities to the single entity scenario for cleaner code review.

Adds `__entity` and `__label` internal system dataset properties and uses those as form fields for submission parsing instead of looking up those form fields by path.

Would also need to include this PR with migration to add these properties to historical entity forms: https://github.com/getodk/central-backend/pull/1552

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
