### PR TITLE
set datasetId foreign key column of table entities to NOT NULL

### DIFF
--- a/lib/model/migrations/20250826-01-entities.datasetId-notnull.js
+++ b/lib/model/migrations/20250826-01-entities.datasetId-notnull.js
@@ -1,0 +1,24 @@
+// Copyright 2025 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.raw(`
+    ALTER TABLE entities
+        ALTER COLUMN "datasetId" SET NOT NULL
+  `);
+};
+
+const down = async (db) => {
+  await db.raw(`
+    ALTER TABLE entities
+        ALTER COLUMN "datasetId" DROP NOT NULL
+  `);
+};
+
+module.exports = { up, down };


### PR DESCRIPTION
Entities will always have a dataset (per [Slack discussion](https://getodk.slack.com/archives/C01TKJ7TG7J/p1756181626036809)).