### PR TITLE
dev/s3: tighten docker network binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ dev-s3: fake-s3-accounts base
 # MINIO_KMS_SECRET_KEY, MINIO_KMS_AUTO_ENCRYPTION enable encryption - this changes how s3 ETags are generated.
 #   See: https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html
 #   See: https://github.com/minio/minio/discussions/19012
-S3_SERVER_ARGS := --network host \
+S3_SERVER_ARGS := -p 127.0.0.1:9000:9000 -p 127.0.0.1:9001:9001 \
 		-e MINIO_ROOT_USER=odk-central-dev \
 		-e MINIO_ROOT_PASSWORD=topSecret123 \
 		-e MINIO_KMS_AUTO_ENCRYPTION=on \


### PR DESCRIPTION
Restrict fake S3 servers to connections from the local machine.

This stops minio from being exposed on the local network or wider.

#### What has been done to verify that this works as intended?

- [x] tested locally
- [x] CI

#### Why is this the best possible solution? Were any other approaches considered?

Minimal change which shouldn't affect existing users, but restricts `fake-s3-server` as it should be.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just for dev.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
