### PR TITLE
ci: faster postgres startup

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -36,7 +36,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
           --health-retries 5
     steps:

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -38,7 +38,7 @@ jobs:
           --health-cmd pg_isready
           --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -24,7 +24,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
           --health-retries 5
     steps:

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -26,7 +26,7 @@ jobs:
           --health-cmd pg_isready
           --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 50
     steps:
 
     # This one weird trick speeds up every build!

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -20,7 +20,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
           --health-retries 5
     steps:

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -22,7 +22,7 @@ jobs:
           --health-cmd pg_isready
           --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -20,7 +20,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
           --health-retries 5
     steps:

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -22,7 +22,7 @@ jobs:
           --health-cmd pg_isready
           --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - run: make fake-s3-server-persistent

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -20,7 +20,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
           --health-retries 5
     steps:

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -22,7 +22,7 @@ jobs:
           --health-cmd pg_isready
           --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - run: ./test/e2e/soak/ci/prepare-postgres.sh

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -23,7 +23,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
           --health-retries 5
     steps:

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -25,7 +25,7 @@ jobs:
           --health-cmd pg_isready
           --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -20,7 +20,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
           --health-retries 5
     steps:

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -22,7 +22,7 @@ jobs:
           --health-cmd pg_isready
           --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version


### PR DESCRIPTION
Decrease the GitHub Actions postgres service's `health-interval` from 10 seconds to 1 second.

In tandem, increase retries 10x, so that the retry period remains constant.

This seems to improve job execution times by ~12 seconds.

Sampling first 10 runs:

* `--health-interval 10s`: https://github.com/getodk/central-backend/actions/runs/24446014889/job/71422456164
* `--health-interval  1s`: https://github.com/getodk/central-backend/actions/runs/24446261001/job/71423323743

interval `10s` | interval `1s`
---------------|-------------
`29s`          | `11s`
`22s`          | `11s`
`19s`          | `10s`
`24s`          | `11s`
`25s`          | `11s`
`22s`          | ` 8s`
`24s`          | `11s`
`22s`          | `11s`
`23s`          | `11s`
`22s`          | `11s`

The previous setting of `--health-interval 10s` appears to have been introduced in b23531231d4b4c10dd0a7803f3539f9c3bd34f13 / #612, and then copy/pasted to new jobs.

Closes getodk/central#

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Faster CI is good.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just CI change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced