### PR TITLE
Add actor properties: project-level key-value pairs settable on app users and public links

### DIFF
--- a/lib/data/actor-properties.js
+++ b/lib/data/actor-properties.js
@@ -8,14 +8,18 @@ const validateActorPropertyName = (name) =>
   name.toLowerCase() !== 'displayname' && validatePropertyName(name);
 
 // Validates and sanitizes a properties object from an API request body.
+// knownNames is an array of property name strings defined for this project.
 // Returns a plain object mapping property names to sanitized values (string or null).
-// Empty strings are coerced to null.
-const extractActorProperties = (properties) => {
+// Empty strings are coerced to null. Throws a 400 if any property name is unknown.
+const extractActorProperties = (properties, knownNames) => {
   if (typeof properties !== 'object' || Array.isArray(properties))
     throw Problem.user.unexpectedValue({ field: 'properties', value: properties, reason: 'Must be an object.' });
 
+  const knownSet = new Set(knownNames);
   const result = Object.create(null);
   for (const [name, value] of Object.entries(properties)) {
+    if (!knownSet.has(name))
+      throw Problem.user.unexpectedValue({ field: 'properties', value: name, reason: 'Unknown property name.' });
     if (value !== null && typeof value !== 'string')
       throw Problem.user.unexpectedValue({ field: name, value, reason: 'Property values must be strings or null.' });
     result[name] = (value == null || value.trim() === '') ? null : value.trim();

--- a/lib/data/actor-properties.js
+++ b/lib/data/actor-properties.js
@@ -1,0 +1,26 @@
+const { validatePropertyName } = require('./dataset');
+const Problem = require('../util/problem');
+
+// Validates an actor property name. Actor property names follow the same rules
+// as entity dataset property names, with the additional restriction that
+// 'displayname' is reserved.
+const validateActorPropertyName = (name) =>
+  name.toLowerCase() !== 'displayname' && validatePropertyName(name);
+
+// Validates and sanitizes a properties object from an API request body.
+// Returns a plain object mapping property names to sanitized values (string or null).
+// Empty strings are coerced to null.
+const extractActorProperties = (properties) => {
+  if (typeof properties !== 'object' || Array.isArray(properties))
+    throw Problem.user.unexpectedValue({ field: 'properties', value: properties, reason: 'Must be an object.' });
+
+  const result = Object.create(null);
+  for (const [name, value] of Object.entries(properties)) {
+    if (value !== null && typeof value !== 'string')
+      throw Problem.user.unexpectedValue({ field: name, value, reason: 'Property values must be strings or null.' });
+    result[name] = (value == null || value.trim() === '') ? null : value.trim();
+  }
+  return result;
+};
+
+module.exports = { validateActorPropertyName, extractActorProperties };

--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -114,6 +114,7 @@ module.exports = (container) => {
   require('../resources/entities')(service, endpoint);
   require('../resources/oidc')(service, endpoint, anonymousEndpoint);
   require('../resources/user-preferences')(service, endpoint);
+  require('../resources/actor-properties')(service, endpoint);
 
   ////////////////////////////////////////////////////////////////////////////////
   // POSTRESOURCE HANDLERS

--- a/lib/model/container.js
+++ b/lib/model/container.js
@@ -90,6 +90,7 @@ const withDefaults = (base, queries) => {
   const defaultQueries = {
     Actees: require('./query/actees'),
     Actors: require('./query/actors'),
+    ActorProperties: require('./query/actor-properties'),
     Analytics: require('./query/analytics'),
     Assignments: require('./query/assignments'),
     Audits: require('./query/audits'),

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -29,6 +29,13 @@ const Actor = Frame.define(
   'updatedAt',  readable,               'deletedAt',    readable
 );
 
+const ActorProperty = Frame.define(
+  table('actor_properties'),
+  'id',
+  'projectId',
+  'name',   readable
+);
+
 class Assignment extends Frame.define(
   table('assignments'),
   'actorId',    readable,               'roleId',       readable,
@@ -212,6 +219,7 @@ class User extends Frame.define(
 module.exports = {
   Actee,
   Actor,
+  ActorProperty,
   Assignment,
   Audit,
   Blob,

--- a/lib/model/migrations/20260505-01-add-project-user-properties.js
+++ b/lib/model/migrations/20260505-01-add-project-user-properties.js
@@ -1,0 +1,37 @@
+const up = async (db) => {
+  await db.raw(``);
+
+  // -- Registry of property names that can be assigned to actors, scoped per project.
+  await db.raw(`
+  CREATE TABLE actor_properties (
+    id integer NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    "projectId" integer NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    "name" text NOT NULL CHECK (length("name") > 0)
+  )`);
+
+  await db.raw(`CREATE UNIQUE INDEX ON actor_properties ("projectId", "name")`);
+
+  // -- Values of actor properties
+  await db.raw(`
+  CREATE TABLE actor_property_values (
+    id integer GENERATED ALWAYS AS IDENTITY,
+    "actorId" integer NOT NULL REFERENCES field_keys ("actorId") ON DELETE CASCADE,  -- FK to field_keys for now; can be widened to actors if needed.
+    "actorPropertyId" integer NOT NULL REFERENCES actor_properties (id) ON DELETE CASCADE,
+    "value" text NOT NULL CHECK (length("value") > 0)
+  )`);
+
+  // -- Each actor can only have one value per property. Multivalued properties were intentionally avoided
+  // -- to keep filtering semantics simple (no conjunction/disjunction complexity).
+  // -- This index also serves as the index for the FK referent side (used when CASCADE-ing).
+  await db.raw(`CREATE UNIQUE INDEX ON actor_property_values ("actorId", "actorPropertyId")`);
+
+  // -- Index to support FK lookup on actorPropertyId (CASCADE deletes from actor_properties).
+  await db.raw(`CREATE INDEX ON actor_property_values ("actorPropertyId")`);
+};
+
+const down = async (db) => {
+  await db.raw('DROP TABLE actor_property_values CASCADE');
+  await db.raw('DROP TABLE actor_properties CASCADE');
+};
+
+module.exports = { up, down };

--- a/lib/model/migrations/20260505-01-add-project-user-properties.js
+++ b/lib/model/migrations/20260505-01-add-project-user-properties.js
@@ -1,5 +1,4 @@
 const up = async (db) => {
-  await db.raw(``);
 
   // -- Registry of property names that can be assigned to actors, scoped per project.
   await db.raw(`

--- a/lib/model/migrations/20260505-01-add-project-user-properties.js
+++ b/lib/model/migrations/20260505-01-add-project-user-properties.js
@@ -15,7 +15,7 @@ const up = async (db) => {
   await db.raw(`
   CREATE TABLE actor_property_values (
     id integer GENERATED ALWAYS AS IDENTITY,
-    "actorId" integer NOT NULL REFERENCES field_keys ("actorId") ON DELETE CASCADE,  -- FK to field_keys for now; can be widened to actors if needed.
+    "actorId" integer NOT NULL REFERENCES actors ("id") ON DELETE CASCADE,
     "actorPropertyId" integer NOT NULL REFERENCES actor_properties (id) ON DELETE CASCADE,
     "value" text NOT NULL CHECK (length("value") > 0)
   )`);

--- a/lib/model/migrations/20260521-01-add-actor-property-verbs.js
+++ b/lib/model/migrations/20260521-01-add-actor-property-verbs.js
@@ -1,0 +1,35 @@
+// Adds new verbs:
+//  - actor_property.list: for the new actor_property feature; available to viewers, managers, and admins
+//  - actor_property.update: for setting/unsetting property values; managers and admins only
+//  - field_key.update: was missing from the verb set. added for consistency with
+//    field_key.create, field_key.list, and field_key.delete already held by managers and admins
+//    as well as public_link.* verbs
+
+const up = async (db) => {
+  await db.raw(`
+    UPDATE roles
+    SET verbs = verbs || '["actor_property.list"]'::jsonb
+    WHERE system in ('admin', 'manager', 'viewer')
+  `);
+  await db.raw(`
+    UPDATE roles
+    SET verbs = verbs || '["actor_property.update", "field_key.update"]'::jsonb
+    WHERE system in ('admin', 'manager')
+  `);
+};
+
+const down = async (db) => {
+  await db.raw(`
+    UPDATE roles
+    SET verbs = (verbs - 'actor_property.list')
+    WHERE system in ('admin', 'manager', 'viewer')
+  `);
+
+  await db.raw(`
+    UPDATE roles
+    SET verbs = (verbs - 'actor_property.update' - 'field_key.update')
+    WHERE system in ('admin', 'manager')
+  `);
+};
+
+module.exports = { up, down };

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -2,7 +2,6 @@ const { sql } = require('slonik');
 const { map } = require('ramda');
 const { ActorProperty } = require('../frames');
 const { construct } = require('../../util/util');
-const { getOrNotFound } = require('../../util/promise');
 
 
 // Creates a new actor property name for a project.
@@ -36,33 +35,32 @@ GROUP BY ap.id
 ORDER BY ap.name`)
     .then(map((row) => ({ name: row.name, values: row.values })));
 
-// Sets or unsets a property value for an app user (actorId).
-// Pass value=null to unset the property (removes the value row).
-// The property must exist in actor_properties for the project.
-const setValueForActor = (projectId, actorId, name, value) => async ({ run, maybeOne }) => {
-  const property = await maybeOne(sql`
-SELECT id FROM actor_properties
-WHERE "projectId" = ${projectId} AND "name" = ${name}`).then(getOrNotFound);
-
-  if (value == null) {
-    await run(sql`
-DELETE FROM actor_property_values
-WHERE "actorId" = ${actorId} AND "actorPropertyId" = ${property.id}`);
-  } else {
-    await run(sql`
-INSERT INTO actor_property_values ("actorId", "actorPropertyId", "value")
-VALUES (${actorId}, ${property.id}, ${value})
-ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."value"`);
-  }
-};
-
-// Sets or unsets multiple property values for an actor in a single operation.
+// Sets or unsets multiple property values for an actor in two bulk queries:
+// one to delete rows for null-valued properties, one to upsert non-null ones.
 // properties is a plain object mapping property names to values (string or null),
 // as returned by extractActorProperties() in lib/data/actor-properties.js.
-const setValuesForActor = (projectId, actorId, properties) => async (container) => {
-  for (const [name, value] of Object.entries(properties)) {
-    // eslint-disable-next-line no-await-in-loop
-    await setValueForActor(projectId, actorId, name, value)(container);
+const setValuesForActor = (projectId, actorId, properties) => async ({ run }) => {
+  const entries = Object.entries(properties);
+  const toDelete = entries.filter(([, v]) => v === null).map(([name]) => name);
+  const toUpsert = entries.filter(([, v]) => v !== null);
+
+  if (toDelete.length > 0) {
+    await run(sql`
+DELETE FROM actor_property_values
+WHERE "actorId" = ${actorId}
+  AND "actorPropertyId" IN (
+    SELECT id FROM actor_properties
+    WHERE "projectId" = ${projectId} AND name = ANY(${sql.array(toDelete, 'text')})
+  )`);
+  }
+
+  if (toUpsert.length > 0) {
+    await run(sql`
+INSERT INTO actor_property_values ("actorId", "actorPropertyId", "value")
+SELECT ${actorId}, ap.id, v.value
+FROM ${sql.unnest(toUpsert, ['text', 'text'])} AS v(name, value)
+JOIN actor_properties ap ON ap."projectId" = ${projectId} AND ap.name = v.name
+ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."value"`);
   }
 };
 

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -56,5 +56,15 @@ ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."val
   }
 };
 
-module.exports = { create, getAllForProject, getAllForProjectWithValues, setValueForActor };
+// Sets or unsets multiple property values for an actor in a single operation.
+// properties is a plain object mapping property names to values (string or null),
+// as returned by extractActorProperties() in lib/data/actor-properties.js.
+const setValuesForActor = (projectId, actorId, properties) => async (container) => {
+  for (const [name, value] of Object.entries(properties)) {
+    // eslint-disable-next-line no-await-in-loop
+    await setValueForActor(projectId, actorId, name, value)(container);
+  }
+};
+
+module.exports = { create, getAllForProject, getAllForProjectWithValues, setValuesForActor };
 

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -1,0 +1,45 @@
+const { sql } = require('slonik');
+const { map } = require('ramda');
+const { ActorProperty } = require('../frames');
+const { construct } = require('../../util/util');
+const { getOrNotFound } = require('../../util/promise');
+
+
+// Creates a new actor property name for a project.
+const create = (projectId, name) => ({ one }) =>
+  one(sql`
+INSERT INTO actor_properties ("projectId", "name")
+VALUES (${projectId}, ${name})
+RETURNING *`)
+    .then(construct(ActorProperty));
+
+// Returns all actor property names for a project.
+const getAllForProject = (projectId) => ({ all }) =>
+  all(sql`
+SELECT * FROM actor_properties
+WHERE "projectId" = ${projectId}
+ORDER BY "name"`)
+    .then(map(construct(ActorProperty)));
+
+// Sets or unsets a property value for an app user (actorId).
+// Pass value=null to unset the property (removes the value row).
+// The property must exist in actor_properties for the project.
+const setValueForActor = (projectId, actorId, name, value) => async ({ run, maybeOne }) => {
+  const property = await maybeOne(sql`
+SELECT id FROM actor_properties
+WHERE "projectId" = ${projectId} AND "name" = ${name}`).then(getOrNotFound);
+
+  if (value == null) {
+    await run(sql`
+DELETE FROM actor_property_values
+WHERE "actorId" = ${actorId} AND "actorPropertyId" = ${property.id}`);
+  } else {
+    await run(sql`
+INSERT INTO actor_property_values ("actorId", "actorPropertyId", "value")
+VALUES (${actorId}, ${property.id}, ${value})
+ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."value"`);
+  }
+};
+
+module.exports = { create, getAllForProject, setValueForActor };
+

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -21,6 +21,21 @@ WHERE "projectId" = ${projectId}
 ORDER BY "name"`)
     .then(map(construct(ActorProperty)));
 
+// Returns all actor property names for a project, each with an array of distinct
+// values currently in use across all actors.
+const getAllForProjectWithValues = (projectId) => ({ all }) =>
+  all(sql`
+SELECT ap.*, coalesce(
+  array_agg(DISTINCT apv.value ORDER BY apv.value) FILTER (WHERE apv.value IS NOT NULL),
+  '{}'
+) AS values
+FROM actor_properties ap
+LEFT JOIN actor_property_values apv ON apv."actorPropertyId" = ap.id
+WHERE ap."projectId" = ${projectId}
+GROUP BY ap.id
+ORDER BY ap.name`)
+    .then(map((row) => ({ name: row.name, values: row.values })));
+
 // Sets or unsets a property value for an app user (actorId).
 // Pass value=null to unset the property (removes the value row).
 // The property must exist in actor_properties for the project.
@@ -41,5 +56,5 @@ ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."val
   }
 };
 
-module.exports = { create, getAllForProject, setValueForActor };
+module.exports = { create, getAllForProject, getAllForProjectWithValues, setValueForActor };
 

--- a/lib/model/query/field-keys.js
+++ b/lib/model/query/field-keys.js
@@ -20,7 +20,7 @@ const create = (fk, project) => ({ Actors, Sessions }) =>
 create.audit = (result) => (log) => log('field_key.create', result.actor);
 create.audit.withResult = true;
 
-const _get = extender(FieldKey, Actor, Frame.define('token', readable))(Actor.alias('created_by', 'createdBy'), Frame.define('lastUsed', readable))((fields, extend, options) => sql`
+const _get = extender(FieldKey, Actor, Frame.define('token', readable))(Actor.alias('created_by', 'createdBy'), Frame.define('lastUsed', readable), Frame.define('properties', readable))((fields, extend, options) => sql`
 select ${fields} from field_keys
   join actors on field_keys."actorId"=actors.id
   left outer join sessions on field_keys."actorId"=sessions."actorId"
@@ -30,6 +30,11 @@ select ${fields} from field_keys
       where action='submission.create'
       group by "actorId") as last_usage
     on last_usage."actorId"=actors.id`}
+  ${extend|| sql`left outer join
+    (select apv."actorId", json_object_agg(ap.name, apv.value) as properties from actor_properties ap
+      join actor_property_values apv on ap.id=apv."actorPropertyId"
+      group by apv."actorId") as actor_props
+    on actor_props."actorId"=actors.id`}
   where ${sqlEquals(options.condition)} and actors."deletedAt" is null
   order by (sessions.token is not null) desc, actors."createdAt" desc`);
 

--- a/lib/model/query/public-links.js
+++ b/lib/model/query/public-links.js
@@ -25,11 +25,16 @@ const create = (publicLink, form) => ({ Actors, Assignments, Sessions }) =>
 create.audit = (pl) => (log) => log('public_link.create', pl.actor, { data: pl });
 create.audit.withResult = true;
 
-const _get = extender(PublicLink, Actor, Frame.define('token', readable))(Actor.alias('created_by', 'createdBy'))((fields, extend, options) => sql`
+const _get = extender(PublicLink, Actor, Frame.define('token', readable))(Actor.alias('created_by', 'createdBy'), Frame.define('properties', readable))((fields, extend, options) => sql`
 select ${fields} from public_links
 join actors on public_links."actorId"=actors.id
 left outer join sessions on public_links."actorId"=sessions."actorId"
 ${extend|| sql`join actors as created_by on public_links."createdBy"=created_by.id`}
+${extend|| sql`left outer join
+  (select apv."actorId", json_object_agg(ap.name, apv.value) as properties from actor_properties ap
+    join actor_property_values apv on ap.id=apv."actorPropertyId"
+    group by apv."actorId") as actor_props
+  on actor_props."actorId"=actors.id`}
 where actors."deletedAt" is null and ${sqlEquals(options.condition)}
 order by (sessions.token is not null) desc, actors."createdAt" desc`);
 

--- a/lib/resources/actor-properties.js
+++ b/lib/resources/actor-properties.js
@@ -1,4 +1,4 @@
-const { validatePropertyName } = require('../data/dataset');
+const { validateActorPropertyName } = require('../data/actor-properties');
 const { getOrNotFound } = require('../util/promise');
 const { success } = require('../util/http');
 const Problem = require('../util/problem');
@@ -11,7 +11,7 @@ module.exports = (service, endpoint) => {
     await auth.canOrReject('project.update', project);
 
     const { name } = body;
-    if (name == null || name.toLowerCase() === 'displayname' || !validatePropertyName(name))
+    if (name == null || !validateActorPropertyName(name))
       throw Problem.user.unexpectedValue({ field: 'name', value: name, reason: 'This is not a valid property name.' });
 
     await ActorProperties.create(project.id, name);

--- a/lib/resources/actor-properties.js
+++ b/lib/resources/actor-properties.js
@@ -8,7 +8,7 @@ module.exports = (service, endpoint) => {
   // Register a new actor property name for a project.
   service.post('/projects/:projectId/actor-properties', endpoint(async ({ ActorProperties, Projects }, { auth, params, body }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
-    await auth.canOrReject('project.update', project);
+    await auth.canOrReject('actor_property.update', project);
 
     const { name } = body;
     if (name == null || !validateActorPropertyName(name))
@@ -21,7 +21,7 @@ module.exports = (service, endpoint) => {
   // List actor property names for a project.
   service.get('/projects/:projectId/actor-properties', endpoint(async ({ ActorProperties, Projects }, { auth, params, queryOptions }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
-    await auth.canOrReject('project.read', project);
+    await auth.canOrReject('actor_property.list', project);
     return queryOptions.extended
       ? ActorProperties.getAllForProjectWithValues(project.id)
       : ActorProperties.getAllForProject(project.id);

--- a/lib/resources/actor-properties.js
+++ b/lib/resources/actor-properties.js
@@ -1,0 +1,28 @@
+const { validatePropertyName } = require('../data/dataset');
+const { getOrNotFound } = require('../util/promise');
+const { success } = require('../util/http');
+const Problem = require('../util/problem');
+
+module.exports = (service, endpoint) => {
+
+  // Register a new actor property name for a project.
+  service.post('/projects/:projectId/actor-properties', endpoint(async ({ ActorProperties, Projects }, { auth, params, body }) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('project.update', project);
+
+    const { name } = body;
+    if (name == null || name.toLowerCase() === 'displayname' || !validatePropertyName(name))
+      throw Problem.user.unexpectedValue({ field: 'name', value: name, reason: 'This is not a valid property name.' });
+
+    await ActorProperties.create(project.id, name);
+    return success;
+  }));
+
+  // List actor property names for a project.
+  service.get('/projects/:projectId/actor-properties', endpoint(async ({ ActorProperties, Projects }, { auth, params }) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('project.read', project);
+    return ActorProperties.getAllForProject(project.id);
+  }));
+
+};

--- a/lib/resources/actor-properties.js
+++ b/lib/resources/actor-properties.js
@@ -19,10 +19,12 @@ module.exports = (service, endpoint) => {
   }));
 
   // List actor property names for a project.
-  service.get('/projects/:projectId/actor-properties', endpoint(async ({ ActorProperties, Projects }, { auth, params }) => {
+  service.get('/projects/:projectId/actor-properties', endpoint(async ({ ActorProperties, Projects }, { auth, params, queryOptions }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('project.read', project);
-    return ActorProperties.getAllForProject(project.id);
+    return queryOptions.extended
+      ? ActorProperties.getAllForProjectWithValues(project.id)
+      : ActorProperties.getAllForProject(project.id);
   }));
 
 };

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -11,7 +11,7 @@ const { FieldKey } = require('../model/frames');
 const { getOrNotFound } = require('../util/promise');
 const { success } = require('../util/http');
 const { QueryOptions } = require('../util/db');
-const Problem = require('../util/problem');
+const { extractActorProperties } = require('../data/actor-properties');
 
 module.exports = (service, endpoint) => {
 
@@ -55,21 +55,10 @@ module.exports = (service, endpoint) => {
 
     const fk = await FieldKeys.getByProjectAndActorId(project.id, params.id).then(getOrNotFound);
 
-    const { properties } = body;
+    const properties = body.properties != null ? extractActorProperties(body.properties) : null;
 
-    // Validate properties: reject non-objects, reject non-strings, trim whitespace
-    // Interpret empty string as null value
-    if (properties != null) {
-      if (typeof properties !== 'object' || Array.isArray(properties))
-        throw Problem.user.unexpectedValue({ field: 'properties', value: properties, reason: 'Must be an object.' });
-      for (const [name, value] of Object.entries(properties)) {
-        if (value !== null && typeof value !== 'string')
-          throw Problem.user.unexpectedValue({ field: name, value, reason: 'Property values must be strings or null.' });
-        const sanitized = value?.trim() ?? null;
-        // eslint-disable-next-line no-await-in-loop
-        await ActorProperties.setValueForActor(project.id, fk.actorId, name, sanitized === '' ? null : sanitized);
-      }
-    }
+    if (properties != null)
+      await ActorProperties.setValuesForActor(project.id, fk.actorId, properties);
 
     return FieldKeys.getByProjectAndActorId(project.id, params.id, QueryOptions.extended).then(getOrNotFound);
   }));

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -51,7 +51,7 @@ module.exports = (service, endpoint) => {
   // Body: { properties: { propName: "value" | null, ... } }
   service.patch('/projects/:projectId/app-users/:id', endpoint(async ({ ActorProperties, FieldKeys, Projects }, { auth, params, body }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
-    await auth.canOrReject('project.update', project);
+    await auth.canOrReject('field_key.update', project);
 
     const fk = await FieldKeys.getByProjectAndActorId(project.id, params.id).then(getOrNotFound);
 

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -55,10 +55,11 @@ module.exports = (service, endpoint) => {
 
     const fk = await FieldKeys.getByProjectAndActorId(project.id, params.id).then(getOrNotFound);
 
-    const properties = body.properties != null ? extractActorProperties(body.properties) : null;
-
-    if (properties != null)
+    if (body.properties != null) {
+      const knownProperties = await ActorProperties.getAllForProject(project.id);
+      const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
       await ActorProperties.setValuesForActor(project.id, fk.actorId, properties);
+    }
 
     return FieldKeys.getByProjectAndActorId(project.id, params.id, QueryOptions.extended).then(getOrNotFound);
   }));

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -34,7 +34,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/app-users/:id', endpoint(({ FieldKeys, Projects }, { auth, params, queryOptions }) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
-      .then((project) => auth.canOrReject('field_key.delete', project))
+      .then((project) => auth.canOrReject('field_key.list', project))
       .then((project) => FieldKeys.getByProjectAndActorId(project.id, params.id, queryOptions))
       .then(getOrNotFound)));
 

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -10,6 +10,8 @@
 const { FieldKey } = require('../model/frames');
 const { getOrNotFound } = require('../util/promise');
 const { success } = require('../util/http');
+const { QueryOptions } = require('../util/db');
+const Problem = require('../util/problem');
 
 module.exports = (service, endpoint) => {
 
@@ -29,6 +31,13 @@ module.exports = (service, endpoint) => {
         return FieldKeys.create(fk, project);
       })));
 
+  service.get('/projects/:projectId/app-users/:id', endpoint(({ FieldKeys, Projects }, { auth, params, queryOptions }) =>
+    Projects.getById(params.projectId)
+      .then(getOrNotFound)
+      .then((project) => auth.canOrReject('field_key.delete', project))
+      .then((project) => FieldKeys.getByProjectAndActorId(project.id, params.id, queryOptions))
+      .then(getOrNotFound)));
+
   service.delete('/projects/:projectId/app-users/:id', endpoint(({ Actors, FieldKeys, Projects }, { auth, params }) =>
     Projects.getById(params.projectId)
       .then(getOrNotFound)
@@ -38,5 +47,31 @@ module.exports = (service, endpoint) => {
       .then((fk) => Actors.del(fk.actor))
       .then(success)));
 
+  // Set/unset actor property values on an app user.
+  // Body: { properties: { propName: "value" | null, ... } }
+  service.patch('/projects/:projectId/app-users/:id', endpoint(async ({ ActorProperties, FieldKeys, Projects }, { auth, params, body }) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('project.update', project);
+
+    const fk = await FieldKeys.getByProjectAndActorId(project.id, params.id).then(getOrNotFound);
+
+    const { properties } = body;
+
+    // Validate properties: reject non-objects, reject non-strings, trim whitespace
+    // Interpret empty string as null value
+    if (properties != null) {
+      if (typeof properties !== 'object' || Array.isArray(properties))
+        throw Problem.user.unexpectedValue({ field: 'properties', value: properties, reason: 'Must be an object.' });
+      for (const [name, value] of Object.entries(properties)) {
+        if (value !== null && typeof value !== 'string')
+          throw Problem.user.unexpectedValue({ field: name, value, reason: 'Property values must be strings or null.' });
+        const sanitized = value?.trim() ?? null;
+        // eslint-disable-next-line no-await-in-loop
+        await ActorProperties.setValueForActor(project.id, fk.actorId, name, sanitized === '' ? null : sanitized);
+      }
+    }
+
+    return FieldKeys.getByProjectAndActorId(project.id, params.id, QueryOptions.extended).then(getOrNotFound);
+  }));
 };
 

--- a/lib/resources/public-links.js
+++ b/lib/resources/public-links.js
@@ -45,10 +45,11 @@ module.exports = (service, endpoint) => {
     await auth.canOrReject('public_link.update', form);
     const pl = await PublicLinks.getByFormAndActorId(form.id, params.id).then(getOrNotFound);
 
-    const properties = body.properties != null ? extractActorProperties(body.properties) : null;
-
-    if (properties != null)
+    if (body.properties != null) {
+      const knownProperties = await ActorProperties.getAllForProject(form.projectId);
+      const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
       await ActorProperties.setValuesForActor(form.projectId, pl.actorId, properties);
+    }
 
     return PublicLinks.getByFormAndActorId(form.id, params.id, QueryOptions.extended).then(getOrNotFound);
   }));

--- a/lib/resources/public-links.js
+++ b/lib/resources/public-links.js
@@ -34,7 +34,7 @@ module.exports = (service, endpoint) => {
   service.get('/projects/:projectId/forms/:xmlFormId/public-links/:id', endpoint(({ Forms, PublicLinks }, { auth, params, queryOptions }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef)
       .then(getOrNotFound)
-      .then((form) => auth.canOrReject('public_link.delete', form))
+      .then((form) => auth.canOrReject('public_link.read', form))
       .then((form) => PublicLinks.getByFormAndActorId(form.id, params.id, queryOptions))
       .then(getOrNotFound)));
 
@@ -42,7 +42,7 @@ module.exports = (service, endpoint) => {
   // Body: { properties: { propName: "value" | null, ... } }
   service.patch('/projects/:projectId/forms/:xmlFormId/public-links/:id', endpoint(async ({ ActorProperties, Forms, PublicLinks }, { auth, params, body }) => {
     const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef).then(getOrNotFound);
-    await auth.canOrReject('public_link.delete', form);
+    await auth.canOrReject('public_link.update', form);
     const pl = await PublicLinks.getByFormAndActorId(form.id, params.id).then(getOrNotFound);
 
     const properties = body.properties != null ? extractActorProperties(body.properties) : null;

--- a/lib/resources/public-links.js
+++ b/lib/resources/public-links.js
@@ -10,6 +10,8 @@
 const { Form, PublicLink } = require('../model/frames');
 const { getOrNotFound } = require('../util/promise');
 const { success } = require('../util/http');
+const { QueryOptions } = require('../util/db');
+const Problem = require('../util/problem');
 
 module.exports = (service, endpoint) => {
 
@@ -28,6 +30,37 @@ module.exports = (service, endpoint) => {
           .with({ createdBy: auth.actor.map((actor) => actor.id).orNull() });
         return PublicLinks.create(pl, form);
       })));
+
+  service.get('/projects/:projectId/forms/:xmlFormId/public-links/:id', endpoint(({ Forms, PublicLinks }, { auth, params, queryOptions }) =>
+    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('public_link.delete', form))
+      .then((form) => PublicLinks.getByFormAndActorId(form.id, params.id, queryOptions))
+      .then(getOrNotFound)));
+
+  // Set/unset actor property values on a public link.
+  // Body: { properties: { propName: "value" | null, ... } }
+  service.patch('/projects/:projectId/forms/:xmlFormId/public-links/:id', endpoint(async ({ ActorProperties, Forms, PublicLinks }, { auth, params, body }) => {
+    const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef).then(getOrNotFound);
+    await auth.canOrReject('public_link.delete', form);
+    const pl = await PublicLinks.getByFormAndActorId(form.id, params.id).then(getOrNotFound);
+
+    const { properties } = body;
+
+    if (properties != null) {
+      if (typeof properties !== 'object' || Array.isArray(properties))
+        throw Problem.user.unexpectedValue({ field: 'properties', value: properties, reason: 'Must be an object.' });
+      for (const [name, value] of Object.entries(properties)) {
+        if (value !== null && typeof value !== 'string')
+          throw Problem.user.unexpectedValue({ field: name, value, reason: 'Property values must be strings or null.' });
+        const sanitized = value?.trim() ?? null;
+        // eslint-disable-next-line no-await-in-loop
+        await ActorProperties.setValueForActor(form.projectId, pl.actorId, name, sanitized === '' ? null : sanitized);
+      }
+    }
+
+    return PublicLinks.getByFormAndActorId(form.id, params.id, QueryOptions.extended).then(getOrNotFound);
+  }));
 
   service.delete('/projects/:projectId/forms/:xmlFormId/public-links/:id', endpoint(({ Actors, Forms, PublicLinks }, { auth, params }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef)

--- a/lib/resources/public-links.js
+++ b/lib/resources/public-links.js
@@ -11,7 +11,7 @@ const { Form, PublicLink } = require('../model/frames');
 const { getOrNotFound } = require('../util/promise');
 const { success } = require('../util/http');
 const { QueryOptions } = require('../util/db');
-const Problem = require('../util/problem');
+const { extractActorProperties } = require('../data/actor-properties');
 
 module.exports = (service, endpoint) => {
 
@@ -45,19 +45,10 @@ module.exports = (service, endpoint) => {
     await auth.canOrReject('public_link.delete', form);
     const pl = await PublicLinks.getByFormAndActorId(form.id, params.id).then(getOrNotFound);
 
-    const { properties } = body;
+    const properties = body.properties != null ? extractActorProperties(body.properties) : null;
 
-    if (properties != null) {
-      if (typeof properties !== 'object' || Array.isArray(properties))
-        throw Problem.user.unexpectedValue({ field: 'properties', value: properties, reason: 'Must be an object.' });
-      for (const [name, value] of Object.entries(properties)) {
-        if (value !== null && typeof value !== 'string')
-          throw Problem.user.unexpectedValue({ field: name, value, reason: 'Property values must be strings or null.' });
-        const sanitized = value?.trim() ?? null;
-        // eslint-disable-next-line no-await-in-loop
-        await ActorProperties.setValueForActor(form.projectId, pl.actorId, name, sanitized === '' ? null : sanitized);
-      }
-    }
+    if (properties != null)
+      await ActorProperties.setValuesForActor(form.projectId, pl.actorId, properties);
 
     return PublicLinks.getByFormAndActorId(form.id, params.id, QueryOptions.extended).then(getOrNotFound);
   }));

--- a/test/integration/api/actor-properties.js
+++ b/test/integration/api/actor-properties.js
@@ -73,38 +73,37 @@ describe('api: /projects/:id/actor-properties', () => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
       await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'plot_id' }).expect(200);
+
+      const { body: fk1 } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'user 1' }).expect(200);
+      const { body: fk2 } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'user 2' }).expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${fk1.id}`)
+        .send({ properties: { region: 'north', plot_id: 'A1' } })
+        .expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${fk2.id}`)
+        .send({ properties: { region: 'south' } })
+        .expect(200);
+
       await asAlice.get('/v1/projects/1/actor-properties')
-        .set('X-Extended-Metadata', true)
-        .expect(200)
-        .then(({ body }) => {
-          body.map(p => p.name).should.eql(['plot_id', 'region']);
-        });
-    }));
-
-    it('should get an app user by id with actor properties', testService(async (service) => {
-      const asAlice = await service.login('alice');
-      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
-      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'worker_id' }).expect(200);
-
-      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
-        .send({ displayName: 'test user' })
-        .expect(200);
-
-      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
-        .send({ properties: { region: 'north' } })
-        .expect(200);
-
-      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
-        .send({ properties: { worker_id: '1234' } })
-        .expect(200);
-
-      await asAlice.get(`/v1/projects/1/app-users/${appUser.id}`)
         .set('X-Extended-Metadata', 'true')
         .expect(200)
         .then(({ body }) => {
-          body.displayName.should.equal('test user');
-          body.properties.region.should.equal('north');
-          body.properties.worker_id.should.equal('1234');
+          body.should.eql([
+            { name: 'plot_id', values: ['A1'] },
+            { name: 'region', values: ['north', 'south'] }
+          ]);
+        });
+    }));
+
+    it('should return empty values arrays when no values are set', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      await asAlice.get('/v1/projects/1/actor-properties')
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.eql([{ name: 'region', values: [] }]);
         });
     }));
   });

--- a/test/integration/api/actor-properties.js
+++ b/test/integration/api/actor-properties.js
@@ -1,0 +1,112 @@
+const { testService } = require('../setup');
+
+describe('api: /projects/:id/actor-properties', () => {
+  describe('POST /projects/:id/actor-properties', () => {
+    it('should return 403 if the user cannot update the project', testService(async (service) => {
+      const asChelsea = await service.login('chelsea');
+      await asChelsea.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(403);
+    }));
+
+    it('should create a actor property and return success', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+    }));
+
+    it('should reject if name is missing', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({})
+        .expect(400);
+    }));
+
+    it('should reject if name is not allowed', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'name' })
+        .expect(400);
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: '__specialSystemName' })
+        .expect(400);
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'displayName' })
+        .expect(400);
+    }));
+
+    it('should reject if existing name is sent again', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(409);
+    }));
+  });
+
+  describe('GET /projects/:id/actor-properties', () => {
+    it('should return an empty list if no properties exist', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.get('/v1/projects/1/actor-properties')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.eql([]);
+        });
+    }));
+
+    it('should return the created properties', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'plot_id' }).expect(200);
+      await asAlice.get('/v1/projects/1/actor-properties')
+        .expect(200)
+        .then(({ body }) => {
+          body.map(p => p.name).should.eql(['plot_id', 'region']);
+        });
+    }));
+
+    it('should return the properties with enumerated values if extended metadata requested', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'plot_id' }).expect(200);
+      await asAlice.get('/v1/projects/1/actor-properties')
+        .set('X-Extended-Metadata', true)
+        .expect(200)
+        .then(({ body }) => {
+          body.map(p => p.name).should.eql(['plot_id', 'region']);
+        });
+    }));
+
+    it('should get an app user by id with actor properties', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'worker_id' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { worker_id: '1234' } })
+        .expect(200);
+
+      await asAlice.get(`/v1/projects/1/app-users/${appUser.id}`)
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.displayName.should.equal('test user');
+          body.properties.region.should.equal('north');
+          body.properties.worker_id.should.equal('1234');
+        });
+    }));
+  });
+
+});

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -175,6 +175,155 @@ describe('api: /projects/:id/app-users', () => {
             })))));
   });
 
+  describe('/:id GET', () => {
+    it('should return 403 unless the user can delete', testService(async (service) => {
+      const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
+      const { body: fk } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'test1' }).expect(200);
+      await asChelsea.get(`/v1/projects/1/app-users/${fk.id}`).expect(403);
+    }));
+
+    it('should return the app user', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: created } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'test1' }).expect(200);
+      const { body } = await asAlice.get(`/v1/projects/1/app-users/${created.id}`).expect(200);
+      body.should.be.a.FieldKey();
+      body.displayName.should.equal('test1');
+    }));
+
+    it('should return 404 if the app user is not in the project', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: project2 } = await asAlice.post('/v1/projects').send({ name: 'project 2' }).expect(200);
+      const { body: fk } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'test1' }).expect(200);
+      await asAlice.get(`/v1/projects/${project2.id}/app-users/${fk.id}`).expect(404);
+    }));
+
+    it('should return extended metadata if requested', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: created } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'test1' }).expect(200);
+      const { body } = await asAlice.get(`/v1/projects/1/app-users/${created.id}`)
+        .set('X-Extended-Metadata', 'true')
+        .expect(200);
+      body.should.be.an.ExtendedFieldKey();
+      body.displayName.should.equal('test1');
+      body.createdBy.displayName.should.equal('Alice');
+    }));
+
+    it('should return null properties when no actor properties are defined on the project', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: created } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'test1' }).expect(200);
+      await asAlice.get(`/v1/projects/1/app-users/${created.id}`)
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          should(body.properties).be.null();
+        });
+    }));
+  });
+
+  describe('/:id PATCH', () => {
+    it('should set actor property values on an app user', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.region.should.equal('north');
+        });
+    }));
+
+    it('should set multiple actor properties at once', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'worker_id' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north', worker_id: '42' } })
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.region.should.equal('north');
+          body.properties.worker_id.should.equal('42');
+        });
+    }));
+
+    it('should set some properties and unset others in the same request', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'worker_id' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north', worker_id: '42' } })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'south', worker_id: null } })
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.region.should.equal('south');
+          body.properties.should.not.have.property('worker_id');
+        });
+    }));
+
+    it('should unset an actor property when passed null', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'worker_id' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north', worker_id: '42' } })
+        .expect(200);
+
+      // unset one — the other remains
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: null } })
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.worker_id.should.equal('42');
+          body.properties.should.not.have.property('region');
+        });
+
+      // unset the last one — properties is null
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { worker_id: null } })
+        .expect(200)
+        .then(({ body }) => {
+          should(body.properties).be.null();
+        });
+    }));
+
+    it('should return 404 if the actor property does not exist', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { nonexistent: 'value' } })
+        .expect(404)
+        .then(({ body }) => {
+          body.code.should.equal(404.1);
+          body.message.should.equal('Could not find the resource you were looking for.');
+        });
+    }));
+  });
+
   describe('/:id DELETE', () => {
     it('should return 403 unless the user can delete', testService((service) =>
       service.login(['alice', 'chelsea'], (asAlice, asChelsea) =>

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -233,7 +233,7 @@ describe('api: /projects/:id/app-users', () => {
         .send({ properties: { region: 'north' } })
         .expect(200)
         .then(({ body }) => {
-          body.properties.region.should.equal('north');
+          body.properties.should.eql({ region: 'north' });
         });
     }));
 
@@ -250,8 +250,7 @@ describe('api: /projects/:id/app-users', () => {
         .send({ properties: { region: 'north', worker_id: '42' } })
         .expect(200)
         .then(({ body }) => {
-          body.properties.region.should.equal('north');
-          body.properties.worker_id.should.equal('42');
+          body.properties.should.eql({ region: 'north', worker_id: '42' });
         });
     }));
 
@@ -272,8 +271,7 @@ describe('api: /projects/:id/app-users', () => {
         .send({ properties: { region: 'south', worker_id: null } })
         .expect(200)
         .then(({ body }) => {
-          body.properties.region.should.equal('south');
-          body.properties.should.not.have.property('worker_id');
+          body.properties.should.eql({ region: 'south' });
         });
     }));
 
@@ -295,8 +293,7 @@ describe('api: /projects/:id/app-users', () => {
         .send({ properties: { region: null } })
         .expect(200)
         .then(({ body }) => {
-          body.properties.worker_id.should.equal('42');
-          body.properties.should.not.have.property('region');
+          body.properties.should.eql({ worker_id: '42' });
         });
 
       // unset the last one — properties is null

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -173,6 +173,26 @@ describe('api: /projects/:id/app-users', () => {
               body.forEach((key) => key.should.be.an.ExtendedFieldKey());
               body.map((key) => key.displayName).should.eql([ 'test 3', 'test 1', 'test 2' ]);
             })))));
+
+    it('should include properties in extended metadata', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: fk1 } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'test 1' }).expect(200);
+      const { body: fk2 } = await asAlice.post('/v1/projects/1/app-users').send({ displayName: 'test 2' }).expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${fk1.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/app-users')
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.find((fk) => fk.id === fk1.id).properties.should.eql({ region: 'north' });
+          should(body.find((fk) => fk.id === fk2.id).properties).be.null();
+        });
+    }));
   });
 
   describe('/:id GET', () => {

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -333,12 +333,86 @@ describe('api: /projects/:id/app-users', () => {
 
       await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
         .send({ properties: { nonexistent: 'value' } })
-        .expect(404)
+        .expect(400)
         .then(({ body }) => {
-          body.code.should.equal(404.1);
-          body.message.should.equal('Could not find the resource you were looking for.');
+          body.code.should.equal(400.8);
+          body.details.field.should.equal('properties');
+          body.details.value.should.equal('nonexistent');
         });
     }));
+
+    it('should be a no-op if properties is absent from the body', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      // patch without properties key — existing values unchanged
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({})
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.should.eql({ region: 'north' });
+        });
+    }));
+
+    it('should treat empty string as null (unsetting the property)', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: '' } })
+        .expect(200)
+        .then(({ body }) => {
+          should(body.properties).be.null();
+        });
+    }));
+
+    it('should return 400 if properties is not an object', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: 'not an object' })
+        .expect(400)
+        .then(({ body }) => { body.code.should.equal(400.8); });
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: ['a', 'b'] })
+        .expect(400)
+        .then(({ body }) => { body.code.should.equal(400.8); });
+    }));
+
+    it('should return 400 if a property value is not a string or null', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 42 } })
+        .expect(400)
+        .then(({ body }) => { body.code.should.equal(400.8); });
+    }));
+
+    // The property-setting logic (validation, coercion, bulk upsert/delete) is shared
+    // under the hood with public links. The tests above cover it fully; public-links
+    // tests only verify the happy-path integration without re-testing every edge case.
   });
 
   describe('/:id DELETE', () => {

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -478,7 +478,8 @@ describe('api: /projects', () => {
                   'dataset.list',
                   'dataset.read',
                   'entity.list',
-                  'entity.read'
+                  'entity.read',
+                  'actor_property.list'
                 ]);
               }))))));
   });

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -1689,7 +1689,8 @@ describe('api: /projects?forms=true', () => {
                   'dataset.list',
                   'dataset.read',
                   'entity.list',
-                  'entity.read'
+                  'entity.read',
+                  'actor_property.list'
                 ]);
               }))))));
   });
@@ -1735,7 +1736,8 @@ describe('api: /projects?forms=true', () => {
               'dataset.list',
               'dataset.read',
               'entity.list',
-              'entity.read'
+              'entity.read',
+              'actor_property.list'
             ]);
           }))))));
 });

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -282,7 +282,7 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
         });
     }));
 
-    it('should return 404 if the actor property does not exist', testService(async (service) => {
+    it('should return 400 if the actor property does not exist', testService(async (service) => {
       const asAlice = await service.login('alice');
       const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
         .send({ displayName: 'test link' })
@@ -290,8 +290,10 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
 
       await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
         .send({ properties: { nonexistent: 'value' } })
-        .expect(404);
+        .expect(400);
     }));
+
+    // Additional behavior tested in app-users test because the machinery of setting properties is the same.
   });
 
   describe('/:id DELETE', () => {

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -150,6 +150,130 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
             })))));
   });
 
+  describe('/:id GET', () => {
+    it('should return 403 unless the user can delete', testService(async (service) => {
+      const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test1' }).expect(200);
+      await asChelsea.get(`/v1/projects/1/forms/simple/public-links/${pl.id}`).expect(403);
+    }));
+
+    it('should return the public link', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: created } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test1' }).expect(200);
+      await asAlice.get(`/v1/projects/1/forms/simple/public-links/${created.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.should.be.a.PublicLink();
+          body.displayName.should.equal('test1');
+        });
+    }));
+
+    it('should return 404 if the public link is not on the form', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test1' }).expect(200);
+      await asAlice.get(`/v1/projects/1/forms/withrepeat/public-links/${pl.id}`).expect(404);
+    }));
+
+    it('should return extended metadata if requested', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: created } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test1' }).expect(200);
+      await asAlice.get(`/v1/projects/1/forms/simple/public-links/${created.id}`)
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.should.be.an.ExtendedPublicLink();
+          body.createdBy.displayName.should.equal('Alice');
+        });
+    }));
+
+    it('should return null properties when no actor properties are defined on the project', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: created } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test1' }).expect(200);
+      await asAlice.get(`/v1/projects/1/forms/simple/public-links/${created.id}`)
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          should(body.properties).be.null();
+        });
+    }));
+  });
+
+  describe('/:id PATCH', () => {
+    it('should set actor property values on a public link', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+        .send({ displayName: 'test link' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.should.eql({ region: 'north' });
+        });
+    }));
+
+    it('should set multiple actor properties at once', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'worker_id' }).expect(200);
+
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+        .send({ displayName: 'test link' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .send({ properties: { region: 'north', worker_id: '42' } })
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.should.eql({ region: 'north', worker_id: '42' });
+        });
+    }));
+
+    it('should unset an actor property when passed null', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'worker_id' }).expect(200);
+
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+        .send({ displayName: 'test link' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .send({ properties: { region: 'north', worker_id: '42' } })
+        .expect(200);
+
+      // unset one — the other remains
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .send({ properties: { region: null } })
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.should.eql({ worker_id: '42' });
+        });
+
+      // unset the last one — properties is null
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .send({ properties: { worker_id: null } })
+        .expect(200)
+        .then(({ body }) => {
+          should(body.properties).be.null();
+        });
+    }));
+
+    it('should return 404 if the actor property does not exist', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+        .send({ displayName: 'test link' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .send({ properties: { nonexistent: 'value' } })
+        .expect(404);
+    }));
+  });
+
   describe('/:id DELETE', () => {
     it('should return 403 unless the user can delete', testService((service) =>
       service.login(['alice', 'chelsea'], (asAlice, asChelsea) =>

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -148,6 +148,26 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
               body.forEach((key) => key.should.be.an.ExtendedPublicLink());
               body.map((key) => key.displayName).should.eql([ 'test 3', 'test 1', 'test 2' ]);
             })))));
+
+    it('should include properties in extended metadata', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: pl1 } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test 1' }).expect(200);
+      const { body: pl2 } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test 2' }).expect(200);
+
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl1.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/forms/simple/public-links')
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.find((pl) => pl.id === pl1.id).properties.should.eql({ region: 'north' });
+          should(body.find((pl) => pl.id === pl2.id).properties).be.null();
+        });
+    }));
   });
 
   describe('/:id GET', () => {

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -171,7 +171,7 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
   });
 
   describe('/:id GET', () => {
-    it('should return 403 unless the user can delete', testService(async (service) => {
+    it('should return 403 unless the user can read', testService(async (service) => {
       const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
       const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links').send({ displayName: 'test1' }).expect(200);
       await asChelsea.get(`/v1/projects/1/forms/simple/public-links/${pl.id}`).expect(403);


### PR DESCRIPTION
Closes getodk/central#1868

Adds support for project-level "actor properties" — named key-value pairs that can be defined on a project and then set on individual app users and public links. These are intended for use by clients to attach metadata (e.g. region, worker ID) to actors for later filtering or reporting.

## New endpoints

**Actor property definitions** (project-scoped):
- `POST /projects/:id/actor-properties` — define a new property name for a project
- `GET /projects/:id/actor-properties` — list all defined property names for a project
- `GET /projects/:id/actor-properties` with `X-Extended-Metadata` returns each property with a `values` array of distinct values currently in use across all actors (empty array if none set).

**App users:**
- `GET /projects/:projectId/app-users/:id` — fetch a single app user (respects `X-Extended-Metadata`)
- `PATCH /projects/:projectId/app-users/:id` — set/unset property values on an app user

**Public links:**
- `GET /projects/:projectId/forms/:xmlFormId/public-links/:id` — fetch a single public link (respects `X-Extended-Metadata`)
- `PATCH /projects/:projectId/forms/:xmlFormId/public-links/:id` — set/unset property values on a public link

## Behavior

- Property names must be pre-defined on the project before values can be set on actors.
- The `PATCH` body accepts `{ properties: { name: "value" | null } }`. Passing `null` unsets the property. String values are trimmed; empty strings are treated as `null`.
- Properties are returned in extended metadata responses as a `properties` object (or `null` if no values are set).
- Both app users and public links share the same underlying `actor_properties` / `actor_property_values` tables.

#### What has been done to verify that this works as intended?

Integration tests for all new endpoints: setting/unsetting properties, partial unset, 403/404
cases, and extended metadata responses (including `null` when no values are set). Tests cover
both app users and public links.

#### Why is this the best possible solution? Were any other approaches considered?

Property names are defined at the project level and shared across app users and public links to
avoid duplicating name management per actor type. Values are in a separate `actor_property_values`
table so unset properties leave no rows. `properties` is `null` in responses when nothing is set.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No existing endpoints changed, but the extended metadata list responses for app users and public
links now include a `properties` field (always `null` unless values have been set). There may be
a minor performance impact from the additional join on those list queries.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes — not included in this PR yet.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced