### PR TITLE
test/unit/util/crypto: split tests for hash & verify

### DIFF
--- a/test/unit/util/crypto.js
+++ b/test/unit/util/crypto.js
@@ -7,8 +7,8 @@ const streamTest = require('streamtest').v2;
 const crypto = require(appRoot + '/lib/util/crypto');
 
 describe('util/crypto', () => {
-  describe('hashPassword/verifyPassword', () => {
-    const { hashPassword, verifyPassword } = crypto;
+  describe('hashPassword()', () => {
+    const { hashPassword } = crypto;
 
     // we do not actually verify the hashing itself, as:
     // 1. it is entirely performed by bcrypt, which has is own tests.
@@ -17,11 +17,18 @@ describe('util/crypto', () => {
     it('should always return a Promise', () => {
       hashPassword('').should.be.a.Promise();
       hashPassword('password').should.be.a.Promise();
-      hashPassword('password', 'hashhash').should.be.a.Promise();
     });
 
     it('should reject given a blank plaintext', () =>
       hashPassword('').should.be.rejectedWith('The password or passphrase provided does not meet the required length.'));
+  });
+
+  describe('verifyPassword()', () => {
+    const { verifyPassword } = crypto;
+
+    it('should always return a Promise', () => {
+      verifyPassword('password', 'hashhash').should.be.a.Promise();
+    });
 
     it('should not attempt to verify empty plaintext', (done) => {
       verifyPassword('', '$2a$12$hCRUXz/7Hx2iKPLCduvrWugC5Q/j5e3bX9KvaYvaIvg/uvFYEpzSy').then((result) => {


### PR DESCRIPTION
* previously `hashPassword()` and `verifyPassword()` were included in the same `describe()` block
* in ea188f4ec8ba932d1263fc1eaabe0e4eb862e19b, one test for verify was mistakenly changed to hash

Ref #1804

#### What has been done to verify that this works as intended?

Tests!

#### Why is this the best possible solution? Were any other approaches considered?

If the unit tests are useful, then they should be correct.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just tests.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced