### PR TITLE
test/api/submissions: clarify duplicate describe() blocks

### DIFF
--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -4354,7 +4354,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
             })))));
   });
 
-  describe('[version] /:rootId/versions/instanceId/attachments GET', () => {
+  describe('[version] /:rootId/versions/instanceId/attachments/:attachment GET', () => {
     it('should return notfound if the attachment does not exist', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms?publish=true')


### PR DESCRIPTION
This `describe()` block previously duplicated the name of the block starting on L4167.  The other block tests `.../attachments`, while this tests `.../attachments/:name`.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

No alternatives were considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
