### PR TITLE
POC (not for merge) - Demo: Filter entities by userprops

### DIFF
--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
@@ -1,4 +1,5 @@
-DROP TABLE propdemo__property_filter CASCADE;
-DROP INDEX "propdemo__property_filter__unique_for_composite_fk_referent";
-DROP TABLE propdemo___actorpropname CASCADE;
-DROP TABLE propdemo___actorpropval;
+DROP INDEX "idx_entity_defs_data" CASCADE;
+DROP TABLE dataset_property_filter CASCADE;
+DROP INDEX "dataset_property_filter__unique_for_composite_fk_referent" CASCADE;
+DROP TABLE project_actor_property_names CASCADE;
+DROP TABLE actor_property_values CASCADE;

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE propdemo__property_filter CASCADE;
+DROP INDEX "propdemo__property_filter__unique_for_composite_fk_referent";
+DROP TABLE propdemo___actorpropname CASCADE;
+DROP TABLE propdemo___actorpropval;

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
@@ -1,56 +1,56 @@
 -- Storing some Authoritative Curated Collection of per-project user props.
-CREATE TABLE propdemo___actorpropname (
+CREATE TABLE project_actor_property_names (
     id integer NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    project_id integer NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
-    propname text NOT NULL CHECK (length(propname) > 0)
+    "projectId" integer NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    "propertyName" text NOT NULL CHECK (length("propertyName") > 0)
 );
-CREATE UNIQUE INDEX ON propdemo___actorpropname (project_id, propname);
+CREATE UNIQUE INDEX ON project_actor_property_names ("projectId", "propertyName");
 
 
-CREATE TABLE propdemo___actorpropval (
-    id int GENERATED ALWAYS AS IDENTITY,
-    actor_id integer NOT NULL REFERENCES field_keys ("actorId") ON DELETE CASCADE,  -- We *could* FK directly to actors instead. But we can start out this way, and if necessary can easily flip the FK over to the actors table; we'd be widening possibilities.
-    actorpropname_id integer NOT NULL REFERENCES propdemo___actorpropname (id) ON DELETE CASCADE,
-    propval text NOT NULL CHECK (length(propval) > 0)
+CREATE TABLE actor_property_values (
+    id integer GENERATED ALWAYS AS IDENTITY,
+    "actorId" integer NOT NULL REFERENCES field_keys ("actorId") ON DELETE CASCADE,  -- We *could* FK directly to actors instead. But we can start out this way, and if necessary can easily flip the FK over to the actors table; we'd be widening possibilities.
+    "projectActorPropertyNameId" integer NOT NULL REFERENCES project_actor_property_names (id) ON DELETE CASCADE,
+    "propertyValue" text NOT NULL CHECK (length("propertyValue") > 0)
 );
 -- A prop is unique for an actor. You can't have two "age"s (which is intuitive) but neither can you have two "region"s which is maybe not
 -- intuitive, yet we decided against it, as if we enable multivalued properties we'll be plunged deeply into the woods with
 -- conjunctions and disjunctions when it comes to filtering semantics, user's expectations of either, arduous query predicate composition, 
 -- and forgoing the simple-fast-succinct containment operator.
 -- BTW this index double-serves as the index for the referer side of the FKs (used when CASCADE-ing).
-CREATE UNIQUE INDEX ON propdemo___actorpropval (actor_id, actorpropname_id);
+CREATE UNIQUE INDEX ON actor_property_values ("actorId", "projectActorPropertyNameId");
 
 
 -- Defines an equation rule (as in: actorprop A must equate to entityprop B)
-CREATE TABLE propdemo__property_filter (
-     dataset_id integer NOT NULL,  -- FK constraint to follow, and explained below: at first glance having this column seems odd, as the dataset_id is already implied by the dsproperty_id, but there's a reason!
-     dsproperty_id integer NOT NULL PRIMARY KEY,  -- FK constraint to follow
-     actorpropname_id integer NOT NULL REFERENCES propdemo___actorpropname (id) ON DELETE CASCADE
+CREATE TABLE dataset_property_filter (
+     "datasetId" integer NOT NULL,  -- FK constraint to follow, and explained below: at first glance having this column seems odd, as the "datasetId" is already implied by the "datasetPropertyId", but there's a reason!
+     "datasetPropertyId" integer NOT NULL PRIMARY KEY,  -- FK constraint to follow
+     "projectActorPropertyNameId" integer NOT NULL REFERENCES project_actor_property_names (id) ON DELETE CASCADE
 );
 -- The following two constraints (unique constraint and foreign key) …
-CREATE UNIQUE INDEX "propdemo__property_filter__unique_for_composite_fk_referent" ON ds_properties USING btree ("datasetId", id);
-ALTER TABLE propdemo__property_filter
-     ADD CONSTRAINT "propdemo__property_filter__composite_fk" FOREIGN KEY (dataset_id, dsproperty_id) REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
+CREATE UNIQUE INDEX "dataset_property_filter__unique_for_composite_fk_referent" ON ds_properties USING btree ("datasetId", id);
+ALTER TABLE dataset_property_filter
+     ADD CONSTRAINT "dataset_property_filter__composite_fk" FOREIGN KEY ("datasetId", "datasetPropertyId") REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
 -- serve to add this third constraint …
-CREATE UNIQUE INDEX "propdemo__property_filter__spend_actorprop_once_per_dsprop" ON propdemo__property_filter (dsproperty_id, actorpropname_id);
--- … which is here to make a `actorprop_name` spendable only once per dataset. And thus we need the `dataset_id` in here for that.
--- But we want to avoid insertion anomalies, so we'll use (dataset_id, dsproperty_id) as a foreign key so that we can only insert 
--- the one and only `dataset_id` consistent with the `dsproperty_id` in re.
+CREATE UNIQUE INDEX "dataset_property_filter__spend_actorprop_once_per_dsprop" ON dataset_property_filter ("datasetPropertyId", "projectActorPropertyNameId");
+-- … which is here to make a `actorprop_name` spendable only once per dataset. And thus we need the `"datasetId"` in here for that.
+-- But we want to avoid insertion anomalies, so we'll use ("datasetId", "datasetPropertyId") as a foreign key so that we can only insert 
+-- the one and only `"datasetId"` consistent with the `"datasetPropertyId"` in re.
 
 
 
-CREATE VIEW propdemo___actor_dataset_filter AS (
+CREATE VIEW actor_dataset_filter AS (
     WITH filter_as_json AS (
         SELECT
-            pfilter.dataset_id,
-            actorpropval.actor_id,
-            jsonb_object_agg_strict (dsprops.name, actorpropval.propval) AS thefilter
+            pfilter."datasetId",
+            aprop."actorId",
+            jsonb_object_agg_strict (dsprops.name, aprop."propertyValue") AS thefilter
         FROM
-            propdemo__property_filter pfilter
-            INNER JOIN ds_properties dsprops ON (pfilter.dsproperty_id = dsprops.id)
-            INNER JOIN propdemo___actorpropval actorpropval USING (actorpropname_id)
+            dataset_property_filter pfilter
+            INNER JOIN ds_properties dsprops ON (pfilter."datasetPropertyId" = dsprops.id)
+            INNER JOIN actor_property_values aprop USING ("projectActorPropertyNameId")
         GROUP BY
-            (pfilter.dataset_id, actorpropval.actor_id)
+            (pfilter."datasetId", aprop."actorId")
     )
     SELECT
         *,

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
@@ -1,0 +1,63 @@
+-- Storing some Authoritative Curated Collection of per-project user props.
+CREATE TABLE propdemo___actorpropname (
+    id integer NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    project_id integer NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    propname text NOT NULL CHECK (length(propname) > 0)
+);
+CREATE UNIQUE INDEX ON propdemo___actorpropname (project_id, propname);
+
+
+CREATE TABLE propdemo___actorpropval (
+    id int GENERATED ALWAYS AS IDENTITY,
+    actor_id integer NOT NULL REFERENCES field_keys ("actorId") ON DELETE CASCADE,  -- We *could* FK directly to actors instead. But we can start out this way, and if necessary can easily flip the FK over to the actors table; we'd be widening possibilities.
+    actorpropname_id integer NOT NULL REFERENCES propdemo___actorpropname (id) ON DELETE CASCADE,
+    propval text NOT NULL CHECK (length(propval) > 0)
+);
+-- A prop is unique for an actor. You can't have two "age"s (which is intuitive) but neither can you have two "region"s which is maybe not
+-- intuitive, yet we decided against it, as if we enable multivalued properties we'll be plunged deeply into the woods with
+-- conjunctions and disjunctions when it comes to filtering semantics, user's expectations of either, arduous query predicate composition, 
+-- and forgoing the simple-fast-succinct containment operator.
+-- BTW this index double-serves as the index for the referer side of the FKs (used when CASCADE-ing).
+CREATE UNIQUE INDEX ON propdemo___actorpropval (actor_id, actorpropname_id);
+
+
+-- Defines an equation rule (as in: actorprop A must equate to entityprop B)
+CREATE TABLE propdemo__property_filter (
+     dataset_id integer NOT NULL,  -- FK constraint to follow, and explained below: at first glance having this column seems odd, as the dataset_id is already implied by the dsproperty_id, but there's a reason!
+     dsproperty_id integer NOT NULL PRIMARY KEY,  -- FK constraint to follow
+     actorpropname_id integer NOT NULL REFERENCES propdemo___actorpropname (id) ON DELETE CASCADE
+);
+-- The following two constraints (unique constraint and foreign key) …
+CREATE UNIQUE INDEX "propdemo__property_filter__unique_for_composite_fk_referent" ON ds_properties USING btree ("datasetId", id);
+ALTER TABLE propdemo__property_filter
+     ADD CONSTRAINT "propdemo__property_filter__composite_fk" FOREIGN KEY (dataset_id, dsproperty_id) REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
+-- serve to add this third constraint …
+CREATE UNIQUE INDEX "propdemo__property_filter__spend_actorprop_once_per_dsprop" ON propdemo__property_filter (dsproperty_id, actorpropname_id);
+-- … which is here to make a `actorprop_name` spendable only once per dataset. And thus we need the `dataset_id` in here for that.
+-- But we want to avoid insertion anomalies, so we'll use (dataset_id, dsproperty_id) as a foreign key so that we can only insert 
+-- the one and only `dataset_id` consistent with the `dsproperty_id` in re.
+
+
+
+CREATE VIEW propdemo___actor_dataset_filter AS (
+    WITH filter_as_json AS (
+        SELECT
+            pfilter.dataset_id,
+            actorpropval.actor_id,
+            jsonb_object_agg_strict (dsprops.name, actorpropval.propval) AS thefilter
+        FROM
+            propdemo__property_filter pfilter
+            INNER JOIN ds_properties dsprops ON (pfilter.dsproperty_id = dsprops.id)
+            INNER JOIN propdemo___actorpropval actorpropval USING (actorpropname_id)
+        GROUP BY
+            (pfilter.dataset_id, actorpropval.actor_id)
+    )
+    SELECT
+        *,
+        md5(thefilter::text) AS filterhash  -- Filterhash is there for making the filter part of a HTTP resource, for incremental entity list download: https://docs.google.com/document/d/1dLkp8-lODo0dA_zDaAMpiPGW2wvH0pCuvwa_ABgzBKY
+    FROM
+        filter_as_json
+);
+
+-- Creating this will take a very long time on big collections and slow databases.
+CREATE INDEX "idx_entity_defs_data" on entity_defs using gin (data);

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties.js
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties.js
@@ -1,0 +1,10 @@
+// Copyright 2025 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+module.exports = require('../pure-sql-migration')(__filename);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -909,8 +909,22 @@ const searchClause = (expr) => {
   return sql`(jsonb_to_tsvector('simple', entity_defs.data, '["string"]') || to_tsvector('simple', entity_defs.label)) @@ websearch_to_tsquery('simple', ${expr})`;
 };
 
-const streamForExport = (datasetId, options = QueryOptions.none) => ({ stream }) =>
-  stream(sql`
+const streamForExport = (datasetId, options = QueryOptions.none, withPropFilterForActor = null) => ({ stream }) => {
+  
+  const maybeFilterByPropJoin = withPropFilterForActor ? sql`
+    LEFT OUTER JOIN propdemo___actor_dataset_filter propfilter ON (
+      (propfilter.dataset_id = entities."datasetId")
+      AND
+      (propfilter.actor_id = ${withPropFilterForActor})
+    )` : sql``;
+  const maybeFilterByPropPredicate = withPropFilterForActor ? sql`
+    AND (
+      (propfilter.thefilter IS NULL)
+      OR
+      (propfilter.thefilter <@ entity_defs.data)
+    )` : sql ``;
+
+  return stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"
 LEFT JOIN actors ON entities."creatorId"=actors.id
@@ -918,7 +932,8 @@ ${options.skiptoken ? sql`
   INNER JOIN
   ( SELECT id, "createdAt" FROM entities WHERE "uuid" = ${options.skiptoken.uuid}::uuid) AS cursor
   ON entities."createdAt" <= cursor."createdAt" AND entities.id < cursor.id
-  `: sql``} 
+  `: sql``}
+${maybeFilterByPropJoin}
 WHERE
   entities."datasetId" = ${datasetId}
   AND ${sqlEquals(options.condition)}
@@ -926,11 +941,13 @@ WHERE
   AND entity_defs.current=true
   AND ${odataFilter(options.filter, odataToColumnMap)}
   AND ${searchClause(options.search)}
+  ${maybeFilterByPropPredicate}
 ${options.orderby ? sql`
   ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}
   `: sql`ORDER BY entities."createdAt" DESC, entities.id DESC`}
 ${page(options)}`)
     .then(stream.map(_exportUnjoiner));
+}
 
 const countByDatasetId = (datasetId, options = QueryOptions.none) => ({ one }) => one(sql`
 SELECT * FROM

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -912,10 +912,10 @@ const searchClause = (expr) => {
 const streamForExport = (datasetId, options = QueryOptions.none, withPropFilterForActor = null) => ({ stream }) => {
   
   const maybeFilterByPropJoin = withPropFilterForActor ? sql`
-    LEFT OUTER JOIN propdemo___actor_dataset_filter propfilter ON (
-      (propfilter.dataset_id = entities."datasetId")
+    LEFT OUTER JOIN actor_dataset_filter propfilter ON (
+      (propfilter."datasetId" = entities."datasetId")
       AND
-      (propfilter.actor_id = ${withPropFilterForActor})
+      (propfilter."actorId" = ${withPropFilterForActor})
     )` : sql``;
   const maybeFilterByPropPredicate = withPropFilterForActor ? sql`
     AND (

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -142,7 +142,7 @@ module.exports = (service, endpoint) => {
     const lastModifiedTime = await Datasets.getLastUpdateTimestamp(dataset.id);
 
     const csv = async () => {
-      const entities = await Entities.streamForExport(dataset.id, options);
+      const entities = await Entities.streamForExport(dataset.id, options, auth.actor.get().id);
       const filename = sanitize(dataset.name);
       const extension = 'csv';
       response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));


### PR DESCRIPTION
For @ktuite, demo of a filter-entityprops-by-userprops implementation. Only active for `/v1/projects/XX/datasets/XXXX/entities.csv`.

Just the DB side of things.

One thing I didn't implement is full referential anomaly prevention. Here's the thing: we have a table of properties (not values, just definitions of the properties) *for a particular project's users*: `project_actor_property_names`. So, scoped to a project.
But then, the filter definition table (aka "permission configuration") links one of those actor properties to some dataset property _but the database allows that dataset property to be from a different project_ :zap: 
(A solution to this can be to apply the compound foreign key pattern of which the foreign key constraint `"dataset_property_filter__composite_fk"` on table `dataset_property_filter` is an example.)


The filters constrain. So if a user doesn't have any properties being filtered by, they see all. But we could do the converse which means that if you give 1 (just 1) user "haircolor=grey" and define a rule "entity.barkcolor == user.haircolor" then this user will see entities with grey bark color, and no one else will see anything else...

Related: getodk/central#1339
Related: getodk/central#1790
Related: getodk/central#1791
Related: getodk/central#1792

