### PR TITLE
Prep API docs changelog for .2 release

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -1925,7 +1925,6 @@ paths:
                   deletedAt: 2018-04-18T23:42:11.406Z
                   token: d1!E2GVHgpr4h9bpxxtqUJ7EVJ1Q$Dusm2RBXg8XyVJMCBCbvyE8cGacxUx3bcUT
                   projectId: 1
-                  lastUsed: 2018-04-14T08:34:21.633Z
             application/json; extended:
               schema:
                 type: array

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -41,6 +41,12 @@ info:
 
     Here major and breaking changes to the API are listed by version.
 
+    ## ODK Central v2026.2
+
+    **Added**:
+
+    **Changed**:
+
     ## ODK Central v2026.1
 
     **Added**:


### PR DESCRIPTION
I've seen some git merge issues in the API docs in the past where if two separate PRs edit the changelog, headers like "**Changed:**" sometimes get duplicated. This is just a little prep work to avoid that.

Additionally, LN noticed an extra field on the `GET app-users` endpoint that was included in non-extended metadata when it wasn't supposed to be. I confirmed that it's really not part of the API response. 

