### PR TITLE
s3: note object names should NOT depend on bucket or server

### DIFF
--- a/lib/external/s3.js
+++ b/lib/external/s3.js
@@ -116,6 +116,7 @@ const init = (config) => {
 
   const objectNameFor = ({ id, sha }) => {
     // Include blob ID in object name to allow easy correlation with postgres data.
+    //
     // Include blob SHA sum to prevent name collision in case multiple odk-central-
     // backend instances point to the same bucket.  There are a few scenarios where
     // this could happen, e.g.
@@ -123,6 +124,12 @@ const init = (config) => {
     //   * instance reset after testing/training
     //   * staging & prod instances pointed to the same bucket
     //   * temporary loss of access to postgres data on upgrade error
+    //
+    // To allow restoring from backups, do NOT include:
+    //
+    //   * S3 server URL
+    //   * bucket name
+
     if (typeof id !== 'number') throw new Error('Invalid id: ' + id);
     if (!sha) throw new Error('Missing sha sum for blob: ' + id);
     return `${objectPrefix??''}blob-${id}-${sha}`;


### PR DESCRIPTION
Ref https://github.com/getodk/central/issues/1862

#### What has been done to verify that this works as intended?

It's just a comment update.

#### Why is this the best possible solution? Were any other approaches considered?

Seems reasonable given https://github.com/getodk/central/issues/1862 / https://forum.getodk.org/t/s3-bucket-migration-for-central-storage/58029 - a user may wish to change bucket name or server when changing providers, when recovering from a regional outage, etc.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just a comment change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

I don't think so.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
