### PR TITLE
Refactor owner only form attachment code for clarity

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -728,7 +728,7 @@ const _fetchActivityStats = (all, datasetIds, filterActorId = null) => {
         SELECT
           datasets.id,
           GREATEST(MAX(entities."createdAt"), MAX(entities."updatedAt")) AS "lastEntityUpdate",
-          COUNT(1) AS entities
+          COUNT(*) AS entities
         FROM entities
         JOIN datasets ON datasets.id = entities."datasetId"
         WHERE

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -734,7 +734,7 @@ const getMetadataForOpenRosa = (datasetIds, filterActorId = null) => ({ all }) =
       ${filterActorId == null ? sql`` : sql`
         WHERE
           (NOT datasets."ownerOnly") OR
-          audits.action IN ('dataset.create', 'dataset.update')
+          audits.action = 'dataset.update'
       `}
       GROUP BY datasets.id
     ) AS "openRosaMetadata" ON "openRosaMetadata".id = datasets.id
@@ -758,12 +758,16 @@ const getMetadataForOpenRosa = (datasetIds, filterActorId = null) => ({ all }) =
   `)
     .then(rows => new Map(rows.map(unjoin).map(ds => {
       const metadata = ds.aux.openRosaMetadata;
-      const lastUpdate = metadata.lastEntityUpdate != null && metadata.lastEntityUpdate > metadata.lastAudit
-        ? metadata.lastEntityUpdate
-        : metadata.lastAudit;
-      const lastIso = lastUpdate.toISOString();
+      const latestEntityCreatedOrUpdated = metadata.lastEntityUpdate?.toISOString() ?? null;
+      const latestAuditEntry = metadata.lastAudit?.toISOString() ?? null;
+      const hashInput = JSON.stringify({
+        owner: metadata.filteredByAuth ? filterActorId : undefined,
+        entities: metadata.filteredByAuth ? (metadata.entities ?? 0) : undefined,
+        latestEntityCreatedOrUpdated,
+        latestAuditEntry,
+      });
       return [ds.id, {
-        openRosaHash: md5sum(metadata.filteredByAuth ? `${metadata.entities ?? 0},${lastIso}` : lastIso),
+        openRosaHash: md5sum(hashInput),
         datasetType: ds.approvalRequired ? 'approvalEntityList' : 'entityList',
         filteredByAuth: metadata.filteredByAuth
       }];

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -9,6 +9,7 @@
 
 const { sql } = require('slonik');
 const { extender, insert, QueryOptions, sqlEquals, unjoiner, updater, markDeleted } = require('../../util/db');
+const { Frame, into } = require('../frame');
 const { Dataset, Form, Audit } = require('../frames');
 const { validatePropertyName } = require('../../data/dataset');
 const { difference, isEmpty, isNil, either, reduceBy, groupBy, uniqWith, equals, map, pipe, values, any, prop, toLower, sortBy } = require('ramda');
@@ -19,6 +20,7 @@ const { construct } = require('../../util/util');
 const { sanitizeOdataIdentifier } = require('../../util/util');
 const { isTrue } = require('../../util/http');
 const { PURGE_DAY_RANGE } = require('../../util/constants');
+const { md5sum } = require('../../util/crypto');
 
 
 ////////////////////////////////////////////////////////////////////////////
@@ -711,6 +713,63 @@ const getLastUpdateTimestamp = (datasetId) => ({ maybeOne }) =>
     .then((t) => (t ? t.loggedAt : null));
 
 
+// Returns dataset metadata needed to compute OpenRosa hashes for dataset-backed form attachments.
+// Takes a list of dataset IDs and an optional filterActorId (for ownerOnly datasets).
+// Returns a Map of datasetId -> metadata object with fields:
+//   approvalRequired, filteredByAuth, lastAudit, and (when filterActorId given) lastEntityUpdate, entities
+const getMetadataForOpenRosa = (datasetIds, filterActorId = null) => ({ all }) => {
+  if (datasetIds.length === 0) return Promise.resolve(new Map());
+
+  const fields = ['filteredByAuth', 'lastAudit'];
+  if (filterActorId != null) fields.push('lastEntityUpdate', 'entities');
+  const unjoin = unjoiner(Dataset, Frame.define(into('openRosaMetadata'), ...fields));
+
+  return all(sql`
+    SELECT ${unjoin.fields} FROM datasets
+    LEFT OUTER JOIN (
+      SELECT datasets.id, MAX("loggedAt") AS "lastAudit",
+        ${filterActorId == null ? sql`FALSE` : sql`datasets."ownerOnly"`} AS "filteredByAuth"
+      FROM audits
+      JOIN datasets ON audits."acteeId" = datasets."acteeId"
+      ${filterActorId == null ? sql`` : sql`
+        WHERE
+          (NOT datasets."ownerOnly") OR
+          audits.action IN ('dataset.create', 'dataset.update')
+      `}
+      GROUP BY datasets.id
+    ) AS "openRosaMetadata" ON "openRosaMetadata".id = datasets.id
+    ${filterActorId == null ? sql`` : sql`
+      LEFT OUTER JOIN (
+        SELECT
+          datasets.id,
+          GREATEST(MAX(entities."createdAt"), MAX(entities."updatedAt")) AS "lastEntityUpdate",
+          COUNT(1) AS entities
+        FROM entities
+        JOIN datasets ON datasets.id = entities."datasetId"
+        WHERE
+          entities."deletedAt" IS NULL
+          AND (
+            (datasets."ownerOnly" AND entities."creatorId" = ${filterActorId})
+          )
+        GROUP BY datasets.id
+      ) AS entity_metadata ON entity_metadata.id = datasets.id
+    `}
+    WHERE datasets.id IN (${sql.join(datasetIds.map(id => sql`${id}`), sql`,`)})
+  `)
+    .then(rows => new Map(rows.map(unjoin).map(ds => {
+      const metadata = ds.aux.openRosaMetadata;
+      const lastUpdate = metadata.lastEntityUpdate != null && metadata.lastEntityUpdate > metadata.lastAudit
+        ? metadata.lastEntityUpdate
+        : metadata.lastAudit;
+      const lastIso = lastUpdate.toISOString();
+      return [ds.id, {
+        openRosaHash: md5sum(metadata.filteredByAuth ? `${metadata.entities ?? 0},${lastIso}` : lastIso),
+        datasetType: ds.approvalRequired ? 'approvalEntityList' : 'entityList',
+        filteredByAuth: metadata.filteredByAuth
+      }];
+    })));
+};
+
 const canReadForOpenRosa = (auth, datasetName, projectId) => ({ oneFirst }) => oneFirst(sql`
       WITH linked_forms AS (
         ${_getLinkedForms(datasetName, projectId)}
@@ -910,7 +969,7 @@ module.exports = {
   getProperties, getFieldsByFormDefId,
   getDiff, update, countUnprocessedSubmissions,
   getUnprocessedSubmissions,
-  getLastUpdateTimestamp, canReadForOpenRosa,
+  getLastUpdateTimestamp, getMetadataForOpenRosa, canReadForOpenRosa,
   del, purge, deleteProperty,
   getTargetDatasetsAndProperties, getLinkedDatasets, getRelatedDatasetsOfForm,
   getListWithProperties

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -484,7 +484,7 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
     .then(rows => rows.map(construct(Dataset.LinkedForm)));
   const sourceForms = await all(_getSourceForms(dataset.name, dataset.projectId))
     .then(rows => rows.map(construct(Dataset.LinkedForm)));
-  const lastUpdate = await Datasets.getLastUpdateTimestamp(dataset.id);
+  const lastUpdate = await Datasets.getDatasetActivity(dataset.id).then(activity => activity?.lastAudit ?? null);
 
   const propertiesMap = new Map();
   for (const property of properties) {
@@ -700,24 +700,9 @@ const getUnprocessedSubmissions = (datasetId) => ({ all }) =>
   all(_unprocessedSubmissions(datasetId, sql`audits.*`))
     .then(map(construct(Audit)));
 
-// To return lastUpdate field for `GET /datasets/:name`
-// Similar query is in form-attachments.js, if the logic lastUpdateTimestamp is changed here then it
-// probably needs to be changed there.
-const getLastUpdateTimestamp = (datasetId) => ({ maybeOne }) =>
-  maybeOne(sql`
-  SELECT "loggedAt" FROM audits
-  JOIN datasets ON audits."acteeId" = datasets."acteeId"
-  WHERE datasets."id"=${datasetId}
-  ORDER BY audits."loggedAt" DESC LIMIT 1`)
-    .then((t) => t.orNull())
-    .then((t) => (t ? t.loggedAt : null));
-
-
-// Returns dataset metadata needed to compute OpenRosa hashes for dataset-backed form attachments.
-// Takes a list of dataset IDs and an optional filterActorId (for ownerOnly datasets).
-// Returns a Map of datasetId -> metadata object with fields:
-//   approvalRequired, filteredByAuth, lastAudit, and (when filterActorId given) lastEntityUpdate, entities
-const getMetadataForOpenRosa = (datasetIds, filterActorId = null) => ({ all }) => {
+// Private: fetches audit and entity activity data for a list of datasets.
+// Returns a Map of datasetId -> { approvalRequired, filteredByAuth, lastAudit, lastEntityUpdate, entities }
+const _fetchActivityStats = (all, datasetIds, filterActorId = null) => {
   if (datasetIds.length === 0) return Promise.resolve(new Map());
 
   const fields = ['filteredByAuth', 'lastAudit'];
@@ -758,21 +743,44 @@ const getMetadataForOpenRosa = (datasetIds, filterActorId = null) => ({ all }) =
   `)
     .then(rows => new Map(rows.map(unjoin).map(ds => {
       const metadata = ds.aux.openRosaMetadata;
-      const latestEntityCreatedOrUpdated = metadata.lastEntityUpdate?.toISOString() ?? null;
-      const latestAuditEntry = metadata.lastAudit?.toISOString() ?? null;
-      const hashInput = JSON.stringify({
-        owner: metadata.filteredByAuth ? filterActorId : undefined,
-        entities: metadata.filteredByAuth ? (metadata.entities ?? 0) : undefined,
-        latestEntityCreatedOrUpdated,
-        latestAuditEntry,
-      });
       return [ds.id, {
-        openRosaHash: md5sum(hashInput),
-        datasetType: ds.approvalRequired ? 'approvalEntityList' : 'entityList',
-        filteredByAuth: metadata.filteredByAuth
+        approvalRequired: ds.approvalRequired,
+        filteredByAuth: metadata.filteredByAuth,
+        lastAudit: metadata.lastAudit ?? null,
+        lastEntityUpdate: metadata.lastEntityUpdate ?? null,
+        entities: metadata.entities ?? null,
       }];
     })));
 };
+
+// Private: computes the OpenRosa hash result from a single dataset's activity stats.
+const _computeHashResult = (stats, filterActorId) => {
+  const latestEntityCreatedOrUpdated = stats.lastEntityUpdate?.toISOString() ?? null;
+  const latestAuditEntry = stats.lastAudit?.toISOString() ?? null;
+  const hashInput = JSON.stringify({
+    owner: stats.filteredByAuth ? filterActorId : undefined,
+    entities: stats.filteredByAuth ? (stats.entities ?? 0) : undefined,
+    latestEntityCreatedOrUpdated,
+    latestAuditEntry,
+  });
+  return {
+    openRosaHash: md5sum(hashInput),
+    datasetType: stats.approvalRequired ? 'approvalEntityList' : 'entityList',
+    filteredByAuth: stats.filteredByAuth
+  };
+};
+
+// Returns activity stats for a single dataset, used in getMetadata for the lastUpdate field.
+// The returned object has: approvalRequired, filteredByAuth, lastAudit, lastEntityUpdate, entities
+const getDatasetActivity = (datasetId, filterActorId = null) => ({ all }) =>
+  _fetchActivityStats(all, [datasetId], filterActorId).then(m => m.get(datasetId) ?? null);
+
+// Returns a Map of datasetId -> { openRosaHash, datasetType, filteredByAuth }
+// for computing OpenRosa hashes for dataset-backed form attachments.
+const computeHashes = (datasetIds, filterActorId = null) => ({ all }) =>
+  _fetchActivityStats(all, datasetIds, filterActorId)
+    .then(statsMap => new Map([...statsMap.entries()].map(([id, stats]) =>
+      [id, _computeHashResult(stats, filterActorId)])));
 
 const canReadForOpenRosa = (auth, datasetName, projectId) => ({ oneFirst }) => oneFirst(sql`
       WITH linked_forms AS (
@@ -973,7 +981,7 @@ module.exports = {
   getProperties, getFieldsByFormDefId,
   getDiff, update, countUnprocessedSubmissions,
   getUnprocessedSubmissions,
-  getLastUpdateTimestamp, getMetadataForOpenRosa, canReadForOpenRosa,
+  getDatasetActivity, computeHashes, canReadForOpenRosa,
   del, purge, deleteProperty,
   getTargetDatasetsAndProperties, getLinkedDatasets, getRelatedDatasetsOfForm,
   getListWithProperties

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -702,6 +702,9 @@ const getUnprocessedSubmissions = (datasetId) => ({ all }) =>
 
 // Private: fetches audit and entity activity data for a list of datasets.
 // Returns a Map of datasetId -> { approvalRequired, filteredByAuth, lastAudit, lastEntityUpdate, entities }
+// filterActorId will be null if dataset filter rules don't apply to the current user's type (e.g. manager),
+//   otherwise it will be used to compute stats on the subset of entities filtered for that user (if that dataset
+//   has an active filter at all).
 const _fetchActivityStats = (all, datasetIds, filterActorId = null) => {
   if (datasetIds.length === 0) return Promise.resolve(new Map());
 

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -909,7 +909,7 @@ const searchClause = (expr) => {
   return sql`(jsonb_to_tsvector('simple', entity_defs.data, '["string"]') || to_tsvector('simple', entity_defs.label)) @@ websearch_to_tsquery('simple', ${expr})`;
 };
 
-const streamForExport = (datasetId, options = QueryOptions.none) => ({ stream }) =>
+const streamForExport = (datasetId, options = QueryOptions.none, actorId) => ({ stream }) =>
   stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"
@@ -926,6 +926,12 @@ WHERE
   AND entity_defs.current=true
   AND ${odataFilter(options.filter, odataToColumnMap)}
   AND ${searchClause(options.search)}
+${actorId != null ? sql`
+  AND (
+    -- ownerOnly: if the dataset is ownerOnly, restrict to entities created by this actor
+    NOT EXISTS (SELECT 1 FROM datasets WHERE datasets.id = entities."datasetId" AND datasets."ownerOnly")
+    OR entities."creatorId" = ${actorId}
+  )` : sql``}
 ${options.orderby ? sql`
   ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}
   `: sql`ORDER BY entities."createdAt" DESC, entities.id DESC`}

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -129,52 +129,64 @@ const autoLinkWithDataset = (form, datasetId) => async ({ FormAttachments, Datas
 ////////////////////////////////////////////////////////////////////////////////
 // GETTERS
 
-// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame.
-// Also adds dataset metadata if datasetMetadata is true,
+// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
+const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
+
+const _getBaseAttachments = (exec, options) =>
+  exec(sql`select ${_unjoinMd5.fields} from form_attachments
+  left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
+  where ${sqlEquals(options.condition)} order by name asc`)
+    .then(map(_unjoinMd5));
+
+const getAllByFormDefId = (formDefId, options = QueryOptions.none) => ({ all }) =>
+  _getBaseAttachments(all, options.withCondition({ formDefId }));
+
+const getByFormDefIdAndName = (formDefId, name, options = QueryOptions.none) => ({ maybeOne }) =>
+  _getBaseAttachments(maybeOne, options.withCondition({ formDefId, name }));
+
+////////////////////////////////////////////////////////////////////////////////
+// EXTENDED GETTERS (includes info about a dataset-backed attachment)
+
+// This unjoiner adds dataset metadata
 // (similar query Datasets.getLastUpdateTimestamp)
 const _unjoin = (datasetMetadata, actorId) => {
   const frames = [Form.Attachment, Frame.define(into('blob'), 'md5')];
 
-  if (datasetMetadata) {
-    const fields = ['approvalRequired', 'ownerOnly', 'lastAudit'];
-    if (actorId != null) fields.push('lastEntityUpdate', 'entities');
-    frames.push(Frame.define(into('dataset'), ...fields));
-  }
+  const fields = ['approvalRequired', 'filteredByAuth', 'lastAudit'];
+  if (actorId != null) fields.push('lastEntityUpdate', 'entities');
+  frames.push(Frame.define(into('dataset'), ...fields));
 
   return unjoiner(...frames);
 };
 
-const _get = (exec, options) => {
-  // actorId is the id of an actor whose entity access should be limited
+const _getWithDatasetMetadata = (exec, options, filterActorId) => {
+  // filterActorId is the id of an actor whose entity access should be limited
   // according to ownerOnly.
-  const { 'entities.creatorId': actorId, ...condition } = options.condition;
-  const unjoin = _unjoin(options.datasetMetadata, actorId);
+  const unjoin = _unjoin(options.datasetMetadata, filterActorId);
   return exec(sql`SELECT ${unjoin.fields} FROM form_attachments
     LEFT OUTER JOIN (SELECT id, md5 FROM blobs) AS blobs ON form_attachments."blobId"=blobs.id
-    ${!options.datasetMetadata ? sql`` : sql`
       LEFT OUTER JOIN (
         SELECT
           id,
           "approvalRequired",
           -- This is not just whether the ownerOnly flag is set, but whether the
           -- flag should apply to the form attachment for the actor.
-          ${actorId == null ? sql`FALSE` : sql`"ownerOnly"`} AS "ownerOnly"
+          ${filterActorId == null ? sql`FALSE` : sql`"ownerOnly"`} AS "filteredByAuth"
           FROM datasets
       ) AS datasets ON datasets.id = form_attachments."datasetId"
       LEFT OUTER JOIN (
         SELECT datasets.id, MAX("loggedAt") AS "lastAudit" FROM audits
         JOIN datasets ON audits."acteeId" = datasets."acteeId"
-        ${actorId == null ? sql`` : sql`
+        ${filterActorId == null ? sql`` : sql`
           -- We're always interested in dataset.create and dataset.update
-          -- actions, even for ownerOnly datasets.
+          -- actions, even for filtered datasets.
           WHERE
             (NOT datasets."ownerOnly") OR
             audits.action IN ('dataset.create', 'dataset.update')
         `}
         GROUP BY datasets.id
       ) AS audit_metadata ON audit_metadata.id = datasets.id
-    `}
-    ${actorId == null ? sql`` : sql`
+    ${filterActorId == null ? sql`` : sql`
       LEFT OUTER JOIN (
         SELECT
           datasets.id,
@@ -183,22 +195,18 @@ const _get = (exec, options) => {
         FROM entities
         JOIN datasets ON datasets.id = entities."datasetId"
         WHERE
-          datasets."ownerOnly"
-          AND entities."creatorId" = ${actorId}
-          AND entities."deletedAt" IS NULL
+          entities."deletedAt" IS NULL
+          AND (
+            -- ownerOnly: only count entities created by this actor
+            (datasets."ownerOnly" AND entities."creatorId" = ${filterActorId})
+          )
         GROUP BY datasets.id
       ) AS entity_metadata ON entity_metadata.id = datasets.id
     `}
-    WHERE ${sqlEquals(condition)}
+    WHERE ${sqlEquals(options.condition)}
     ORDER BY form_attachments.name ASC`)
     .then(map(unjoin));
 };
-
-const getAllByFormDefId = (formDefId, options = QueryOptions.none) => ({ all }) =>
-  _get(all, options.withCondition({ formDefId }));
-
-const getByFormDefIdAndName = (formDefId, name, options = QueryOptions.none) => ({ maybeOne }) =>
-  _get(maybeOne, options.withCondition({ formDefId, name }));
 
 // This function decides on the OpenRosa hash (functionally equivalent to an http Etag)
 // It uses the blob md5 directly if it exists.
@@ -215,21 +223,21 @@ const _chooseOpenRosaHash = (attachment) => {
       : dataset.lastAudit;
     const lastIso = lastUpdate.toISOString();
     return attachment.with({
-      openRosaHash: md5sum(dataset.ownerOnly ? `${dataset.entities ?? 0},${lastIso}` : lastIso),
+      openRosaHash: md5sum(dataset.filteredByAuth ? `${dataset.entities ?? 0},${lastIso}` : lastIso),
       datasetType: dataset.approvalRequired ? 'approvalEntityList' : 'entityList',
-      ownerOnly: dataset.ownerOnly
+      filteredByAuth: dataset.filteredByAuth
     });
   }
 
   return attachment.with({ openRosaHash: null });
 };
 
-const getAllByFormDefIdForOpenRosa = (formDefId, options = QueryOptions.none) => ({ FormAttachments }) =>
-  FormAttachments.getAllByFormDefId(formDefId, options.with({ datasetMetadata: true }))
+const getAllByFormDefIdForOpenRosa = (formDefId, filterActorId = null) => ({ all }) =>
+  _getWithDatasetMetadata(all, QueryOptions.none.withCondition({ formDefId }), filterActorId)
     .then((attachments) => attachments.map(_chooseOpenRosaHash));
 
-const getByFormDefIdAndNameForOpenRosa = (formDefId, name, options = QueryOptions.none) => ({ FormAttachments }) =>
-  FormAttachments.getByFormDefIdAndName(formDefId, name, options.with({ datasetMetadata: true }))
+const getByFormDefIdAndNameForOpenRosa = (formDefId, name, filterActorId = null) => ({ maybeOne }) =>
+  _getWithDatasetMetadata(maybeOne, QueryOptions.none.withCondition({ formDefId, name }), filterActorId)
     .then(maybeAttachment => maybeAttachment.map(_chooseOpenRosaHash));
 
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -20,7 +20,6 @@ const { QueryOptions, unjoiner, insertMany, sqlEquals } = require('../../util/db
 const { ignoringResult, resolve } = require('../../util/promise');
 const { construct } = require('../../util/util');
 const Option = require('../../util/option');
-const { md5sum } = require('../../util/crypto');
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -132,113 +131,44 @@ const autoLinkWithDataset = (form, datasetId) => async ({ FormAttachments, Datas
 // This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
 const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
 
-const _getBaseAttachments = (exec, options) =>
+const _get = (exec, options) =>
   exec(sql`select ${_unjoinMd5.fields} from form_attachments
   left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
   where ${sqlEquals(options.condition)} order by name asc`)
     .then(map(_unjoinMd5));
 
 const getAllByFormDefId = (formDefId, options = QueryOptions.none) => ({ all }) =>
-  _getBaseAttachments(all, options.withCondition({ formDefId }));
+  _get(all, options.withCondition({ formDefId }));
 
 const getByFormDefIdAndName = (formDefId, name, options = QueryOptions.none) => ({ maybeOne }) =>
-  _getBaseAttachments(maybeOne, options.withCondition({ formDefId, name }));
+  _get(maybeOne, options.withCondition({ formDefId, name }));
 
 ////////////////////////////////////////////////////////////////////////////////
-// EXTENDED GETTERS (includes info about a dataset-backed attachment)
+// EXTENDED GETTERS for Open Rosa
 
-// This unjoiner adds dataset metadata
-// (similar query Datasets.getLastUpdateTimestamp)
-const _unjoin = (datasetMetadata, actorId) => {
-  const frames = [Form.Attachment, Frame.define(into('blob'), 'md5')];
-
-  const fields = ['approvalRequired', 'filteredByAuth', 'lastAudit'];
-  if (actorId != null) fields.push('lastEntityUpdate', 'entities');
-  frames.push(Frame.define(into('dataset'), ...fields));
-
-  return unjoiner(...frames);
-};
-
-const _getWithDatasetMetadata = (exec, options, filterActorId) => {
-  // filterActorId is the id of an actor whose entity access should be limited
-  // according to ownerOnly.
-  const unjoin = _unjoin(options.datasetMetadata, filterActorId);
-  return exec(sql`SELECT ${unjoin.fields} FROM form_attachments
-    LEFT OUTER JOIN (SELECT id, md5 FROM blobs) AS blobs ON form_attachments."blobId"=blobs.id
-      LEFT OUTER JOIN (
-        SELECT
-          id,
-          "approvalRequired",
-          -- This is not just whether the ownerOnly flag is set, but whether the
-          -- flag should apply to the form attachment for the actor.
-          ${filterActorId == null ? sql`FALSE` : sql`"ownerOnly"`} AS "filteredByAuth"
-          FROM datasets
-      ) AS datasets ON datasets.id = form_attachments."datasetId"
-      LEFT OUTER JOIN (
-        SELECT datasets.id, MAX("loggedAt") AS "lastAudit" FROM audits
-        JOIN datasets ON audits."acteeId" = datasets."acteeId"
-        ${filterActorId == null ? sql`` : sql`
-          -- We're always interested in dataset.create and dataset.update
-          -- actions, even for filtered datasets.
-          WHERE
-            (NOT datasets."ownerOnly") OR
-            audits.action IN ('dataset.create', 'dataset.update')
-        `}
-        GROUP BY datasets.id
-      ) AS audit_metadata ON audit_metadata.id = datasets.id
-    ${filterActorId == null ? sql`` : sql`
-      LEFT OUTER JOIN (
-        SELECT
-          datasets.id,
-          GREATEST(MAX(entities."createdAt"), MAX(entities."updatedAt")) AS "lastEntityUpdate",
-          COUNT(1) AS entities
-        FROM entities
-        JOIN datasets ON datasets.id = entities."datasetId"
-        WHERE
-          entities."deletedAt" IS NULL
-          AND (
-            -- ownerOnly: only count entities created by this actor
-            (datasets."ownerOnly" AND entities."creatorId" = ${filterActorId})
-          )
-        GROUP BY datasets.id
-      ) AS entity_metadata ON entity_metadata.id = datasets.id
-    `}
-    WHERE ${sqlEquals(options.condition)}
-    ORDER BY form_attachments.name ASC`)
-    .then(map(unjoin));
-};
-
-// This function decides on the OpenRosa hash (functionally equivalent to an http Etag)
-// It uses the blob md5 directly if it exists.
-// If the attachment is actually an entity list, it looks up the last modified time
-// in the database, which is computed from the latest dataset/entity audit timestamp.
-// It is dynamic because it can change when a dataset's data is updated.
-const _chooseOpenRosaHash = (attachment) => {
+// Augments an attachment with OpenRosa-specific fields (openRosaHash, datasetType, filteredByAuth).
+// For blob attachments, uses the blob md5 directly.
+// For dataset attachments, uses pre-fetched metadata (see getMetadataForOpenRosa in datasets.js).
+// The resulting fields are consumed by formManifest() in formats/openrosa.js.
+const _augmentWithOpenRosaFields = (attachment, datasetMetadata) => {
   if (attachment.blobId) return attachment.with({ openRosaHash: attachment.aux.blob.md5 });
-
-  if (attachment.datasetId) {
-    const { dataset } = attachment.aux;
-    const lastUpdate = dataset.lastEntityUpdate != null && dataset.lastEntityUpdate > dataset.lastAudit
-      ? dataset.lastEntityUpdate
-      : dataset.lastAudit;
-    const lastIso = lastUpdate.toISOString();
-    return attachment.with({
-      openRosaHash: md5sum(dataset.filteredByAuth ? `${dataset.entities ?? 0},${lastIso}` : lastIso),
-      datasetType: dataset.approvalRequired ? 'approvalEntityList' : 'entityList',
-      filteredByAuth: dataset.filteredByAuth
-    });
-  }
-
+  if (attachment.datasetId) return attachment.with(datasetMetadata.get(attachment.datasetId) ?? { openRosaHash: null });
   return attachment.with({ openRosaHash: null });
 };
 
-const getAllByFormDefIdForOpenRosa = (formDefId, filterActorId = null) => ({ all }) =>
-  _getWithDatasetMetadata(all, QueryOptions.none.withCondition({ formDefId }), filterActorId)
-    .then((attachments) => attachments.map(_chooseOpenRosaHash));
+const getAllByFormDefIdForOpenRosa = (formDefId, filterActorId = null) => async ({ all, Datasets }) => {
+  const attachments = await _get(all, QueryOptions.none.withCondition({ formDefId }));
+  const datasetIds = attachments.filter(a => a.datasetId != null).map(a => a.datasetId);
+  const datasetMetadata = await Datasets.getMetadataForOpenRosa(datasetIds, filterActorId);
+  return attachments.map((attachment) => _augmentWithOpenRosaFields(attachment, datasetMetadata));
+};
 
-const getByFormDefIdAndNameForOpenRosa = (formDefId, name, filterActorId = null) => ({ maybeOne }) =>
-  _getWithDatasetMetadata(maybeOne, QueryOptions.none.withCondition({ formDefId, name }), filterActorId)
-    .then(maybeAttachment => maybeAttachment.map(_chooseOpenRosaHash));
+const getByFormDefIdAndNameForOpenRosa = (formDefId, name, filterActorId = null) => async ({ maybeOne, Datasets }) => {
+  const maybeAttachment = await _get(maybeOne, QueryOptions.none.withCondition({ formDefId, name }));
+  const datasetIds = maybeAttachment.filter(a => a.datasetId != null).map(a => [a.datasetId]).orElse([]);
+  const datasetMetadata = await Datasets.getMetadataForOpenRosa(datasetIds, filterActorId);
+  return maybeAttachment.map((attachment) => _augmentWithOpenRosaFields(attachment, datasetMetadata));
+};
 
 
 module.exports = {
@@ -246,7 +176,6 @@ module.exports = {
   update,
   autoLinkWithDataset,
   getAllByFormDefId, getByFormDefIdAndName,
-  getAllByFormDefIdForOpenRosa, getByFormDefIdAndNameForOpenRosa,
-  _chooseOpenRosaHash
+  getAllByFormDefIdForOpenRosa, getByFormDefIdAndNameForOpenRosa
 };
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -148,7 +148,7 @@ const getByFormDefIdAndName = (formDefId, name, options = QueryOptions.none) => 
 
 // Augments an attachment with OpenRosa-specific fields (openRosaHash, datasetType, filteredByAuth).
 // For blob attachments, uses the blob md5 directly.
-// For dataset attachments, uses pre-fetched metadata (see getMetadataForOpenRosa in datasets.js).
+// For dataset attachments, uses pre-fetched metadata (see computeHashes in datasets.js).
 // The resulting fields are consumed by formManifest() in formats/openrosa.js.
 const _augmentWithOpenRosaFields = (attachment, datasetMetadata) => {
   if (attachment.blobId) return attachment.with({ openRosaHash: attachment.aux.blob.md5 });
@@ -159,14 +159,14 @@ const _augmentWithOpenRosaFields = (attachment, datasetMetadata) => {
 const getAllByFormDefIdForOpenRosa = (formDefId, filterActorId = null) => async ({ all, Datasets }) => {
   const attachments = await _get(all, QueryOptions.none.withCondition({ formDefId }));
   const datasetIds = attachments.filter(a => a.datasetId != null).map(a => a.datasetId);
-  const datasetMetadata = await Datasets.getMetadataForOpenRosa(datasetIds, filterActorId);
+  const datasetMetadata = await Datasets.computeHashes(datasetIds, filterActorId);
   return attachments.map((attachment) => _augmentWithOpenRosaFields(attachment, datasetMetadata));
 };
 
 const getByFormDefIdAndNameForOpenRosa = (formDefId, name, filterActorId = null) => async ({ maybeOne, Datasets }) => {
   const maybeAttachment = await _get(maybeOne, QueryOptions.none.withCondition({ formDefId, name }));
   const datasetIds = maybeAttachment.filter(a => a.datasetId != null).map(a => [a.datasetId]).orElse([]);
-  const datasetMetadata = await Datasets.getMetadataForOpenRosa(datasetIds, filterActorId);
+  const datasetMetadata = await Datasets.computeHashes(datasetIds, filterActorId);
   return maybeAttachment.map((attachment) => _augmentWithOpenRosaFields(attachment, datasetMetadata));
 };
 

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -152,7 +152,10 @@ module.exports = (service, endpoint) => {
 
     if (options.filter) return csv();
 
-    const serverEtag = md5sum(lastModifiedTime?.toISOString() ?? '1970-01-01');
+    const serverEtag = md5sum(JSON.stringify({
+      latestEntityCreatedOrUpdated: null,
+      latestAuditEntry: lastModifiedTime?.toISOString() ?? null,
+    }));
 
     return withEtag(serverEtag, csv);
   }));

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -12,7 +12,6 @@ const { getOrNotFound, reject } = require('../util/promise');
 const { streamEntityCsv } = require('../data/entity');
 const { validateDatasetName, validatePropertyName } = require('../data/dataset');
 const { contentDisposition, success, withEtag } = require('../util/http');
-const { md5sum } = require('../util/crypto');
 const { Dataset } = require('../model/frames');
 const Problem = require('../util/problem');
 const { QueryOptions } = require('../util/db');
@@ -139,7 +138,6 @@ module.exports = (service, endpoint) => {
 
     const dataset = await Datasets.get(params.projectId, params.name, true, true).then(getOrNotFound);
     const properties = await Datasets.getProperties(dataset.id);
-    const lastModifiedTime = await Datasets.getLastUpdateTimestamp(dataset.id);
 
     const csv = async () => {
       const entities = await Entities.streamForExport(dataset.id, options);
@@ -152,10 +150,8 @@ module.exports = (service, endpoint) => {
 
     if (options.filter) return csv();
 
-    const serverEtag = md5sum(JSON.stringify({
-      latestEntityCreatedOrUpdated: null,
-      latestAuditEntry: lastModifiedTime?.toISOString() ?? null,
-    }));
+    const datasetHashMetadata = await Datasets.computeHashes([dataset.id]).then(res => res.get(dataset.id));
+    const serverEtag = datasetHashMetadata.openRosaHash;
 
     return withEtag(serverEtag, csv);
   }));

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -49,12 +49,14 @@ const canReadForm = async (authOrVerbs, form) => {
   }
   return form;
 };
-// Returns QueryOptions to use to limit entity access according to ownerOnly.
-const getOwnerOnlyOptions = async (auth, project) => ((await auth.can('entity.list', project))
-  ? QueryOptions.none
-  : QueryOptions.none.withCondition({ 'entities.creatorId': auth.actor.get().id }));
 
-const streamAttachment = async (container, attachment, ownerOnlyOptions, response) => {
+// Check auth verbs on project to determine if user might use auth access-based entity filter
+const filteredAccessActorId = async (auth, project) => ((await auth.can('entity.list', project))
+  ? null
+  : auth.actor.get().id);
+
+
+const streamAttachment = async (container, attachment, filterActorId, response) => {
   const { s3, Blobs, Datasets, Entities } = container;
 
   if (attachment.blobId == null && attachment.datasetId == null) {
@@ -65,8 +67,7 @@ const streamAttachment = async (container, attachment, ownerOnlyOptions, respons
   } else {
     const properties = await Datasets.getProperties(attachment.datasetId);
     return withEtag(attachment.openRosaHash, async () => {
-      const options = attachment.ownerOnly ? ownerOnlyOptions : QueryOptions.none;
-      const entities = await Entities.streamForExport(attachment.datasetId, options);
+      const entities = await Entities.streamForExport(attachment.datasetId, QueryOptions.none, filterActorId);
       response.set('Content-Disposition', contentDisposition(`${attachment.name}`));
       response.set('Content-Type', 'text/csv');
       return streamEntityCsvAttachment(entities, properties);
@@ -313,8 +314,8 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
       const form = await getInstance(Forms, params);
       await canReadForm(auth, form);
       const project = await Projects.getById(form.projectId).then(getOrNotFound);
-      const options = await getOwnerOnlyOptions(auth, project);
-      const attachments = await FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id, options);
+      const filterActorId = await filteredAccessActorId(auth, project);
+      const attachments = await FormAttachments.getAllByFormDefIdForOpenRosa(form.def.id, filterActorId);
       return formManifest({
         attachments,
         basePath: path.resolve(originalUrl, '..'),
@@ -338,10 +339,10 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
       const form = await getInstance(Forms, params);
       await canReadForm(auth, form);
       const project = await Projects.getById(form.projectId).then(getOrNotFound);
-      const options = await getOwnerOnlyOptions(auth, project);
-      const attachment = await FormAttachments.getByFormDefIdAndNameForOpenRosa(form.def.id, params.name, options)
+      const filterActorId = await filteredAccessActorId(auth, project);
+      const attachment = await FormAttachments.getByFormDefIdAndNameForOpenRosa(form.def.id, params.name, filterActorId)
         .then(getOrNotFound);
-      return streamAttachment(container, attachment, options, response);
+      return streamAttachment(container, attachment, filterActorId, response);
     }));
   };
 
@@ -521,9 +522,9 @@ module.exports = (service, endpoint, anonymousEndpoint) => {
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))
-      .then((form) => FormAttachments.getByFormDefIdAndNameForOpenRosa(form.def.id, params.name, QueryOptions.none)
+      .then((form) => FormAttachments.getByFormDefIdAndNameForOpenRosa(form.def.id, params.name)
         .then(getOrNotFound)
-        .then(attachment => streamAttachment(container, attachment, QueryOptions.none, response)));
+        .then(attachment => streamAttachment(container, attachment, null, response)));
   }));
 
 };

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -7119,22 +7119,16 @@ describe('datasets and entities', () => {
         // Two data collectors with ownerOnly=true and no entities each should still
         // get different hashes from each other, because the hash must include the
         // actor ID to prevent one user's cache from being incorrectly reused by another.
-        const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
+        const [asAlice, asBob, asChelsea] = await service.login(['alice', 'bob', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
-
-        // Create a second data-collector-only user (no pre-existing project access).
-        await asAlice.post('/v1/users')
-          .send({ email: 'dana@getodk.org', password: 'password4dana' })
-          .expect(200);
-        const asDana = await service.login('dana');
-        await assignToProject(asAlice, asDana, 'formfill');
+        await assignToProject(asAlice, asBob, 'formfill');
 
         // Neither Chelsea nor Dana has created any entities. They should still
         // get different hashes because the actor ID is part of the hash.
         const chelseaHash = await getHash(asChelsea);
-        const danaHash = await getHash(asDana);
-        chelseaHash.should.not.equal(danaHash);
+        const bobHash = await getHash(asBob);
+        chelseaHash.should.not.equal(bobHash);
       }));
     });
   });

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -7069,13 +7069,22 @@ describe('datasets and entities', () => {
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
 
+        const chelseaId = await asChelsea.get('/v1/users/current')
+          .expect(200)
+          .then(({ body }) => body.id);
+
         const { loggedAt } = await asAlice.get('/v1/audits?action=dataset.update')
           .expect(200)
           .then(({ body }) => {
             body.length.should.equal(1);
             return body[0];
           });
-        (await getHash(asChelsea)).should.equal(md5sum(`0,${loggedAt}`));
+        (await getHash(asChelsea)).should.equal(md5sum(JSON.stringify({
+          owner: chelseaId,
+          entities: 0,
+          latestEntityCreatedOrUpdated: null,
+          latestAuditEntry: loggedAt,
+        })));
 
         // Have Chelsea create an entity.
         await asChelsea.post('/v1/projects/1/forms/simpleEntity/submissions')
@@ -7086,14 +7095,46 @@ describe('datasets and entities', () => {
         const { createdAt } = await asAlice.get('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc')
           .expect(200)
           .then(({ body }) => body);
-        (await getHash(asChelsea)).should.equal(md5sum(`1,${createdAt}`));
+        (await getHash(asChelsea)).should.equal(md5sum(JSON.stringify({
+          owner: chelseaId,
+          entities: 1,
+          latestEntityCreatedOrUpdated: createdAt,
+          latestAuditEntry: loggedAt,
+        })));
 
         // Update the entity.
         const { updatedAt } = await asAlice.patch('/v1/projects/1/datasets/people/entities/12345678-1234-4123-8234-123456789abc?baseVersion=1')
           .send({ data: { age: '120' } })
           .expect(200)
           .then(({ body }) => body);
-        (await getHash(asChelsea)).should.equal(md5sum(`1,${updatedAt}`));
+        (await getHash(asChelsea)).should.equal(md5sum(JSON.stringify({
+          owner: chelseaId,
+          entities: 1,
+          latestEntityCreatedOrUpdated: updatedAt,
+          latestAuditEntry: loggedAt,
+        })));
+      }));
+
+      it('returns different hashes to two data collectors who both have zero owned entities', testService(async (service) => {
+        // Two data collectors with ownerOnly=true and no entities each should still
+        // get different hashes from each other, because the hash must include the
+        // actor ID to prevent one user's cache from being incorrectly reused by another.
+        const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
+        await createData(asAlice);
+        await assignToProject(asAlice, asChelsea, 'formfill');
+
+        // Create a second data-collector-only user (no pre-existing project access).
+        await asAlice.post('/v1/users')
+          .send({ email: 'dana@getodk.org', password: 'password4dana' })
+          .expect(200);
+        const asDana = await service.login('dana');
+        await assignToProject(asAlice, asDana, 'formfill');
+
+        // Neither Chelsea nor Dana has created any entities. They should still
+        // get different hashes because the actor ID is part of the hash.
+        const chelseaHash = await getHash(asChelsea);
+        const danaHash = await getHash(asDana);
+        chelseaHash.should.not.equal(danaHash);
       }));
     });
   });


### PR DESCRIPTION
This refactors the code around form attachments that generates hashes/etags for dataset-backed form attachments, building on the previous commit to go further in separating concerns.

The key changes are:

1. **Moved dataset OpenRosa metadata fetching out of `form-attachments.js` and into `datasets.js`** as `computeHashes` (batch) and `getDatasetActivity` (single dataset). The `_get` query in form-attachments is now simpler — it just fetches attachments with blob md5s, with no conditional dataset metadata JOINs.

How code is structured and shared in Datasets query module:
```
_fetchActivityStats(all, datasetIds, filterActorId)   ← SQL, returns Map<id, rawStats>
    └── used by:
        ├── getDatasetActivity(datasetId, filterActorId)   ← single dataset, returns rawStats object
        │       └── used in getMetadata for the lastUpdate field
        └── computeHashes(datasetIds, filterActorId)       ← batch, pipes each rawStats through:
                └── _computeHashResult(stats, filterActorId)   ← pure fn, rawStats → { openRosaHash, datasetType, filteredByAuth }
```

3. **Replaced `QueryOptions` as the ownerOnly mechanism** — instead of threading a `QueryOptions` with a special `entities.creatorId` condition through multiple layers, callers now pass a plain `filterActorId` (or `null`). This makes the intent explicit and avoids leaking query-layer abstractions into resource/business logic code.

4. **`Entities.streamForExport` now handles the ownerOnly filter itself** given an `actorId`, rather than relying on the caller to pass the right `QueryOptions`.

5. **Renamed `getOwnerOnlyOptions` → `filteredAccessActorId`** in `forms.js` to reflect what it now returns.

6. **Aligned the REST CSV ETag format with the OpenRosa manifest hash** — the `GET /datasets/:name/entities.csv` ETag is now computed using the same JSON structure (`{ latestEntityCreatedOrUpdated, latestAuditEntry }`) as `getMetadataForOpenRosa`, so the two values agree. Previously they used different hash inputs and would never match, which broke the manifest hash tests that compared them.

#### What has been done to verify that this works as intended?

Tests all still pass. New tests added for dataset-backed form attachment hash behavior with ownerOnly. This is built on top of and used by: https://github.com/getodk/central-backend/pull/1843

#### Why is this the best possible solution? Were any other approaches considered?

Fetching dataset metadata in a separate query (rather than via JOINs inside the form attachments query) makes each query simpler and more focused. The tradeoff is an extra round-trip, but these are manifest/manifest-item requests that aren't on a hot path.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No intentional behavior changes — this is a pure refactor. Regression risk is around etag/hash values for dataset-backed attachments changing; the new test coverage addresses this.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced