### PR TITLE
Set actor properties when creating public link or app user

### DIFF
--- a/lib/resources/app-users.js
+++ b/lib/resources/app-users.js
@@ -21,15 +21,21 @@ module.exports = (service, endpoint) => {
       .then((project) => auth.canOrReject('field_key.list', project))
       .then((project) => FieldKeys.getAllForProject(project, queryOptions))));
 
-  service.post('/projects/:projectId/app-users', endpoint(({ FieldKeys, Projects }, { auth, body, params }) =>
-    Projects.getById(params.projectId)
-      .then(getOrNotFound)
-      .then((project) => auth.canOrReject('field_key.create', project))
-      .then((project) => {
-        const fk = FieldKey.fromApi(body)
-          .with({ createdBy: auth.actor.map((actor) => actor.id).orNull() });
-        return FieldKeys.create(fk, project);
-      })));
+  service.post('/projects/:projectId/app-users', endpoint(async ({ ActorProperties, FieldKeys, Projects }, { auth, body, params }) => {
+    const project = await Projects.getById(params.projectId).then(getOrNotFound);
+    await auth.canOrReject('field_key.create', project);
+    const partial = FieldKey.fromApi(body).with({ createdBy: auth.actor.map((actor) => actor.id).orNull() });
+    const fk = await FieldKeys.create(partial, project);
+
+    if (body.properties != null) {
+      const knownProperties = await ActorProperties.getAllForProject(project.id);
+      const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
+      await ActorProperties.setValuesForActor(project.id, fk.actorId, properties);
+    }
+
+    // Returns the raw FK from create() without new properties
+    return fk;
+  }));
 
   service.get('/projects/:projectId/app-users/:id', endpoint(({ FieldKeys, Projects }, { auth, params, queryOptions }) =>
     Projects.getById(params.projectId)

--- a/lib/resources/public-links.js
+++ b/lib/resources/public-links.js
@@ -21,15 +21,21 @@ module.exports = (service, endpoint) => {
       .then((form) => auth.canOrReject('public_link.list', form))
       .then((form) => PublicLinks.getAllForForm(form, queryOptions))));
 
-  service.post('/projects/:projectId/forms/:xmlFormId/public-links', endpoint(({ Forms, PublicLinks }, { auth, body, params }) =>
-    Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef)
-      .then(getOrNotFound)
-      .then((form) => auth.canOrReject('public_link.create', form))
-      .then((form) => {
-        const pl = PublicLink.fromApi(body)
-          .with({ createdBy: auth.actor.map((actor) => actor.id).orNull() });
-        return PublicLinks.create(pl, form);
-      })));
+  service.post('/projects/:projectId/forms/:xmlFormId/public-links', endpoint(async ({ ActorProperties, Forms, PublicLinks }, { auth, body, params }) => {
+    const form = await Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef).then(getOrNotFound);
+    await auth.canOrReject('public_link.create', form);
+    const partial = PublicLink.fromApi(body).with({ createdBy: auth.actor.map((actor) => actor.id).orNull() });
+    const pl = await PublicLinks.create(partial, form);
+
+    if (body.properties != null) {
+      const knownProperties = await ActorProperties.getAllForProject(form.projectId);
+      const properties = extractActorProperties(body.properties, knownProperties.map((p) => p.name));
+      await ActorProperties.setValuesForActor(form.projectId, pl.actorId, properties);
+    }
+
+    // Returns the raw public link from create() without new properties
+    return pl;
+  }));
 
   service.get('/projects/:projectId/forms/:xmlFormId/public-links/:id', endpoint(({ Forms, PublicLinks }, { auth, params, queryOptions }) =>
     Forms.getByProjectAndXmlFormId(params.projectId, params.xmlFormId, Form.WithoutDef)

--- a/test/integration/api/app-users.js
+++ b/test/integration/api/app-users.js
@@ -61,6 +61,25 @@ describe('api: /projects/:id/app-users', () => {
               body[0].actorId.should.equal(5);
               body[0].acteeId.should.be.a.uuid();
             })))));
+
+    it('should set actor property values when creating app user', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({
+          displayName: 'test user',
+          properties: { region: 'north' }
+        })
+        .expect(200);
+
+      await asAlice.get(`/v1/projects/1/app-users/${appUser.id}`)
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.should.eql({ region: 'north' });
+        });
+    }));
   });
 
   describe('GET', () => {

--- a/test/integration/api/public-links.js
+++ b/test/integration/api/public-links.js
@@ -60,6 +60,25 @@ describe('api: /projects/:id/forms/:id/public-links', () => {
               body[0].actorId.should.equal(5);
               body[0].acteeId.should.be.a.uuid();
             })))));
+
+    it('should set actor property values when creating public link', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+      const { body: pl } = await asAlice.post('/v1/projects/1/forms/simple/public-links')
+        .send({
+          displayName: 'test link',
+          properties: { region: 'north' }
+        })
+        .expect(200);
+
+      await asAlice.get(`/v1/projects/1/forms/simple/public-links/${pl.id}`)
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.properties.should.eql({ region: 'north' });
+        });
+    }));
   });
 
   describe('GET', () => {


### PR DESCRIPTION
This PR makes it possible to send actor properties in the POST creation request for app users and public links. Previously, you could only set the properties in a follow-up PATCH request. 

This is a piece that was missing from https://github.com/getodk/central-backend/pull/1824
Needed for
- Issue https://github.com/getodk/central/issues/1339
- Frontend PR https://github.com/getodk/central-frontend/pull/1557

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, using it.

#### Why is this the best possible solution? Were any other approaches considered?

The response from the POST create event is the same as before - the properties have not been added to the response. This may be a little awkward, but the POST response is already different from the GET response because it contains the full `session` details, whereas the GET only contains the token from the session.

Example public link response from POST
```
  once: null,
  id: 10,
  type: 'public_link',
  displayName: 'test link',
  createdAt: '2026-05-27T20:19:54.422Z',
  updatedAt: null,
  deletedAt: null,
  token: 'eBKNv1ZebMm5kuEqbR9ucpuYZ3vkSJdrTgnJGOVaFXSNGj0WujEiUdZUK5Hkbaex',
  csrf: 'EaecdhEr4Y1sef5pmT6ifwUtIS8hg!QbwHaWVHld89pJcNauD8j1sC8XHECP!L2G',
  expiresAt: '9999-12-31T23:59:59.000Z'
```

from GET
```
  once: null,
  id: 10,
  type: 'public_link',
  displayName: 'test link',
  createdAt: '2026-05-27T20:19:54.421Z',
  updatedAt: null,
  deletedAt: null,
  token: 'eBKNv1ZebMm5kuEqbR9ucpuYZ3vkSJdrTgnJGOVaFXSNGj0WujEiUdZUK5Hkbaex'
```


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Extends API for app user and public link creation to use new actor properties.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Will update docs in followup PR 

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
