### PR TITLE
Submissions.newVersion(): reduce repeated data

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -79,24 +79,55 @@ const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn
   const deviceId = applyPipe(deviceIdIn, truncateString(255), blankStringToNull);
   const userAgent = applyPipe(userAgentIn, truncateString(255), blankStringToNull);
 
-  const _unjoiner = unjoiner(Submission, Submission.Def.into('currentVersion'));
-
   // we already do transactions but it just feels nice to have the cte do it all at once.
   return one(sql`
-with logical as (update submissions set "reviewState"='edited', "updatedAt"=clock_timestamp()
-  where id=${deprecated.submissionId} 
-  returning * )
-, upd as (update submission_defs set current=false where "submissionId"=${deprecated.submissionId} returning *)
-, def as (
-  ${_defInsert(deprecated.submissionId, partial, form.def.id, actorId, null, deviceId, userAgent)}
-)
-select ${_unjoiner.fields} from (
-  select logical.*, upd."userAgent" from logical
-  join upd on logical.id = upd."submissionId" and root
-) submissions
-join def submission_defs on submissions.id = submission_defs."submissionId"
+WITH
+  updatedSubmission AS (
+    UPDATE submissions
+      SET "reviewState"='edited'
+        , "updatedAt"=clock_timestamp()
+      WHERE id=${deprecated.submissionId}
+    RETURNING *
+  ),
+  deprecatedDef AS (
+    UPDATE submission_defs
+      SET current = FALSE
+      WHERE "submissionId"=${deprecated.submissionId}
+        AND current IS TRUE
+  ),
+  newDef AS (
+    INSERT INTO submission_defs ( "submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
+      VALUES (${deprecated.submissionId}, ${sql.binary(partial.xml)}, ${form.def.id}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), null, true, ${deviceId}, ${userAgent})
+      RETURNING id AS "submissionDefId", "createdAt" as "submissionDefCreatedAt"
+  )
+SELECT updatedSubmission.*
+     , submission_defs."userAgent"
+     , newDef.*
+  FROM updatedSubmission
+  JOIN submission_defs
+    ON "submissionId"=${deprecated.submissionId} AND root IS TRUE
+  CROSS JOIN newDef
 `)
-    .then(_unjoiner);
+    .then(({ submissionDefId, submissionDefCreatedAt, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
+      new Submission({ id: deprecated.submissionId, ...submissionData }, {
+        currentVersion: new Submission.Def({
+          id:                    submissionDefId,                   // eslint-disable-line key-spacing, no-multi-spaces
+          submissionId:          deprecated.submissionId,           // eslint-disable-line key-spacing, no-multi-spaces
+          formDefId:             form.def.id,                       // eslint-disable-line key-spacing, no-multi-spaces
+          submitterId:           actorId,                           // eslint-disable-line key-spacing, no-multi-spaces
+          localKey:              partial.def.localKey,              // eslint-disable-line key-spacing, no-multi-spaces
+          encDataAttachmentName: partial.def.encDataAttachmentName, // eslint-disable-line key-spacing, no-multi-spaces
+          signature:             partial.def.signature,             // eslint-disable-line key-spacing, no-multi-spaces
+          createdAt:             submissionDefCreatedAt,            // eslint-disable-line key-spacing, no-multi-spaces
+          instanceName:          partial.def.instanceName,          // eslint-disable-line key-spacing, no-multi-spaces
+          instanceId:            partial.instanceId,                // eslint-disable-line key-spacing, no-multi-spaces
+          current:               true,                              // eslint-disable-line key-spacing, no-multi-spaces
+          xml:                   partial.xml.toString(),            // eslint-disable-line key-spacing, no-multi-spaces
+          root:                  null,                              // eslint-disable-line key-spacing, no-multi-spaces
+          deviceId,
+          userAgent,
+        }),
+      }));
 };
 
 createVersion.audit = (submission, partial, deprecated, form) => (log) =>

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -96,7 +96,7 @@ WITH
         AND current IS TRUE
   ),
   newDef AS (
-    INSERT INTO submission_defs ( "submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
+    INSERT INTO submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
       VALUES (${deprecated.submissionId}, ${sql.binary(partial.xml)}, ${form.def.id}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), null, true, ${deviceId}, ${userAgent})
       RETURNING id AS "submissionDefId", "createdAt" as "submissionDefCreatedAt"
   )

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -7,6 +7,8 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
+/* eslint-disable key-spacing, no-multi-spaces */
+
 const { always, equals, identity, ifElse, map, pick, without } = require('ramda');
 const { sql } = require('slonik');
 const { Frame, table } = require('../frame');
@@ -111,19 +113,19 @@ const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn
     .then(({ submissionDefId, submissionDefCreatedAt, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
       new Submission({ id: deprecated.submissionId, ...submissionData }, {
         currentVersion: new Submission.Def({
-          id:                    submissionDefId,                   // eslint-disable-line key-spacing, no-multi-spaces
-          submissionId:          deprecated.submissionId,           // eslint-disable-line key-spacing, no-multi-spaces
-          formDefId:             form.def.id,                       // eslint-disable-line key-spacing, no-multi-spaces
-          submitterId:           actorId,                           // eslint-disable-line key-spacing, no-multi-spaces
-          localKey:              partial.def.localKey,              // eslint-disable-line key-spacing, no-multi-spaces
-          encDataAttachmentName: partial.def.encDataAttachmentName, // eslint-disable-line key-spacing, no-multi-spaces
-          signature:             partial.def.signature,             // eslint-disable-line key-spacing, no-multi-spaces
-          createdAt:             submissionDefCreatedAt,            // eslint-disable-line key-spacing, no-multi-spaces
-          instanceName:          partial.def.instanceName,          // eslint-disable-line key-spacing, no-multi-spaces
-          instanceId:            partial.instanceId,                // eslint-disable-line key-spacing, no-multi-spaces
-          current:               true,                              // eslint-disable-line key-spacing, no-multi-spaces
-          xml:                   partial.xml.toString(),            // eslint-disable-line key-spacing, no-multi-spaces
-          root:                  null,                              // eslint-disable-line key-spacing, no-multi-spaces
+          id:                    submissionDefId,
+          submissionId:          deprecated.submissionId,
+          formDefId:             form.def.id,
+          submitterId:           actorId,
+          localKey:              partial.def.localKey,
+          encDataAttachmentName: partial.def.encDataAttachmentName,
+          signature:             partial.def.signature,
+          createdAt:             submissionDefCreatedAt,
+          instanceName:          partial.def.instanceName,
+          instanceId:            partial.instanceId,
+          current:               true,
+          xml:                   partial.xml.toString(),
+          root:                  null,
           deviceId,
           userAgent,
         }),

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -81,33 +81,33 @@ const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn
 
   // we already do transactions but it just feels nice to have the cte do it all at once.
   return one(sql`
-WITH
-  updatedSubmission AS (
-    UPDATE submissions
-      SET "reviewState"='edited'
-        , "updatedAt"=clock_timestamp()
-      WHERE id=${deprecated.submissionId}
-    RETURNING *
-  ),
-  deprecatedDef AS (
-    UPDATE submission_defs
-      SET current = FALSE
-      WHERE "submissionId"=${deprecated.submissionId}
-        AND current IS TRUE
-  ),
-  newDef AS (
-    INSERT INTO submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
-      VALUES (${deprecated.submissionId}, ${sql.binary(partial.xml)}, ${form.def.id}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), null, true, ${deviceId}, ${userAgent})
-      RETURNING id AS "submissionDefId", "createdAt" as "submissionDefCreatedAt"
-  )
-SELECT updatedSubmission.*
-     , submission_defs."userAgent"
-     , newDef.*
-  FROM updatedSubmission
-  JOIN submission_defs
-    ON "submissionId"=${deprecated.submissionId} AND root IS TRUE
-  CROSS JOIN newDef
-`)
+    WITH
+      updatedSubmission AS (
+        UPDATE submissions
+          SET "reviewState"='edited'
+            , "updatedAt"=clock_timestamp()
+          WHERE id=${deprecated.submissionId}
+        RETURNING *
+      ),
+      deprecatedDef AS (
+        UPDATE submission_defs
+          SET current = FALSE
+          WHERE "submissionId"=${deprecated.submissionId}
+            AND current IS TRUE
+      ),
+      newDef AS (
+        INSERT INTO submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
+          VALUES (${deprecated.submissionId}, ${sql.binary(partial.xml)}, ${form.def.id}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), null, true, ${deviceId}, ${userAgent})
+          RETURNING id AS "submissionDefId", "createdAt" as "submissionDefCreatedAt"
+      )
+    SELECT updatedSubmission.*
+         , submission_defs."userAgent"
+         , newDef.*
+      FROM updatedSubmission
+      JOIN submission_defs
+        ON "submissionId"=${deprecated.submissionId} AND root IS TRUE
+      CROSS JOIN newDef
+  `)
     .then(({ submissionDefId, submissionDefCreatedAt, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
       new Submission({ id: deprecated.submissionId, ...submissionData }, {
         currentVersion: new Submission.Def({


### PR DESCRIPTION
1. only return data from the db which is not already available
2. reduce nested queries
3. only update the `current` row in submission_defs
4. add extra JOIN on submission_defs to return root row's userAgent (necessary to achieve 4)

Neater rewrite of https://github.com/getodk/central-backend/pull/1544
Related: https://github.com/getodk/central/issues/1170

#### What has been done to verify that this works as intended?

CI!

#### Why is this the best possible solution? Were any other approaches considered?

Discussion at https://github.com/getodk/central-backend/pull/1544; this is a neater rewrite of that, specifically tackling the `Submissions.createVersion()` function, where the `xml` field was previously passed to the database and then returned.

This PR could be changed to return query formatting to match the original more closely.  To me this makes understanding the query significantly harder.

Potential follow-ups:

* Look at refactoring `Submissions.createNew()`.  It looks like the query can be inverted and simplified.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not affect users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
