### PR TITLE
test/api/users: fix typo: sidewide -> site-wide

### DIFF
--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -437,13 +437,13 @@ describe('api: /users', () => {
           .expect(200)
           .then(({ body }) => body.email.should.equal('chelsea@getodk.org')))));
 
-    it('should not return sidewide verbs if not extended', testService((service) =>
+    it('should not return site-wide verbs if not extended', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.get('/v1/users/current')
           .expect(200)
           .then(({ body }) => { should.not.exist(body.verbs); }))));
 
-    it('should return sidewide verbs if logged in (alice)', testService((service) =>
+    it('should return site-wide verbs if logged in (alice)', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.get('/v1/users/current')
           .set('X-Extended-Metadata', 'true')
@@ -456,7 +456,7 @@ describe('api: /users', () => {
             body.verbs.should.containDeep([ 'user.password.invalidate', 'assignment.create', 'role.update' ]);
           }))));
 
-    it('should return sidewide verbs if logged in (chelsea)', testService((service) =>
+    it('should return site-wide verbs if logged in (chelsea)', testService((service) =>
       service.login('chelsea', (asChelsea) =>
         asChelsea.get('/v1/users/current')
           .set('X-Extended-Metadata', 'true')


### PR DESCRIPTION
Noted while considering https://github.com/getodk/central/issues/1315#issuecomment-3234750850.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I read the context of the verb loading, and they look to be site-wide.

#### Why is this the best possible solution? Were any other approaches considered?

There are probably syonyms to site-wide, including "sitewide".  Both are already in use in this repo.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
