### PR TITLE
Add link to file new issue in central repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links: 
+  - name: "Blank issue"
+    about: "Create a new issue from scratch in getodk/central"
+    url: "https://github.com/getodk/central/issues/new"
   - name: "Report an issue"
     about: "For when Central is behaving in an unexpected way"
     url: "https://forum.getodk.org/c/support/6"


### PR DESCRIPTION
All issues are now filed in the `central` repo. However, this PR adds a cross-link from this repo to `central` to make it easier to initiate issue creation from this repo.

#### What has been done to verify that this works as intended?

I'll verify it once the PR is merged.

#### Why is this the best possible solution? Were any other approaches considered?

I thought about listing the link on the bottom so that end users are less tempted to click it. We really want users to post issues in the forum. But in practice, users don't file GitHub issues often; it doesn't come up that often. Ultimately, I think it's helpful to parallel the order in the `central` repo, where GitHub automatically places "Blank issue" on top.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
