### PR TITLE
odata: fix comment typo (thing -> think)

### DIFF
--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -345,7 +345,7 @@ describe('api: /forms/:id.svc', () => {
           }))));
 
     // HACK: this test sort of relies on some trickery to make the backend
-    // thing the submission is encrypted even though it isn't (see the replace
+    // think the submission is encrypted even though it isn't (see the replace
     // call). there is some chance this methodology is fragile. (mark1)
     it('should gracefully degrade on encrypted subtables', testService((service) =>
       service.login('alice', (asAlice) =>


### PR DESCRIPTION
Noted while considering https://github.com/getodk/central-backend/pull/1608/files#r2327615484.

#### What has been done to verify that this works as intended?

CI

#### Why is this the best possible solution? Were any other approaches considered?

Minimal intervention to correct intent.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
