### PR TITLE
Delete specific submission attachment by rootId and instanceId

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -6945,6 +6945,9 @@ paths:
         _(introduced: version 0.4)_
 
         Because Submission Attachments are completely determined by the XML data of the submission itself, there is no direct way to entirely remove a Submission Attachment entry from the list, only to clear its uploaded content. Thus, when you issue a `DELETE` to the attachment's endpoint, that is what happens.
+
+        This endpoint clears attachments on the current version of the submission.
+        See [Clearing the Attachment of a specific Submission Version](/central-api-submission-management/#clearing-a-submission-version-s-attachment) for more control over attachments on past versions.
       operationId: clearSubmissionAttachment
       parameters:
       - name: projectId
@@ -7357,6 +7360,59 @@ paths:
             '{the MIME type of the attachment file itself}':
               example: |
                 (binary data)
+    delete:
+      tags:
+      - Submission Versions
+      summary: Clearing a Submission Version's Attachment
+      description: |-
+        This endpoint clears attachments on submission versions.
+
+        Because Submission Attachments are completely determined by the XML data of the submission itself, there is no direct way to entirely remove a Submission Attachment entry from the list, only to clear its uploaded content. Thus, when you issue a DELETE to the attachment's endpoint, that is what happens.
+      operationId: clearVersionedAttachment
+      parameters:
+      - name: projectId
+        in: path
+        description: The numeric ID of the Project
+        required: true
+        schema:
+          type: number
+        example: "16"
+      - name: xmlFormId
+        in: path
+        description: The `xmlFormId` of the Form being referenced.
+        required: true
+        schema:
+          type: string
+        example: simple
+      - name: instanceId
+        in: path
+        description: The `instanceId` of the Submission being referenced.
+        required: true
+        schema:
+          type: string
+        example: uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44
+      - name: versionId
+        in: path
+        description: The `instanceId` of the particular version of this submission
+          in question.
+        required: true
+        schema:
+          type: string
+        example: uuid:b1628661-65ed-4cab-8e30-19c17fef2de0
+      - name: filename
+        in: path
+        description: The name of the file as given by the Attachments listing resource.
+        required: true
+        schema:
+          type: string
+        example: file1.jpg
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Success'
   /v1/projects/{projectId}/forms/{xmlFormId}/submissions/{instanceId}/diffs:
     get:
       tags:

--- a/lib/model/query/submission-attachments.js
+++ b/lib/model/query/submission-attachments.js
@@ -207,7 +207,6 @@ const getAllByDefId = (submissionDefId) => ({ all }) =>
   all(sql`select * from submission_attachments where "submissionDefId"=${submissionDefId} order by name`)
     .then(map(construct(Submission.Attachment)));
 
-// TODO: i think this is only used in tests
 const getBySubmissionDefIdAndName = (subDefId, name) => ({ maybeOne }) =>
   maybeOne(sql`select * from submission_attachments where "submissionDefId"=${subDefId} and name=${name}`)
     .then(map(construct(Submission.Attachment)));

--- a/lib/model/query/submission-attachments.js
+++ b/lib/model/query/submission-attachments.js
@@ -212,6 +212,10 @@ const getBySubmissionDefIdAndName = (subDefId, name) => ({ maybeOne }) =>
   maybeOne(sql`select * from submission_attachments where "submissionDefId"=${subDefId} and name=${name}`)
     .then(map(construct(Submission.Attachment)));
 
+const getByFormAndInstanceIdAndName = (formId, instanceId, name, draft) => ({ maybeOne }) =>
+  maybeOne(_getVersion(formId, instanceId, name, draft))
+    .then(map(construct(Submission.Attachment)));
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // EXPORT
@@ -236,7 +240,8 @@ where submission_defs.current=true
 module.exports = {
   create, upsert, attach, clear,
   getCurrentForSubmissionId, getCurrentBlobByIds,
-  getForFormAndInstanceId, getBlobByFormAndInstanceId,
+  getForFormAndInstanceId, getByFormAndInstanceIdAndName,
+  getBlobByFormAndInstanceId,
   getAllByDefId, getBySubmissionDefIdAndName,
   streamForExport
 };

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -539,6 +539,21 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
           .then(success))
     );
 
+    service.delete(
+      `${base}/:rootId/versions/:instanceId/attachments/:name`,
+      endpoint(({ Forms, SubmissionAttachments, Submissions }, { params, auth }) =>
+        getForm(params, Forms)
+          .then((form) => auth.canOrReject('submission.update', form))
+          .then((form) => Promise.all([
+            SubmissionAttachments.getByFormAndInstanceIdAndName(form.id, params.instanceId, params.name, draft),
+            Submissions.verifyVersion(form.id, params.rootId, params.instanceId, draft)
+          ])
+            .then(([ attachment ]) => attachment)
+            .then(getOrNotFound)
+            .then((attachment) => SubmissionAttachments.clear(attachment, form, params.instanceId)))
+          .then(success))
+    );
+
     ////////////////////////////////////////////////////////////////////////////////
     // VERSIONS
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -5021,7 +5021,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
   });
 
   describe('[version] /:rootId/versions/:instanceId/attachments/:name DELETE', () => {
-    it('async await should return notfound if the attachment does not exist', testService(async (service) => {
+    it('should return notfound if the attachment does not exist', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/forms?publish=true')
         .set('Content-Type', 'application/xml')
@@ -5037,7 +5037,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
         .expect(404);
     }));
 
-    it('async await should reject if the user cannot update a submission', testService(async (service) => {
+    it('should reject if the user cannot update a submission', testService(async (service) => {
       const asAlice = await service.login('alice');
       const asChelsea = await service.login('chelsea');
       await asAlice.post('/v1/projects/1/forms?publish=true')
@@ -5095,7 +5095,6 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
       await asAlice.post('/v1/projects/1/submission')
         .set('X-OpenRosa-Version', '1.0')
         .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both
-          .replace('id="binaryType"', 'id="binaryType"')
           .replace('<instanceID>both', '<deprecatedID>both</deprecatedID><instanceID>both2')),
         { filename: 'data.xml' })
         .expect(201);
@@ -5104,7 +5103,6 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
       await asAlice.post('/v1/projects/1/submission')
         .set('X-OpenRosa-Version', '1.0')
         .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both
-          .replace('id="binaryType"', 'id="binaryType"')
           .replace('<instanceID>both', '<deprecatedID>both2</deprecatedID><instanceID>both3')),
         { filename: 'data.xml' })
         .expect(201);
@@ -5145,7 +5143,7 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
 
     }));
 
-    it('should log an audit entry about the deletion', testService(async (service, { Audits }) => {
+    it('should log an audit entry about the deletion', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/forms?publish=true')
         .set('Content-Type', 'application/xml')
@@ -5158,11 +5156,15 @@ one,h,/data/h,2000-01-01T00:06,2000-01-01T00:07,-5,-6,,ee,ff,,
         .expect(201);
       await asAlice.delete('/v1/projects/1/forms/binaryType/submissions/both/versions/both/attachments/here_is_file2.jpg')
         .expect(200);
-      const log = await Audits.getLatestByAction('submission.attachment.update').then(o => o.get());
-      log.details.instanceId.should.eql('both');
-      log.details.name.should.eql('here_is_file2.jpg');
-      should.exist(log.details.oldBlobId);
-      should.not.exist(log.details.newBlobId);
+
+      await asAlice.get('/v1/audits?action=submission.attachment.update')
+        .then(({ body }) => {
+          const log = body[0];
+          log.details.instanceId.should.eql('both');
+          log.details.name.should.eql('here_is_file2.jpg');
+          should.exist(log.details.oldBlobId);
+          should.not.exist(log.details.newBlobId);
+        });
     }));
   });
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1612

This PR adds a new resource for issuing a `DELETE` request to:

`/projects/:projectId/forms/:xmlFormId/submissions/:rootId/versions/:deprecatedId/attachments/:attachmentName`

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

We talked about it on slack. Having a redirect for a delete doesn't really make sense. If someone tries to access (via GET) an attachment on an old version, that GET will return the redirected URL. They can then use the DELETE method on that URL that contains the root ID and the instance ID. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Lets users clear out more data, which can then get purged.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes. I made some changes to the docs, though the wording could be improved.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
