### PR TITLE
Fixes: Exclude deleted properties from the SQL query for geojson

### DIFF
--- a/lib/model/query/geo-extracts.js
+++ b/lib/model/query/geo-extracts.js
@@ -184,6 +184,10 @@ const getEntityFeatureCollectionGeoJson = (datasetPK, odataQuery, limit=null, se
                 ds.id = ${datasetPK}
                 AND
                 (dsprops.name, dsprops."datasetId") = ('geometry', ds.id)
+                AND
+                dsprops."deletedAt" IS NULL
+                AND
+                dsprops."publishedAt" IS NOT NULL
               )
               INNER JOIN entities ON (
                   entities."datasetId" = ds.id

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -8437,6 +8437,48 @@ describe('datasets and entities', () => {
         });
     }));
 
+    // Bug getodk/central#1769
+    it('should not return duplicate features when geometry property has been soft-deleted and re-created', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'trees' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/trees/properties')
+        .send({ name: 'geometry' })
+        .expect(200);
+
+      await asAlice.delete('/v1/projects/1/datasets/trees/properties/geometry')
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/trees/properties')
+        .send({ name: 'geometry' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/trees/entities')
+        .send({
+          uuid: '12345678-1234-4123-8234-123456789abc',
+          label: 'My Tree',
+          data: { geometry: '11.434 45.545' }
+        })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/datasets/trees/entities.geojson')
+        .expect(200)
+        .then(({ body }) => {
+          body.features.length.should.equal(1);
+          body.features[0].geometry.coordinates.should.eql([45.545, 11.434]);
+        });
+
+      await asAlice.get('/v1/projects/1/datasets/trees/entities/12345678-1234-4123-8234-123456789abc/geojson')
+        .expect(200)
+        .then(({ body }) => {
+          body.features.length.should.equal(1);
+          body.features[0].geometry.coordinates.should.eql([45.545, 11.434]);
+        });
+    }));
+
     it('should be able to recreate the property via Form', testService(async service => {
       const asAlice = await service.login('alice');
 


### PR DESCRIPTION
Closes getodk/central#1769

#### What has been done to verify that this works as intended?

Added tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Fixes the issue. Other option is to remove the join with `ds_properties` altogether because I don't think it is possible to create an entity with the data that includes non-existent properties.

I think similar fix is required in `getDatasetProperties` of `analytics.js`. Will create a separate PR for that if required.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
