### PR TITLE
Save userAgent and deviceId when editing submission using openRosa

### DIFF
--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -127,7 +127,7 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
                     })
                   // SUBMISSION EDIT REQUEST: find the now-deprecated submission and supplant it.
                   : Promise.all([
-                    Submissions.createVersion(partial, deprecated, form),
+                    Submissions.createVersion(partial, deprecated, form, query.deviceID, userAgent, headers[ODK_CLIENT]),
                     Forms.getBinaryFields(form.def.id),
                     SubmissionAttachments.getForFormAndInstanceId(form.id, deprecatedId, draft)
                   ]).then(([ saved, binaryFields, deprecatedAtts ]) =>

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -220,6 +220,29 @@ describe('api: /submission', () => {
               .then(({ text }) => { text.should.equal(testData.instances.simple.one); })
           ])))));
 
+    it('should save device id and user agent when editing a submission using OpenRosa', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/submission?deviceID=imei%3A358240051111110')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'central/test')
+        .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
+        .expect(201);
+
+      await asAlice.post('/v1/projects/1/submission?deviceID=updated')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'central/test_updated')
+        .attach('xml_submission_file', Buffer.from(testData.instances.simple.one.replace('<instanceID>one', '<deprecatedID>one</deprecatedID><instanceID>one_v2')), { filename: 'data.xml' })
+        .expect(201);
+
+      await asAlice.get('/v1/projects/1/forms/simple/submissions/one/versions')
+        .expect(200)
+        .then(({ body }) => {
+          body[0].deviceId.should.equal('updated');
+          body[0].userAgent.should.equal('central/test_updated');
+        });
+    }));
+
     it('should prepand odk-client to the user agent string', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/submission?deviceID=imei%3A358240051111110')


### PR DESCRIPTION
Closes getodk/central#1706

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
