### PR TITLE
Semantic hashes as IDs for formschemas, and DB-based form inspection

### DIFF
--- a/lib/model/migrations/20260202-01-formfields-and-formschemas-03.up.sql
+++ b/lib/model/migrations/20260202-01-formfields-and-formschemas-03.up.sql
@@ -1,0 +1,16 @@
+-- Copyright 2025 ODK Central Developers
+-- See the NOTICE file at the top-level directory of this distribution and at
+-- https://github.com/getodk/central-backend/blob/master/NOTICE.
+-- This file is part of ODK Central. It is subject to the license terms in
+-- the LICENSE file found in the top-level directory of this distribution and at
+-- https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+-- including this file, may be copied, modified, propagated, or distributed
+-- except according to the terms contained in the LICENSE file.
+
+BEGIN;
+
+ALTER TABLE form_defs DISABLE TRIGGER check_managed_key;  -- pesky thing may prevent us from updating as there may be invalid state from before this trigger was installed
+UPDATE form_defs SET "schemaId" = NULL;  -- this backfills the form_schemas and formschema_fields tables
+ALTER TABLE form_defs ENABLE TRIGGER check_managed_key;
+
+COMMIT;

--- a/lib/model/migrations/20260302-01-formfields-and-formschemas-01.up.sql
+++ b/lib/model/migrations/20260302-01-formfields-and-formschemas-01.up.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS ltree;  -- Builtin extension. Used for storing the XML ordinality path to a particular field.
+
+-- Recreate form_schemas table (empty)
+ALTER TABLE form_defs
+	DROP CONSTRAINT "form_defs_schemaid_foreign";
+ALTER TABLE form_fields
+	DROP CONSTRAINT "form_fields_schemaid_foreign";
+DROP TABLE form_schemas;
+CREATE TABLE form_schemas (
+    id uuid PRIMARY KEY
+);
+
+
+CREATE TABLE formschema_fields (
+    schemahash uuid NOT NULL REFERENCES form_schemas (id) ON DELETE CASCADE,
+    fieldhash bigint NOT NULL,
+    instanceorder integer NOT NULL,
+    repeatdimensions integer NOT NULL,
+    is_leaf boolean NOT NULL,
+    relpath text NOT NULL CHECK (starts_with (relpath, '/')),
+    datatype text,
+    bodyelement text,
+    ordinalitypath ltree NOT NULL,
+    lelementpath text[] NOT NULL,  -- An array rather than a handy ltree, as not all ODK path components are valid labels (for instance, labels may not contain a dot)
+    elementpath text[] NOT NULL,  -- Also an array for the same reason. This one contains the namespaced element names.
+	bodyordinalitypath ltree,  -- may be NULL, not every instance element is necessarily referenced by a body element
+    PRIMARY KEY (schemahash, fieldhash)
+);
+CREATE INDEX ON formschema_fields (fieldhash);
+CREATE INDEX ON formschema_fields (relpath text_pattern_ops);
+CREATE INDEX ON formschema_fields (repeatdimensions);
+CREATE INDEX ON formschema_fields (datatype);
+
+DROP VIEW form_field_geo;
+DROP VIEW form_field_meta;
+DROP VIEW form_field_repeatmembership;
+
+DROP TABLE form_fields;
+-- Optionally, for debugging purposes:
+-- Rather than dropping form_fields, keep that state aside for debugging any differences:
+-- ALTER TABLE form_fields
+--     RENAME TO form_fields_bak;
+-- And preserve the original formdef -> schema_id mapping
+-- CREATE TABLE fdsi AS SELECT id, "schemaId" FROM form_defs ORDER BY id;
+
+-- Switcheroo. Some legacy triggers get in the way
+ALTER TABLE form_defs
+    DISABLE TRIGGER check_managed_key;
+ALTER TABLE form_defs
+	ALTER COLUMN "schemaId" SET DATA TYPE uuid USING NULL;
+ALTER TABLE form_defs
+    ENABLE TRIGGER check_managed_key;
+ALTER TABLE form_defs
+	ADD CONSTRAINT "form_defs_schemaid_foreign" FOREIGN KEY ("schemaId") REFERENCES form_schemas (id) ON DELETE SET NULL;
+
+COMMIT;

--- a/lib/model/migrations/20260302-01-formfields-and-formschemas-02.up.sql
+++ b/lib/model/migrations/20260302-01-formfields-and-formschemas-02.up.sql
@@ -1,0 +1,488 @@
+--- create: form_fields ---
+CREATE VIEW "public"."form_fields" AS
+    WITH schema_to_form AS (
+        SELECT DISTINCT
+            "formId",
+            "schemaId"
+        FROM
+            form_defs
+    )
+    SELECT
+        sf."formId",  -- TODO investigate: do we absolutely need this
+        ff.relpath AS path,
+        ff.lelementpath[array_length(ff.lelementpath, 1)] AS name,  -- actually the local-name(); with namespaces stripped...
+        CASE
+            WHEN
+                (ff.datatype = 'group')  -- they called a group 'structure' before
+                OR
+                (ff.datatype IS NULL AND NOT ff.is_leaf)  -- if we don't have a group reference (from the /h:html/h:body), yet it's not a leaf (eg `/meta`), then they also called it 'structure'
+                OR
+                (ff.relpath = '/meta/entity')  -- many things (some sans descendants) were deemed to be a "structure"
+            THEN
+                'structure'
+
+            WHEN
+                (ff.relpath = '/meta/instanceID')
+            THEN
+                'string'  -- even if there is no bind
+
+            ELSE
+                coalesce(ff.datatype, 'unknown')
+        END AS type,
+        nullif (ff.datatype = 'binary', FALSE) AS binary,  -- Redundant attribute: something was either a binary, or... NULL
+        (row_number() OVER (PARTITION BY ff.schemahash ORDER BY ff.instanceOrder)) - 1 AS "order",  -- order was 0-based (cf 1-based XML ordinality), and derived from depth-first traversal order
+        nullif (ff.bodyelement = 'select', FALSE) AS "selectMultiple",  -- Redundant attribute: something was either a "selectMultiple", or... NULL
+        ff.schemahash AS "schemaId"  -- we use the hash as an ID
+    FROM
+        formschema_fields ff
+        INNER JOIN schema_to_form sf ON (sf."schemaId" = ff.schemahash)
+;
+
+--- sign: form_fields ---
+COMMENT ON VIEW "public"."form_fields" IS '{"dbsamizdat": {"version": 1, "definition_hash": "f5953e85665cabe17d8819fe48667de1"}}';
+
+--- create: odkform_binds(formxml xml) ---
+CREATE FUNCTION "public"."odkform_binds"(formxml xml)
+    RETURNS table (nodeset text, datatype text)
+    AS
+        $BODY$
+            SELECT xmltable.*
+            FROM
+            XMLTABLE(
+                XMLNAMESPACES( 'http://www.w3.org/2002/xforms' AS "x" , 'http://www.w3.org/1999/xhtml' AS "h" , 'http://www.w3.org/2001/xml-events' AS "ev" , 'http://www.w3.org/2001/XMLSchema' AS "xsd" , 'http://openrosa.org/javarosa' AS "jr" , 'http://openrosa.org/xforms' AS "orx" , 'http://www.opendatakit.org/xforms' AS "odk" , 'http://www.opendatakit.org/xforms/entities' AS "entities" ),
+                '/h:html/h:head/x:model/x:bind'
+                PASSING formxml
+                COLUMNS
+                    nodeset text PATH '@nodeset',
+                    datatype text PATH '@type'
+            )
+        $BODY$
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+;
+
+--- sign: odkform_binds(formxml xml) ---
+COMMENT ON FUNCTION "public"."odkform_binds"(formxml xml) IS '{"dbsamizdat": {"version": 1, "definition_hash": "a699fc8b251d895850509db001681aec"}}';
+
+--- create: odkform_body(formxml xml) ---
+CREATE FUNCTION "public"."odkform_body"(formxml xml)
+    RETURNS table (
+        depth integer,
+        ordinalitystack integer[],
+        elementstack text[],
+        elname text,
+        is_leaf boolean,
+        ref text
+    )
+    AS
+        $BODY$
+            WITH RECURSIVE traversal (passno, ordinalitystack, elementstack, elname, ref, is_leaf, xml_current) AS (
+                SELECT
+                    0 AS passno,
+                    ARRAY[1],
+                    ARRAY[initialpass.elname] AS elementstack,
+                    initialpass.elname,
+                    initialpass.ref,
+                    FALSE AS is_leaf,
+                    initialpass.xmlnode AS xml_current
+                FROM xmltable(
+                        XMLNAMESPACES( 'http://www.w3.org/2002/xforms' AS "x" , 'http://www.w3.org/1999/xhtml' AS "h" , 'http://www.w3.org/2001/xml-events' AS "ev" , 'http://www.w3.org/2001/XMLSchema' AS "xsd" , 'http://openrosa.org/javarosa' AS "jr" , 'http://openrosa.org/xforms' AS "orx" , 'http://www.opendatakit.org/xforms' AS "odk" , 'http://www.opendatakit.org/xforms/entities' AS "entities" ),
+                        '/h:html/h:body'
+                        PASSING formxml
+                        COLUMNS
+                            elname text PATH 'name(.)',
+                            ref text PATH '@ref',
+                            xmlnode xml PATH '.'
+                    ) as initialpass
+                UNION ALL SELECT
+                    traversal.passno + 1,
+                    traversal.ordinalitystack || ARRAY[nextpass.ordinality],
+                    traversal.elementstack || nextpass.elname,
+                    nextpass.elname,
+                    nextpass.ref,
+                    NOT xmlexists('/*/*' PASSING BY REF nextpass.xmlnode),
+                    nextpass.xmlnode
+                FROM
+                    traversal,
+                    xmltable(
+                        XMLNAMESPACES( 'http://www.w3.org/2002/xforms' AS "x" , 'http://www.w3.org/1999/xhtml' AS "h" , 'http://www.w3.org/2001/xml-events' AS "ev" , 'http://www.w3.org/2001/XMLSchema' AS "xsd" , 'http://openrosa.org/javarosa' AS "jr" , 'http://openrosa.org/xforms' AS "orx" , 'http://www.opendatakit.org/xforms' AS "odk" , 'http://www.opendatakit.org/xforms/entities' AS "entities" ),
+                        '/*/*'
+                        PASSING traversal.xml_current
+                        COLUMNS
+                            ordinality FOR ORDINALITY,
+                            elname text path 'name(.)',
+                            ref text PATH '@ref',
+                            xmlnode xml PATH '.'
+                    ) as nextpass
+                WHERE traversal.is_leaf = False
+            )
+            SELECT
+                passno,
+                ordinalitystack,
+                elementstack,
+                elname,
+                is_leaf,
+                ref
+            FROM traversal
+            WHERE ref IS NOT NULL
+            ORDER BY ordinalitystack
+        $BODY$
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+;
+
+--- sign: odkform_body(formxml xml) ---
+COMMENT ON FUNCTION "public"."odkform_body"(formxml xml) IS '{"dbsamizdat": {"version": 1, "definition_hash": "ecb42034a68f47f700f42a9de75ef958"}}';
+
+--- create: odkform_primary_instance(formxml xml) ---
+CREATE FUNCTION "public"."odkform_primary_instance"(formxml xml)
+    RETURNS table (
+        depth integer,
+        ordinalitystack integer[],
+        lelementstack text[],
+        elementstack text[],
+        is_leaf boolean
+    )
+    AS
+        $BODY$
+            WITH RECURSIVE traversal (passno, ordinalitystack, lelementstack, elementstack, lelname, elname, is_leaf, xml_current) AS (
+                SELECT
+                    0 AS passno,
+                    ARRAY[1],
+                    ARRAY[initialpass.lelname] AS lelementstack,
+                    ARRAY[initialpass.elname] AS elementstack,
+                    initialpass.lelname,
+                    initialpass.elname,
+                    FALSE AS is_leaf,
+                    initialpass.xmlnode AS xml_current
+                FROM xmltable(
+                        XMLNAMESPACES( 'http://www.w3.org/2002/xforms' AS "x" , 'http://www.w3.org/1999/xhtml' AS "h" , 'http://www.w3.org/2001/xml-events' AS "ev" , 'http://www.w3.org/2001/XMLSchema' AS "xsd" , 'http://openrosa.org/javarosa' AS "jr" , 'http://openrosa.org/xforms' AS "orx" , 'http://www.opendatakit.org/xforms' AS "odk" , 'http://www.opendatakit.org/xforms/entities' AS "entities" ),
+                        '/h:html/h:head/x:model/x:instance[1 and not(@id)]/*[1]'
+                        PASSING formxml
+                        COLUMNS
+                            lelname text PATH 'local-name(.)',
+                            elname text PATH 'name(.)',
+                            xmlnode xml PATH '.'
+                    ) as initialpass
+                UNION ALL SELECT
+                    traversal.passno + 1,
+                    traversal.ordinalitystack || ARRAY[nextpass.ordinality],
+                    traversal.lelementstack || nextpass.lelname,
+                    traversal.elementstack || nextpass.elname,
+                    nextpass.lelname,
+                    nextpass.elname,
+                    NOT xmlexists('/*/*' PASSING BY REF nextpass.xmlnode),
+                    nextpass.xmlnode
+                FROM
+                    traversal,
+                    xmltable(
+                        XMLNAMESPACES( 'http://www.w3.org/2002/xforms' AS "x" , 'http://www.w3.org/1999/xhtml' AS "h" , 'http://www.w3.org/2001/xml-events' AS "ev" , 'http://www.w3.org/2001/XMLSchema' AS "xsd" , 'http://openrosa.org/javarosa' AS "jr" , 'http://openrosa.org/xforms' AS "orx" , 'http://www.opendatakit.org/xforms' AS "odk" , 'http://www.opendatakit.org/xforms/entities' AS "entities" ),
+                        '/*/*'
+                        PASSING traversal.xml_current
+                        COLUMNS
+                            ordinality FOR ORDINALITY,
+                            lelname text path 'local-name(.)',
+                            elname text path 'name(.)',
+                            xmlnode xml PATH '.'
+                    ) as nextpass
+                WHERE traversal.is_leaf = False
+            )
+            SELECT
+                passno,
+                ordinalitystack,
+                lelementstack,
+                elementstack,
+                is_leaf
+            FROM traversal
+            ORDER BY ordinalitystack
+        $BODY$
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+;
+
+--- sign: odkform_primary_instance(formxml xml) ---
+COMMENT ON FUNCTION "public"."odkform_primary_instance"(formxml xml) IS '{"dbsamizdat": {"version": 1, "definition_hash": "9645d7aaba6918d5499255a92f515764"}}';
+
+--- create: odkform_xpath(path text, formxml xml) ---
+        CREATE FUNCTION "public"."odkform_xpath"(path text, formxml xml)
+            RETURNS xml[]
+            AS
+                $BODY$
+                    SELECT xpath(
+                        path,
+                        formxml,
+                        ARRAY[
+                            ARRAY['x', 'http://www.w3.org/2002/xforms'],
+ARRAY['h', 'http://www.w3.org/1999/xhtml'],
+ARRAY['ev', 'http://www.w3.org/2001/xml-events'],
+ARRAY['xsd', 'http://www.w3.org/2001/XMLSchema'],
+ARRAY['jr', 'http://openrosa.org/javarosa'],
+ARRAY['orx', 'http://openrosa.org/xforms'],
+ARRAY['odk', 'http://www.opendatakit.org/xforms'],
+ARRAY['entities', 'http://www.opendatakit.org/xforms/entities']
+                        ]
+                    )
+                $BODY$
+            LANGUAGE sql
+            IMMUTABLE
+            STRICT
+            PARALLEL SAFE
+        ;
+
+--- sign: odkform_xpath(path text, formxml xml) ---
+COMMENT ON FUNCTION "public"."odkform_xpath"(path text, formxml xml) IS '{"dbsamizdat": {"version": 1, "definition_hash": "40eecd33f00ca0dae89b33cc13b34700"}}';
+
+--- create: odkform_fields(formxml xml) ---
+CREATE FUNCTION "public"."odkform_fields"(formxml xml)
+    RETURNS table (
+        schemahash uuid,
+        fieldhash bigint,
+        instanceorder integer,
+        repeatdimensions integer,
+        is_leaf boolean,
+        relpath text,
+        datatype text,
+        bodyelement text,
+        ordinalitypath ltree,
+        lelementpath text[],
+        elementpath text[],
+        bodyordinalitypath ltree
+    )
+    AS
+        $BODY$
+            WITH
+                binds AS MATERIALIZED (
+                    SELECT
+                        (odkform_binds(
+                            formxml
+                        )).*
+                ),
+                repeats AS MATERIALIZED (
+                    SELECT
+                        odkform_xpath(
+                            '/h:html/h:body//x:repeat/@nodeset',
+                            formxml
+                        )::text[] AS extracted_repeats
+                ),
+                instance_pathed AS MATERIALIZED (
+                    WITH pi AS (
+                        SELECT (odkform_primary_instance(formxml)).*
+                    )
+                    SELECT
+                        '/' || array_to_string(lelementstack, '/') as lfullpath,
+                        '/' || array_to_string(elementstack, '/') as fullpath,
+                        depth,
+                        ordinalitystack,
+                        lelementstack,
+                        elementstack,
+                        is_leaf
+                    FROM
+                        pi
+                ),
+                bodyrefs AS MATERIALIZED (
+                    SELECT
+                        (odkform_body(
+                            formxml
+                        )).*
+                ),
+                instance_reffed AS MATERIALIZED (
+                    SELECT
+                        bodyrefs.elname as reffingelement,
+                        bodyrefs.ordinalitystack as bodyordinalitystack,
+                        binds.datatype,
+                        ip.*
+                    FROM
+                        instance_pathed ip
+                        LEFT OUTER JOIN binds ON (
+                            ip.fullpath = binds.nodeset
+                        )
+                        LEFT OUTER JOIN bodyrefs ON (
+                            ip.fullpath = bodyrefs.ref
+                        )
+                    WHERE ip.depth > 0
+                ),
+                instance_typed AS MATERIALIZED (
+                    SELECT
+                        CASE
+                            WHEN (reffed.fullpath = ANY (repeats.extracted_repeats)) THEN 'repeat'
+                            WHEN (reffed.reffingelement = 'group') THEN 'group'
+                            WHEN (reffed.is_leaf) THEN reffed.datatype
+                        END as datatype,
+                        reffed.reffingelement,
+                        reffed.lfullpath,
+                        reffed.fullpath,
+                        reffed.depth,
+                        reffed.ordinalitystack,
+                        reffed.lelementstack,
+                        reffed.elementstack,
+                        reffed.bodyordinalitystack,
+                        reffed.is_leaf
+                    FROM
+                        instance_reffed reffed,
+                        repeats
+                ),
+                repeat_prefixes AS MATERIALIZED (
+                    SELECT unnest(extracted_repeats) || '/' as repeatgroup
+                    FROM repeats
+                ),
+                instance_repeatadorned AS MATERIALIZED (
+                    SELECT
+                        (select count(*) from repeat_prefixes where starts_with(it.fullpath, repeatgroup))::integer as repeatdimensions,
+                        it.is_leaf,
+                        '/' || array_to_string(it.lelementstack[2:], '/') as relpath,
+                        it.datatype,
+                        it.reffingelement,
+                        it.ordinalitystack,
+                        it.lelementstack,
+                        it.elementstack,
+                        it.bodyordinalitystack
+                    FROM
+                        instance_typed it,
+                        repeats
+                ),
+                fieldhashed_and_numbered AS MATERIALIZED (
+                    SELECT
+                        hash_text_to_bigint(
+                            relpath,
+                            datatype,
+                            (repeatdimensions > 0)::text,
+                            CASE reffingelement
+                                WHEN 'select' THEN reffingelement
+                                WHEN 'select1' THEN reffingelement
+                            END  -- fieldhash should change when flipflopping between these two, so that we get a new formschema
+                        ) as fieldhash,
+                        row_number() OVER (ORDER BY ordinalitystack, bodyordinalitystack)::integer as instanceorder,
+                        repeatdimensions,
+                        is_leaf,
+                        relpath,
+                        datatype,
+                        reffingelement,
+                        text2ltree(array_to_string(ordinalitystack, '.')) as ordinalitystack,
+                        lelementstack,
+                        elementstack,
+                        text2ltree(array_to_string(bodyordinalitystack, '.')) as bodyordinalitystack
+                    FROM
+                        instance_repeatadorned ra
+                ),
+                schemahashed AS MATERIALIZED (
+                    SELECT
+                        (hash_text(VARIADIC (array_agg(fieldhash ORDER BY instanceorder))::text[]))::uuid as schemahash
+                    FROM
+                        fieldhashed_and_numbered
+                )
+                SELECT
+                    *
+                FROM
+                    schemahashed,
+                    fieldhashed_and_numbered
+        $BODY$
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+;
+
+--- sign: odkform_fields(formxml xml) ---
+COMMENT ON FUNCTION "public"."odkform_fields"(formxml xml) IS '{"dbsamizdat": {"version": 1, "definition_hash": "7293fe1615faa483b68db3fe027eab0f"}}';
+
+--- create: safe_to_odkform(input text) ---
+CREATE FUNCTION "public"."safe_to_odkform"(input text)
+    RETURNS xml AS
+        $BODY$
+        DECLARE hopefully_xml xml DEFAULT NULL;
+        DECLARE root_el_name text DEFAULT NULL;
+        BEGIN
+            BEGIN
+                hopefully_xml := input::xml;  -- pass 1: is it well-formed
+                SELECT INTO root_el_name odkform_xpath('name(.)', hopefully_xml);  -- pass 2: are all namespaces declared
+            EXCEPTION WHEN OTHERS THEN
+                RETURN NULL;
+            END;
+        RETURN hopefully_xml;
+        END;
+        $BODY$
+    LANGUAGE plpgsql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+;
+
+--- sign: safe_to_odkform(input text) ---
+COMMENT ON FUNCTION "public"."safe_to_odkform"(input text) IS '{"dbsamizdat": {"version": 1, "definition_hash": "feb4cda6030e3374f28fc5ae010ad43e"}}';
+
+--- create: odk_formdef_schemahandler_triggerfn ---
+    CREATE FUNCTION "public"."odk_formdef_schemahandler_triggerfn"()
+    RETURNS trigger
+    AS
+        $BODY$
+            DECLARE
+                calculated_schemahash uuid;
+            BEGIN
+                WITH
+                    extracted_form_fields AS (
+                        SELECT
+                            (odkform_fields(safe_to_odkform(NEW.xml))).*
+                    ),
+                    schemahash AS (
+                        SELECT
+                            DISTINCT schemahash as hash
+                        FROM
+                            extracted_form_fields
+                    ),
+                    schemahash_created AS (
+                        INSERT INTO form_schemas
+                            SELECT
+                                hash
+                            FROM
+                                schemahash
+                            ON CONFLICT (id)
+                                DO NOTHING
+                    ),
+                    formschema_fields_created AS (
+                        INSERT INTO formschema_fields
+                            SELECT
+                                schemahash,
+                                fieldhash,
+                                instanceorder,
+                                repeatdimensions,
+                                is_leaf,
+                                relpath,
+                                datatype,
+                                bodyelement,
+                                ordinalitypath,
+                                lelementpath,
+                                elementpath,
+                                bodyordinalitypath
+                            FROM
+                                extracted_form_fields
+                            ON CONFLICT
+                                DO NOTHING
+                    )
+                SELECT INTO calculated_schemahash hash from schemahash;
+                NEW."schemaId" := calculated_schemahash;
+                RETURN NEW;
+            END;
+        $BODY$
+    LANGUAGE plpgsql
+    VOLATILE
+    STRICT
+    PARALLEL UNSAFE
+;
+
+--- sign: odk_formdef_schemahandler_triggerfn ---
+COMMENT ON FUNCTION "public"."odk_formdef_schemahandler_triggerfn"() IS '{"dbsamizdat": {"version": 1, "definition_hash": "339a055195aa077c9be3067ecd54fc99"}}';
+
+--- create: public.form_defs.formdef_create_formfields_trigger ---
+CREATE TRIGGER "formdef_create_formfields_trigger" BEFORE INSERT OR UPDATE ON "public"."form_defs"
+FOR ROW
+EXECUTE PROCEDURE odk_formdef_schemahandler_triggerfn()
+;
+
+--- sign: public.form_defs.formdef_create_formfields_trigger ---
+COMMENT ON TRIGGER "formdef_create_formfields_trigger" ON "public"."form_defs" IS '{"dbsamizdat": {"version": 1, "definition_hash": "d4a1307a6d49d58bc12ee394e48e9488"}}';

--- a/lib/model/migrations/20260302-01-formfields-and-formschemas-04.up.sql
+++ b/lib/model/migrations/20260302-01-formfields-and-formschemas-04.up.sql
@@ -1,0 +1,93 @@
+--- create: form_field_repeatmembership ---
+CREATE VIEW "public"."form_field_repeatmembership" AS
+WITH repeatmembership AS (
+    SELECT
+        ff1."schemaId",
+        ff1.path AS fieldpath,
+        ff2.path AS repeatpath
+    FROM
+        form_fields ff1
+        LEFT OUTER JOIN form_fields ff2 ON (
+            ff1."schemaId" = ff2."schemaId"
+            AND
+            starts_with (ff1.path, ff2.path || '/') -- add the '/' to anchor on element name boundary, otherwise both repeatgroups named "/repeatgrou" and "/repeatgroup" would prefix-match a "/repeatgroup/somefield" field.
+            AND
+            ff2.type = 'repeat'
+        )
+)
+SELECT
+    "schemaId",
+    fieldpath as path,
+    array_remove(array_agg(repeatpath ORDER BY length(repeatpath)), NULL) AS repeatgroups
+FROM
+    repeatmembership
+GROUP BY (
+    "schemaId",
+    fieldpath
+)
+;
+
+--- sign: form_field_repeatmembership ---
+COMMENT ON VIEW "public"."form_field_repeatmembership" IS '{"dbsamizdat": {"version": 1, "definition_hash": "ec5eddaa15a263de704fd258891c4c1b"}}';
+
+--- create: form_field_meta ---
+CREATE VIEW "public"."form_field_meta" AS
+SELECT
+    ff."formId" as form_id,
+    ff."schemaId" AS formschema_id,
+    hash_text_to_bigint(ff.type, ff.path, (cardinality(ffr.repeatgroups) > 0)::text) AS fieldhash,
+    ff.order AS occurrence_order,
+    cardinality(ffr.repeatgroups) AS repeatgroup_cardinality,
+    ff.type,
+    ff.path
+FROM
+    form_fields ff
+    INNER JOIN "public"."form_field_repeatmembership" ffr ON (
+        (ff."schemaId", ff.path) = (ffr."schemaId", ffr.path)
+    )
+;
+
+--- sign: form_field_meta ---
+COMMENT ON VIEW "public"."form_field_meta" IS '{"dbsamizdat": {"version": 1, "definition_hash": "cd0367f94f1a74b8e537a90a1cd10383"}}';
+
+--- create: form_field_geo ---
+CREATE VIEW "public"."form_field_geo" AS
+-- Augments `form_field_meta`: adds a predicate to appoint it as the `default`
+-- field for a given schema.
+--
+-- Currently, by policy, the first geofield that is not in any repeatgroup will
+-- be `default` one.
+-- See https://github.com/getodk/central/issues/1165
+
+WITH first_non_repeat_geo_annotated AS (
+    SELECT
+        (
+            (
+                rank() OVER (
+                    PARTITION BY
+                        formschema_id,
+                        repeatgroup_cardinality = 0
+                    ORDER BY occurrence_order
+                    )
+                ) = 1
+                AND
+                repeatgroup_cardinality = 0
+            ) AS is_first_non_repeat_geofeature,
+        *
+    FROM
+        form_field_meta
+        WHERE type IN ('geopoint', 'geotrace', 'geoshape')
+)
+SELECT
+    formschema_id,
+    is_first_non_repeat_geofeature as is_default,
+    fieldhash,
+    repeatgroup_cardinality,
+    type,
+    path
+FROM
+    first_non_repeat_geo_annotated
+;
+
+--- sign: form_field_geo ---
+COMMENT ON VIEW "public"."form_field_geo" IS '{"dbsamizdat": {"version": 1, "definition_hash": "d41db151c588548301cc0edd0952b433"}}';

--- a/lib/model/migrations/20260302-01-formfields-and-formschemas.js
+++ b/lib/model/migrations/20260302-01-formfields-and-formschemas.js
@@ -1,0 +1,1 @@
+module.exports = require('../pure-sql-migration')(__filename);

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -525,6 +525,7 @@ const getProperties = (datasetId, includeForms = false) => ({ all }) => all(sql`
   LEFT OUTER JOIN form_fields ON
       ds_property_fields.path = form_fields.path
       AND form_fields."schemaId" = fd."schemaId"
+      AND form_fields."formId" = fd."formId"
   ${includeForms ? sql`
   LEFT OUTER JOIN forms ON
       ds_property_fields."formDefId" = forms."currentDefId"
@@ -547,8 +548,11 @@ SELECT
   form_fields.*, ds_properties."name" as "propertyName", ds_properties."datasetId"
 FROM
   form_fields
-JOIN form_schemas fs ON fs.id = form_fields."schemaId"
-JOIN form_defs ON fs.id = form_defs."schemaId"
+JOIN form_defs ON (
+  form_fields."schemaId" = form_defs."schemaId"
+  AND
+  form_fields."formId" = form_defs."formId"
+)
 JOIN ds_property_fields ON
   ds_property_fields."formDefId" = form_defs."id"
     AND ds_property_fields."path" = form_fields."path"
@@ -607,8 +611,13 @@ const _getFormSpecificProperties = (projectId, xmlFormId, forDraft) => sql`
     JOIN ds ON ds.id = dp."datasetId"
     LEFT JOIN ds_property_fields dpf ON dpf."dsPropertyId" = dp.id
     JOIN form f ON dpf."formDefId" = f."formDefId"
-    JOIN form_fields ff ON f."schemaId" = ff."schemaId"
-      AND dpf."path" = ff."path"
+    JOIN form_fields ff ON (
+      f."schemaId" = ff."schemaId"
+      AND
+      dpf."path" = ff."path"
+      AND
+      ff."formId" = f.id
+    )
   )
   SELECT ds.name "datasetName", ds.id "datasetId", ds."isNew" "isDatasetNew", p.name "propertyName", p."isNew" "isPropertyNew"
   FROM ds

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -730,28 +730,25 @@ const getAllByAuth = (auth, options = QueryOptions.none) => ({ all }) =>
 ////////////////////////////////////////////////////////////////////////////////
 // SCHEMA
 
-const getFields = (formDefId) => ({ all }) =>
-  all(sql`SELECT form_fields.* FROM form_fields
-  JOIN form_schemas ON form_schemas."id" = form_fields."schemaId"
-  JOIN form_defs ON form_schemas."id" = form_defs."schemaId"
-  WHERE form_defs."id"=${formDefId} ORDER BY form_fields."order" ASC`)
+const getFields = (formDefId, filter) => ({ all }) => {
+  const extraFilter = filter || sql``;
+  return all(sql`
+    SELECT form_fields.* FROM form_fields
+    INNER JOIN form_defs ON (
+      form_defs."schemaId" = form_fields."schemaId"
+      AND
+      form_defs."formId" = form_fields."formId"
+    )
+    WHERE
+      form_defs."id"=${formDefId}
+      ${extraFilter}
+    ORDER BY form_fields."order" ASC
+  `)
     .then(map(construct(Form.Field)));
+};
 
-const getBinaryFields = (formDefId) => ({ all }) =>
-  all(sql`SELECT form_fields.* FROM form_fields
-  JOIN form_schemas ON form_schemas."id" = form_fields."schemaId"
-  JOIN form_defs ON form_schemas."id" = form_defs."schemaId"
-  WHERE form_defs."id"=${formDefId} AND form_fields."binary"=true
-  ORDER BY form_fields."order" ASC`)
-    .then(map(construct(Form.Field)));
-
-const getStructuralFields = (formDefId) => ({ all }) =>
-  all(sql`select form_fields.* from form_fields
-  join form_schemas ON form_schemas."id" = form_fields."schemaId"
-  join form_defs ON form_schemas."id" = form_defs."schemaId"
-  WHERE form_defs."id"=${formDefId} AND (form_fields.type='repeat' OR form_fields.type='structure')
-  ORDER BY form_fields."order" ASC`)
-    .then(map(construct(Form.Field)));
+const getBinaryFields = (formDefId) => getFields(formDefId, sql`AND form_fields."binary"`);
+const getStructuralFields = (formDefId) => getFields(formDefId, sql`AND (form_fields.type='repeat' OR form_fields.type='structure')`);
 
 // TODO: this could be split up into eg getFieldsForAllVersions and a lot of the
 // merging work could happen elsewhere. but where isn't all that obvious so it's

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -14,7 +14,7 @@ const { Actor, Blob, Form } = require('../frames');
 const { getFormFields, merge, compare } = require('../../data/schema');
 const { getDatasets, matchFieldsWithDatasets } = require('../../data/dataset');
 const { generateToken } = require('../../util/crypto');
-const { unjoiner, extender, updater, sqlEquals, insert, insertMany, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
+const { unjoiner, extender, updater, sqlEquals, insert, markDeleted, markUndeleted, QueryOptions } = require('../../util/db');
 const { resolve, reject, timebound } = require('../../util/promise');
 const { splitStream } = require('../../util/stream');
 const { construct } = require('../../util/util');
@@ -92,27 +92,14 @@ const _parseFormXml = (partial) => Promise.all([
   (partial.aux.key.isDefined() ? resolve(Option.none()) : getDatasets(partial.xml)) // Don't parse dataset schema if Form has encryption key
 ]);
 
-const _insertFormFields = (fields, formId, schemaId) => async ({ run }) => {
-  // Combine form fields as parsed from the form XML with the top level formId
-  // and the schemaId (rather than formDefId)
-  const ids = { formId, schemaId };
-  const fieldsForInsert = fields.map((field) => new Form.Field(Object.assign({}, { ...field, ...ids })));
-  await run(insertMany(fieldsForInsert));
-};
-
 ////////////////////////////////////////////////////////////////////////////////
 // CREATING NEW FORMS
 
 const _createNew = (form, def, project) => ({ oneFirst, Forms }) =>
   oneFirst(sql`
-with sch as
-  (insert into form_schemas (id)
-    values (default)
-    returning *),
-def as
-  (insert into form_defs ("formId", "schemaId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "enketoId", "createdAt")
-  select nextval(pg_get_serial_sequence('forms', 'id')), sch.id, ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${def.draftToken || null}, ${def.enketoId || null}, clock_timestamp()
-    from sch
+with def as
+  (insert into form_defs ("formId", xml, name, hash, sha, sha256, version, "keyId", "xlsBlobId", "draftToken", "enketoId", "createdAt")
+  select nextval(pg_get_serial_sequence('forms', 'id')), ${form.xml}, ${def.name}, ${def.hash}, ${def.sha}, ${def.sha256}, ${def.version}, ${def.keyId}, ${form.xls.xlsBlobId || null}, ${def.draftToken || null}, ${def.enketoId || null}, clock_timestamp()
   returning *),
 form as
   (insert into forms (id, "xmlFormId", state, "projectId", "draftDefId", "acteeId", "enketoId", "enketoOnceId", "createdAt", "webformsEnabled")
@@ -155,8 +142,7 @@ const createNew = (partial, project) => async ({ Actees, Datasets, FormAttachmen
     project
   );
 
-  // Insert form fields and attachments for new form def
-  await Forms._insertFormFields(fields, savedForm.id, savedForm.def.schemaId);
+  // Insert attachments for new form def
   await FormAttachments.createNew(partial.xml, savedForm, partial.xls.itemsets);
 
   // Update datasets and properties, if defined
@@ -223,23 +209,12 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   // Parse form fields and dataset/entity definition from form XML
   const [fields, parsedDatasets] = await _parseFormXml(partial);
 
-  // Compute the intermediate schema ID
-  let schemaId;
-  let match;
-
-  // If there is no current published def, only a draft, we definitely need a new schema
-  // and we don't need to compare against old schemas/check for structural changes
-  if (!form.currentDefId) {
-    schemaId = await Forms._newSchema();
-    match = false;
-  } else {
+  // If there is a current published def we need to compare against the previous
+  // schema and check if the changes (if any) are compatible with this schema.
+  if (form.currentDefId) {
     // Fetch fields of previous version to compare new schema against
     const prevFields = await Forms.getFields(form.currentDefId);
-    match = compare(prevFields, fields);
-
-    if (match)
-      schemaId = prevFields[0].schemaId;
-    else {
+    if (!compare(prevFields, fields)) {
       // Only need to check new fields against old fields if the structure does not match
       const allFields = await Forms.getMergedFields(form.id);
       await Forms.checkFieldDowncast(allFields, fields);
@@ -249,8 +224,6 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
       if (!duplicating) {
         await Forms.checkStructuralChange(prevFields, fields);
       }
-      // If we haven't been rejected or warned yet, make a new schema id
-      schemaId = await Forms._newSchema();
     }
   }
 
@@ -271,11 +244,7 @@ const createVersion = (partial, form, publish, duplicating = false) => async ({ 
   // will just copy over whatever enketo ids do or don't exist already.
 
   // Save draft def
-  const savedDef = await Forms._createNewDef(partial, form, publish, { draftToken, enketoId, schemaId, keyId });
-
-  // Prepare the form fields
-  if (!match)
-    await Forms._insertFormFields(fields, form.id, schemaId);
+  const savedDef = await Forms._createNewDef(partial, form, publish, { draftToken, enketoId, keyId });
 
   // Insert attachments
   await FormAttachments.createVersion(partial.xml, form, savedDef, partial.xls.itemsets, publish);
@@ -877,13 +846,8 @@ const checkFieldDowncast = (allFields, fields) => () => {
   return resolve();
 };
 
-const _newSchema = () => ({ one }) =>
-  one(sql`insert into form_schemas (id) values (default) returning *`)
-    .then((s) => s.id);
-
 module.exports = {
   fromXls, pushDraftToEnketo, pushFormToEnketo,
-  _insertFormFields,
   _createNew, createNew, _createNewDef, createVersion,
   publish, clearDraft,
   _update, update, _updateDef, replaceDef, del, restore, purge,
@@ -895,7 +859,5 @@ module.exports = {
   getAllByAuth,
   getFields, getBinaryFields, getStructuralFields, getMergedFields,
   rejectIfWarnings, checkMeta, checkDeletedForms, checkStructuralChange, checkFieldDowncast, checkDatasetWarnings,
-  _newSchema,
   lockDefs, getAllSubmitters
 };
-

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1439,12 +1439,18 @@ describe('datasets and entities', () => {
 
             sourceForms.should.be.eql([
               { name: 'simpleEntity', xmlFormId: 'simpleEntity' },
-              { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }]);
+              { name: 'simpleEntity2', xmlFormId: 'simpleEntity2' }
+            ]);
 
-            properties.map(({ publishedAt, ...p }) => {
+            const props = properties.map(({ publishedAt, ...p }) => {
               publishedAt.should.be.isoDate();
               return p;
-            }).should.be.eql([
+            });
+            props.forEach(el => {
+              // Sort, since the order in which this comes back is undefined
+              el.forms.sort((a, b) => (a.name > b.name ? 1 : a.name < b.name ? -1 : 0));
+            });
+            props.should.be.eql([
               {
                 name: 'first_name', odataName: 'first_name', forms: [
                   { name: 'simpleEntity', xmlFormId: 'simpleEntity' },

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -834,7 +834,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 .set('Content-Type', 'application/xml')
                 .expect(200)
                 .then(() => asAlice.post('/v1/projects/1/forms/simple2/draft')
-                  .send(testData.forms.simple2.replace('id="simple2"', 'id="simple2" version="drafty2"').replace(/age/g, 'number'))
+                  .send(testData.forms.simple2.replace('id="simple2 version=2.1"', 'id="simple2" version="drafty2"').replace(/age/g, 'number'))
                   .set('Content-Type', 'application/xml')
                   .expect(200))
                 .then(() => Promise.all([

--- a/test/integration/api/geodata.js
+++ b/test/integration/api/geodata.js
@@ -421,7 +421,7 @@ describe('api: submission-geodata', () => {
   it('form upload creates geofield-descriptors', testService(async (service, { db }) => {
     await setupGeoSubmissions(service, db);
 
-    const formSchemaId = await db.oneFirst(sql`select currval('form_schemas_id_seq'::regclass)`);
+    const lastFormSchemaId = await db.oneFirst(sql`select "schemaId" from form_defs order by id desc limit 1`);
     // This depends on the policy. If we enable more/other fields than just the first non-repeatgroup field,
     // then this test will need to be adapted.
 
@@ -430,7 +430,7 @@ describe('api: submission-geodata', () => {
       from form_field_geo
       order by formschema_id, fieldhash
     `);
-    geoFieldDescriptors.should.deepEqual(expectedGeoFieldDescriptors(formSchemaId));
+    geoFieldDescriptors.should.deepEqual(expectedGeoFieldDescriptors(lastFormSchemaId));
   }));
 
 

--- a/test/integration/other/select-many.js
+++ b/test/integration/other/select-many.js
@@ -117,7 +117,7 @@ describe('select many value processing', () => {
       .set('Content-Type', 'application/xml')
       .expect(200);
 
-    // <q1>b</q1><g1><q2>x</q2>
+    // <q1>b</q1><g1><q2>x</q2></g1>
     await asAlice.post('/v1/projects/1/forms/selectMultiple/submissions')
       .send(testData.instances.selectMultiple.two.replace('m x', 'x')) // just send one value for each field
       .set('Content-Type', 'application/xml')
@@ -132,7 +132,7 @@ describe('select many value processing', () => {
     await asAlice.post('/v1/projects/1/forms/selectMultiple/draft/publish?version=2')
       .expect(200);
 
-    //<q1>a b</q1><g1><q2>x y z</q2>
+    //<q1>a b</q1><g1><q2>x y z</q2></g1>
     await asAlice.post('/v1/projects/1/forms/selectMultiple/submissions')
       .send(testData.instances.selectMultiple.one.replace('id="selectMultiple"', 'id="selectMultiple" version="2"'))
       .set('Content-Type', 'text/xml')


### PR DESCRIPTION
Towards getodk/central#1670

Demonstrates an alternative approach to form XML parsing — in-DB, using boring XML tech (xpath, and the `xmltable` Postgres function).
It does not replace the in-Node parsing here in this PR. But we could. It's meant to prove the concept and show feature parity; we can later switch to 100% in-DB for the form ingestion path, if we want. 

When it comes to extracting field information, the new in-DB parsing has feature parity with the still-there in-Node [imperative parsing](https://github.com/getodk/central-backend/blob/v2025.4.2/lib/data/schema.js), evidenced by a) the tests and b) the fact that compatibility comparisons upon upload of a new form version get done by comparing the in-Node field information with the in-DB field information. This is done through the `form_fields` shim: previously a table, with the information therein originating from the in-node parser (at form upload time), now a view on `formschema_fields` which contains the information yielded by the in-DB parser, which also runs upon formdef insertion via a trigger (`odk_formdef_schemahandler_triggerfn`), but you can run it on any XML; it's just a function — for instance, to run on existing forms (I should make a migration that does this):
```sql
with bla as (select (odkform_fields(safe_to_odkform(xml))).* from form_defs) select * from bla
```
But one can also just feed in XML from the application via an XML (or string) literal in the query, which is how one could do form introspection in the application layer without running that `htmlparser2` machinery:
```sql
select odkform_fields('somexml'::xml)
```

The new in-DB parser yields a superset of the field information that the in-Node parser created, see columns outputted by the `odkform_fields()` function. They'll need documentation and a walkthrough, but here I'd just like to note:
- it's interesting to see those columns mapped to the `form_fields` compat shim view, there's a few semantic idiosyncracies (see view definition). But what's great is that those historic idiosyncracies are now declaratively contained (and becommented) in that view definition.
- the `ordinalitypath` concept gives you the reverse path into the source XML, which can be turned into an xpath expression giving you the *concrete single* source element (node) of which the information in the row is derived! Bijection :heart_hands: ! Veracity! :heart_eyes: ! Thus an `ordinalitypath` of `1.3.2` corresponds with an XPath expression of `/*[1]/*[3]/*[2]`. That's in contrast with the `lelementpath` column which (when `/`-joined) gives you an xpath expression which may yield a nodeset as, of course, element names are not necessarily unique but element positions are (many `<li>`'s in an `<ul>`, thus many `/ul/li`'s in xpath, but only one `/*[1]/*[3]` concrete `<li>`!).
- With the ordinalitypath mechanism it also becomes easy to select siblings or parents of fields, in SQL, using the `ltree` type's operators.
- We now have information on the **body element** (the presentation node) associated with a field :partying_face:! How lovely! So instead of a boolean `is_selectMultiple` as we have on the `form_fields` compat shim, we have the literal value `select` right there in the `bodyelement` column, straight from the horse's (XML's) mouth. Also, we know the actual presentation order of fields (just sort by `bodyordinalitypath`) so we can finally truthfully determine "the first geofield".

This PR also introduces a change in how "form schemas" are treated. Here a schema version is the semantic hashes of forms (via the semantic hashes of their form fields), and uses that form-semantic-hash as the formschema identifier. Same form schema, same form schema ID!
Previously, which forms' schemas get seen as distinct and which forms' schemas are determined "the same" was dependent on accidental insertion order. IOW previously you could upload the same form and it'd be possible for it to get a distinct schema ID, which I found confusing; I found it hard to give a one-sentence definition of what a "schema ID" is, which feels like an ontology smell.

#### What has been done to verify that this works as intended?

Old tests pass!
But it'd be nice to add some direct tests for the DB functions. They're only tested indirectly now, in the form revision upload/compare tests.

#### Why is this the best possible solution? Were any other approaches considered?

Leave things be? :clown_face: 
See getodk/central#1670 for background info.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
