### PR TITLE
ci/s3-e2e: show server logs at end of run

### DIFF
--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -37,3 +37,6 @@ jobs:
     - name: E2E Test
       timeout-minutes: 10
       run: ./test/e2e/s3/run-tests.sh
+    - name: Backend Logs
+      if: always()
+      run: "! [[ -f ./server.log ]] || cat ./server.log"

--- a/test/e2e/s3/run-tests.sh
+++ b/test/e2e/s3/run-tests.sh
@@ -56,7 +56,7 @@ log "Waiting for fake-s3-server to start..."
 wait-for-it localhost:9000 --strict --timeout=10 -- echo '[test/e2e/s3/run-tests] fake-s3-server is UP!'
 
 NODE_CONFIG_ENV=s3-dev node lib/bin/s3-create-bucket.js
-NODE_CONFIG_ENV=s3-dev make run &
+NODE_CONFIG_ENV=s3-dev make run | tee server.log &
 serverPid=$!
 
 log 'Waiting for backend to start...'


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

- [x] ci test run without this change: https://github.com/getodk/central-backend/actions/runs/25487471555/job/74786668952
- [x] ci test run with this change: https://github.com/getodk/central-backend/actions/runs/25492612833/job/74804197773?pr=1827

#### Why is this the best possible solution? Were any other approaches considered?

Helpful to see any server logs that are output while the s3 e2e tests are run.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
