### PR TITLE
Ci action upload artifact

### DIFF
--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -43,7 +43,7 @@ jobs:
     - run: make test-oidc-e2e
     - name: Archive Playwright Test Report
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Playwright Test Report
         path: test/e2e/oidc/playwright-tests/results/html-report/


### PR DESCRIPTION
Fixes:
    
	Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24.
    
Reviewed:
    
* https://github.com/actions/upload-artifact/releases/tag/v5.0.0
* https://github.com/actions/upload-artifact/releases/tag/v6.0.0
* https://github.com/actions/upload-artifact/releases/tag/v7.0.0


#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

No other options considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
