### PR TITLE
inline content: lock down CSP

### DIFF
--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -355,6 +355,7 @@ describe('api: /key/:key', () => {
       .then(({ headers, body }) => {
         headers['content-type'].should.equal('image/jpeg');
         headers['content-disposition'].should.equal('inline; filename="here_is_file2.jpg"; filename*=UTF-8\'\'here_is_file2.jpg');
+        headers['content-security-policy'].should.equal(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
         body.toString('utf8').should.equal('this is test file two');
       });
 
@@ -437,6 +438,7 @@ describe('api: /key/:key', () => {
       .then(({ headers, body }) => {
         headers['content-type'].should.equal('image/jpeg');
         headers['content-disposition'].should.equal('inline; filename="here_is_file2.jpg"; filename*=UTF-8\'\'here_is_file2.jpg');
+        headers['content-security-policy'].should.equal(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
         body.toString('utf8').should.equal('this is test file two');
       });
 

--- a/test/integration/api/config.js
+++ b/test/integration/api/config.js
@@ -79,6 +79,7 @@ describe('api: /config', () => {
               .expect(200)
               .then(({ headers }) => {
                 headers['content-disposition'].should.startWith('attachment');
+                headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; report-uri /csp-report`);
               });
           }));
         });

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -584,6 +584,7 @@ describe('api: /submission', () => {
                 .then(({ headers, body }) => {
                   headers['content-type'].should.equal('image/jpeg');
                   headers['content-disposition'].should.equal('inline; filename="here_is_file2.jpg"; filename*=UTF-8\'\'here_is_file2.jpg');
+                  headers['content-security-policy'].should.equal(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
                   headers['etag'].should.equal('"25bdb03b7942881c279788575997efba"'); // eslint-disable-line dot-notation
                   body.toString('utf8').should.equal('this is test file two');
                 }))
@@ -620,6 +621,7 @@ describe('api: /submission', () => {
         .then(({ headers, body }) => {
           headers['content-type'].should.equal('image/jpeg');
           headers['content-disposition'].should.equal('inline; filename="here_is_file2.jpg"; filename*=UTF-8\'\'here_is_file2.jpg');
+          headers['content-security-policy'].should.equal(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
           body.toString('utf8').should.equal('this is test file two');
         });
 
@@ -667,6 +669,7 @@ describe('api: /submission', () => {
                 .then(({ headers, body }) => {
                   headers['content-type'].should.equal('image/jpeg');
                   headers['content-disposition'].should.equal('inline; filename="here_is_file2.jpg"; filename*=UTF-8\'\'here_is_file2.jpg');
+                  headers['content-security-policy'].should.equal(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
                   headers['etag'].should.equal('"25bdb03b7942881c279788575997efba"'); // eslint-disable-line dot-notation
                   body.toString('utf8').should.equal('this is test file two');
                 }))


### PR DESCRIPTION
# TODO

- [x] ~extend test cases to `text/xml` files (e.g. .svc)?  or~ separate to new issue -- filed at https://github.com/getodk/central/issues/1851
- [ ] fix implementations

---

* allow favicons to load
* don't allow much of anything else

Closes https://github.com/getodk/central/issues/1779

#### What has been done to verify that this works as intended?

- [ ] updated integration tests
- [ ] related CSP (report-only) reports in Sentry

#### Why is this the best possible solution? Were any other approaches considered?

Alternatives

* could do from nginx, but much harder to identify what is being served with `Content-Disposition: inline`
* could filter favicon-related CSP reports at ingestion (Sentry).  This would be a simple approach, and safer than allowing all images, but would create more traffic for users
* could explicitly allow the URL of the favicon, if central-backend knows its own domain name

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Risk could be reduced by initially service CSPs as report-only.  Likely won't be a problem though as:

1. no existing worrying reports
2. the new CSP included here reflects the CSP served from nginx, but with an `img-src` change
3. surprises will be reports to /csp-report

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
