### PR TITLE
Prevent sentry logging thing in test/bin from being run on its own

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -9,6 +9,7 @@
 
 module.exports = {
   ignore: [
+    'test/bin/**',
     'test/db-migrations/**',
     'test/e2e/**',
   ],


### PR DESCRIPTION
I was running into a frustrating situation where when i ran `make test`, my dev database got erased and replaced with test fixtures (simple and withrepeat in the forms table).

I had ~3 assorted dev databases in docker so I burned through two of them switching them out before realizing it really was something going on with the backend code and not me getting into a bad state with my database on my own. 

Some  example output: 
```
% make test
node lib/bin/enforce-node-version.js
npx eslint --cache --max-warnings 0 .
npm warn Unknown project config "min-release-age". This will stop working in the next major version of npm.
BCRYPT=insecure npx mocha --recursive
npm warn Unknown project config "min-release-age". This will stop working in the next major version of npm.
attempted to log Sentry exception in development:
Error: --recursive
    at /Users/ktuite/Desktop/code/odk/central-backend/test/bin/test-sentry-logging.js:6:26
    at /Users/ktuite/Desktop/code/odk/central-backend/lib/task/task.js:62:48
    at Object.startSpan (/Users/ktuite/Desktop/code/odk/central-backend/lib/external/sentry.js:149:24)
    at /Users/ktuite/Desktop/code/odk/central-backend/lib/task/task.js:58:19
    at Object.<anonymous> (/Users/ktuite/Desktop/code/odk/central-backend/test/bin/test-sentry-logging.js:8:3)
    at Module._compile (node:internal/modules/cjs/loader:1761:14)
    at Object..js (node:internal/modules/cjs/loader:1893:10)
    at Module.load (node:internal/modules/cjs/loader:1481:32)
    at Module._load (node:internal/modules/cjs/loader:1300:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at loadCJSModuleWithModuleLoad (node:internal/modules/esm/translators:339:3)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:242:7)
    at ModuleJob.run (node:internal/modules/esm/module_job:413:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:660:26)
    at async formattedImport (/Users/ktuite/Desktop/code/odk/central-backend/node_modules/mocha/lib/nodejs/esm-utils.js:9:14)
    at async exports.requireOrImport (/Users/ktuite/Desktop/code/odk/central-backend/node_modules/mocha/lib/nodejs/esm-utils.js:42:28)
    at async exports.loadFilesAsync (/Users/ktuite/Desktop/code/odk/central-backend/node_modules/mocha/lib/nodejs/esm-utils.js:100:20)
    at async singleRun (/Users/ktuite/Desktop/code/odk/central-backend/node_modules/mocha/lib/cli/run-helpers.js:162:3)
    at async exports.handler (/Users/ktuite/Desktop/code/odk/central-backend/node_modules/mocha/lib/cli/run.js:375:5)
attempted to log Sentry transaction in development:
{ op: 'task', name: 'mocha', duration: 0.45429200000000947 }
Warning: Environment variable "PGDATABASE" already set.
Not applying DB configuration of "database".


Warning: Environment variable "PGDATABASE" already set.
Not applying DB configuration of "database".
  api: /analytics/preview
    GET
```

After looking through recent commits, I narrowed it down to https://github.com/getodk/central-backend/commit/08db5c9cb75c8188c7a3d359860450dd9490426d 

Adding this to `test/integration/external/sentry.js`
```
      console.log('PGDATABASE before:', process.env.PGDATABASE);
      await promisify(exec)('node test/bin/test-sentry-logging test error', { env });
      console.log('PGDATABASE after:', process.env.PGDATABASE);
```

when running with `make test` or `BCRYPT=insecure npx mocha --recursive` i saw: 
```
PGDATABASE before: jubilant
PGDATABASE after: jubilant
```

when running with `make test-integration` i just saw

```
PGDATABASE before: jubilant_test
PGDATABASE after: jubilant_test
```

Just skipping the test in the other file (`test/integration/external/sentry.js`) didn't fix the issue but commenting out everything in `test/bin/test-sentry-logging.js` did.

Seems like the problem is stemming from `test/bin/test-sentry-logging.js` and being executed on its own.

I believe just excluding it from the mocha file fixes things.


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I've tried it but it would be nice for another person to try it. 

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
