### PR TITLE
test/integration: mark more tests as slow

### DIFF
--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -6967,7 +6967,7 @@ describe('datasets and entities', () => {
         (await getHash(asChelsea)).should.not.equal(originalHash);
       }));
 
-      it('does not change hash after an entity is purged', testServiceFullTrx(async (service, container) => {
+      it('does not change hash after an entity is purged @slow', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -6992,7 +6992,7 @@ describe('datasets and entities', () => {
         hash3.should.not.equal(hash1);
       }));
 
-      it('changes hash after an entity is restored', testServiceFullTrx(async (service, container) => {
+      it('changes hash after an entity is restored @slow', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7018,7 +7018,7 @@ describe('datasets and entities', () => {
         [hash1, hash2, hash3].should.be.unique();
       }));
 
-      it('changes hash after an entity is undeleted, then another entity is deleted', testServiceFullTrx(async (service, container) => {
+      it('changes hash after an entity is undeleted, then another entity is deleted @slow', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7064,7 +7064,7 @@ describe('datasets and entities', () => {
         (await getHash(asChelsea)).should.not.equal(originalHash);
       }));
 
-      it('computes hash based on timestamps and the entity count', testServiceFullTrx(async (service, container) => {
+      it('computes hash based on timestamps and the entity count @slow', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');

--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1923,11 +1923,11 @@ describe('Offline Entities', () => {
     }));
   });
 
-  describe('locking an entity while processing a related submission', function() {
+  describe('locking an entity while processing a related submission @slow', function() {
     this.timeout(16_000);
 
     // https://github.com/getodk/central/issues/705
-    it('should concurrently process an offline create + update @slow', testServiceFullTrx(async (service, container) => {
+    it('should concurrently process an offline create + update', testServiceFullTrx(async (service, container) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/forms?publish=true')
         .send(testData.forms.offlineEntity)

--- a/test/integration/external/sentry.js
+++ b/test/integration/external/sentry.js
@@ -17,7 +17,7 @@ describe('sentry', () => {
       mockSentry?.close();
     });
 
-    it('should include odk-task tag in error event', async () => {
+    it('should include odk-task tag in error event @slow', async () => {
       // given
       const env = {
         PATH: process.env.PATH, // ensure NodeJS is available to child process

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -98,7 +98,7 @@ const submitToForm = (service, user, projectId, xmlFormId, xml, deviceId = 'abcd
 ////////////////////////////////////////////////////////////////////////////////
 // Tests!
 ////////////////////////////////////////////////////////////////////////////////
-describe('analytics task queries', function () {
+describe('analytics task queries @slow', function () {
   // increasing timeouts on this set of tests
   this.timeout(8000);
 

--- a/test/integration/other/db-stream.js
+++ b/test/integration/other/db-stream.js
@@ -38,7 +38,7 @@ describe('db.stream()', () => {
     });
     afterEach(() => clock?.uninstall());
 
-    it('should time out after 2 mins if no activity at all', async () => {
+    it('should time out after 2 mins if no activity at all @slow', async () => {
       // given
       const stream = await db.stream(sql`SELECT * FROM GENERATE_SERIES(1, 1000)`);
 
@@ -56,7 +56,7 @@ describe('db.stream()', () => {
       stream.destroyed.should.equal(true);
     });
 
-    it('should not time out after 2 mins if the stream is read', async () => {
+    it('should not time out after 2 mins if the stream is read @slow', async () => {
       // given
       const stream = await db.stream(sql`SELECT * FROM GENERATE_SERIES(1, 1000)`);
 

--- a/test/integration/other/knex-migrations.js
+++ b/test/integration/other/knex-migrations.js
@@ -57,7 +57,7 @@ testMigration.only = (filename, tests) =>
 testMigration.skip = (filename, tests) =>
   testMigration(filename, tests, { skip: true });
 
-describe('database migrations: removing default project', function() {
+describe('database migrations: removing default project @slow', function() {
   this.timeout(8000);
 
   it('should put old forms into project', testServiceFullTrx(async (service, container) => {
@@ -94,7 +94,7 @@ describe('database migrations: removing default project', function() {
   }));
 });
 
-describe('database migrations: intermediate form schema', function() {
+describe('database migrations: intermediate form schema @slow', function() {
   this.timeout(20000);
 
   it('should test migration', testServiceFullTrx(async (service, container) => {
@@ -223,7 +223,7 @@ describe('database migrations: intermediate form schema', function() {
   }));
 });
 
-describe('database migrations: 20230123-01-remove-google-backups', function() {
+describe('database migrations: 20230123-01-remove-google-backups @slow', function() {
   this.timeout(20000);
 
   beforeEach(() => upToMigration('20230123-01-remove-google-backups.js', false));

--- a/test/integration/other/legacy-backup-format.js
+++ b/test/integration/other/legacy-backup-format.js
@@ -82,7 +82,7 @@ describe('legacy backups', () => {
       (await promisify(readFile)(join(dirpath, 'two'))).toString('utf8').should.equal('test file two');
     }));
 
-    it('should create archive that is immediately decryptable', async function() {
+    it('should create archive that is immediately decryptable @slow', async function() {
       this.timeout(30_000);
 
       // given


### PR DESCRIPTION
Mark all tests with `@slow` which:

* explicitly declare `this.timeout(...)`
* took more than 300ms on my computer

This should make `make test-fast` more useful.  For me, it sped it up from ~3m25s to ~2m40s.

#### What has been done to verify that this works as intended?

Ran `make test-fast`.

#### Why is this the best possible solution? Were any other approaches considered?

I think it's reasonably logical.  Adding the tests between 100-200ms might save another 10 seconds.

An additional extension might be to update `make test` to run:

1. unit tests
2. fast integration tests
3. slow integration tests

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
