### PR TITLE
hashPassword(): fix max-length check

### DIFF
--- a/lib/util/crypto.js
+++ b/lib/util/crypto.js
@@ -36,7 +36,7 @@ const BCRYPT_COST_FACTOR = process.env.BCRYPT === 'insecure' ? 1 : 12;
 const hashPassword = (plain) => {
   if (typeof plain !== 'string') return reject(Problem.user.invalidDataTypeOfParameter({ value: plain, expected: 'string' }));
   if (plain.length < 10) return reject(Problem.user.passwordTooShort());
-  if (plain.length > 72) return reject(Problem.user.passwordTooLong());
+  if (Buffer.byteLength(plain) > 72) return reject(Problem.user.passwordTooLong());
   return isBlank(plain) ? resolve(null) : bcrypt.hash(plain, BCRYPT_COST_FACTOR);
 };
 const verifyPassword = (plain, hash) => ((typeof plain !== 'string' || isBlank(plain) || isBlank(hash))

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -23,6 +23,25 @@ describe('util/crypto', () => {
     it('should reject given a blank plaintext', () =>
       hashPassword('').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
 
+    it('should reject given a short plaintext', () =>
+      hashPassword('2short').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
+
+    it('should reject given a short plaintext (measured in bytes)', () =>
+      // This emoji is a single char on some devices, but in UTF-8 is 11 bytes.  A
+      // single character is too short to use as a password, even if its byte length
+      // is above the password length limit.
+      hashPassword('👩‍💻').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
+
+    it('should reject given a long plaintext', () =>
+      hashPassword('longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg').should.be.rejectedWith('The password or passphrase provided exceeds the maximum length.'));
+
+    it('should reject given a long plaintext (measured in bytes)', () => {
+      const password = '❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️';
+      password.length.should.be.lessThan(72);
+      Buffer.byteLength(password).should.be.greaterThan(72);
+      return hashPassword(password).should.be.rejectedWith('The password or passphrase provided exceeds the maximum length.');
+    });
+
     it('should not attempt to verify empty plaintext', (done) => {
       verifyPassword('', '$2a$12$hCRUXz/7Hx2iKPLCduvrWugC5Q/j5e3bX9KvaYvaIvg/uvFYEpzSy').then((result) => {
         result.should.equal(false);

--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -21,14 +21,6 @@ describe('util/crypto', () => {
 
     it('should reject given a blank plaintext', () =>
       hashPassword('').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
-  });
-
-  describe('verifyPassword()', () => {
-    const { verifyPassword } = crypto;
-
-    it('should always return a Promise', () => {
-      verifyPassword('password', 'hashhash').should.be.a.Promise();
-    });
 
     it('should reject given a short plaintext', () =>
       hashPassword('2short').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
@@ -47,6 +39,14 @@ describe('util/crypto', () => {
       password.length.should.be.lessThan(72);
       Buffer.byteLength(password).should.be.greaterThan(72);
       return hashPassword(password).should.be.rejectedWith('The password or passphrase provided exceeds the maximum length.');
+    });
+  });
+
+  describe('verifyPassword()', () => {
+    const { verifyPassword } = crypto;
+
+    it('should always return a Promise', () => {
+      verifyPassword('password', 'hashhash').should.be.a.Promise();
     });
 
     it('should not attempt to verify empty plaintext', (done) => {


### PR DESCRIPTION
* add tests for min & max length, both with ascii chars & emojis
* test max-length by bytes instead of characters

Noted while reviewing https://github.com/getodk/central-backend/pull/1804

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

The example long-short password of `👩‍💻` would also be rejected by `zxcvbn` in #1804, but testing it for length first seems reasonable defence-in-depth.

Password length should be tested in bytes because this is how `bcrypt` functions:

```js
const { hashSync, compareSync } = require('bcrypt');
const examplePassword = '❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️';
const clippedExamplePassword = Buffer.from(examplePassword).subarray(0, -4).toString();
console.log(JSON.stringify({
  examplePassword: [ examplePassword, examplePassword.length, Buffer.byteLength(examplePassword) ],
  clippedExamplePassword: [ clippedExamplePassword, clippedExamplePassword.length, Buffer.byteLength(clippedExamplePassword) ],
  match: compareSync(clippedExamplePassword, hashSync(examplePassword, 1)),
}, null, 2));
```

output:

```json
{
  "examplePassword": [
    "❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️",
    26,
    78
  ],
  "clippedExamplePassword": [
    "❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️�",
    25,
    75
  ],
  "match": true
}
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change only affects `hashPassword()`, which is only used when create/updating a user's password.  This means it should not affect existing users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

`docs/api.yaml` does not currently mention password length restrictions (or other password requiredments).

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
