### PR TITLE
ci: include 500 Error response bodies

### DIFF
--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -255,11 +255,15 @@ const defaultErrorWriter = (error, request, response) => {
   if (error?.isProblem === true) {
     writeProblemJson(response, error);
   } else {
+    const responseBody = {
+      message: 'Internal Server Error',
+    };
+
+    if (process.env.CI === 'true' && error?.stack != null) responseBody.stack = error?.stack;
+
     debugger; // trip debugger if attached.
     process.stderr.write(inspect(error) + '\n');
-    response.status(500).type('application/json').send({
-      message: 'Internal Server Error',
-    });
+    response.status(500).type('application/json').send(responseBody);
   }
 };
 

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -259,7 +259,7 @@ const defaultErrorWriter = (error, request, response) => {
       message: 'Internal Server Error',
     };
 
-    if (process.env.CI === 'true' && error?.stack != null) responseBody.stack = error?.stack;
+    if (process.env.ERR_500_STACKS === 'insecure' && error?.stack != null) responseBody.stack = error?.stack;
 
     debugger; // trip debugger if attached.
     process.stderr.write(inspect(error) + '\n');

--- a/test/e2e/soak/ci
+++ b/test/e2e/soak/ci
@@ -19,7 +19,7 @@ make base
 echo "$userPassword" | node ./lib/bin/cli.js user-create  -u "$userEmail"
 node ./lib/bin/cli.js user-promote -u "$userEmail"
 
-make run >backend.log 2>&1 &
+ERR_500_STACKS=insecure make run >backend.log 2>&1 &
 
 log 'Waiting for backend to start...'
 timeout 30 bash -c "while ! curl -s -o /dev/null $serverUrl; do sleep 1; done"

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -13,28 +13,27 @@ const Problem = require(appRoot + '/lib/util/problem');
 
 describe('endpoints', () => {
   describe('defaultErrorWriter', () => {
-    describe('in CI', () => {
+    describe('with ERR_500_STACKS=insecure', () => {
       let originalEnv;
 
       beforeEach(() => {
-        originalEnv = process.env.CI;
-        process.env.CI = 'true';
+        originalEnv = process.env.ERR_500_STACKS;
+        process.env.ERR_500_STACKS = 'insecure';
       });
 
       afterEach(() => {
-        process.env.CI = originalEnv;
+        process.env.ERR_500_STACKS = originalEnv;
       });
 
       it('should include stacktrace in 500 errors', (done) => {
         const response = createResponse();
         const error = new Error('oops');
-        console.log('stack', typeof error.stack, error.stack);
         response.on('end', () => {
           response.statusCode.should.equal(500);
           const responseBody = response._getData();
           Object.keys(responseBody).should.deepEqual([ 'message', 'stack' ]);
           responseBody.message.should.eql('Internal Server Error');
-          responseBody.stack.should.match(/^Error: oops\n    at Context\.<anonymous>/m);
+          responseBody.stack.should.match(/^Error: oops\n {4}at Context\.<anonymous>/m);
           done();
         });
         defaultErrorWriter(error, null, response);

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -50,77 +50,64 @@ describe('endpoints', () => {
       });
     });
 
-    describe('in production', () => {
-      let originalEnv;
-
-      beforeEach(() => {
-        originalEnv = process.env.CI;
-        delete process.env.CI;
+    it('should adapt Problem code to http code', (done) => {
+      const response = createResponse();
+      response.on('end', () => {
+        response.statusCode.should.equal(409);
+        done();
       });
+      defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
+    });
 
-      afterEach(() => {
-        process.env.CI = originalEnv;
+    it('should set json return type', (done) => {
+      const response = createResponse();
+      response.on('end', () => {
+        response.getHeader('Content-Type').should.equal('application/json');
+        done();
       });
+      defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
+    });
 
-      it('should adapt Problem code to http code', (done) => {
-        const response = createResponse();
-        response.on('end', () => {
-          response.statusCode.should.equal(409);
-          done();
-        });
-        defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
+    it('should provide Problem details in the body', (done) => {
+      const response = createResponse();
+      response.on('end', () => {
+        response._getData().code.should.equal(409.1138);
+        response._getData().message.should.equal('test message');
+        response._getData().details.should.eql({ x: 1 });
+        done();
       });
+      defaultErrorWriter(new Problem(409.1138, 'test message', { x: 1 }), null, response);
+    });
 
-      it('should set json return type', (done) => {
-        const response = createResponse();
-        response.on('end', () => {
-          response.getHeader('Content-Type').should.equal('application/json');
-          done();
-        });
-        defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
+    it('should turn remaining errors into internal server errors', (done) => {
+      const response = createResponse();
+      const error = new Error('oops');
+      response.on('end', () => {
+        response.statusCode.should.equal(500);
+        response._getData().should.deepEqual({ message: 'Internal Server Error' });
+        done();
       });
+      defaultErrorWriter(error, null, response);
+    });
 
-      it('should provide Problem details in the body', (done) => {
-        const response = createResponse();
-        response.on('end', () => {
-          response._getData().code.should.equal(409.1138);
-          response._getData().message.should.equal('test message');
-          response._getData().details.should.eql({ x: 1 });
-          done();
-        });
-        defaultErrorWriter(new Problem(409.1138, 'test message', { x: 1 }), null, response);
+    it('should not translate 403 to 401 if user agent header is not present', (done) => {
+      const response = createResponse();
+      const request = createRequest();
+      response.on('end', () => {
+        response.statusCode.should.equal(403);
+        done();
       });
+      defaultErrorWriter(Problem.user.insufficientRights(), request, response);
+    });
 
-      it('should turn remaining errors into internal server errors', (done) => {
-        const response = createResponse();
-        const error = new Error('oops');
-        response.on('end', () => {
-          response.statusCode.should.equal(500);
-          response._getData().should.deepEqual({ message: 'Internal Server Error' });
-          done();
-        });
-        defaultErrorWriter(error, null, response);
+    it('should not throw if given a null error', (done) => {
+      const response = createResponse();
+      response.on('end', () => {
+        response.statusCode.should.equal(500);
+        response._getData().should.deepEqual({ message: 'Internal Server Error' });
+        done();
       });
-
-      it('should not translate 403 to 401 if user agent header is not present', (done) => {
-        const response = createResponse();
-        const request = createRequest();
-        response.on('end', () => {
-          response.statusCode.should.equal(403);
-          done();
-        });
-        defaultErrorWriter(Problem.user.insufficientRights(), request, response);
-      });
-
-      it('should not throw if given a null error', (done) => {
-        const response = createResponse();
-        response.on('end', () => {
-          response.statusCode.should.equal(500);
-          response._getData().should.deepEqual({ message: 'Internal Server Error' });
-          done();
-        });
-        defaultErrorWriter(null, null, response);
-      });
+      defaultErrorWriter(null, null, response);
     });
   });
 
@@ -627,7 +614,7 @@ describe('endpoints', () => {
 
         response.statusCode.should.equal(500);
         response.getHeader('Content-Type').should.equal('application/json');
-        response._getData().message.should.eql('Internal Server Error');
+        response._getData().should.deepEqual({ message: 'Internal Server Error' });
       });
 
       it('should wrap problems in openrosa xml envelopes', () => {

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -13,64 +13,115 @@ const Problem = require(appRoot + '/lib/util/problem');
 
 describe('endpoints', () => {
   describe('defaultErrorWriter', () => {
-    it('should adapt Problem code to http code', (done) => {
-      const response = createResponse();
-      response.on('end', () => {
-        response.statusCode.should.equal(409);
-        done();
+    describe('in CI', () => {
+      let originalEnv;
+
+      beforeEach(() => {
+        originalEnv = process.env.CI;
+        process.env.CI = 'true';
       });
-      defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
+
+      afterEach(() => {
+        process.env.CI = originalEnv;
+      });
+
+      it('should include stacktrace in 500 errors', (done) => {
+        const response = createResponse();
+        const error = new Error('oops');
+        console.log('stack', typeof error.stack, error.stack);
+        response.on('end', () => {
+          response.statusCode.should.equal(500);
+          const responseBody = response._getData();
+          Object.keys(responseBody).should.deepEqual([ 'message', 'stack' ]);
+          responseBody.message.should.eql('Internal Server Error');
+          responseBody.stack.should.match(/^Error: oops\n    at Context\.<anonymous>/m);
+          done();
+        });
+        defaultErrorWriter(error, null, response);
+      });
+
+      it('should not throw if given a null error', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response.statusCode.should.equal(500);
+          response._getData().should.deepEqual({ message: 'Internal Server Error' });
+          done();
+        });
+        defaultErrorWriter(null, null, response);
+      });
     });
 
-    it('should set json return type', (done) => {
-      const response = createResponse();
-      response.on('end', () => {
-        response.getHeader('Content-Type').should.equal('application/json');
-        done();
-      });
-      defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
-    });
+    describe('in production', () => {
+      let originalEnv;
 
-    it('should provide Problem details in the body', (done) => {
-      const response = createResponse();
-      response.on('end', () => {
-        response._getData().code.should.equal(409.1138);
-        response._getData().message.should.equal('test message');
-        response._getData().details.should.eql({ x: 1 });
-        done();
+      beforeEach(() => {
+        originalEnv = process.env.CI;
+        delete process.env.CI;
       });
-      defaultErrorWriter(new Problem(409.1138, 'test message', { x: 1 }), null, response);
-    });
 
-    it('should turn remaining errors into internal server errors', (done) => {
-      const response = createResponse();
-      const error = new Error('oops');
-      response.on('end', () => {
-        response.statusCode.should.equal(500);
-        response._getData().should.deepEqual({ message: 'Internal Server Error' });
-        done();
+      afterEach(() => {
+        process.env.CI = originalEnv;
       });
-      defaultErrorWriter(error, null, response);
-    });
 
-    it('should not translate 403 to 401 if user agent header is not present', (done) => {
-      const response = createResponse();
-      const request = createRequest();
-      response.on('end', () => {
-        response.statusCode.should.equal(403);
-        done();
+      it('should adapt Problem code to http code', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response.statusCode.should.equal(409);
+          done();
+        });
+        defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
       });
-      defaultErrorWriter(Problem.user.insufficientRights(), request, response);
-    });
 
-    it('should not throw if given a null error', (done) => {
-      const response = createResponse();
-      response.on('end', () => {
-        response.statusCode.should.equal(500);
-        response._getData().should.deepEqual({ message: 'Internal Server Error' });
-        done();
+      it('should set json return type', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response.getHeader('Content-Type').should.equal('application/json');
+          done();
+        });
+        defaultErrorWriter(new Problem(409.1138, 'test message'), null, response);
       });
-      defaultErrorWriter(null, null, response);
+
+      it('should provide Problem details in the body', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response._getData().code.should.equal(409.1138);
+          response._getData().message.should.equal('test message');
+          response._getData().details.should.eql({ x: 1 });
+          done();
+        });
+        defaultErrorWriter(new Problem(409.1138, 'test message', { x: 1 }), null, response);
+      });
+
+      it('should turn remaining errors into internal server errors', (done) => {
+        const response = createResponse();
+        const error = new Error('oops');
+        response.on('end', () => {
+          response.statusCode.should.equal(500);
+          response._getData().should.deepEqual({ message: 'Internal Server Error' });
+          done();
+        });
+        defaultErrorWriter(error, null, response);
+      });
+
+      it('should not translate 403 to 401 if user agent header is not present', (done) => {
+        const response = createResponse();
+        const request = createRequest();
+        response.on('end', () => {
+          response.statusCode.should.equal(403);
+          done();
+        });
+        defaultErrorWriter(Problem.user.insufficientRights(), request, response);
+      });
+
+      it('should not throw if given a null error', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response.statusCode.should.equal(500);
+          response._getData().should.deepEqual({ message: 'Internal Server Error' });
+          done();
+        });
+        defaultErrorWriter(null, null, response);
+      });
     });
   });
 
@@ -577,7 +628,7 @@ describe('endpoints', () => {
 
         response.statusCode.should.equal(500);
         response.getHeader('Content-Type').should.equal('application/json');
-        response._getData().should.deepEqual({ message: 'Internal Server Error' });
+        response._getData().message.should.eql('Internal Server Error');
       });
 
       it('should wrap problems in openrosa xml envelopes', () => {


### PR DESCRIPTION
This should help diagnose unexpected soak-test failures more easily.

Ref getodk/central#1734

#### What has been done to verify that this works as intended?

- [x] tested locally
- [x] CI

#### Why is this the best possible solution? Were any other approaches considered?

Helpful details are included in errors, e.g. Soak Test failure: https://github.com/getodk/central-backend/actions/runs/23974467961/job/69929231034#step:7:43531

```
2026-04-04T07:50:22.4728057Z [2026-04-04T07:50:22.472Z] REPORT [test/e2e/soak]             Errors:
2026-04-04T07:50:22.4775082Z [2026-04-04T07:50:22.476Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at listOnTimeout (node:internal/timers:567:9)\n    at process.processTimers (node:internal/timers:541:7)"}
2026-04-04T07:50:22.4782008Z [2026-04-04T07:50:22.476Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at async fullzip (/home/runner/work/central-backend/central-backend/lib/resources/submissions.js:344:20)"}
2026-04-04T07:50:22.4787580Z [2026-04-04T07:50:22.476Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at listOnTimeout (node:internal/timers:567:9)\n    at process.processTimers (node:internal/timers:541:7)\n    at async Promise.all (index 5)"}
2026-04-04T07:50:22.4791865Z [2026-04-04T07:50:22.476Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at listOnTimeout (node:internal/timers:567:9)\n    at process.processTimers (node:internal/timers:541:7)\n    at async fullzip (/home/runner/work/central-backend/central-backend/lib/resources/submissions.js:344:20)"}
2026-04-04T07:50:22.4796123Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at listOnTimeout (node:internal/timers:567:9)\n    at process.processTimers (node:internal/timers:541:7)\n    at async Promise.all (index 0)"}
2026-04-04T07:50:22.4800254Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at listOnTimeout (node:internal/timers:567:9)\n    at process.processTimers (node:internal/timers:541:7)\n    at async Promise.all (index 2)"}
2026-04-04T07:50:22.4804560Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at listOnTimeout (node:internal/timers:567:9)\n    at process.processTimers (node:internal/timers:541:7)\n    at async fullzip (/home/runner/work/central-backend/central-backend/lib/resources/submissions.js:346:31)"}
2026-04-04T07:50:22.4808682Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at async fullzip (/home/runner/work/central-backend/central-backend/lib/resources/submissions.js:346:31)"}
2026-04-04T07:50:22.4811498Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)"}
2026-04-04T07:50:22.4814005Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at async Promise.all (index 2)"}
2026-04-04T07:50:22.4816630Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at async Promise.all (index 5)"}
2026-04-04T07:50:22.4820313Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at process.processTimers (node:internal/timers:538:9)\n    at async fullzip (/home/runner/work/central-backend/central-backend/lib/resources/submissions.js:344:20)"}
2026-04-04T07:50:22.4823664Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at async Promise.all (index 0)"}
2026-04-04T07:50:22.4826814Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at process.processTimers (node:internal/timers:538:9)\n    at async Promise.all (index 5)"}
2026-04-04T07:50:22.4830869Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at process.processTimers (node:internal/timers:538:9)\n    at async fullzip (/home/runner/work/central-backend/central-backend/lib/resources/submissions.js:346:31)"}
2026-04-04T07:50:22.4834600Z [2026-04-04T07:50:22.477Z] REPORT [test/e2e/soak]               * 500: {"message":"Internal Server Error","error":"ConnectionError: timeout exceeded when trying to connect\n    at Object.createConnection (/home/runner/work/central-backend/central-backend/node_modules/slonik/dist/src/factories/createConnection.js:55:23)\n    at runNextTicks (node:internal/process/task_queues:64:5)\n    at process.processTimers (node:internal/timers:538:9)"}
```

Alternatives:

* manually enable when trying to diagnose specific errors.  This is the status quo, and is a bit annoying.
* an implicit setting, e.g. `CI=true`.  This would make testing the stacks a bit weirder, but would mean the helpful info is available in ALL CI envs.  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
