### PR TITLE
Remove support for case-insensitive file extensions in routes

### DIFF
--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -32,7 +32,7 @@ const { QueryOptions } = require('../util/db');
 // Given an OData URL subpath and a Form instance, returns that same URL up
 // through the .svc base path.
 const getServiceRoot = (subpath) => {
-  const match = /\.svc\//i.exec(subpath);
+  const match = /\.svc\//.exec(subpath);
   if (match == null) throw Problem.user.notFound(); // something else? shouldn't be possible.
   return subpath.slice(0, match.index + 4); // .svc <- len is 4
 };

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -48,7 +48,7 @@ const isXmlType = (x) => /(^|,)(application\/(atom(svc)?\+)?xml|atom|xml)($|;|,)
 
 // determines if a request needs a transaction.
 const phony = (request) => {
-  if (/submissions\.csv(\.zip)?$/i.test(request.path)) return true;
+  if (/submissions\.csv(\.zip)?$/.test(request.path)) return true;
   return false;
 };
 const isWriteRequest = (request) => !phony(request) &&

--- a/lib/util/odata.js
+++ b/lib/util/odata.js
@@ -43,7 +43,7 @@ const jsonDataFooter = template(stripWhitespace(`
 }`));
 
 const getServiceRoot = (subpath) => {
-  const match = /\.svc\//i.exec(subpath);
+  const match = /\.svc\//.exec(subpath);
   if (match == null) throw Problem.user.notFound(); // something else? shouldn't be possible.
   return subpath.slice(0, match.index + 4); // .svc <- len is 4
 };


### PR DESCRIPTION
Case-insensitive support no longer required after https://github.com/getodk/central-backend/pull/1786.

#### What has been done to verify that this works as intended?

Well, nothing broke.  Case-specific tests could be added, and checked against the previous implementation.

#### Why is this the best possible solution? Were any other approaches considered?

Could leave as-is, but it might be a surprise that very small parts of some routes are case-insensitive.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Seems unlikely, but some users may rely on case-insensitivity.  #1786 may also have been disruptive in the same way.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No - all docs URLs are lower-case.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
