### PR TITLE
test/entites: increase timeout for backlog processing

### DIFF
--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1924,7 +1924,7 @@ describe('Offline Entities', () => {
   });
 
   describe('locking an entity while processing a related submission', function() {
-    this.timeout(8000);
+    this.timeout(16_000);
 
     // https://github.com/getodk/central/issues/705
     it('should concurrently process an offline create + update @slow', testServiceFullTrx(async (service, container) => {


### PR DESCRIPTION
With the old timeout, seems to fail ~1% of the time.

Ref getodk/central#705
Closes getodk/central#1813

#### What has been done to verify that this works as intended?

Ran a few hundred times with:

* old timeout: https://github.com/getodk/central-backend/actions/runs/24451721936
* new timeout: https://github.com/getodk/central-backend/actions/runs/24452019760

#### Why is this the best possible solution? Were any other approaches considered?

Could:

* increase the timeout more?  Doubling seems like a safe bet.
* understand why the database is responding so slowly under such minor load?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just a test change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
