### PR TITLE
Features: Return publishing notes for the Form and Versions API

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -3361,7 +3361,7 @@ paths:
                 updatedAt: 2018-03-21T12:45:02.312Z
             application/json; extended:
               schema:
-                $ref: '#/components/schemas/ExtendedForm'
+                $ref: '#/components/schemas/ExtendedFormWithPublishNotes'
               example:
                 projectId: 1
                 xmlFormId: simple
@@ -3389,6 +3389,7 @@ paths:
                   deletedAt: 2018-04-18T23:42:11.406Z
                 entityRelated: false
                 publicLinks: 4
+                publishNotes: 'Fixed validation rules for required fields'
     delete:
       tags:
       - Individual Form
@@ -12618,6 +12619,11 @@ components:
               type: number
               example: 4
               description: The number of Public Links that can submit to the Form. This does not include Public Links that have been revoked.
+    ExtendedFormWithPublishNotes:
+      allOf:
+        - $ref: '#/components/schemas/ExtendedForm'
+        - type: object
+          properties:
             publishNotes:
               type: string
               example: Fixed validation rules for required fields

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -44,7 +44,7 @@ info:
     ## ODK Central v2026.2
 
     **Changed**:
-    - The [Getting Form Details](/central-api-form-management/#getting-form-details), [Listing Published Form Versions](/central-api-form-management/#listing-published-form-versions) and [Getting Form Version Details](/central-api-form-management/#getting-form-version-details) endpoints now return a `publishingNotes` field (conditionally) in extended metadata. 
+    - The [Getting Form Details](/central-api-form-management/#getting-form-details), [Listing Published Form Versions](/central-api-form-management/#listing-published-form-versions) and [Getting Form Version Details](/central-api-form-management/#getting-form-version-details) endpoints now return a `publishNotes` field in extended metadata. 
 
     ## ODK Central v2026.1
 
@@ -4618,7 +4618,7 @@ paths:
                   type: user
                   updatedAt: 2018-04-18T23:42:11.406Z
                   deletedAt: 2018-04-18T23:42:11.406Z
-                publishingNotes: Fixed validation rules for required fields
+                publishNotes: Fixed validation rules for required fields
   /v1/projects/{projectId}/forms/{xmlFormId}/versions/{version}:
     get:
       tags:
@@ -12618,9 +12618,10 @@ components:
               type: number
               example: 4
               description: The number of Public Links that can submit to the Form. This does not include Public Links that have been revoked.
-            publishingNotes:
+            publishNotes:
               type: string
-              description: The notes provided when this version was published (via the `X-Action-Notes` header). Only returned to users with `form.update` permission.
+              example: Fixed validation rules for required fields
+              description: The notes provided when the current Form version was published (via the `X-Action-Notes` header). Only returned to users with `form.update` permission.
     ExtendedFormVersion:
       allOf:
         - $ref: '#/components/schemas/Form'
@@ -12632,8 +12633,9 @@ components:
             excelContentType:
               type: string
               description: If the Form was created by uploading an Excel file, this field contains the MIME type of that file.
-            publishingNotes:
+            publishNotes:
               type: string
+              example: Fixed validation rules for required fields
               description: The notes provided when this version was published (via the `X-Action-Notes` header). Only returned to users with `form.update` permission.
     FormAttachment:
       type: object

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -41,6 +41,11 @@ info:
 
     Here major and breaking changes to the API are listed by version.
 
+    ## ODK Central v2026.2
+
+    **Changed**:
+    - The [Getting Form Details](/central-api-form-management/#getting-form-details), [Listing Published Form Versions](/central-api-form-management/#listing-published-form-versions) and [Getting Form Version Details](/central-api-form-management/#getting-form-version-details) endpoints now return a `publishingNotes` field (conditionally) in extended metadata. 
+
     ## ODK Central v2026.1
 
     **Added**:
@@ -4613,6 +4618,7 @@ paths:
                   type: user
                   updatedAt: 2018-04-18T23:42:11.406Z
                   deletedAt: 2018-04-18T23:42:11.406Z
+                publishingNotes: Fixed validation rules for required fields
   /v1/projects/{projectId}/forms/{xmlFormId}/versions/{version}:
     get:
       tags:
@@ -4654,6 +4660,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Form'
+            application/json; extended:
+              schema:
+                $ref: '#/components/schemas/ExtendedFormVersion'
   /v1/projects/{projectId}/forms/{xmlFormId}/versions/{version}.xml:
     get:
       tags:
@@ -12609,6 +12618,9 @@ components:
               type: number
               example: 4
               description: The number of Public Links that can submit to the Form. This does not include Public Links that have been revoked.
+            publishingNotes:
+              type: string
+              description: The notes provided when this version was published (via the `X-Action-Notes` header). Only returned to users with `form.update` permission.
     ExtendedFormVersion:
       allOf:
         - $ref: '#/components/schemas/Form'
@@ -12620,6 +12632,9 @@ components:
             excelContentType:
               type: string
               description: If the Form was created by uploading an Excel file, this field contains the MIME type of that file.
+            publishingNotes:
+              type: string
+              description: The notes provided when this version was published (via the `X-Action-Notes` header). Only returned to users with `form.update` permission.
     FormAttachment:
       type: object
       required:

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -161,7 +161,7 @@ Form.Partial = class extends Form {};
 
 Form.Extended = class extends Frame.define(
   'submissions',        readable,       'lastSubmission', readable,
-  'excelContentType',   readable,       'publishingNotes', readable,
+  'excelContentType',   readable,       'publishNotes', readable,
   // counts of submissions in various review states
   'receivedCount',                      'hasIssuesCount',
   'editedCount',                        'entityRelated',  readable,
@@ -178,7 +178,7 @@ Form.Extended = class extends Frame.define(
       },
       lastSubmission: this.lastSubmission,
       excelContentType: this.excelContentType,
-      publishingNotes: this.publishingNotes,
+      publishNotes: this.publishNotes,
       publicLinks: this.publicLinks ?? 0
     };
   }
@@ -186,7 +186,7 @@ Form.Extended = class extends Frame.define(
 
 Form.ExtendedVersion = Frame.define(
   'excelContentType', readable,
-  'publishingNotes', readable
+  'publishNotes', readable
 );
 
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -160,8 +160,9 @@ Form.Partial = class extends Form {};
 // EXTENDED FORM
 
 Form.Extended = class extends Frame.define(
+  into('formExtended'),
   'submissions',        readable,       'lastSubmission', readable,
-  'excelContentType',   readable,       'publishNotes', readable,
+  'excelContentType',   readable,       'publishNotes',
   // counts of submissions in various review states
   'receivedCount',                      'hasIssuesCount',
   'editedCount',                        'entityRelated',  readable,
@@ -178,15 +179,15 @@ Form.Extended = class extends Frame.define(
       },
       lastSubmission: this.lastSubmission,
       excelContentType: this.excelContentType,
-      publishNotes: this.publishNotes,
       publicLinks: this.publicLinks ?? 0
     };
   }
 };
 
 Form.ExtendedVersion = Frame.define(
+  into('formVersionExtended'),
   'excelContentType', readable,
-  'publishNotes', readable
+  'publishNotes'
 );
 
 

--- a/lib/model/frames/form.js
+++ b/lib/model/frames/form.js
@@ -161,7 +161,7 @@ Form.Partial = class extends Form {};
 
 Form.Extended = class extends Frame.define(
   'submissions',        readable,       'lastSubmission', readable,
-  'excelContentType',   readable,
+  'excelContentType',   readable,       'publishingNotes', readable,
   // counts of submissions in various review states
   'receivedCount',                      'hasIssuesCount',
   'editedCount',                        'entityRelated',  readable,
@@ -178,12 +178,16 @@ Form.Extended = class extends Frame.define(
       },
       lastSubmission: this.lastSubmission,
       excelContentType: this.excelContentType,
+      publishingNotes: this.publishingNotes,
       publicLinks: this.publicLinks ?? 0
     };
   }
 };
 
-Form.ExtendedVersion = Frame.define('excelContentType', readable);
+Form.ExtendedVersion = Frame.define(
+  'excelContentType', readable,
+  'publishingNotes', readable
+);
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -607,7 +607,7 @@ const _getVersions = extender(Form, Form.Def)(Form.ExtendedVersion, Option.of(Ac
 select ${fields} from forms
 join form_defs on ${versionJoinCondition(Form.AllVersions)}
 ${extend|| sql`
-  left outer join (select "acteeId", "actorId", details, notes as "publishingNotes" from audits where action='form.update.publish') as audits
+  left outer join (select "acteeId", "actorId", details, notes as "publishNotes" from audits where action='form.update.publish') as audits
     on forms."acteeId"=audits."acteeId" and audits.details->'newDefId'=to_jsonb(form_defs.id)
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
@@ -667,7 +667,7 @@ ${extend|| sql`
     on forms.id=submission_stats."formId"
   left outer join (select * from audits where action='form.create') as audits
     on forms."acteeId"=audits."acteeId"
-  left outer join (select "acteeId", details, notes as "publishingNotes" from audits where action='form.update.publish') as publish_audits
+  left outer join (select "acteeId", details, notes as "publishNotes" from audits where action='form.update.publish') as publish_audits
     on forms."acteeId"=publish_audits."acteeId" and publish_audits.details->'newDefId'=to_jsonb(form_defs.id)
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -607,7 +607,7 @@ const _getVersions = extender(Form, Form.Def)(Form.ExtendedVersion, Option.of(Ac
 select ${fields} from forms
 join form_defs on ${versionJoinCondition(Form.AllVersions)}
 ${extend|| sql`
-  left outer join (select * from audits where action='form.update.publish') as audits
+  left outer join (select "acteeId", "actorId", details, notes as "publishingNotes" from audits where action='form.update.publish') as audits
     on forms."acteeId"=audits."acteeId" and audits.details->'newDefId'=to_jsonb(form_defs.id)
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
@@ -667,6 +667,8 @@ ${extend|| sql`
     on forms.id=submission_stats."formId"
   left outer join (select * from audits where action='form.create') as audits
     on forms."acteeId"=audits."acteeId"
+  left outer join (select "acteeId", details, notes as "publishingNotes" from audits where action='form.update.publish') as publish_audits
+    on forms."acteeId"=publish_audits."acteeId" and publish_audits.details->'newDefId'=to_jsonb(form_defs.id)
   left outer join actors on audits."actorId"=actors.id
   left outer join (select id, "contentType" as "excelContentType" from blobs) as xls
     on form_defs."xlsBlobId"=xls.id

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -29,27 +29,25 @@ const excelMimeTypes = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 };
 
-const _checkActorPermission = (authOrVerbs, requiredVerbs, form) => {
-  if (authOrVerbs instanceof Array) {
-    const requiredVerbsArray = typeof requiredVerbs === 'string' ? [requiredVerbs] : requiredVerbs;
-    const authOrVerbsSet = new Set(authOrVerbs);
-    if (requiredVerbsArray.every(v => !authOrVerbsSet.has(v))) {
-      return reject(Problem.user.insufficientRights());
-    }
-    return form;
-  } else {
-    return authOrVerbs.canOrReject(requiredVerbs, form);
+const checkActorVerbs = (actorVerbs, requiredVerbs) => {
+  const actorVerbsSet = new Set(actorVerbs);
+  if (requiredVerbs.every(v => !actorVerbsSet.has(v))) {
+    return reject(Problem.user.insufficientRights());
   }
 };
 
-const canReadForm = (authOrVerbs, form) => {
+const canReadForm = async (authOrVerbs, form) => {
+  const verbs = authOrVerbs instanceof Array
+    ? authOrVerbs
+    : (await authOrVerbs.verbsOn(form));
   if (form.def?.publishedAt == null) {
-    return _checkActorPermission(authOrVerbs, 'form.update', form);
+    await checkActorVerbs(verbs, ['form.update']);
   } else if (form.state === 'closed') {
-    return _checkActorPermission(authOrVerbs, 'form.read', form);
+    await checkActorVerbs(verbs, ['form.read']);
   } else {
-    return _checkActorPermission(authOrVerbs, ['open_form.read', 'form.read'], form);
+    await checkActorVerbs(verbs, ['open_form.read', 'form.read']);
   }
+  return form;
 };
 // Returns QueryOptions to use to limit entity access according to ownerOnly.
 const getOwnerOnlyOptions = async (auth, project) => ((await auth.can('entity.list', project))
@@ -296,7 +294,7 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
 
       await canReadForm(verbs, form);
 
-      return verbs.includes('form.update') ? form : omit(['publishingNotes'], form.forApi());
+      return verbs.includes('form.update') ? form : omit(['publishNotes'], form.forApi());
     }));
 
     // returns form fields, optionally sanitizing names to match odata.
@@ -394,7 +392,7 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
 
     const versions = await Forms.getVersions(form.id, queryOptions);
 
-    return verbs.includes('form.update') ? versions : versions.map(v => omit(['publishingNotes'], v.forApi()));
+    return verbs.includes('form.update') ? versions : versions.map(v => omit(['publishNotes'], v.forApi()));
   }));
 
   ////////////////////////////////////////

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -19,7 +19,7 @@ const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
 const { getOrNotFound, reject, resolve, rejectIf } = require('../util/promise');
 const { success } = require('../util/http');
 const { formList, formManifest } = require('../formats/openrosa');
-const { noargs, isPresent, isBlank, attachmentToDatasetName } = require('../util/util');
+const { noargs, isPresent, isBlank, attachmentToDatasetName, omit } = require('../util/util');
 const { streamEntityCsvAttachment } = require('../data/entity');
 
 // excel-related util funcs/data used below:
@@ -29,13 +29,26 @@ const excelMimeTypes = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 };
 
-const canReadForm = (auth, form) => {
-  if (form.def?.publishedAt == null) {
-    return auth.canOrReject('form.update', form);
-  } else if (form.state === 'closed') {
-    return auth.canOrReject('form.read', form);
+const _checkActorPermission = (authOrVerbs, requiredVerbs, form) => {
+  if (authOrVerbs instanceof Array) {
+    const requiredVerbsArray = typeof requiredVerbs === 'string' ? [requiredVerbs] : requiredVerbs;
+    const authOrVerbsSet = new Set(authOrVerbs);
+    if (requiredVerbsArray.every(v => !authOrVerbsSet.has(v))) {
+      return reject(Problem.user.insufficientRights());
+    }
+    return form;
   } else {
-    return auth.canOrReject(['open_form.read', 'form.read'], form);
+    return authOrVerbs.canOrReject(requiredVerbs, form);
+  }
+};
+
+const canReadForm = (authOrVerbs, form) => {
+  if (form.def?.publishedAt == null) {
+    return _checkActorPermission(authOrVerbs, 'form.update', form);
+  } else if (form.state === 'closed') {
+    return _checkActorPermission(authOrVerbs, 'form.read', form);
+  } else {
+    return _checkActorPermission(authOrVerbs, ['open_form.read', 'form.read'], form);
   }
 };
 // Returns QueryOptions to use to limit entity access according to ownerOnly.
@@ -276,9 +289,15 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
     service.get(`${base}.xls`, getXls('xls'));
     service.get(`${base}.xlsx`, getXls('xlsx'));
 
-    service.get(`${base}`, endpoint(({ Forms }, { auth, params, queryOptions }) =>
-      getInstance(Forms, params, false, queryOptions)
-        .then((form) => canReadForm(auth, form))));
+    service.get(`${base}`, endpoint(async ({ Forms }, { auth, params, queryOptions }) => {
+      const form = await getInstance(Forms, params, false, queryOptions);
+
+      const verbs = await auth.verbsOn(form);
+
+      await canReadForm(verbs, form);
+
+      return verbs.includes('form.update') ? form : omit(['publishingNotes'], form.forApi());
+    }));
 
     // returns form fields, optionally sanitizing names to match odata.
     service.get(`${base}/fields`, endpoint(({ Forms }, { params, query, auth }) =>
@@ -365,12 +384,18 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
   ////////////////////////////////////////
   // VERSIONS LISTING
 
-  service.get('/projects/:projectId/forms/:xmlFormId/versions', endpoint(({ Forms }, { auth, params, queryOptions }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.AnyVersion)
-      .then(getOrNotFound)
-      .then((form) => canReadForm(auth, form))
-      .then((form) => Forms.getVersions(form.id, queryOptions))));
+  service.get('/projects/:projectId/forms/:xmlFormId/versions', endpoint(async ({ Forms }, { auth, params, queryOptions }) => {
+    const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.AnyVersion)
+      .then(getOrNotFound);
 
+    const verbs = await auth.verbsOn(form);
+
+    await canReadForm(verbs, form);
+
+    const versions = await Forms.getVersions(form.id, queryOptions);
+
+    return verbs.includes('form.update') ? versions : versions.map(v => omit(['publishingNotes'], v.forApi()));
+  }));
 
   ////////////////////////////////////////
   // RESTORE / UNDELETE

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -19,7 +19,7 @@ const { sanitizeFieldsForOdata, setVersion } = require('../data/schema');
 const { getOrNotFound, reject, resolve, rejectIf } = require('../util/promise');
 const { success } = require('../util/http');
 const { formList, formManifest } = require('../formats/openrosa');
-const { noargs, isPresent, isBlank, attachmentToDatasetName, omit } = require('../util/util');
+const { noargs, isPresent, isBlank, attachmentToDatasetName } = require('../util/util');
 const { streamEntityCsvAttachment } = require('../data/entity');
 
 // excel-related util funcs/data used below:
@@ -294,7 +294,11 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
 
       await canReadForm(verbs, form);
 
-      return verbs.includes('form.update') ? form : omit(['publishNotes'], form.forApi());
+      if (verbs.includes('form.update') && queryOptions.extended) {
+        return { ...form.forApi(), publishNotes: form.aux.formExtended.publishNotes };
+      }
+
+      return form;
     }));
 
     // returns form fields, optionally sanitizing names to match odata.
@@ -392,7 +396,10 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
 
     const versions = await Forms.getVersions(form.id, queryOptions);
 
-    return verbs.includes('form.update') ? versions : versions.map(v => omit(['publishNotes'], v.forApi()));
+    if (verbs.includes('form.update') && queryOptions.extended) {
+      return versions.map(v => ({ ...v.forApi(), publishNotes: v.aux.formVersionExtended.publishNotes }));
+    }
+    return versions;
   }));
 
   ////////////////////////////////////////

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -1094,8 +1094,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                   }));
             }))));
 
-      describe('publishingNotes', () => {
-        it('should return publishingNotes with extended metadata', testService(async (service) => {
+      describe('publishNotes', () => {
+        it('should return publishNotes with extended metadata', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'this is a publishing note');
@@ -1104,10 +1104,10 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .set('X-Extended-Metadata', true)
             .expect(200);
 
-          body.publishingNotes.should.equal('this is a publishing note');
+          body.publishNotes.should.equal('this is a publishing note');
         }));
 
-        it('should not return publishingNotes for app-user', testService(async (service) => {
+        it('should not return publishNotes for app-user', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'this is a publishing note');
@@ -1123,10 +1123,10 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .set('X-Extended-Metadata', true)
             .expect(200);
 
-          should.not.exist(body.publishingNotes);
+          should.not.exist(body.publishNotes);
         }));
 
-        it('should not return publishingNotes for project-viewer', testService(async (service) => {
+        it('should not return publishNotes for project-viewer', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'this is a publishing note');
@@ -1142,10 +1142,10 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .set('X-Extended-Metadata', true)
             .expect(200);
 
-          should.not.exist(body.publishingNotes);
+          should.not.exist(body.publishNotes);
         }));
 
-        it('should not return publishingNotes for data-collector', testService(async (service) => {
+        it('should not return publishNotes for data-collector', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'this is a publishing note');
@@ -1161,7 +1161,7 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
             .set('X-Extended-Metadata', true)
             .expect(200);
 
-          should.not.exist(body.publishingNotes);
+          should.not.exist(body.publishNotes);
         }));
       });
     });

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -1163,6 +1163,44 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
 
           should.not.exist(body.publishNotes);
         }));
+
+        it('should not return publishNotes for data-collector using /forms endpoint', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'this is a publishing note');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaActorId}`)
+            .expect(200);
+
+          const { body } = await chelsea.get('/v1/projects/1/forms')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          body.length.should.be.greaterThan(0);
+          body.forEach((form) => should.not.exist(form.publishNotes));
+        }));
+
+        it('should not return publishNotes for data-collector using /projects?forms=true endpoint', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'this is a publishing note');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaActorId}`)
+            .expect(200);
+
+          const { body: projects } = await chelsea.get('/v1/projects?forms=true')
+            .expect(200);
+
+          projects[0].formList.forEach((form) => should.not.exist(form.publishNotes));
+        }));
       });
     });
 

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -7,6 +7,7 @@ const superagent = require('superagent');
 const { DateTime } = require('luxon');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
+const { publishWithNote } = require('../../../util/scenarios');
 const { Form } = require(appRoot + '/lib/model/frames');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 const { omit } = require(appRoot + '/lib/util/util');
@@ -1092,6 +1093,77 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                     body.enketoOnceId.should.equal('::::abcdefgh');
                   }));
             }))));
+
+      describe('publishingNotes', () => {
+        it('should return publishingNotes with extended metadata', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'this is a publishing note');
+
+          const { body } = await asAlice.get('/v1/projects/1/forms/simple')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          body.publishingNotes.should.equal('this is a publishing note');
+        }));
+
+        it('should not return publishingNotes for app-user', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'this is a publishing note');
+
+          const appUser = await asAlice.post('/v1/projects/1/app-users')
+            .send({ displayName: 'test app user' })
+            .expect(200)
+            .then(({ body }) => body);
+          await asAlice.post(`/v1/projects/1/forms/simple/assignments/app-user/${appUser.id}`)
+            .expect(200);
+
+          const { body } = await service.get(`/v1/key/${appUser.token}/projects/1/forms/simple`)
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          should.not.exist(body.publishingNotes);
+        }));
+
+        it('should not return publishingNotes for project-viewer', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'this is a publishing note');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/viewer/${chelseaActorId}`)
+            .expect(200);
+
+          const { body } = await chelsea.get('/v1/projects/1/forms/simple')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          should.not.exist(body.publishingNotes);
+        }));
+
+        it('should not return publishingNotes for data-collector', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'this is a publishing note');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaActorId}`)
+            .expect(200);
+
+          const { body } = await chelsea.get('/v1/projects/1/forms/simple')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          should.not.exist(body.publishingNotes);
+        }));
+      });
     });
 
     ////////////////////////////////////////

--- a/test/integration/api/forms/versions.js
+++ b/test/integration/api/forms/versions.js
@@ -195,7 +195,7 @@ describe('api: /projects/:id/forms (versions)', () => {
                 body.map((version) => version.version).should.eql([ '2', '3', '' ]);
               })))));
 
-      describe('publishing notes', () => {
+      describe('publish notes', () => {
         it('should return publish notes', testService(async (service) => {
           const asAlice = await service.login('alice');
 
@@ -207,7 +207,7 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
 
           body.map((form) => form.version).should.eql(['3', '2', '']);
-          body.map((form) => form.publishingNotes).should.eql([
+          body.map((form) => form.publishNotes).should.eql([
             'publishing version 3',
             'publishing version 2',
             null
@@ -231,7 +231,7 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
           body.map((form) => form.version).should.eql(['2', '']);
           body.forEach((form) => {
-            should.not.exist(form.publishingNotes);
+            should.not.exist(form.publishNotes);
           });
         }));
 
@@ -249,7 +249,7 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
           body.map((form) => form.version).should.eql(['2', '']);
           body.forEach((form) => {
-            should.not.exist(form.publishingNotes);
+            should.not.exist(form.publishNotes);
           });
         }));
 
@@ -269,7 +269,7 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
           body.map((form) => form.version).should.eql(['2', '']);
           body.forEach((form) => {
-            should.not.exist(form.publishingNotes);
+            should.not.exist(form.publishNotes);
           });
         }));
 
@@ -289,7 +289,7 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
           body.map((form) => form.version).should.eql(['2', '']);
           body.forEach((form) => {
-            should.not.exist(form.publishingNotes);
+            should.not.exist(form.publishNotes);
           });
         }));
       });
@@ -484,8 +484,8 @@ describe('api: /projects/:id/forms (versions)', () => {
                 })))));
       });
 
-      describe('publishing notes', () => {
-        it('should return publishing notes', testService(async (service) => {
+      describe('publish notes', () => {
+        it('should return publishNotes', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'publishing version 2');
@@ -495,10 +495,10 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
 
           body.version.should.equal('2');
-          body.publishingNotes.should.equal('publishing version 2');
+          body.publishNotes.should.equal('publishing version 2');
         }));
 
-        it('should not return publishing notes for app-user', testService(async (service) => {
+        it('should not return publishNotes for app-user', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'publishing version 2');
@@ -515,10 +515,10 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
 
           body.version.should.equal('2');
-          should.not.exist(body.publishingNotes);
+          should.not.exist(body.publishNotes);
         }));
 
-        it('should not return publishing notes for project-viewer', testService(async (service) => {
+        it('should not return publishNotes for project-viewer', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'publishing version 2');
@@ -535,10 +535,27 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
 
           body.version.should.equal('2');
-          should.not.exist(body.publishingNotes);
+          should.not.exist(body.publishNotes);
         }));
 
-        it('should not return publishing notes for data-collector', testService(async (service) => {
+        it('should not return notes for public-link', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const publicLinkToken = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+            .send({ displayName: 'test public link' })
+            .expect(200)
+            .then(({ body }) => body.token);
+
+          const { body } = await service.get(`/v1/projects/1/forms/simple/versions/2?st=${publicLinkToken}`)
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+          body.version.should.equal('2');
+          should.not.exist(body.publishNotes);
+        }));
+
+        it('should not return publishNotes for data-collector', testService(async (service) => {
           const asAlice = await service.login('alice');
 
           await publishWithNote(asAlice, '2', 'publishing version 2');
@@ -555,7 +572,7 @@ describe('api: /projects/:id/forms (versions)', () => {
             .expect(200);
 
           body.version.should.equal('2');
-          should.not.exist(body.publishingNotes);
+          should.not.exist(body.publishNotes);
         }));
       });
     });

--- a/test/integration/api/forms/versions.js
+++ b/test/integration/api/forms/versions.js
@@ -6,6 +6,7 @@ const { sql } = require('slonik');
 const superagent = require('superagent');
 const { testService } = require('../../setup');
 const testData = require('../../../data/xml');
+const { publishWithNote } = require('../../../util/scenarios');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 
 describe('api: /projects/:id/forms (versions)', () => {
@@ -193,6 +194,105 @@ describe('api: /projects/:id/forms (versions)', () => {
               .then(({ body }) => {
                 body.map((version) => version.version).should.eql([ '2', '3', '' ]);
               })))));
+
+      describe('publishing notes', () => {
+        it('should return publish notes', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+          await publishWithNote(asAlice, '3', 'publishing version 3');
+
+          const { body } = await asAlice.get('/v1/projects/1/forms/simple/versions')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          body.map((form) => form.version).should.eql(['3', '2', '']);
+          body.map((form) => form.publishingNotes).should.eql([
+            'publishing version 3',
+            'publishing version 2',
+            null
+          ]);
+        }));
+
+        it('should not return notes for app-user', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const appUser = await asAlice.post('/v1/projects/1/app-users')
+            .send({ displayName: 'test app user' })
+            .expect(200)
+            .then(({ body }) => body);
+          await asAlice.post(`/v1/projects/1/forms/simple/assignments/app-user/${appUser.id}`)
+            .expect(200);
+
+          const { body } = await service.get(`/v1/key/${appUser.token}/projects/1/forms/simple/versions`)
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+          body.map((form) => form.version).should.eql(['2', '']);
+          body.forEach((form) => {
+            should.not.exist(form.publishingNotes);
+          });
+        }));
+
+        it('should not return notes for public-link', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const publicLinkToken = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+            .send({ displayName: 'test public link' })
+            .expect(200)
+            .then(({ body }) => body.token);
+
+          const { body } = await service.get(`/v1/projects/1/forms/simple/versions?st=${publicLinkToken}`)
+            .expect(200);
+          body.map((form) => form.version).should.eql(['2', '']);
+          body.forEach((form) => {
+            should.not.exist(form.publishingNotes);
+          });
+        }));
+
+        it('should not return notes for project-viewer', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/viewer/${chelseaActorId}`)
+            .expect(200);
+
+          const { body } = await chelsea.get('/v1/projects/1/forms/simple/versions')
+            .expect(200);
+          body.map((form) => form.version).should.eql(['2', '']);
+          body.forEach((form) => {
+            should.not.exist(form.publishingNotes);
+          });
+        }));
+
+        it('should not return notes for data-collector', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaActorId}`)
+            .expect(200);
+
+          const { body } = await chelsea.get('/v1/projects/1/forms/simple/versions')
+            .expect(200);
+          body.map((form) => form.version).should.eql(['2', '']);
+          body.forEach((form) => {
+            should.not.exist(form.publishingNotes);
+          });
+        }));
+      });
     });
 
     describe('/:version', () => {
@@ -382,6 +482,81 @@ describe('api: /projects/:id/forms (versions)', () => {
                 .then(({ text }) => {
                   text.should.equal('this is goodone.csv');
                 })))));
+      });
+
+      describe('publishing notes', () => {
+        it('should return publishing notes', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const { body } = await asAlice.get('/v1/projects/1/forms/simple/versions/2')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          body.version.should.equal('2');
+          body.publishingNotes.should.equal('publishing version 2');
+        }));
+
+        it('should not return publishing notes for app-user', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const appUser = await asAlice.post('/v1/projects/1/app-users')
+            .send({ displayName: 'test app user' })
+            .expect(200)
+            .then(({ body }) => body);
+          await asAlice.post(`/v1/projects/1/forms/simple/assignments/app-user/${appUser.id}`)
+            .expect(200);
+
+          const { body } = await service.get(`/v1/key/${appUser.token}/projects/1/forms/simple/versions/2`)
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          body.version.should.equal('2');
+          should.not.exist(body.publishingNotes);
+        }));
+
+        it('should not return publishing notes for project-viewer', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/viewer/${chelseaActorId}`)
+            .expect(200);
+
+          const { body } = await chelsea.get('/v1/projects/1/forms/simple/versions/2')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          body.version.should.equal('2');
+          should.not.exist(body.publishingNotes);
+        }));
+
+        it('should not return publishing notes for data-collector', testService(async (service) => {
+          const asAlice = await service.login('alice');
+
+          await publishWithNote(asAlice, '2', 'publishing version 2');
+
+          const chelsea = await service.login('chelsea');
+          const chelseaActorId = await chelsea.get('/v1/users/current')
+            .expect(200)
+            .then(({ body }) => body.id);
+          await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaActorId}`)
+            .expect(200);
+
+          const { body } = await chelsea.get('/v1/projects/1/forms/simple/versions/2')
+            .set('X-Extended-Metadata', true)
+            .expect(200);
+
+          body.version.should.equal('2');
+          should.not.exist(body.publishingNotes);
+        }));
       });
     });
   });

--- a/test/util/scenarios.js
+++ b/test/util/scenarios.js
@@ -2,6 +2,14 @@ const appRoot = require('app-root-path');
 const { exhaust } = require(appRoot + '/lib/worker/worker');
 const testData = require(appRoot + '/test/data/xml');
 
+const publishWithNote = async (asAlice, version, note) => {
+  await asAlice.post('/v1/projects/1/forms/simple/draft')
+    .expect(200);
+  await asAlice.post(`/v1/projects/1/forms/simple/draft/publish?version=${version}`)
+    .set('X-Action-Notes', note)
+    .expect(200);
+};
+
 const createConflict = async (user, container) => {
   await user.post('/v1/projects/1/forms/simpleEntity/submissions')
     .send(testData.instances.simpleEntity.one)
@@ -29,5 +37,6 @@ const createConflict = async (user, container) => {
 };
 
 module.exports = {
-  createConflict
+  createConflict,
+  publishWithNote
 };


### PR DESCRIPTION
Towards https://github.com/getodk/central/issues/1834

#### What has been done to verify that this works as intended?

Added test, checked with frontend.

#### Why is this the best possible solution? Were any other approaches considered?

It is small and simple change to achieve the objective. I thought about introducing symbol/attribute in our `Frame` framework for `restrictedReadonly` field but that would have been a complicated change. We may consider that approach if there is proliferation of conditional fields in our APIs.

I added `publishingNotes` field for the `/forms/:xmlFormId` as well because we need to show notes for the "Published" Form page as well.

Is `publishingNotes` a right name for this field? We can call this just `notes`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Once related frontend PRs are merged, QA team should test all Form and Form version functionality. 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Added.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
