### PR TITLE
datasets: use idiomatic PostgreSQL ID generation

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -22,8 +22,8 @@ const { sanitizeOdataIdentifier } = require('../../util/util');
 
 const _insertDatasetDef = (dataset, acteeId, actions) => sql`
   WITH ds_ins AS (
-    INSERT INTO datasets (id, name, "projectId", "createdAt", "acteeId")
-    VALUES (nextval(pg_get_serial_sequence('datasets', 'id')), ${dataset.name}, ${dataset.projectId}, clock_timestamp(), ${acteeId})
+    INSERT INTO datasets (name, "projectId", "createdAt", "acteeId")
+    VALUES (${dataset.name}, ${dataset.projectId}, clock_timestamp(), ${acteeId})
     ON CONFLICT ON CONSTRAINT datasets_name_projectid_unique 
     DO NOTHING
     RETURNING *
@@ -46,8 +46,8 @@ const _insertProperties = (fields) => sql`
   ${sql.join(fields.map(p => sql`( ${sql.join([p.aux.propertyName, p.aux.formDefId, p.aux.schemaId, p.path], sql`,`)} )`), sql`,`)}
 ),
 insert_properties AS (
-    INSERT INTO ds_properties (id, name, "datasetId")
-    SELECT nextval(pg_get_serial_sequence('ds_properties', 'id')), fields."propertyName", ds.id FROM fields, ds
+    INSERT INTO ds_properties (name, "datasetId")
+    SELECT fields."propertyName", ds.id FROM fields, ds
     ON CONFLICT  ON CONSTRAINT ds_properties_name_datasetid_unique
     DO NOTHING 
     RETURNING ds_properties.id, ds_properties.name, ds_properties."datasetId"


### PR DESCRIPTION
Noted while working on https://github.com/getodk/central-backend/pull/1606

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Why is the current approach used?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
