### PR TITLE
Feature: New endpoint to get list of creators for the entities

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -40,6 +40,11 @@ info:
 
     Here major and breaking changes to the API are listed by version.
 
+    ## ODK Central v2025.3
+
+    **Added**:
+    - New endpoint [GET /projects/:id/datasets/:name/entities/creators](/central-api-entity-management/#entities-creators) to retrieve a list of all Actors who have created Entities in a Dataset, sorted by display name.
+
     ## ODK Central v2025.2
 
     **Added**:
@@ -8994,6 +8999,58 @@ paths:
                     type: user
                     updatedAt: '2018-04-18T23:42:11.406Z'
                     deletedAt: '2018-04-18T23:42:11.406Z'
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+  /projects/{projectId}/datasets/{name}/entities/creators:
+    get:
+      tags:
+      - Entity Management
+      summary: Entities Creators
+      description: |-
+        This endpoint returns a list of all Actors who have created Entities in the Dataset, sorted by display name.
+      operationId: Entities Creators
+      parameters:
+      - name: projectId
+        in: path
+        description: The numeric ID of the Project
+        required: true
+        schema:
+          type: number
+        example: "16"
+      - name: name
+        in: path
+        description: Name of the Dataset
+        required: true
+        schema:
+          type: string
+        example: people
+      responses:        
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                description: List of Actors who created Entities
+                items:
+                  $ref: '#/components/schemas/Actor'
+              example:
+              - id: 115
+                type: user
+                displayName: Alice Johnson
+                createdAt: '2018-04-18T23:19:14.802Z'
+                updatedAt: '2018-04-18T23:42:11.406Z'
+                deletedAt: null
+              - id: 23
+                type: user
+                displayName: Bob Smith
+                createdAt: '2018-03-15T15:30:22.150Z'
+                updatedAt: '2018-03-15T15:30:22.150Z'
+                deletedAt: null
         403:
           description: Forbidden
           content:

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -1018,6 +1018,17 @@ const getEntitiesState = (dataset, options = QueryOptions.none) => ({ all }) => 
   -- union with not approved
 `);
 
+
+const getAllCreators = (datasetId) => ({ all }) => all(sql`
+select actors.* from actors
+inner join
+  (select "creatorId" from entities
+    where "deletedAt" is null and "datasetId"=${datasetId}
+    group by "creatorId")
+  as creators on creators."creatorId"=actors.id
+order by actors."displayName" asc`)
+  .then(map(construct(Actor)));
+
 module.exports = {
   createNew, _processSubmissionEvent,
   createSource,
@@ -1034,5 +1045,6 @@ module.exports = {
   countByDatasetId, getById, getDef,
   getAll, getAllDefs, del,
   createEntitiesFromPendingSubmissions,
-  resolveConflict, restore, purge, getEntitiesState
+  resolveConflict, restore, purge, getEntitiesState,
+  getAllCreators
 };

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -29,7 +29,7 @@ module.exports = (service, endpoint) => {
 
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
 
-    await auth.canOrReject('entity.read', dataset);
+    await auth.canOrReject('entity.list', dataset);
 
     return Entities.getAllCreators(dataset.id);
   }));

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -25,6 +25,15 @@ module.exports = (service, endpoint) => {
     return Entities.getAll(dataset.id, queryOptions);
   }));
 
+  service.get('/projects/:projectId/datasets/:name/entities/creators', endpoint(async ({ Datasets, Entities }, { params, auth }) => {
+
+    const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
+
+    await auth.canOrReject('entity.read', dataset);
+
+    return Entities.getAllCreators(dataset.id);
+  }));
+
   service.get('/projects/:projectId/datasets/:name/entities/:uuid', endpoint(async ({ Datasets, Entities }, { params, auth, queryOptions }) => {
 
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -4008,4 +4008,148 @@ describe('Entities API', () => {
         });
     }));
   });
+
+  describe('GET /datasets/:name/entities/creators', () => {
+
+    it('should return notfound if the dataset does not exist', testEntities(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.get('/v1/projects/1/datasets/nonexistent/entities/creators')
+        .expect(404);
+    }));
+
+    it('should reject if the user cannot read', testEntities(async (service) => {
+      const asChelsea = await service.login('chelsea');
+
+      await asChelsea.get('/v1/projects/1/datasets/people/entities/creators')
+        .expect(403);
+    }));
+
+    it('should return empty array if no entities exist', testDataset(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.get('/v1/projects/1/datasets/people/entities/creators')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.eql([]);
+        });
+    }));
+
+    it('should return creators sorted by display name', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const asBob = await service.login('bob');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      // Create entities as different users
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Alice Entity',
+        })
+        .expect(200);
+
+      await asBob.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-123456789def',
+          label: 'Bob Entity',
+        })
+        .expect(200);
+
+      // Get creators
+      await asAlice.get('/v1/projects/1/datasets/people/entities/creators')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.be.an.Array();
+          body.length.should.equal(2);
+
+          // Should be sorted by displayName
+          body[0].displayName.should.equal('Alice');
+          body[0].type.should.equal('user');
+          body[0].should.have.property('id');
+          body[0].should.have.property('createdAt');
+          body[0].should.have.property('updatedAt');
+
+          body[1].displayName.should.equal('Bob');
+          body[1].type.should.equal('user');
+          body[1].should.have.property('id');
+          body[1].should.have.property('createdAt');
+          body[1].should.have.property('updatedAt');
+        });
+    }));
+
+    it('should not include duplicate creators', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      // Create form and dataset
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      // Create multiple entities as the same user
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Alice Entity 1',
+        })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-123456789def',
+          label: 'Alice Entity 2',
+        })
+        .expect(200);
+
+      // Get creators
+      await asAlice.get('/v1/projects/1/datasets/people/entities/creators')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.be.an.Array();
+          body.length.should.equal(1);
+          body[0].displayName.should.equal('Alice');
+        });
+    }));
+
+    it('should only include creators of non-deleted entities', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const asBob = await service.login('bob');
+
+      // Create form and dataset
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      // Create entities as different users
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'Alice Entity',
+        })
+        .expect(200);
+
+      await asBob.post('/v1/projects/1/datasets/people/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-123456789def',
+          label: 'Bob Entity',
+        })
+        .expect(200);
+
+      // Delete Bob's entity
+      await asBob.delete('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789def')
+        .expect(200);
+
+      // Get creators - should only include Alice now
+      await asAlice.get('/v1/projects/1/datasets/people/entities/creators')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.be.an.Array();
+          body.length.should.equal(1);
+          body[0].displayName.should.equal('Alice');
+        });
+    }));
+
+  });
 });

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -4067,16 +4067,10 @@ describe('Entities API', () => {
 
           // Should be sorted by displayName
           body[0].displayName.should.equal('Alice');
-          body[0].type.should.equal('user');
-          body[0].should.have.property('id');
-          body[0].should.have.property('createdAt');
-          body[0].should.have.property('updatedAt');
+          body[0].should.be.an.Actor();
 
           body[1].displayName.should.equal('Bob');
-          body[1].type.should.equal('user');
-          body[1].should.have.property('id');
-          body[1].should.have.property('createdAt');
-          body[1].should.have.property('updatedAt');
+          body[1].should.be.an.Actor();
         });
     }));
 


### PR DESCRIPTION
this endpoint facilitates 'created by' filter on the frontend (getodk/central#973)

#### What has been done to verify that this works as intended?

Added a tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Follows same approach as getting list of submitters.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Done

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
