### PR TITLE
Support app-user properties for filtering dataset CSV attachments on forms

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -112,6 +112,7 @@ module.exports = (container) => {
   require('../resources/analytics')(service, endpoint);
   require('../resources/datasets')(service, endpoint);
   require('../resources/entities')(service, endpoint);
+  require('../resources/user-properties')(service, endpoint);
   require('../resources/oidc')(service, endpoint, anonymousEndpoint);
   require('../resources/user-preferences')(service, endpoint);
 

--- a/lib/model/container.js
+++ b/lib/model/container.js
@@ -112,6 +112,7 @@ const withDefaults = (base, queries) => {
     Datasets: require('./query/datasets'),
     Entities: require('./query/entities'),
     UserPreferences: require('./query/user-preferences'),
+    UserProperties: require('./query/user-properties'),
     GeoExtracts: require('./query/geo-extracts'),
   };
 

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -79,6 +79,19 @@ const ClientAudit = Frame.define(
   fieldTypes(['int4', 'jsonb', ...headers.map(() => 'text')])
 );
 
+const ActorProperty = Frame.define(
+  table('actor_properties'),
+  'id',
+  'projectId',
+  'name',   readable
+);
+
+const DatasetAccessFilter = Frame.define(
+  table('dataset_access_filters'),
+  'datasetProperty', readable,
+  'userProperty',    readable
+);
+
 const Comment = Frame.define(
   table('comments'),
   'body',       readable, writable,     'actorId',      readable,
@@ -210,6 +223,7 @@ class User extends Frame.define(
 
 
 module.exports = {
+  ActorProperty,
   Actee,
   Actor,
   Assignment,
@@ -219,6 +233,7 @@ module.exports = {
   Comment,
   Config,
   Dataset,
+  DatasetAccessFilter,
   Entity,
   FieldKey,
   Form,

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE dataset_access_filters CASCADE;
+DROP TABLE actor_property_values CASCADE;
+DROP TABLE actor_properties CASCADE;

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.down.sql
@@ -1,3 +1,5 @@
+DROP VIEW IF EXISTS actor_dataset_filter;
 DROP TABLE dataset_access_filters CASCADE;
+DROP INDEX IF EXISTS "dataset_access_filters__unique_for_composite_fk_referent";
 DROP TABLE actor_property_values CASCADE;
 DROP TABLE actor_properties CASCADE;

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
@@ -1,0 +1,59 @@
+-- Registry of property names that can be assigned to actors, scoped per project.
+CREATE TABLE actor_properties (
+    id integer NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    "projectId" integer NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    "name" text NOT NULL CHECK (length("name") > 0)
+);
+CREATE UNIQUE INDEX ON actor_properties ("projectId", "name");
+
+
+CREATE TABLE actor_property_values (
+    id integer GENERATED ALWAYS AS IDENTITY,
+    "actorId" integer NOT NULL REFERENCES field_keys ("actorId") ON DELETE CASCADE,  -- FK to field_keys for now; can be widened to actors if needed.
+    "actorPropertyId" integer NOT NULL REFERENCES actor_properties (id) ON DELETE CASCADE,
+    "value" text NOT NULL CHECK (length("value") > 0)
+);
+-- Each actor can only have one value per property. Multivalued properties were intentionally avoided
+-- to keep filtering semantics simple (no conjunction/disjunction complexity).
+-- This index also serves as the index for the FK referent side (used when CASCADE-ing).
+CREATE UNIQUE INDEX ON actor_property_values ("actorId", "actorPropertyId");
+
+
+-- Maps a dataset property to an actor property, defining a filter rule:
+-- entities are visible to an actor only if their value for "datasetPropertyId" matches the actor's value for "actorPropertyId".
+CREATE TABLE dataset_access_filters (
+    "datasetId" integer NOT NULL,  -- Redundant with "datasetPropertyId" but needed for the composite FK below to prevent insertion anomalies.
+    "datasetPropertyId" integer NOT NULL PRIMARY KEY,
+    "actorPropertyId" integer NOT NULL REFERENCES actor_properties (id) ON DELETE CASCADE
+);
+-- The unique index on ds_properties enables the composite FK, which ensures "datasetId" is always
+-- consistent with "datasetPropertyId" (preventing insertion anomalies).
+CREATE UNIQUE INDEX "dataset_access_filters__unique_for_composite_fk_referent" ON ds_properties USING btree ("datasetId", id);
+ALTER TABLE dataset_access_filters
+    ADD CONSTRAINT "dataset_access_filters__composite_fk" FOREIGN KEY ("datasetId", "datasetPropertyId") REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
+-- Ensures each actor property is used at most once per dataset.
+CREATE UNIQUE INDEX "dataset_access_filters__spend_actorprop_once_per_dsprop" ON dataset_access_filters ("datasetPropertyId", "actorPropertyId");
+
+
+CREATE VIEW actor_dataset_filter AS (
+    WITH filter_as_json AS (
+        SELECT
+            pfilter."datasetId",
+            aprop."actorId",
+            jsonb_object_agg (dsprops."name", aprop."value") AS thefilter
+        FROM
+            dataset_access_filters pfilter
+            INNER JOIN ds_properties dsprops ON (pfilter."datasetPropertyId" = dsprops.id)
+            INNER JOIN actor_property_values aprop USING ("actorPropertyId")
+        GROUP BY
+            (pfilter."datasetId", aprop."actorId")
+    )
+    SELECT
+        *,
+        md5(thefilter::text) AS filterhash  -- Used to make the filter part of an HTTP resource for incremental entity list download.
+    FROM
+        filter_as_json
+);
+
+-- Commented out: would take a very long time on large databases.
+-- CREATE INDEX "idx_entity_defs_data" on entity_defs using gin (data);

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties-01.up.sql
@@ -17,6 +17,8 @@ CREATE TABLE actor_property_values (
 -- to keep filtering semantics simple (no conjunction/disjunction complexity).
 -- This index also serves as the index for the FK referent side (used when CASCADE-ing).
 CREATE UNIQUE INDEX ON actor_property_values ("actorId", "actorPropertyId");
+-- Index to support FK lookup on actorPropertyId (CASCADE deletes from actor_properties).
+CREATE INDEX ON actor_property_values ("actorPropertyId");
 
 
 -- Maps a dataset property to an actor property, defining a filter rule:
@@ -33,6 +35,10 @@ ALTER TABLE dataset_access_filters
     ADD CONSTRAINT "dataset_access_filters__composite_fk" FOREIGN KEY ("datasetId", "datasetPropertyId") REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
 -- Ensures each actor property is used at most once per dataset.
 CREATE UNIQUE INDEX "dataset_access_filters__spend_actorprop_once_per_dsprop" ON dataset_access_filters ("datasetPropertyId", "actorPropertyId");
+-- Index to support FK lookup on actorPropertyId (CASCADE deletes from actor_properties).
+CREATE INDEX ON dataset_access_filters ("actorPropertyId");
+-- Index to support FK lookup on (datasetId, datasetPropertyId) (CASCADE deletes from ds_properties).
+CREATE INDEX ON dataset_access_filters ("datasetId", "datasetPropertyId");
 
 
 CREATE VIEW actor_dataset_filter AS (

--- a/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties.js
+++ b/lib/model/migrations/20260424-01-user-properties-and-dataset-filtering-by-userproperties.js
@@ -1,0 +1,10 @@
+// Copyright 2026 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/getodk/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+module.exports = require('../pure-sql-migration')(__filename);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -919,8 +919,10 @@ ${options.skiptoken ? sql`
   ( SELECT id, "createdAt" FROM entities WHERE "uuid" = ${options.skiptoken.uuid}::uuid) AS cursor
   ON entities."createdAt" <= cursor."createdAt" AND entities.id < cursor.id
   `: sql``}
+${actorId != null ? sql`
 LEFT OUTER JOIN actor_dataset_filter propfilter
   ON propfilter."datasetId" = entities."datasetId" AND propfilter."actorId" = ${actorId}
+` : sql``}
 WHERE
   entities."datasetId" = ${datasetId}
   AND ${sqlEquals(options.condition)}
@@ -928,7 +930,7 @@ WHERE
   AND entity_defs.current=true
   AND ${odataFilter(options.filter, odataToColumnMap)}
   AND ${searchClause(options.search)}
-  AND (propfilter.thefilter IS NULL OR propfilter.thefilter <@ entity_defs.data)
+  AND (${actorId != null ? sql`propfilter.thefilter IS NULL OR propfilter.thefilter <@ entity_defs.data` : sql`true`})
 ${options.orderby ? sql`
   ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}
   `: sql`ORDER BY entities."createdAt" DESC, entities.id DESC`}

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -909,7 +909,7 @@ const searchClause = (expr) => {
   return sql`(jsonb_to_tsvector('simple', entity_defs.data, '["string"]') || to_tsvector('simple', entity_defs.label)) @@ websearch_to_tsquery('simple', ${expr})`;
 };
 
-const streamForExport = (datasetId, options = QueryOptions.none) => ({ stream }) =>
+const streamForExport = (datasetId, options = QueryOptions.none, actorId) => ({ stream }) =>
   stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"
@@ -918,7 +918,9 @@ ${options.skiptoken ? sql`
   INNER JOIN
   ( SELECT id, "createdAt" FROM entities WHERE "uuid" = ${options.skiptoken.uuid}::uuid) AS cursor
   ON entities."createdAt" <= cursor."createdAt" AND entities.id < cursor.id
-  `: sql``} 
+  `: sql``}
+LEFT OUTER JOIN actor_dataset_filter propfilter
+  ON propfilter."datasetId" = entities."datasetId" AND propfilter."actorId" = ${actorId}
 WHERE
   entities."datasetId" = ${datasetId}
   AND ${sqlEquals(options.condition)}
@@ -926,6 +928,7 @@ WHERE
   AND entity_defs.current=true
   AND ${odataFilter(options.filter, odataToColumnMap)}
   AND ${searchClause(options.search)}
+  AND (propfilter.thefilter IS NULL OR propfilter.thefilter <@ entity_defs.data)
 ${options.orderby ? sql`
   ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}
   `: sql`ORDER BY entities."createdAt" DESC, entities.id DESC`}

--- a/lib/model/query/user-properties.js
+++ b/lib/model/query/user-properties.js
@@ -1,0 +1,78 @@
+const { sql } = require('slonik');
+const { ActorProperty, DatasetAccessFilter } = require('../frames');
+const { getOrNotFound } = require('../../util/promise');
+
+// Registers a new actor property name for a project.
+const create = (projectId, name) => ({ one }) =>
+  one(sql`
+INSERT INTO actor_properties ("projectId", "name")
+VALUES (${projectId}, ${name})
+RETURNING *`)
+    .then((row) => new ActorProperty(row));
+
+// Returns all actor property names for a project.
+const getAllForProject = (projectId) => ({ all }) =>
+  all(sql`
+SELECT * FROM actor_properties
+WHERE "projectId" = ${projectId}
+ORDER BY "name"`)
+    .then((rows) => rows.map((row) => new ActorProperty(row)));
+
+// Sets or unsets a property value for an app user (actorId).
+// Pass value=null to unset the property (removes the value row).
+// The property must exist in actor_properties for the project.
+const setValueForActor = (projectId, actorId, name, value) => async ({ run, maybeOne }) => {
+  const property = await maybeOne(sql`
+SELECT id FROM actor_properties
+WHERE "projectId" = ${projectId} AND "name" = ${name}`).then(getOrNotFound);
+
+  if (value == null) {
+    await run(sql`
+DELETE FROM actor_property_values
+WHERE "actorId" = ${actorId} AND "actorPropertyId" = ${property.id}`);
+  } else {
+    await run(sql`
+INSERT INTO actor_property_values ("actorId", "actorPropertyId", "value")
+VALUES (${actorId}, ${property.id}, ${value})
+ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."value"`);
+  }
+};
+
+// Returns all property values for an app user as { name, value } rows.
+const getValuesForActor = (actorId) => ({ all }) =>
+  all(sql`
+SELECT ap."name", apv."value"
+FROM actor_property_values apv
+JOIN actor_properties ap ON ap.id = apv."actorPropertyId"
+WHERE apv."actorId" = ${actorId}
+ORDER BY ap."name"`);
+
+// Adds or updates a single access filter rule for a dataset.
+// datasetPropertyName and userPropertyName are names (strings).
+const setAccessFilter = (datasetId, datasetPropertyName, userPropertyName) => async ({ run, maybeOne }) => {
+  const dsProp = await maybeOne(sql`
+SELECT id FROM ds_properties WHERE "datasetId" = ${datasetId} AND "name" = ${datasetPropertyName} AND "publishedAt" IS NOT NULL`).then(getOrNotFound);
+
+  const actorProp = await maybeOne(sql`
+SELECT ap.id FROM actor_properties ap
+JOIN datasets d ON d."projectId" = ap."projectId"
+WHERE d.id = ${datasetId} AND ap."name" = ${userPropertyName}`).then(getOrNotFound);
+
+  await run(sql`
+INSERT INTO dataset_access_filters ("datasetId", "datasetPropertyId", "actorPropertyId")
+VALUES (${datasetId}, ${dsProp.id}, ${actorProp.id})
+ON CONFLICT ("datasetPropertyId") DO UPDATE SET "actorPropertyId" = EXCLUDED."actorPropertyId"`);
+};
+
+// Returns all access filter rules for a dataset as DatasetAccessFilter instances.
+const getAccessFilter = (datasetId) => ({ all }) =>
+  all(sql`
+SELECT dsp."name" AS "datasetProperty", ap."name" AS "userProperty"
+FROM dataset_access_filters daf
+JOIN ds_properties dsp ON dsp.id = daf."datasetPropertyId"
+JOIN actor_properties ap ON ap.id = daf."actorPropertyId"
+WHERE daf."datasetId" = ${datasetId}
+ORDER BY dsp."name"`)
+    .then((rows) => rows.map((row) => new DatasetAccessFilter(row)));
+
+module.exports = { create, getAllForProject, setValueForActor, getValuesForActor, setAccessFilter, getAccessFilter };

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -38,5 +38,26 @@ module.exports = (service, endpoint) => {
       .then((fk) => Actors.del(fk.actor))
       .then(success)));
 
+  // Set/unset user property values on an app user.
+  // Body: { userProperties: { propName: "value" | null, ... } }
+  service.patch('/projects/:projectId/app-users/:id', endpoint(async ({ UserProperties, FieldKeys, Projects }, { auth, params, body }) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('project.update', project);
+
+    const fk = await FieldKeys.getByProjectAndActorId(project.id, params.id).then(getOrNotFound);
+
+    const { userProperties } = body;
+    if (userProperties != null) {
+      for (const [name, value] of Object.entries(userProperties)) {
+        // eslint-disable-next-line no-await-in-loop
+        await UserProperties.setValueForActor(project.id, fk.actorId, name, value);
+      }
+    }
+
+    const values = await UserProperties.getValuesForActor(fk.actorId);
+    const userPropertiesMap = Object.fromEntries(values.map(({ name, value }) => [name, value]));
+    return { ...fk.forApi(), userProperties: userPropertiesMap };
+  }));
+
 };
 

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -142,7 +142,7 @@ module.exports = (service, endpoint) => {
     const lastModifiedTime = await Datasets.getLastUpdateTimestamp(dataset.id);
 
     const csv = async () => {
-      const entities = await Entities.streamForExport(dataset.id, options);
+      const entities = await Entities.streamForExport(dataset.id, options, auth.actor.get().id);
       const filename = sanitize(dataset.name);
       const extension = 'csv';
       response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -131,6 +131,28 @@ module.exports = (service, endpoint) => {
     return success;
   }));
 
+  // Add or update a single access filter rule for a dataset.
+  // Body: { "datasetProperty": "<name>", "userProperty": "<name>" }
+  service.put('/projects/:projectId/datasets/:name/access-filter', endpoint(async ({ UserProperties, Datasets }, { auth, params, body }) => {
+    const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
+    await auth.canOrReject('dataset.update', dataset);
+
+    const { datasetProperty, userProperty } = body ?? {};
+    if (!datasetProperty || !userProperty)
+      throw Problem.user.unexpectedValue({ field: 'datasetProperty/userProperty', value: null, reason: 'Both datasetProperty and userProperty are required.' });
+    await UserProperties.setAccessFilter(dataset.id, datasetProperty, userProperty);
+    const filters = await UserProperties.getAccessFilter(dataset.id);
+    return filters.find((f) => f.datasetProperty === datasetProperty) ?? null;
+  }));
+
+  // Get all access filter rules for a dataset.
+  service.get('/projects/:projectId/datasets/:name/access-filter', endpoint(async ({ UserProperties, Datasets }, { auth, params }) => {
+    const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
+    await auth.canOrReject('dataset.read', dataset);
+    const filters = await UserProperties.getAccessFilter(dataset.id);
+    return filters[0] ?? null;
+  }));
+
   service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(async ({ Datasets, Entities, Projects }, { params, auth, query }, request, response) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -43,7 +43,7 @@ const getOwnerOnlyOptions = async (auth, project) => ((await auth.can('entity.li
   ? QueryOptions.none
   : QueryOptions.none.withCondition({ 'entities.creatorId': auth.actor.get().id }));
 
-const streamAttachment = async (container, attachment, ownerOnlyOptions, response) => {
+const streamAttachment = async (container, attachment, ownerOnlyOptions, response, auth) => {
   const { s3, Blobs, Datasets, Entities } = container;
 
   if (attachment.blobId == null && attachment.datasetId == null) {
@@ -55,7 +55,8 @@ const streamAttachment = async (container, attachment, ownerOnlyOptions, respons
     const properties = await Datasets.getProperties(attachment.datasetId);
     return withEtag(attachment.openRosaHash, async () => {
       const options = attachment.ownerOnly ? ownerOnlyOptions : QueryOptions.none;
-      const entities = await Entities.streamForExport(attachment.datasetId, options);
+      const actorId = auth.actor.get().id;
+      const entities = await Entities.streamForExport(attachment.datasetId, options, actorId);
       response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
       response.append('Content-Type', 'text/csv');
       return streamEntityCsvAttachment(entities, properties);
@@ -320,7 +321,7 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
       const options = await getOwnerOnlyOptions(auth, project);
       const attachment = await FormAttachments.getByFormDefIdAndNameForOpenRosa(form.def.id, params.name, options)
         .then(getOrNotFound);
-      return streamAttachment(container, attachment, options, response);
+      return streamAttachment(container, attachment, options, response, auth);
     }));
   };
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -55,7 +55,7 @@ const streamAttachment = async (container, attachment, ownerOnlyOptions, respons
     const properties = await Datasets.getProperties(attachment.datasetId);
     return withEtag(attachment.openRosaHash, async () => {
       const options = attachment.ownerOnly ? ownerOnlyOptions : QueryOptions.none;
-      const actorId = auth.actor.get().id;
+      const actorId = auth != null ? auth.actor.get().id : null;
       const entities = await Entities.streamForExport(attachment.datasetId, options, actorId);
       response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
       response.append('Content-Type', 'text/csv');

--- a/lib/resources/user-properties.js
+++ b/lib/resources/user-properties.js
@@ -1,0 +1,28 @@
+const { validatePropertyName } = require('../data/dataset');
+const { getOrNotFound } = require('../util/promise');
+const { success } = require('../util/http');
+const Problem = require('../util/problem');
+
+module.exports = (service, endpoint) => {
+
+  // Register a new user property name for a project.
+  service.post('/projects/:projectId/user-properties', endpoint(async ({ UserProperties, Projects }, { auth, params, body }) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('project.update', project);
+
+    const { name } = body;
+    if (name == null || !validatePropertyName(name))
+      throw Problem.user.unexpectedValue({ field: 'name', value: name, reason: 'This is not a valid property name.' });
+
+    await UserProperties.create(project.id, name);
+    return success;
+  }));
+
+  // List user property names for a project.
+  service.get('/projects/:projectId/user-properties', endpoint(async ({ UserProperties, Projects }, { auth, params }) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('project.read', project);
+    return UserProperties.getAllForProject(project.id);
+  }));
+
+};

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -3637,7 +3637,6 @@ describe('datasets and entities', () => {
           await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
             .expect(200)
             .then(({ text }) => {
-              console.log(text)
               const rows = text.trim().split('\n');
               rows.length.should.equal(3); // 1 header + 2 north oak trees
               text.should.containEql('north');

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -8,6 +8,7 @@ const should = require('should');
 const { sql } = require('slonik');
 const { QueryOptions } = require('../../../lib/util/db');
 const { createConflict } = require('../../util/scenarios');
+const { createDataset, createEntities } = require('../../util/entities');
 const { omit, last } = require('ramda');
 const xml2js = require('xml2js');
 const { v4: uuid } = require('uuid');
@@ -3458,6 +3459,81 @@ describe('datasets and entities', () => {
             secondEtag.should.not.be.equal(etag);
           });
       }));
+
+      describe('filter attached dataset', () => {
+        it.only('should only return the entities that the user has access to based on property filter', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          // Scenario: a forestry survey app where field workers are assigned to a
+          // specific plot but coordinate with community contacts across a broader region.
+          // Two datasets are filtered by different actor properties to test that
+          // each filter rule is applied independently.
+
+          // Create a "trees" dataset with properties: species, plot_id
+          await createDataset(asAlice, 1, 'trees', ['species', 'plot_id']);
+
+          // Create 3 tree entities with plot_id = "plot-A" and 2 with plot_id = "plot-B"
+          await createEntities(asAlice, 3, 1, 'trees', [], { species: 'oak', plot_id: 'plot-A' }, 'Plot-A Tree');
+          await createEntities(asAlice, 2, 1, 'trees', [], { species: 'pine', plot_id: 'plot-B' }, 'Plot-B Tree');
+
+          // Create a "people" (community contacts) dataset with properties: first_name, region
+          await createDataset(asAlice, 1, 'people', ['first_name', 'region']);
+
+          // Create 2 contact entities with region = "north" and 3 with region = "south"
+          await createEntities(asAlice, 2, 1, 'people', [], { first_name: 'north_contact', region: 'north' }, 'North Contact');
+          await createEntities(asAlice, 3, 1, 'people', [], { first_name: 'south_contact', region: 'south' }, 'South Contact');
+
+          // Publish a survey form (consumeDatasets) that links both datasets as attachments:
+          //   trees.csv -> trees dataset, people.csv -> people dataset
+          await asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.consumeDatasets)
+            .set('Content-Type', 'application/xml')
+            .expect(200);
+          await asAlice.patch('/v1/projects/1/forms/consumeDatasets/draft/attachments/trees.csv')
+            .send({ dataset: true })
+            .expect(200);
+          await asAlice.patch('/v1/projects/1/forms/consumeDatasets/draft/attachments/people.csv')
+            .send({ dataset: true })
+            .expect(200);
+          await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/publish')
+            .expect(200);
+
+          // Create an app user "Survey Worker A" representing a worker assigned to
+          // plot-A in the north region.
+          const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+            .send({ displayName: 'Survey Worker A' })
+            .expect(200);
+
+          // Assign the app user to the form so they can access its attachments.
+          await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUser.id}`)
+            .expect(200);
+
+          // TODO: Set up filter rules:
+          //   trees.plot_id -> actor property plot_id
+          //   people.region -> actor property region
+          // TODO: Set actor property plot_id = "plot-A" and region = "north" on the app user
+
+          // Fetch trees.csv as the app user.
+          // Once filtering is implemented, expect only the 3 plot-A trees (not the 2 plot-B trees).
+          await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+            .expect(200)
+            .then(({ text }) => {
+              // Without filters, all 5 trees are returned.
+              text.should.containEql('plot-A');
+              text.should.containEql('plot-B');
+            });
+
+          // Fetch people.csv as the app user.
+          // Once filtering is implemented, expect only the 2 north contacts (not the 3 south contacts).
+          await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/people.csv`)
+            .expect(200)
+            .then(({ text }) => {
+              // Without filters, all 5 contacts are returned.
+              text.should.containEql('north');
+              text.should.containEql('south');
+            });
+        }));
+      });
     });
   });
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -3461,7 +3461,7 @@ describe('datasets and entities', () => {
       }));
 
       describe('filter attached dataset', () => {
-        it.only('should only return the entities that the user has access to based on property filter', testService(async (service) => {
+        it('should only return the entities that the user has access to based on property filter', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           // Scenario: a forestry survey app where field workers are assigned to a
@@ -3508,29 +3508,142 @@ describe('datasets and entities', () => {
           await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUser.id}`)
             .expect(200);
 
-          // TODO: Set up filter rules:
+          // Register actor property names for the project.
+          await asAlice.post('/v1/projects/1/user-properties').send({ name: 'plot_id' }).expect(200);
+          await asAlice.post('/v1/projects/1/user-properties').send({ name: 'region' }).expect(200);
+
+          // Set filter rules:
           //   trees.plot_id -> actor property plot_id
           //   people.region -> actor property region
-          // TODO: Set actor property plot_id = "plot-A" and region = "north" on the app user
+          await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+            .send({ datasetProperty: 'plot_id', userProperty: 'plot_id' })
+            .expect(200);
+          await asAlice.put('/v1/projects/1/datasets/people/access-filter')
+            .send({ datasetProperty: 'region', userProperty: 'region' })
+            .expect(200);
 
-          // Fetch trees.csv as the app user.
-          // Once filtering is implemented, expect only the 3 plot-A trees (not the 2 plot-B trees).
+          // Set actor property values on the app user: plot_id = "plot-A", region = "north"
+          await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+            .send({ userProperties: { plot_id: 'plot-A', region: 'north' } })
+            .expect(200);
+
+          // Fetch trees.csv as the app user — expect only the 3 plot-A trees.
           await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
             .expect(200)
             .then(({ text }) => {
-              // Without filters, all 5 trees are returned.
+              const rows = text.trim().split('\n');
+              rows.length.should.equal(4); // 1 header + 3 plot-A trees
               text.should.containEql('plot-A');
-              text.should.containEql('plot-B');
+              text.should.not.containEql('plot-B');
             });
 
-          // Fetch people.csv as the app user.
-          // Once filtering is implemented, expect only the 2 north contacts (not the 3 south contacts).
+          // Fetch people.csv as the app user — expect only the 2 north contacts.
           await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/people.csv`)
             .expect(200)
             .then(({ text }) => {
-              // Without filters, all 5 contacts are returned.
+              const rows = text.trim().split('\n');
+              rows.length.should.equal(3); // 1 header + 2 north contacts
               text.should.containEql('north');
-              text.should.containEql('south');
+              text.should.not.containEql('south');
+            });
+
+          // Create another app user with no properties set and assign to form.
+          const { body: appUser2 } = await asAlice.post('/v1/projects/1/app-users')
+            .send({ displayName: 'Survey Worker B' })
+            .expect(200);
+          await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUser2.id}`)
+            .expect(200);
+
+          // Fetch trees.csv as the second app user (no properties set)
+          await service.get(`/v1/key/${appUser2.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+            .expect(200)
+            .then(({ text }) => {
+              const rows = text.trim().split('\n');
+              // Should get all trees since no filter can be applied without plot_id property
+              rows.length.should.equal(6); // 1 header + 5 total trees
+            });
+
+          // Fetch people.csv as the second app user (no properties set)
+          await service.get(`/v1/key/${appUser2.token}/projects/1/forms/consumeDatasets/attachments/people.csv`)
+            .expect(200)
+            .then(({ text }) => {
+              const rows = text.trim().split('\n');
+              // Should get all contacts since no filter can be applied without region property
+              rows.length.should.equal(6); // 1 header + 5 total contacts
+            });
+        }));
+
+        it('should filter single dataset by multiple user properties', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          // Scenario: a forestry survey app with a single trees dataset that has multiple
+          // properties (region and species). Field workers can only access trees in their
+          // region AND with a species that matches their expertise.
+
+          // Create a "trees" dataset with properties: region, species
+          await createDataset(asAlice, 1, 'trees', ['region', 'species']);
+
+          // Create tree entities with different combinations of region and species
+          // North region: oak
+          await createEntities(asAlice, 2, 1, 'trees', [], { region: 'north', species: 'oak' }, 'North Oak');
+          // North region: pine
+          await createEntities(asAlice, 2, 1, 'trees', [], { region: 'north', species: 'pine' }, 'North Pine');
+          // South region: oak
+          await createEntities(asAlice, 2, 1, 'trees', [], { region: 'south', species: 'oak' }, 'South Oak');
+          // South region: birch
+          await createEntities(asAlice, 1, 1, 'trees', [], { region: 'south', species: 'birch' }, 'South Birch');
+
+          // Publish a survey form with the trees dataset
+          await asAlice.post('/v1/projects/1/forms')
+            .send(testData.forms.consumeDatasets)
+            .set('Content-Type', 'application/xml')
+            .expect(200);
+          await asAlice.patch('/v1/projects/1/forms/consumeDatasets/draft/attachments/trees.csv')
+            .send({ dataset: true })
+            .expect(200);
+          await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/publish')
+            .expect(200);
+
+          // Create an app user
+          const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+            .send({ displayName: 'Regional Species Expert' })
+            .expect(200);
+
+          // Assign the app user to the form
+          await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUser.id}`)
+            .expect(200);
+
+          // Register actor property names for the project
+          await asAlice.post('/v1/projects/1/user-properties').send({ name: 'region' }).expect(200);
+          await asAlice.post('/v1/projects/1/user-properties').send({ name: 'expertise' }).expect(200);
+
+          // Set up access filter rules for trees dataset:
+          //   trees.region -> actor property region
+          //   trees.species -> actor property expertise
+          await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+            .send({ datasetProperty: 'region', userProperty: 'region' })
+            .expect(200);
+          await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+            .send({ datasetProperty: 'species', userProperty: 'expertise' })
+            .expect(200);
+
+          // Set actor properties on the app user: region = "north", expertise = "oak"
+          await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+            .send({ userProperties: { region: 'north', expertise: 'oak' } })
+            .expect(200);
+
+          // Fetch trees.csv as the app user
+          // Should only get trees that match BOTH region=north AND species=oak (2 trees)
+          await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+            .expect(200)
+            .then(({ text }) => {
+              console.log(text)
+              const rows = text.trim().split('\n');
+              rows.length.should.equal(3); // 1 header + 2 north oak trees
+              text.should.containEql('north');
+              text.should.containEql('oak');
+              text.should.not.containEql('pine');
+              text.should.not.containEql('south');
             });
         }));
       });

--- a/test/integration/api/user-properties.js
+++ b/test/integration/api/user-properties.js
@@ -1,0 +1,169 @@
+const { testService } = require('../setup');
+const { createDataset } = require('../../util/entities');
+
+describe('api: /projects/:id/user-properties', () => {
+  describe('POST /projects/:id/user-properties', () => {
+    it('should return 403 if the user cannot update the project', testService(async (service) => {
+      const asChelsea = await service.login('chelsea');
+      await asChelsea.post('/v1/projects/1/user-properties')
+        .send({ name: 'region' })
+        .expect(403);
+    }));
+
+    it('should create a user property and return success', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/user-properties')
+        .send({ name: 'region' })
+        .expect(200);
+    }));
+
+    it('should reject if name is missing', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/user-properties')
+        .send({})
+        .expect(400);
+    }));
+  });
+
+  describe('GET /projects/:id/user-properties', () => {
+    it('should return an empty list if no properties exist', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.get('/v1/projects/1/user-properties')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.eql([]);
+        });
+    }));
+
+    it('should return the created properties', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'plot_id' }).expect(200);
+      await asAlice.get('/v1/projects/1/user-properties')
+        .expect(200)
+        .then(({ body }) => {
+          body.map(p => p.name).should.containDeep(['plot_id', 'region']);
+        });
+    }));
+  });
+
+  describe('PATCH /projects/:id/app-users/:id', () => {
+    it('should set user property values on an app user', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'region' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ userProperties: { region: 'north' } })
+        .expect(200)
+        .then(({ body }) => {
+          body.userProperties.region.should.equal('north');
+        });
+    }));
+
+    it('should unset a user property when passed null', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'region' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ userProperties: { region: 'north' } })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ userProperties: { region: null } })
+        .expect(200)
+        .then(({ body }) => {
+          body.userProperties.should.eql({});
+        });
+    }));
+
+    it('should return 404 if the user property does not exist', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ userProperties: { nonexistent: 'value' } })
+        .expect(404);
+    }));
+  });
+
+  describe('PUT /projects/:id/datasets/:name/access-filter', () => {
+    it('should set an access filter rule', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await createDataset(asAlice, 1, 'trees', ['plot_id']);
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'plot_id' }).expect(200);
+
+      await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+        .send({ datasetProperty: 'plot_id', userProperty: 'plot_id' })
+        .expect(200)
+        .then(({ body }) => {
+          body.datasetProperty.should.equal('plot_id');
+          body.userProperty.should.equal('plot_id');
+        });
+    }));
+
+    it('should replace an existing rule', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await createDataset(asAlice, 1, 'trees', ['plot_id', 'region']);
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'plot_id' }).expect(200);
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'region' }).expect(200);
+
+      await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+        .send({ datasetProperty: 'plot_id', userProperty: 'plot_id' })
+        .expect(200);
+
+      await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+        .send({ datasetProperty: 'region', userProperty: 'region' })
+        .expect(200)
+        .then(({ body }) => {
+          body.datasetProperty.should.equal('region');
+          body.userProperty.should.equal('region');
+        });
+    }));
+
+    it.skip('should clear the rule when sent null body', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await createDataset(asAlice, 1, 'trees', ['plot_id']);
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'plot_id' }).expect(200);
+
+      await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+        .send({ datasetProperty: 'plot_id', userProperty: 'plot_id' })
+        .expect(200);
+
+      await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+        .send({})
+        .expect(200)
+        .then(({ body }) => {
+          (body === null || body === undefined || Object.keys(body).length === 0).should.be.true();
+        });
+    }));
+  });
+
+  describe('GET /projects/:id/datasets/:name/access-filter', () => {
+    it('should return the current access filter', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await createDataset(asAlice, 1, 'trees', ['plot_id']);
+      await asAlice.post('/v1/projects/1/user-properties').send({ name: 'plot_id' }).expect(200);
+
+      await asAlice.put('/v1/projects/1/datasets/trees/access-filter')
+        .send({ datasetProperty: 'plot_id', userProperty: 'plot_id' })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/datasets/trees/access-filter')
+        .expect(200)
+        .then(({ body }) => {
+          body.datasetProperty.should.equal('plot_id');
+          body.userProperty.should.equal('plot_id');
+        });
+    }));
+  });
+});

--- a/test/util/entities.js
+++ b/test/util/entities.js
@@ -51,18 +51,14 @@ const deleteDatasets = async (user, names, projectId) => {
   }
 };
 
-const createEntities = async (user, count, projectId, datasetName, properties = []) => {
+const createEntities = async (user, count, projectId, datasetName, properties = [], data = null, label = 'John Doe') => {
   const uuids = [];
+  const entityData = data ?? Object.fromEntries(properties.map((property) => [property, 'foo']));
   for (let i = 0; i < count; i += 1) {
     const _uuid = uuid();
-    const data = Object.fromEntries(properties.map((property) => [property, 'foo']));
     // eslint-disable-next-line no-await-in-loop
     await user.post(`/v1/projects/${projectId}/datasets/${datasetName}/entities`)
-      .send({
-        uuid: _uuid,
-        label: 'John Doe',
-        ...(properties.length ? { data } : {})
-      })
+      .send({ uuid: _uuid, label, data: entityData })
       .expect(200);
     uuids.push(_uuid);
   }


### PR DESCRIPTION

## Overview

Adds backend support for restricting which entities an app user receives when downloading a dataset CSV attachment as part of a form, based on properties assigned to that user.

Closes https://github.com/getodk/central/issues/1852

## Changes

### Database (migration `20260424-01-user-properties-and-dataset-filtering-by-userproperties`)

Three new tables and one view:

- **`actor_properties`** — registry of named property keys scoped per project
- **`actor_property_values`** — one value per app user per property
- **`dataset_access_filters`** — maps a dataset property to a user property as a filter rule; one row per dataset property, upsert semantics
- **`actor_dataset_filter` (view)** — aggregates active filter rules for a `(datasetId, actorId)` pair into a JSONB object used in the filtering query

### New API endpoints

| Method | Path | Description |
|---|---|---|
| `POST` | `/projects/:id/user-properties` | Register a new property name for a project |
| `GET` | `/projects/:id/user-properties` | List all property names for a project |
| `PATCH` | `/projects/:id/app-users/:id` | Set or unset property values on an app user |
| `PUT` | `/projects/:id/datasets/:name/access-filter` | Add or update one filter rule for a dataset |
| `GET` | `/projects/:id/datasets/:name/access-filter` | List all filter rules for a dataset |

### Filtering

The filter is applied in `streamForExport` via a `LEFT OUTER JOIN` on the `actor_dataset_filter` view, using JSONB containment (`<@`). Multiple rules on a dataset are conjunctive. An app user with no matching property values sees all entities.

### Code

- New `ActorProperty` and `DatasetAccessFilter` frames in `frames.js`
- New query module `lib/model/query/user-properties.js`
- New resource file `lib/resources/user-properties.js`; access-filter endpoints added to `lib/resources/datasets.js`; app-user property-value endpoint added to `lib/resources/app-users.js`
- Property name validation reuses `validatePropertyName` from the dataset layer

## Not included (follow-up)

- Audit logging for property and filter mutations
- UI for managing user properties and filter rules
#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes — the five new endpoints (`/user-properties`, `/app-users/:id` PATCH, `/datasets/:name/access-filter`) are not yet documented in `docs/api.yaml`. Documentation should be added before this is merged.
