### PR TITLE
model/query: remove TODOs expecting unjoiner

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -103,7 +103,7 @@ ins as (insert into entities (id, "datasetId", "uuid", "createdAt", "creatorId")
   select def."entityId", ${dataset.id}, ${partial.uuid}, def."createdAt", ${creatorId} from def
   returning entities.*)
 select ins.*, def.id as "entityDefId" from ins, def;`)
-    .then(({ entityDefId, ...entityData }) => // TODO/HACK: starting to need more reassembling
+    .then(({ entityDefId, ...entityData }) =>
       new Entity(entityData, {
         currentVersion: new Entity.Def({
           id: entityDefId,

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -41,7 +41,7 @@ ins as (insert into submissions (id, "formId", "instanceId", "submitterId", "dev
   select def."submissionId", ${form.id}, ${partial.instanceId}, def."submitterId", ${deviceId}, ${form.def.isDraft()}, def."createdAt" from def
   returning submissions.*)
 select ins.*, def.id as "submissionDefId" from ins, def;`)
-    .then(({ submissionDefId, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
+    .then(({ submissionDefId, ...submissionData }) =>
       new Submission(submissionData, {
         def: new Submission.Def({
           id: submissionDefId,
@@ -110,7 +110,7 @@ const createVersion = (partial, deprecated, form, deviceIdIn = null, userAgentIn
         ON "submissionId"=${deprecated.submissionId} AND root IS TRUE
       CROSS JOIN newDef
   `)
-    .then(({ submissionDefId, submissionDefCreatedAt, ...submissionData }) => // TODO/HACK: reassembling this from bits and bobs.
+    .then(({ submissionDefId, submissionDefCreatedAt, ...submissionData }) =>
       new Submission({ id: deprecated.submissionId, ...submissionData }, {
         currentVersion: new Submission.Def({
           id:                    submissionDefId,


### PR DESCRIPTION
Various comments in `lib/model/query/` imply that `unjoiner()` is the one true way to map SQL query results to Javascript objects.

`unjoiner()` is inflexible and does not currently support approaches which significantly reduce database traffic.

This PR removes the TODO/HACK comments.

Noted in review at https://github.com/getodk/central-backend/pull/1608/files#r2327615484

Closes getodk/central#

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
