### PR TITLE
Update OpenRosa hash after deletion of property in ownerOnly entity list

### DIFF
--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -165,11 +165,11 @@ const _get = (exec, options) => {
         SELECT datasets.id, MAX("loggedAt") AS "lastAudit" FROM audits
         JOIN datasets ON audits."acteeId" = datasets."acteeId"
         ${actorId == null ? sql`` : sql`
-          -- We're always interested in dataset.create and dataset.update
-          -- actions, even for ownerOnly datasets.
+          -- We're always interested in dataset.create and in actions that add
+          -- or delete entity properties -- even for ownerOnly datasets.
           WHERE
             (NOT datasets."ownerOnly") OR
-            audits.action IN ('dataset.create', 'dataset.update')
+            audits.action IN ('dataset.create', 'dataset.update', 'dataset.update.property.delete')
         `}
         GROUP BY datasets.id
       ) AS audit_metadata ON audit_metadata.id = datasets.id

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -7064,6 +7064,23 @@ describe('datasets and entities', () => {
         (await getHash(asChelsea)).should.not.equal(originalHash);
       }));
 
+      it('changes hash after a dataset property is deleted', testServiceFullTrx(async (service) => {
+        const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
+        await createData(asAlice);
+        await assignToProject(asAlice, asChelsea, 'formfill');
+
+        // Add an entity property.
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'foo' })
+          .expect(200);
+        const originalHash = await getHash(asChelsea);
+
+        // Delete the property.
+        await asAlice.delete('/v1/projects/1/datasets/people/properties/foo')
+          .expect(200);
+        (await getHash(asChelsea)).should.not.equal(originalHash);
+      }));
+
       it('computes hash based on timestamps and the entity count', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);


### PR DESCRIPTION
Closes getodk/central#1849.

#### What has been done to verify that this works as intended?

I wrote a test that failed before the fix was made.

#### Why is this the best possible solution? Were any other approaches considered?

I tried to follow the current pattern. I just added the new audit log action to the list of actions in the query.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I'm pretty sure that this change only affects the OpenRosa hash. I'm adding a single, specific new audit log action, so I think the risk of regression is low.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

We don't seem to document that changes to the structure of the entity list (i.e., adding or deleting entity properties) changes the OpenRosa hash of the entity list. Given that, I don't think there are any API docs that this PR needs to patch, and we don't need to mention this change in the API docs changelog. We could document this effect on the OpenRosa hash, but it feels to me like too much of a detail and doesn't need to be documented.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
