### PR TITLE
Log creating and setting properties on app users and public links

### DIFF
--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -67,9 +67,11 @@ ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."val
 };
 
 setValuesForActor.audit = (_, fieldKeyOrLink, properties) => (log) => {
-  // Look up `public_link` or `field_key` type from fieldKeyOrLink
-  const action = `${fieldKeyOrLink.constructor.actorType}.property.set`;
-  return log(action, fieldKeyOrLink.actor, { properties });
+  if (Object.keys(properties).length > 0) {
+    // Look up `public_link` or `field_key` type from fieldKeyOrLink
+    const action = `${fieldKeyOrLink.constructor.actorType}.property.set`;
+    return log(action, fieldKeyOrLink.actor, { properties });
+  }
 };
 
 module.exports = { create, getAllForProject, getAllForProjectWithValues, setValuesForActor };

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -5,12 +5,14 @@ const { construct } = require('../../util/util');
 
 
 // Creates a new actor property name for a project.
-const create = (projectId, name) => ({ one }) =>
+const create = (project, name) => ({ one }) =>
   one(sql`
 INSERT INTO actor_properties ("projectId", "name")
-VALUES (${projectId}, ${name})
+VALUES (${project.id}, ${name})
 RETURNING *`)
     .then(construct(ActorProperty));
+
+create.audit = (project, name) => (log) => log('actor_property.create', project, { name });
 
 // Returns all actor property names for a project.
 const getAllForProject = (projectId) => ({ all }) =>
@@ -39,7 +41,7 @@ ORDER BY ap.name`)
 // one to delete rows for null-valued properties, one to upsert non-null ones.
 // properties is a plain object mapping property names to values (string or null),
 // as returned by extractActorProperties() in lib/data/actor-properties.js.
-const setValuesForActor = (projectId, actorId, properties) => async ({ run }) => {
+const setValuesForActor = (projectId, fieldKeyOrLink, properties) => async ({ run }) => {
   const entries = Object.entries(properties);
   const toDelete = entries.filter(([, v]) => v === null).map(([name]) => name);
   const toUpsert = entries.filter(([, v]) => v !== null);
@@ -47,7 +49,7 @@ const setValuesForActor = (projectId, actorId, properties) => async ({ run }) =>
   if (toDelete.length > 0) {
     await run(sql`
 DELETE FROM actor_property_values
-WHERE "actorId" = ${actorId}
+WHERE "actorId" = ${fieldKeyOrLink.actorId}
   AND "actorPropertyId" IN (
     SELECT id FROM actor_properties
     WHERE "projectId" = ${projectId} AND name = ANY(${sql.array(toDelete, 'text')})
@@ -57,11 +59,17 @@ WHERE "actorId" = ${actorId}
   if (toUpsert.length > 0) {
     await run(sql`
 INSERT INTO actor_property_values ("actorId", "actorPropertyId", "value")
-SELECT ${actorId}, ap.id, v.value
+SELECT ${fieldKeyOrLink.actorId}, ap.id, v.value
 FROM ${sql.unnest(toUpsert, ['text', 'text'])} AS v(name, value)
 JOIN actor_properties ap ON ap."projectId" = ${projectId} AND ap.name = v.name
 ON CONFLICT ("actorId", "actorPropertyId") DO UPDATE SET "value" = EXCLUDED."value"`);
   }
+};
+
+setValuesForActor.audit = (_, fieldKeyOrLink, properties) => (log) => {
+  // Look up `public_link` or `field_key` type from fieldKeyOrLink
+  const action = `${fieldKeyOrLink.constructor.actorType}.property.set`;
+  return log(action, fieldKeyOrLink.actor, { properties });
 };
 
 module.exports = { create, getAllForProject, getAllForProjectWithValues, setValuesForActor };

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -42,11 +42,11 @@ const actionCondition = (action) => {
   else if (action === 'user')
     return sql`action in ('user.create', 'user.update', 'user.delete', 'user.assignment.create', 'user.assignment.delete', 'user.session.create')`;
   else if (action === 'field_key')
-    return sql`action in ('field_key.create', 'field_key.assignment.create', 'field_key.assignment.delete', 'field_key.session.end', 'field_key.delete')`;
+    return sql`action in ('field_key.create', 'field_key.assignment.create', 'field_key.assignment.delete', 'field_key.session.end', 'field_key.delete', 'field_key.property.set')`;
   else if (action === 'public_link')
-    return sql`action in ('public_link.create', 'public_link.assignment.create', 'public_link.assignment.delete', 'public_link.session.end', 'public_link.delete')`;
+    return sql`action in ('public_link.create', 'public_link.assignment.create', 'public_link.assignment.delete', 'public_link.session.end', 'public_link.delete', 'public_link.property.set')`;
   else if (action === 'project')
-    return sql`action in ('project.create', 'project.update', 'project.delete')`;
+    return sql`action in ('project.create', 'project.update', 'project.delete', 'actor_property.create')`;
   else if (action === 'form')
     return sql`action in ('form.create', 'form.update', 'form.delete', 'form.restore', 'form.purge', 'form.attachment.update', 'form.submission.export', 'form.update.draft.set', 'form.update.draft.delete', 'form.update.draft.replace', 'form.update.publish')`;
   else if (action === 'submission')

--- a/lib/resources/actor-properties.js
+++ b/lib/resources/actor-properties.js
@@ -14,7 +14,7 @@ module.exports = (service, endpoint) => {
     if (name == null || !validateActorPropertyName(name))
       throw Problem.user.unexpectedValue({ field: 'name', value: name, reason: 'This is not a valid property name.' });
 
-    await ActorProperties.create(project.id, name);
+    await ActorProperties.create(project, name);
     return success;
   }));
 

--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -30,7 +30,7 @@ module.exports = (service, endpoint) => {
     if (body.properties != null) {
       const knownProperties = await ActorProperties.getAllForProject(project.id);
       const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
-      await ActorProperties.setValuesForActor(project.id, fk.actorId, properties);
+      await ActorProperties.setValuesForActor(project.id, fk, properties);
     }
 
     // Returns the raw FK from create() without new properties
@@ -64,7 +64,7 @@ module.exports = (service, endpoint) => {
     if (body.properties != null) {
       const knownProperties = await ActorProperties.getAllForProject(project.id);
       const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
-      await ActorProperties.setValuesForActor(project.id, fk.actorId, properties);
+      await ActorProperties.setValuesForActor(project.id, fk, properties);
     }
 
     return FieldKeys.getByProjectAndActorId(project.id, params.id, QueryOptions.extended).then(getOrNotFound);

--- a/lib/resources/public-links.js
+++ b/lib/resources/public-links.js
@@ -30,7 +30,7 @@ module.exports = (service, endpoint) => {
     if (body.properties != null) {
       const knownProperties = await ActorProperties.getAllForProject(form.projectId);
       const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
-      await ActorProperties.setValuesForActor(form.projectId, pl.actorId, properties);
+      await ActorProperties.setValuesForActor(form.projectId, pl, properties);
     }
 
     // Returns the raw public link from create() without new properties
@@ -54,7 +54,7 @@ module.exports = (service, endpoint) => {
     if (body.properties != null) {
       const knownProperties = await ActorProperties.getAllForProject(form.projectId);
       const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
-      await ActorProperties.setValuesForActor(form.projectId, pl.actorId, properties);
+      await ActorProperties.setValuesForActor(form.projectId, pl, properties);
     }
 
     return PublicLinks.getByFormAndActorId(form.id, params.id, QueryOptions.extended).then(getOrNotFound);

--- a/test/integration/api/actor-properties.js
+++ b/test/integration/api/actor-properties.js
@@ -16,6 +16,21 @@ describe('api: /projects/:id/actor-properties', () => {
         .expect(200);
     }));
 
+    it('should log the property creation in the audit log', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      const project = await container.Projects.getById(1).then((o) => o.get());
+
+      const { body: audits } = await asAlice.get('/v1/audits?action=actor_property.create').expect(200);
+      audits.length.should.equal(1);
+      audits[0].actorId.should.equal(5); // alice
+      audits[0].acteeId.should.equal(project.acteeId);
+      audits[0].details.should.eql({ name: 'region' });
+    }));
+
     it('should reject if name is missing', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/actor-properties')

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -80,6 +80,26 @@ describe('api: /projects/:id/app-users', () => {
           body.properties.should.eql({ region: 'north' });
         });
     }));
+
+    it('should log the property set in the audit log', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({
+          displayName: 'test user',
+          properties: { region: 'north' }
+        })
+        .expect(200);
+
+      const actor = await container.Actors.getById(appUser.id).then((o) => o.get());
+
+      const { body: audits } = await asAlice.get('/v1/audits?action=field_key.property.set').expect(200);
+      audits.length.should.equal(1);
+      audits[0].actorId.should.equal(5); // alice
+      audits[0].acteeId.should.equal(actor.acteeId);
+      audits[0].details.properties.should.eql({ region: 'north' });
+    }));
   });
 
   describe('GET', () => {
@@ -432,6 +452,27 @@ describe('api: /projects/:id/app-users', () => {
     // The property-setting logic (validation, coercion, bulk upsert/delete) is shared
     // under the hood with public links. The tests above cover it fully; public-links
     // tests only verify the happy-path integration without re-testing every edge case.
+
+    it('should log the property set in the audit log', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'test user' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      const actor = await container.Actors.getById(appUser.id).then((o) => o.get());
+
+      const { body: audits } = await asAlice.get('/v1/audits?action=field_key.property.set').expect(200);
+      audits.length.should.equal(1);
+      audits[0].actorId.should.equal(5); // alice
+      audits[0].acteeId.should.equal(actor.acteeId);
+      audits[0].details.properties.should.eql({ region: 'north' });
+    }));
   });
 
   describe('/:id DELETE', () => {

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -100,6 +100,48 @@ describe('api: /projects/:id/app-users', () => {
       audits[0].acteeId.should.equal(actor.acteeId);
       audits[0].details.properties.should.eql({ region: 'north' });
     }));
+
+    it('should not log add audit log event if property set is empty', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      await asAlice.post('/v1/projects/1/app-users')
+        .send({
+          displayName: 'test user',
+          properties: { }
+        })
+        .expect(200);
+
+      const { body: audits } = await asAlice.get('/v1/audits?action=field_key.property.set').expect(200);
+      audits.length.should.equal(0);
+    }));
+
+    it('should log when a property is unset in the audit log', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'team' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({
+          displayName: 'test user',
+          properties: { team: 'abc', region: 'north' }
+        })
+        .expect(200);
+
+      // unset a property
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: '' } })
+        .expect(200);
+
+      const actor = await container.Actors.getById(appUser.id).then((o) => o.get());
+
+      const { body: audits } = await asAlice.get('/v1/audits?action=field_key.property.set').expect(200);
+      audits.length.should.equal(2);
+      audits[0].actorId.should.equal(5); // alice
+      audits[0].acteeId.should.equal(actor.acteeId);
+
+      audits[0].details.properties.should.eql({ region: null });
+    }));
   });
 
   describe('GET', () => {

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -79,6 +79,26 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
           body.properties.should.eql({ region: 'north' });
         });
     }));
+
+    it('should log the property set in the audit log', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+        .send({
+          displayName: 'test link',
+          properties: { region: 'north' }
+        })
+        .expect(200);
+
+      const actor = await container.Actors.getById(pl.id).then((o) => o.get());
+
+      const { body: audits } = await asAlice.get('/v1/audits?action=public_link.property.set').expect(200);
+      audits.length.should.equal(1);
+      audits[0].actorId.should.equal(5); // alice
+      audits[0].acteeId.should.equal(actor.acteeId);
+      audits[0].details.properties.should.eql({ region: 'north' });
+    }));
   });
 
   describe('GET', () => {
@@ -313,6 +333,27 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
     }));
 
     // Additional behavior tested in app-users test because the machinery of setting properties is the same.
+
+    it('should log the property set in the audit log', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+        .send({ displayName: 'test link' })
+        .expect(200);
+
+      await asAlice.patch(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      const actor = await container.Actors.getById(pl.id).then((o) => o.get());
+
+      const { body: audits } = await asAlice.get('/v1/audits?action=public_link.property.set').expect(200);
+      audits.length.should.equal(1);
+      audits[0].actorId.should.equal(5); // alice
+      audits[0].acteeId.should.equal(actor.acteeId);
+      audits[0].details.properties.should.eql({ region: 'north' });
+    }));
   });
 
   describe('/:id DELETE', () => {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1869

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added integration tests covering audit log entries for:
- Creating an actor property (`actor_property.create`)
- Setting properties on app users at creation and via PATCH (`field_key.property.set`)
- Setting properties on public links at creation and via PATCH (`public_link.property.set`)

#### Why is this the best possible solution? Were any other approaches considered?

Both `actor_property.create` and `field_key/public_link.property.set` audit logging is handled via `.audit` functions attached directly to the query functions in `actor-properties.js`. 

The action name for setting a property on a Field Key or Public Link is derived dynamically from `fieldKeyOrLink.constructor.actorType`, so the shared `setValuesForActor` query function can emit the correct action (`field_key.property.set` vs. `public_link.property.set`) without needing separate code paths in the resource layer. 

The actee for `actor_property.create` is the project; the actee for `property.set` events is the app user or public link actor.

The `field_key` and `public_link` audit action filters have been updated to include the new `property.set` events, and `actor_property.create` has been added to the `project` filter.


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just make this top level feature more auditable.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes, working on separate PR for that now.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
