### PR TITLE
Fixes: create db schema and verbose logging

### DIFF
--- a/lib/util/backup.js
+++ b/lib/util/backup.js
@@ -98,11 +98,10 @@ const restoreBackupFromRestoreStream = (dumpRestoreStream) => {
     [
       '--no-password',
       '--no-psqlrc',
-      '--quiet',
-      '--echo-errors',
+      '--echo-all',
     ],
     {
-      stdio: ['pipe', 'ignore', 'inherit'],
+      stdio: ['pipe', 'inherit', 'inherit'],
     },
   );
 
@@ -140,6 +139,8 @@ const restoreBackupFromRestoreStream = (dumpRestoreStream) => {
       -- Objects (such as an extension) not owned by the connecting user (eg placed there by a DB superuser without chowning)
       -- will not be dropped, which is going to be a problem when that object is included in the dump.
       DROP OWNED BY CURRENT_USER CASCADE;
+
+      CREATE SCHEMA IF NOT EXISTS public;
   `);
   const postamble = Readable.from(`
       COMMIT;


### PR DESCRIPTION
- Create `public` schema if doesn't exists (it can be dropped by `DROP OWNED BY CURRENT_USER CASCADE`)
- print all messages from `psql`

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
