### PR TITLE
csp: serve text/xml with tight CSP

### DIFF
--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -46,6 +46,8 @@ const writeProblemJson = (response, error) => {
 const isJsonType = (x) => /(^|,)(application\/json|json)($|;|,)/i.test(x);
 const isXmlType = (x) => /(^|,)(application\/(atom(svc)?\+)?xml|atom|xml)($|;|,)/i.test(x);
 
+const asXml = response => response.type('text/xml').setHeader('Content-Security-Policy', `default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
+
 // determines if a request needs a transaction.
 const phony = (request) => {
   if (/submissions\.csv(\.zip)?$/.test(request.path)) return true;
@@ -326,7 +328,7 @@ const openRosaBefore = (response) => {
 // streaming openRosa responses. if we do someday, we'll have to code a fallback
 // to a common streaming handler.
 const openRosaResultWriter = (result, _, response) => {
-  response.type('text/xml').status(result.code).send(result.body);
+  asXml(response).status(result.code).send(result.body);
 };
 
 const openRosaErrorWriter = (error, request, response) => {
@@ -334,7 +336,7 @@ const openRosaErrorWriter = (error, request, response) => {
     // if something really unexpected happened, use the standard sendError routine.
     defaultErrorWriter(error, request, response);
   else
-    response.type('text/xml').status(error.httpCode).send(openRosaError(error.message)); // TODO: include more of the error detail.
+    asXml(response).status(error.httpCode).send(openRosaError(error.message)); // TODO: include more of the error detail.
 };
 
 // combine the above into the actual endpoint.
@@ -405,7 +407,7 @@ const odataXmlErrorWriter = (error, request, response) => {
     // if something really unexpected happened, use the standard sendError routine.
     return defaultErrorWriter(error, request, response);
   else
-    response.type('text/xml').status(error.httpCode).send(odataXmlError(error));
+    asXml(response).status(error.httpCode).send(odataXmlError(error));
 };
 
 // finally, the actual endpoint definition for odata endpoints:
@@ -447,6 +449,6 @@ module.exports = {
   Context, endpointBase,
   defaultResultWriter,
   openRosaPreprocessor, openRosaBefore, openRosaResultWriter, openRosaErrorWriter,
-  odataPreprocessor, odataBefore
+  odataPreprocessor, odataBefore, odataXmlErrorWriter,
 };
 

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -2110,6 +2110,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 .expect(200)
                 .then(({ headers, text }) => {
                   headers['content-type'].should.startWith('text/xml');
+                  headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
                   text.should.equal('test,csv\n1,2');
                 })))));
 

--- a/test/integration/api/forms/list.js
+++ b/test/integration/api/forms/list.js
@@ -130,6 +130,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
           .then(({ text, headers }) => {
             // Collect is particular about this:
             headers['content-type'].should.equal('text/xml; charset=utf-8');
+            headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
 
             const domain = config.get('default.env.domain');
             text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -159,6 +160,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
           .then(({ text, headers }) => {
             // Collect is particular about this:
             headers['content-type'].should.equal('text/xml; charset=utf-8');
+            headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
 
             const domain = config.get('default.env.domain');
             text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -181,6 +183,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
           .then(({ text, headers }) => {
             // Collect is particular about this:
             headers['content-type'].should.equal('text/xml; charset=utf-8');
+            headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
 
             text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
   <xforms xmlns="http://openrosa.org/xforms/xformsList">
@@ -201,6 +204,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
               .then(({ text, headers }) => {
                 // Collect is particular about this:
                 headers['content-type'].should.equal('text/xml; charset=utf-8');
+                headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
 
                 const domain = config.get('default.env.domain');
                 text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -229,6 +233,7 @@ describe('api: /projects/:id/forms (listing forms)', () => {
               .then(({ text, headers }) => {
                 // Collect is particular about this:
                 headers['content-type'].should.equal('text/xml; charset=utf-8');
+                headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
 
                 const domain = config.get('default.env.domain');
                 text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -73,6 +73,7 @@ describe('api: /forms/:id.svc', () => {
           .expect(404)
           .then(({ headers, text }) => {
             headers['content-type'].should.equal('text/xml; charset=utf-8');
+            headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
             text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
 <error code="404.1">
   <message>Could not find the resource you were looking for.</message>
@@ -95,6 +96,7 @@ describe('api: /forms/:id.svc', () => {
           .expect(403)
           .then(({ headers, text }) => {
             headers['content-type'].should.equal('text/xml; charset=utf-8');
+            headers['content-security-policy'].should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
             text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
 <error code="403.1">
   <message>The authentication you provided does not have rights to perform that action.</message>

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -6,7 +6,7 @@ const streamTest = require('streamtest').v2;
 const { always } = require('ramda');
 
 const appRoot = require('app-root-path');
-const { endpointBase, defaultErrorWriter, Context, defaultResultWriter, openRosaPreprocessor, openRosaBefore, openRosaResultWriter, openRosaErrorWriter, odataPreprocessor, odataBefore } = require(appRoot + '/lib/http/endpoint');
+const { endpointBase, defaultErrorWriter, Context, defaultResultWriter, openRosaPreprocessor, openRosaBefore, openRosaResultWriter, openRosaErrorWriter, odataPreprocessor, odataBefore, odataXmlErrorWriter } = require(appRoot + '/lib/http/endpoint');
 const { PartialPipe } = require(appRoot + '/lib/util/stream');
 const { noop } = require(appRoot + '/lib/util/util');
 const Problem = require(appRoot + '/lib/util/problem');
@@ -594,12 +594,13 @@ describe('endpoints', () => {
     describe('resultWriter', () => {
       const { createdMessage } = require(appRoot + '/lib/formats/openrosa');
 
-      it('should send the appropriate content with the appropriate header', () => {
+      it('should send the appropriate content with the appropriate headers', () => {
         const response = createResponse();
         openRosaResultWriter(createdMessage({}), null, response);
 
         response.statusCode.should.equal(201);
         response.getHeader('Content-Type').should.equal('text/xml');
+        response.getHeader('Content-Security-Policy').should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
         response._getData().trim().should.equal('<OpenRosaResponse xmlns="http://openrosa.org/http/response" items="0">\n    <message nature=""></message>\n  </OpenRosaResponse>');
       });
     });
@@ -623,6 +624,7 @@ describe('endpoints', () => {
 
         response.statusCode.should.equal(404);
         response.getHeader('Content-Type').should.equal('text/xml');
+        response.getHeader('Content-Security-Policy').should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
         response._getData().trim().should.equal('<OpenRosaResponse xmlns="http://openrosa.org/http/response" items="0">\n    <message nature="error">Could not find the resource you were looking for.</message>\n  </OpenRosaResponse>');
       });
     });
@@ -696,6 +698,41 @@ describe('endpoints', () => {
         odataBefore(response);
 
         response.get('OData-Version').should.equal('4.0');
+      });
+    });
+
+    describe('odataXmlErrorWriter', () => {
+      it('should set appropriate response headers for null error', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response.statusCode.should.equal(500);
+          response.getHeader('Content-Type').should.eql('application/json'); // this is surprising
+          should(response.getHeader('Content-Security-Policy')).be.undefined;
+          done();
+        });
+        odataXmlErrorWriter(null, null, response);
+      });
+
+      it('should set appropriate response headers for Error', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response.statusCode.should.equal(500);
+          response.getHeader('Content-Type').should.eql('application/json'); // this is surprising
+          should(response.getHeader('Content-Security-Policy')).be.undefined;
+          done();
+        });
+        odataXmlErrorWriter(new Error('standard JS error'), null, response);
+      });
+
+      it('should set appropriate response headers for Problem', (done) => {
+        const response = createResponse();
+        response.on('end', () => {
+          response.statusCode.should.equal(403);
+          response.getHeader('Content-Type').should.eql('text/xml');
+          response.getHeader('Content-Security-Policy').should.eql(`default-src 'report-sample' 'none'; form-action 'none'; frame-ancestors 'none'; img-src: 'self'; report-uri /csp-report`);
+          done();
+        });
+        odataXmlErrorWriter(Problem.user.insufficientRights(), null, response);
       });
     });
   });


### PR DESCRIPTION
# TODO

- [ ] unit tests for
  - [ ] `openRosaResultWriter`
  - [ ] `openRosaErrorWriter`
  - [ ] `odataXmlErrorWriter`
  - [ ] odata result writer (may need to create this)
- [ ] implementation

---

* disallow by default
* allow `img-src: 'self'` for favicon

Closes getodk/central#1851

#### What has been done to verify that this works as intended?

Updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

Alternatives

* could do from nginx, but much harder to identify what is being served with `Content-Disposition: inline`
* could filter favicon-related CSP reports at ingestion (Sentry).  This would be a simple approach, and safer than allowing all images, but would create more traffic for users
* could explicitly allow the URL of the favicon, if central-backend knows its own domain name

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
