### PR TITLE
util/problem: reject problems with duplicate codes

### DIFF
--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -23,7 +23,7 @@ const log = (actor, action, actee, details) => ({ run, context }) => {
   const acteeId = Option.of(actee).map((x) => x.acteeId).orNull();
   const processed = Audit.actionableEvents.includes(action) ? null : sql`clock_timestamp()`;
 
-  const notes = Option.of(context?.headers[xActionNotes]).map(val => urlDecode(val).orThrow(Problem.user.invalidHeader(xActionNotes))).orNull();
+  const notes = Option.of(context?.headers[xActionNotes]).map(val => urlDecode(val).orThrow(Problem.user.invalidHeader({ field: xActionNotes }))).orNull();
 
   return run(sql`
 insert into audits ("actorId", action, "acteeId", details, notes, "loggedAt", processed, failures)

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -66,10 +66,9 @@ const problems = {
     // 400.5 (uniquenessViolation), was used in the past, but has been deprecated
 
     // { header: "the problematic header", value: "the supplied (problematic) value" }
-    invalidHeader: problem(400.6, ifElse(
-      is(String),
-      field => `An expected header field (${field}) did not match the expected format.`,
-      ({ field, value }) => `An expected header field (${field}) did not match the expected format (got: ${(value == null) ? '[nothing]' : value}).`,
+    invalidHeader: problem(400.6, ({ field, value }) => {
+      if (typeof value === 'undefined') return `An expected header field (${field}) did not match the expected format.`;
+      else return `An expected header field (${field}) did not match the expected format (got: ${(value == null) ? '[nothing]' : value}).`;
     )),
 
     // { field: "the name of the missing field" }

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -309,7 +309,9 @@ const problems = {
     // returned if ODK Analytics returns an unexpected response.
     analyticsUnexpectedResponse: problem(500.5, () => 'The Analytics service returned an unexpected response.'),
 
-    fieldTypesNotDefined: problem(500.6, (frame) => `fieldTypes are not defined on the ${frame} Frame, please define them to use insertMany.`)
+    fieldTypesNotDefined: problem(500.6, (frame) => `fieldTypes are not defined on the ${frame} Frame, please define them to use insertMany.`),
+
+    deliberatelyDuplicatedProblemNumber: problem(500.6, () => ''),
   }
 };
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -14,7 +14,6 @@
 // A list of our Problems with their codes and messages can be found below.
 
 const { floor } = Math;
-const { ifElse, is } = require('ramda');
 const { printPairs } = require('./util');
 
 class Problem extends Error {
@@ -69,7 +68,7 @@ const problems = {
     invalidHeader: problem(400.6, ({ field, value }) => {
       if (typeof value === 'undefined') return `An expected header field (${field}) did not match the expected format.`;
       else return `An expected header field (${field}) did not match the expected format (got: ${(value == null) ? '[nothing]' : value}).`;
-    )),
+    }),
 
     // { field: "the name of the missing field" }
     missingMultipartField: problem(400.7, ({ field }) => `Required multipart POST field ${field} missing.`),

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -217,12 +217,12 @@ const problems = {
     // tried to create a form while encryption was being enabled.
     encryptionActivating: problem(409.5, () => 'Could not create form, because the project was being prepared for managed encryption. Please try again in a moment.'),
 
-    // tried to delete a draft w no published version.
-    noPublishedVersion: problem(409.7, () => 'Could not delete draft, because the form has not been published. Either delete the whole form, or replace the draft.'),
-
     // special version of uniquenessViolation to be more informative about the publish-version
     // conflict case.
     versionUniquenessViolation: problem(409.6, ({ xmlFormId, version }) => `You tried to publish the form '${xmlFormId}' with version '${version}', but a published form has already existed in this project with those identifiers.`),
+
+    // tried to delete a draft w no published version.
+    noPublishedVersion: problem(409.7, () => 'Could not delete draft, because the form has not been published. Either delete the whole form, or replace the draft.'),
 
     // tried to reuse an instanceId
     instanceIdConflict: problem(409.8, () => 'You tried to update a submission, but the instanceID you provided already exists on this server. Please try again with a unique instanceID.'),

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -66,11 +66,11 @@ const problems = {
     // 400.5 (uniquenessViolation), was used in the past, but has been deprecated
 
     // { header: "the problematic header", value: "the supplied (problematic) value" }
-    invalidHeader: ifElse(
+    invalidHeader: problem(400.6, ifElse(
       is(String),
-      field => new Problem(400.6, `An expected header field (${field}) did not match the expected format.`, { field }),
-      problem(400.6, ({ field, value }) => `An expected header field (${field}) did not match the expected format (got: ${(value == null) ? '[nothing]' : value}).`),
-    ),
+      field => `An expected header field (${field}) did not match the expected format.`,
+      ({ field, value }) => `An expected header field (${field}) did not match the expected format (got: ${(value == null) ? '[nothing]' : value}).`,
+    )),
 
     // { field: "the name of the missing field" }
     missingMultipartField: problem(400.7, ({ field }) => `Required multipart POST field ${field} missing.`),
@@ -266,9 +266,17 @@ const problems = {
     // only called for development, theoretically.
     emptyResponse: problem(500.3, () => 'The resource returned no data. This is likely a developer problem.'),
 
-    s3accessDenied: problem(500.4, () => `The S3 account details or permissions are incorret.`),
+    // returned if Enketo returns an unexpected response.
+    enketoUnexpectedResponse: problem(500.4, () => 'The Enketo service returned an unexpected response.'),
 
-    s3upstreamError: problem(500.5, ({ amzRequestId, operation }) => `The upstream S3 server had an internal problem performing '${operation}'. Amazon request ID: '${amzRequestId}'.`),
+    // returned if ODK Analytics returns an unexpected response.
+    analyticsUnexpectedResponse: problem(500.5, () => 'The Analytics service returned an unexpected response.'),
+
+    fieldTypesNotDefined: problem(500.6, (frame) => `fieldTypes are not defined on the ${frame} Frame, please define them to use insertMany.`),
+
+    s3accessDenied: problem(500.7, () => `The S3 account details or permissions are incorret.`),
+
+    s3upstreamError: problem(500.9, ({ amzRequestId, operation }) => `The upstream S3 server had an internal problem performing '${operation}'. Amazon request ID: '${amzRequestId}'.`),
 
     // used to indicate missing odata functionality.
     notImplemented: problem(501.1, ({ feature }) => `The requested feature ${feature} is not supported by this server.`),
@@ -302,16 +310,6 @@ const problems = {
 
     // returned if Enketo is configured but it cannot be contacted.
     enketoNotAvailable: problem(502.3, () => 'Enketo could not be contacted.'),
-
-    // returned if Enketo returns an unexpected response.
-    enketoUnexpectedResponse: problem(500.4, () => 'The Enketo service returned an unexpected response.'),
-
-    // returned if ODK Analytics returns an unexpected response.
-    analyticsUnexpectedResponse: problem(500.5, () => 'The Analytics service returned an unexpected response.'),
-
-    fieldTypesNotDefined: problem(500.6, (frame) => `fieldTypes are not defined on the ${frame} Frame, please define them to use insertMany.`),
-
-    deliberatelyDuplicatedProblemNumber: problem(500.6, () => ''),
   }
 };
 

--- a/test/unit/external/s3.js
+++ b/test/unit/external/s3.js
@@ -81,7 +81,7 @@ describe('external/s3', () => {
         {
           name: 'Error',
           message: 'The S3 account details or permissions are incorret.',
-          problemCode: 500.4,
+          problemCode: 500.7,
           problemDetails: {
             amzRequestId,
             operation: 'removeObjects',
@@ -101,7 +101,7 @@ describe('external/s3', () => {
         {
           name: 'Error',
           message: `The upstream S3 server had an internal problem performing 'removeObjects'. Amazon request ID: 'tx000000000000000000000-0000000000-000000001-xxxxx'.`,
-          problemCode: 500.5,
+          problemCode: 500.9,
           problemDetails: {
             amzRequestId,
             operation: 'removeObjects',
@@ -124,7 +124,7 @@ describe('external/s3', () => {
         {
           name: 'Error',
           message: 'The S3 account details or permissions are incorret.',
-          problemCode: 500.4,
+          problemCode: 500.7,
           problemDetails: {
             amzRequestId,
             operation: 'getObject',
@@ -144,7 +144,7 @@ describe('external/s3', () => {
         {
           name: 'Error',
           message: `The upstream S3 server had an internal problem performing 'getObject'. Amazon request ID: 'tx000000000000000000000-0000000000-000000001-xxxxx'.`,
-          problemCode: 500.5,
+          problemCode: 500.9,
           problemDetails: {
             amzRequestId,
             operation: 'getObject',
@@ -172,7 +172,7 @@ describe('external/s3', () => {
         {
           name: 'Error',
           message: 'The S3 account details or permissions are incorret.',
-          problemCode: 500.4,
+          problemCode: 500.7,
           problemDetails: {
             amzRequestId,
             operation: 'putObject',
@@ -192,7 +192,7 @@ describe('external/s3', () => {
         {
           name: 'Error',
           message: `The upstream S3 server had an internal problem performing 'putObject'. Amazon request ID: 'tx000000000000000000000-0000000000-000000001-xxxxx'.`,
-          problemCode: 500.5,
+          problemCode: 500.9,
           problemDetails: {
             amzRequestId,
             operation: 'putObject',

--- a/test/unit/util/problem.js
+++ b/test/unit/util/problem.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert/strict');
+const appRoot = require('app-root-path');
+const Problem = require(appRoot + '/lib/util/problem');
+
+describe.only('Problem', () => {
+  const expectedRanges = {
+    user: 400,
+    internal: 500,
+  };
+
+  for (const [ type, problemMap ] of Object.entries(Problem)) {
+    describe(`type: ${type}`, () => {
+      const expectedRange = expectedRanges[type];
+
+      it('should define an expected code range', () => {
+        assert.equal(Number.isFinite(expectedRange), true);
+        assert.equal(Math.floor(expectedRange / 100) * 100, expectedRange);
+      });
+
+      it('should not have duplicate Problem IDs', () => {
+        const duplicates = Object.entries(
+          Object
+            .entries(problemMap)
+            .reduce(
+              (acc, [ name, { code } ]) => {
+                if (!acc[code]) acc[code] = [];
+                acc[code].push(name)
+                return acc;
+              },
+              {},
+            ),
+        ).filter(([ code, names ]) => names.length > 1);
+
+        assert.deepEqual(duplicates, [], 'One or more numeric codes is shared by multiple Problems.');
+      });
+      
+      for (const [ name, { code } ] of Object.entries(problemMap)) {
+        describe(`problem: ${name}`, () => {
+          it('should define a numeric code', () => {
+            assert.equal(Number.isFinite(code), true, 'Code is not a valid number.');
+          });
+
+          it(`should be within ${expectedRange.toString().replace(/0/g, 'x')}`, () => {
+            assert.equal(Math.floor(code / 100) * 100, expectedRange);
+          });
+        });
+      }
+    });
+  }
+});

--- a/test/unit/util/problem.js
+++ b/test/unit/util/problem.js
@@ -14,7 +14,7 @@ describe('Problem', () => {
 
       it('should define an expected code range', () => {
         Number.isFinite(expectedRange).should.be.true();
-        assert.equal(Math.floor(expectedRange / 100) * 100, expectedRange);
+        (Math.floor(expectedRange / 100) * 100).should.eql(expectedRange);
       });
 
       it('should declare all Problems in numeric order', () => {
@@ -47,13 +47,13 @@ describe('Problem', () => {
             ),
         ).filter(([ , names ]) => names.length > 1);
 
-        assert.deepEqual(duplicates, [], 'One or more numeric codes is shared by multiple Problems.');
+        duplicates.should.eql([], 'One or more numeric codes is shared by multiple Problems.');
       });
 
       for (const [ name, { code } ] of Object.entries(problemMap)) {
         describe(`problem: ${name}`, () => {
           it('should define a numeric code', () => {
-            assert.equal(Number.isFinite(code), true, 'Code is not a valid number.');
+            Number.isFinite(code).should.be.true('Code is not a valid number.');
           });
 
           it(`should be within ${expectedRange.toString().replace(/0/g, 'x')}`, () => {

--- a/test/unit/util/problem.js
+++ b/test/unit/util/problem.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const appRoot = require('app-root-path');
 const Problem = require(appRoot + '/lib/util/problem');
 
@@ -57,7 +56,7 @@ describe('Problem', () => {
           });
 
           it(`should be within ${expectedRange.toString().replace(/0/g, 'x')}`, () => {
-            assert.equal(Math.floor(code / 100) * 100, expectedRange);
+            (Math.floor(code / 100) * 100).should.eql(expectedRange);
           });
         });
       }

--- a/test/unit/util/problem.js
+++ b/test/unit/util/problem.js
@@ -20,11 +20,11 @@ describe('Problem', () => {
         const declaredCodes = Object.values(problemMap).map(({ code }) => code);
 
         const sortedCodes = [ ...declaredCodes ].sort((a, b) => {
-          const [intA, fracA] = a.toString().split('.');
-          const [intB, fracB] = b.toString().split('.');
+          const [intA, frcA] = a.toString().split('.');
+          const [intB, frcB] = b.toString().split('.');
 
-          if(intA !== intB) return intA - intB;
-          if(fracA !== fracB) return fracA - fracB;
+          if (intA !== intB) return intA - intB;
+          if (frcA !== frcB) return frcA - frcB;
 
           return 0;
         });

--- a/test/unit/util/problem.js
+++ b/test/unit/util/problem.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const appRoot = require('app-root-path');
 const Problem = require(appRoot + '/lib/util/problem');
 
-describe.only('Problem', () => {
+describe('Problem', () => {
   const expectedRanges = {
     user: 400,
     internal: 500,
@@ -24,16 +24,16 @@ describe.only('Problem', () => {
             .reduce(
               (acc, [ name, { code } ]) => {
                 if (!acc[code]) acc[code] = [];
-                acc[code].push(name)
+                acc[code].push(name);
                 return acc;
               },
               {},
             ),
-        ).filter(([ code, names ]) => names.length > 1);
+        ).filter(([ , names ]) => names.length > 1);
 
         assert.deepEqual(duplicates, [], 'One or more numeric codes is shared by multiple Problems.');
       });
-      
+
       for (const [ name, { code } ] of Object.entries(problemMap)) {
         describe(`problem: ${name}`, () => {
           it('should define a numeric code', () => {

--- a/test/unit/util/problem.js
+++ b/test/unit/util/problem.js
@@ -13,7 +13,7 @@ describe('Problem', () => {
       const expectedRange = expectedRanges[type];
 
       it('should define an expected code range', () => {
-        assert.equal(Number.isFinite(expectedRange), true);
+        Number.isFinite(expectedRange).should.be.true();
         assert.equal(Math.floor(expectedRange / 100) * 100, expectedRange);
       });
 

--- a/test/unit/util/problem.js
+++ b/test/unit/util/problem.js
@@ -17,6 +17,22 @@ describe('Problem', () => {
         assert.equal(Math.floor(expectedRange / 100) * 100, expectedRange);
       });
 
+      it('should declare all Problems in numeric order', () => {
+        const declaredCodes = Object.values(problemMap).map(({ code }) => code);
+
+        const sortedCodes = [ ...declaredCodes ].sort((a, b) => {
+          const [intA, fracA] = a.toString().split('.');
+          const [intB, fracB] = b.toString().split('.');
+
+          if(intA !== intB) return intA - intB;
+          if(fracA !== fracB) return fracA - fracB;
+
+          return 0;
+        });
+
+        declaredCodes.should.eql(sortedCodes);
+      });
+
       it('should not have duplicate Problem IDs', () => {
         const duplicates = Object.entries(
           Object


### PR DESCRIPTION
eabd14c443ac7818c83546b89075021839339303 introduced new problem codes, but broke conventional ordering.

Due to lack of tests, this allowed later introduction of problems redefining the same error numbers.

This commit:

* changes construction of `problem.internal.invalidHeader` to be consistent with all other problems
* re-orders all problems to be sorted numerically by code
* renumbers s3 problem codes, as
  * the initial duplicate was `problem.internal.s3accessDenied` (formerly `500.4`, clashing with `problem.internal.enketoUnexpectedResponse`)
  * the next duplicate was `problem.internal.analyticsUnexpectedResponse` (formerly `500.5`, clashing with `problem.internal.s3upstreamError`), but it seems pragmatic to keep all the renumbering in the same functional area

#### What has been done to verify that this works as intended?

* added new tests
* existing test suite

#### Why is this the best possible solution? Were any other approaches considered?

Alternatives:

* maintain current duplicates, while preventing future duplicates
* renumber the most-recently-created duplicates.  Discussed above, but it seems helpful to keep renumberings in the same functional area.
* renumber all the duplicates, and retire the old duplicate codes

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Might affect users depending on the s3 problem codes.  This seems fairly unlikely, but worth mentioning in release notes.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

- [x] check for mentions of renumbered problem codes in `docs/api.yml`

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
