### PR TITLE
Submissions.createNew(): return less data

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -46,7 +46,8 @@ const createNew = (partial, form, deviceIdIn = null, userAgentIn = null) => ({ o
     SELECT newSubmission.id
          , newSubmission."createdAt"
          , newDef.id AS "submissionDefId"
-      FROM newSubmission, newDef;
+      FROM newSubmission
+      CROSS JOIN newDef
   `)
     .then(({ id, createdAt, submissionDefId }) => // TODO/HACK: reassembling this from bits and bobs.
       new Submission({

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -24,11 +24,6 @@ const { PURGE_DAY_RANGE } = require('../../util/constants');
 ////////////////////////////////////////////////////////////////////////////////
 // SUBMISSION CREATE
 
-const _defInsert = (id, partial, formDefId, actorId, root, deviceId, userAgent) => sql`insert into submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", "signature", "createdAt", root, current, "deviceId", "userAgent")
-  values (${id}, ${sql.binary(partial.xml)}, ${formDefId}, ${partial.instanceId}, ${partial.def.instanceName}, ${actorId}, ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, clock_timestamp(), ${root}, true, ${deviceId}, ${userAgent})
-  returning *`;
-const nextval = sql`nextval(pg_get_serial_sequence('submissions', 'id'))`;
-
 // creates both the submission and its initial submission def in one go.
 const createNew = (partial, form, deviceIdIn = null, userAgentIn = null) => ({ one, context }) => {
   const actorId = context.auth.actor.map((actor) => actor.id).orNull();
@@ -36,32 +31,52 @@ const createNew = (partial, form, deviceIdIn = null, userAgentIn = null) => ({ o
   const userAgent = applyPipe(userAgentIn, truncateString(255), blankStringToNull);
 
   return one(sql`
-with def as (${_defInsert(nextval, partial, form.def.id, actorId, true, deviceId, userAgent)}),
-ins as (insert into submissions (id, "formId", "instanceId", "submitterId", "deviceId", draft, "createdAt")
-  select def."submissionId", ${form.id}, ${partial.instanceId}, def."submitterId", ${deviceId}, ${form.def.isDraft()}, def."createdAt" from def
-  returning submissions.*)
-select ins.*, def.id as "submissionDefId" from ins, def;`)
-    .then(({ submissionDefId, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
-      new Submission(submissionData, {
+    WITH
+      newSubmission AS (
+        INSERT INTO submissions ("formId", "instanceId", "submitterId", "deviceId", draft, "createdAt")
+          VALUES(${form.id}, ${partial.instanceId}, ${actorId}, ${deviceId}, ${form.def.isDraft()}, clock_timestamp())
+        RETURNING *
+      ),
+      newDef AS (
+        INSERT INTO submission_defs ("submissionId", xml, "formDefId", "instanceId", "instanceName", "submitterId", "localKey", "encDataAttachmentName", signature, "createdAt", root, current, "deviceId", "userAgent")
+          SELECT newSubmission.id AS "submissionId", ${sql.binary(partial.xml)}, ${form.def.id}, "instanceId", ${partial.def.instanceName}, "submitterId", ${partial.def.localKey}, ${partial.def.encDataAttachmentName}, ${partial.def.signature}, "createdAt", true, true, "deviceId", ${userAgent}
+            FROM newSubmission
+        RETURNING id
+      )
+    SELECT newSubmission.id
+         , newSubmission."createdAt"
+         , newDef.id AS "submissionDefId"
+      FROM newSubmission, newDef;
+  `)
+    .then(({ id, createdAt, submissionDefId }) => // TODO/HACK: reassembling this from bits and bobs.
+      new Submission({
+        id,
+        instanceId: partial.instanceId,
+        submitterId: actorId,
+        deviceId,
+        createdAt,
+        updatedAt: null,
+        userAgent,
+      }, {
         def: new Submission.Def({
           id: submissionDefId,
-          submissionId: submissionData.id,
+          submissionId: id,
           formDefId: form.def.id,
-          submitterId: submissionData.submitterId,
+          submitterId: actorId,
           localKey: partial.def.localKey,
           encDataAttachmentName: partial.def.encDataAttachmentName,
           signature: partial.def.signature,
-          createdAt: submissionData.createdAt,
+          createdAt,
           userAgent
         }),
         currentVersion: new Submission.Def({
           instanceId: partial.instanceId,
-          createdAt: submissionData.createdAt,
+          createdAt,
           deviceId,
           userAgent,
           instanceName: partial.def.instanceName,
           current: true,
-          submitterId: submissionData.submitterId
+          submitterId: actorId,
         }),
         xml: new Submission.Xml({ xml: partial.xml })
       }));


### PR DESCRIPTION
* inline `_defInsert()`
* invert INSERT query to replace `nextval()` with standard key generation
* reduce data returned from PostgreSQL which NodeJS already has
* reformat main query

Follow-up to https://github.com/getodk/central-backend/pull/1606

Having read `_defInsert()` enough times to understand it, it seemed helpful to rewrite it.  I assume the reason why the `submission_def` was being inserted _before_ the `submission` was to allow use of `_defInsert()` by both `Submissions.createNew()` and `Submissions.createVersion()`, which is no longer happening.

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

* This PR inverts the insertion order of `submission` and `submission_def` to rely on PostgreSQL to assign the `submission`'s `id`.  This is orthogonal to decreasing the data passed between PostgreSQL and NodeJS.
* This PR could be changed to return query formatting to match the original more closely. To me this makes understanding the query significantly harder.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
