### PR TITLE
express: use res.set() in preference to res.append()

### DIFF
--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -145,8 +145,8 @@ module.exports = (service, endpoint) => {
       const entities = await Entities.streamForExport(dataset.id, options);
       const filename = sanitize(dataset.name);
       const extension = 'csv';
-      response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
-      response.append('Content-Type', 'text/csv');
+      response.set('Content-Disposition', contentDisposition(`${filename}.${extension}`));
+      response.set('Content-Type', 'text/csv');
       return streamEntityCsv(entities, properties);
     };
 
@@ -169,8 +169,8 @@ module.exports = (service, endpoint) => {
     const entities = await Entities.streamForExport(dataset.id, QueryOptions.extended);
     const filename = sanitize(dataset.name);
     const extension = 'csv';
-    response.append('Content-Disposition', contentDisposition(`${filename}-deleted.${extension}`));
-    response.append('Content-Type', 'text/csv');
+    response.set('Content-Disposition', contentDisposition(`${filename}-deleted.${extension}`));
+    response.set('Content-Type', 'text/csv');
     return streamEntityCsv(entities, properties);
   }));
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -56,8 +56,8 @@ const streamAttachment = async (container, attachment, ownerOnlyOptions, respons
     return withEtag(attachment.openRosaHash, async () => {
       const options = attachment.ownerOnly ? ownerOnlyOptions : QueryOptions.none;
       const entities = await Entities.streamForExport(attachment.datasetId, options);
-      response.append('Content-Disposition', contentDisposition(`${attachment.name}`));
-      response.append('Content-Type', 'text/csv');
+      response.set('Content-Disposition', contentDisposition(`${attachment.name}`));
+      response.set('Content-Type', 'text/csv');
       return streamEntityCsvAttachment(entities, properties);
     });
   }

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -360,8 +360,8 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
               draft ? null : Audits.log(auth.actor, 'form.submission.export', form)
             ]).then(([fields, rows, selectValues, attachments, clientAudits]) => {
               const filename = sanitize(form.xmlFormId);
-              response.append('Content-Disposition', contentDisposition(`${filename}.zip`));
-              response.append('Content-Type', 'application/zip');
+              response.set('Content-Disposition', contentDisposition(`${filename}.zip`));
+              response.set('Content-Type', 'application/zip');
               return zipStreamFromParts(
                 // TODO: not 100% sure that these streams close right on crash.
                 streamBriefcaseCsvs(rows, fields, form.xmlFormId, selectValues, decryptor, false, options),
@@ -390,8 +390,8 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
         .then(([fields, rows, selectValues, decryptor]) => {
           const filename = sanitize(form.xmlFormId);
           const extension = (rootOnly === true) ? 'csv' : 'csv.zip';
-          response.append('Content-Disposition', contentDisposition(`${filename}.${extension}`));
-          response.append('Content-Type', (rootOnly === true) ? 'text/csv' : 'application/zip');
+          response.set('Content-Disposition', contentDisposition(`${filename}.${extension}`));
+          response.set('Content-Type', (rootOnly === true) ? 'text/csv' : 'application/zip');
           const envelope = (rootOnly === true) ? identity : zipStreamFromParts;
           return envelope(streamBriefcaseCsvs(rows, fields, form.xmlFormId, selectValues, decryptor, rootOnly, options));
         });


### PR DESCRIPTION
Closes getodk/central#1900

#### What has been done to verify that this works as intended?

Run existing test suite.  Nothing broke.

#### Why is this the best possible solution? Were any other approaches considered?

No particular requirement in these cases for using `append()` in favour of `set()`, and the intention of `set()` is clearer.

Duplicate headers don't make sense for either referenced header:

* `Content-Type`
* `Content-Disposition`

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
