### PR TITLE
Migration and API to add dataset access filters

### DIFF
--- a/lib/model/frames/dataset.js
+++ b/lib/model/frames/dataset.js
@@ -77,4 +77,10 @@ Dataset.LinkedForm = class extends Frame.define(
   }
 };
 
+Dataset.AccessFilter = Frame.define(
+  table('dataset_access_filters'),
+  'datasetProperty', readable,
+  'actorProperty', readable
+);
+
 module.exports = { Dataset };

--- a/lib/model/migrations/20260602-01-add-dataset-filters-01.down.sql
+++ b/lib/model/migrations/20260602-01-add-dataset-filters-01.down.sql
@@ -1,0 +1,3 @@
+DROP VIEW IF EXISTS actor_dataset_filter;
+DROP TABLE dataset_access_filters CASCADE;
+DROP INDEX IF EXISTS "dataset_access_filters__unique_for_composite_fk_referent";

--- a/lib/model/migrations/20260602-01-add-dataset-filters-01.up.sql
+++ b/lib/model/migrations/20260602-01-add-dataset-filters-01.up.sql
@@ -1,0 +1,41 @@
+-- Maps a dataset property to an actor property, defining a filter rule:
+-- entities are visible to an actor only if their value for "datasetPropertyId" matches the actor's value for "actorPropertyId".
+CREATE TABLE dataset_access_filters (
+    "datasetId" integer NOT NULL,  -- Redundant with "datasetPropertyId" but needed for the composite FK below to prevent insertion anomalies.
+    "datasetPropertyId" integer NOT NULL PRIMARY KEY,
+    "actorPropertyId" integer NOT NULL REFERENCES actor_properties (id) ON DELETE CASCADE
+);
+-- The unique index on ds_properties enables the composite FK, which ensures "datasetId" is always
+-- consistent with "datasetPropertyId" (preventing insertion anomalies).
+CREATE UNIQUE INDEX "dataset_access_filters__unique_for_composite_fk_referent" ON ds_properties USING btree ("datasetId", id);
+ALTER TABLE dataset_access_filters
+    ADD CONSTRAINT "dataset_access_filters__composite_fk" FOREIGN KEY ("datasetId", "datasetPropertyId") REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
+-- Ensures each actor property is used at most once per dataset.
+CREATE UNIQUE INDEX "dataset_access_filters__spend_actorprop_once_per_dsprop" ON dataset_access_filters ("datasetPropertyId", "actorPropertyId");
+-- Index to support FK lookup on actorPropertyId (CASCADE deletes from actor_properties).
+CREATE INDEX ON dataset_access_filters ("actorPropertyId");
+-- Index to support FK lookup on (datasetId, datasetPropertyId) (CASCADE deletes from ds_properties).
+CREATE INDEX ON dataset_access_filters ("datasetId", "datasetPropertyId");
+
+CREATE VIEW actor_dataset_filter AS (
+    WITH filter_as_json AS (
+        SELECT
+            pfilter."datasetId",
+            aprop."actorId",
+            jsonb_object_agg (dsprops."name", aprop."value") AS thefilter
+        FROM
+            dataset_access_filters pfilter
+            INNER JOIN ds_properties dsprops ON (pfilter."datasetPropertyId" = dsprops.id)
+            INNER JOIN actor_property_values aprop USING ("actorPropertyId")
+        GROUP BY
+            (pfilter."datasetId", aprop."actorId")
+    )
+    SELECT
+        *,
+        md5(thefilter::text) AS filterhash  -- Used to make the filter part of an HTTP resource for incremental entity list download.
+    FROM
+        filter_as_json
+);
+
+-- Commented out: add back w/ info about taking a long time
+-- CREATE INDEX "idx_entity_defs_data" on entity_defs using gin (data);

--- a/lib/model/migrations/20260602-01-add-dataset-filters-01.up.sql
+++ b/lib/model/migrations/20260602-01-add-dataset-filters-01.up.sql
@@ -2,16 +2,15 @@
 -- entities are visible to an actor only if their value for "datasetPropertyId" matches the actor's value for "actorPropertyId".
 CREATE TABLE dataset_access_filters (
     "datasetId" integer NOT NULL,  -- Redundant with "datasetPropertyId" but needed for the composite FK below to prevent insertion anomalies.
-    "datasetPropertyId" integer NOT NULL PRIMARY KEY,
-    "actorPropertyId" integer NOT NULL REFERENCES actor_properties (id) ON DELETE CASCADE
+    "datasetPropertyId" integer NOT NULL,
+    "actorPropertyId" integer NOT NULL REFERENCES actor_properties (id) ON DELETE CASCADE,
+    PRIMARY KEY ("datasetPropertyId", "actorPropertyId")
 );
 -- The unique index on ds_properties enables the composite FK, which ensures "datasetId" is always
 -- consistent with "datasetPropertyId" (preventing insertion anomalies).
 CREATE UNIQUE INDEX "dataset_access_filters__unique_for_composite_fk_referent" ON ds_properties USING btree ("datasetId", id);
 ALTER TABLE dataset_access_filters
     ADD CONSTRAINT "dataset_access_filters__composite_fk" FOREIGN KEY ("datasetId", "datasetPropertyId") REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
--- Ensures each actor property is used at most once per dataset property.
-CREATE UNIQUE INDEX "dataset_access_filters__spend_actorprop_once_per_dsprop" ON dataset_access_filters ("datasetPropertyId", "actorPropertyId");
 -- Index to support FK lookup on actorPropertyId (CASCADE deletes from actor_properties).
 CREATE INDEX ON dataset_access_filters ("actorPropertyId");
 -- Index to support FK lookup on (datasetId, datasetPropertyId) (CASCADE deletes from ds_properties).
@@ -29,6 +28,3 @@ CREATE VIEW actor_dataset_filter AS (
     GROUP BY
         (pfilter."datasetId", aprop."actorId")
 );
-
--- Commented out: add back w/ info about taking a long time
--- CREATE INDEX "idx_entity_defs_data" on entity_defs using gin (data);

--- a/lib/model/migrations/20260602-01-add-dataset-filters-01.up.sql
+++ b/lib/model/migrations/20260602-01-add-dataset-filters-01.up.sql
@@ -10,7 +10,7 @@ CREATE TABLE dataset_access_filters (
 CREATE UNIQUE INDEX "dataset_access_filters__unique_for_composite_fk_referent" ON ds_properties USING btree ("datasetId", id);
 ALTER TABLE dataset_access_filters
     ADD CONSTRAINT "dataset_access_filters__composite_fk" FOREIGN KEY ("datasetId", "datasetPropertyId") REFERENCES ds_properties ("datasetId", id) ON DELETE CASCADE;
--- Ensures each actor property is used at most once per dataset.
+-- Ensures each actor property is used at most once per dataset property.
 CREATE UNIQUE INDEX "dataset_access_filters__spend_actorprop_once_per_dsprop" ON dataset_access_filters ("datasetPropertyId", "actorPropertyId");
 -- Index to support FK lookup on actorPropertyId (CASCADE deletes from actor_properties).
 CREATE INDEX ON dataset_access_filters ("actorPropertyId");
@@ -18,23 +18,16 @@ CREATE INDEX ON dataset_access_filters ("actorPropertyId");
 CREATE INDEX ON dataset_access_filters ("datasetId", "datasetPropertyId");
 
 CREATE VIEW actor_dataset_filter AS (
-    WITH filter_as_json AS (
-        SELECT
-            pfilter."datasetId",
-            aprop."actorId",
-            jsonb_object_agg (dsprops."name", aprop."value") AS thefilter
-        FROM
-            dataset_access_filters pfilter
-            INNER JOIN ds_properties dsprops ON (pfilter."datasetPropertyId" = dsprops.id)
-            INNER JOIN actor_property_values aprop USING ("actorPropertyId")
-        GROUP BY
-            (pfilter."datasetId", aprop."actorId")
-    )
     SELECT
-        *,
-        md5(thefilter::text) AS filterhash  -- Used to make the filter part of an HTTP resource for incremental entity list download.
+        pfilter."datasetId",
+        aprop."actorId",
+        jsonb_object_agg (dsprops."name", aprop."value") AS thefilter
     FROM
-        filter_as_json
+        dataset_access_filters pfilter
+        INNER JOIN ds_properties dsprops ON (pfilter."datasetPropertyId" = dsprops.id)
+        INNER JOIN actor_property_values aprop USING ("actorPropertyId")
+    GROUP BY
+        (pfilter."datasetId", aprop."actorId")
 );
 
 -- Commented out: add back w/ info about taking a long time

--- a/lib/model/migrations/20260602-01-add-dataset-filters.js
+++ b/lib/model/migrations/20260602-01-add-dataset-filters.js
@@ -1,0 +1,1 @@
+module.exports = require('../pure-sql-migration')(__filename);

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -510,6 +510,22 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
     }
   }
 
+  const accessFilterRules = await Datasets.getAccessFilter(dataset.id);
+
+  // Compute the unified accessFilter field:
+  //   - { type: 'ownerOnly' }                        if ownerOnly flag is set
+  //   - { type: 'property', rules: [...] }           if property-based rules exist
+  //   - null                                         otherwise
+  let accessFilter = null;
+  if (dataset.ownerOnly) {
+    accessFilter = { type: 'ownerOnly' };
+  } else if (accessFilterRules.length > 0) {
+    accessFilter = {
+      type: 'property',
+      rules: accessFilterRules.map(r => r.forApi())
+    };
+  }
+
   // return all dataset metadata
   return {
     ...dataset.forApi(),
@@ -518,7 +534,8 @@ const getMetadata = (dataset) => async ({ all, Datasets }) => {
     sourceForms: sourceForms.filter(f => !f.draft).map(f => f.forApi()),
     draftLinkedForms: linkedForms.filter(f => f.draft).map(f => f.forApi()),
     draftSourceForms: sourceForms.filter(f => f.draft).map(f => f.forApi()),
-    properties: Array.from(propertiesMap.values())
+    properties: Array.from(propertiesMap.values()),
+    ...(accessFilter && { accessFilter }) // only add accessFilter if set
   };
 };
 
@@ -975,6 +992,56 @@ const getListWithProperties = (projectId, ids) => async ({ all }) => {
   return Array.from(rows.reduce(_dsPropertiesReducer, new Map()).values());
 };
 
+////////////////////////////////////////////////////////////////////////////
+// DATASET ACCESS FILTERS
+
+// Adds or updates a single access filter rule for a dataset.
+// datasetPropertyName and userPropertyName are names (strings).
+const setAccessFilter = (datasetId, datasetPropertyName, userPropertyName) => ({ maybeOne }) =>
+  maybeOne(sql`
+WITH ds_prop AS (
+  SELECT id FROM ds_properties
+  WHERE "datasetId" = ${datasetId} AND "name" = ${datasetPropertyName} AND "publishedAt" IS NOT NULL
+), actor_prop AS (
+  SELECT ap.id FROM actor_properties ap
+  JOIN datasets d ON d."projectId" = ap."projectId"
+  WHERE d.id = ${datasetId} AND ap."name" = ${userPropertyName}
+), inserted AS (
+  INSERT INTO dataset_access_filters ("datasetId", "datasetPropertyId", "actorPropertyId")
+  SELECT ${datasetId}, ds_prop.id, actor_prop.id FROM ds_prop, actor_prop
+  ON CONFLICT ("datasetPropertyId") DO UPDATE SET "actorPropertyId" = EXCLUDED."actorPropertyId"
+  RETURNING *
+)
+SELECT * FROM inserted`)
+    .then((rows) => rows.map((row) => new Dataset.AccessFilter(row)));
+
+// Returns all access filter rules for a dataset as DatasetAccessFilter instances.
+const getAccessFilter = (datasetId) => ({ all }) =>
+  all(sql`
+SELECT dsp."name" AS "datasetProperty", ap."name" AS "actorProperty"
+FROM dataset_access_filters daf
+JOIN ds_properties dsp ON dsp.id = daf."datasetPropertyId"
+JOIN actor_properties ap ON ap.id = daf."actorPropertyId"
+WHERE daf."datasetId" = ${datasetId}
+ORDER BY dsp."name"`)
+    .then((rows) => rows.map((row) => new Dataset.AccessFilter(row)));
+
+
+// Deletes all access filter rules for a dataset.
+const deleteAllAccessFilters = (datasetId) => ({ run }) =>
+  run(sql`DELETE FROM dataset_access_filters WHERE "datasetId" = ${datasetId}`);
+
+// Atomically replaces all access filter rules for a dataset.
+// rules is an array of { datasetProperty, actorProperty } objects.
+// Passing an empty array deletes all rules.
+const setAccessFilters = (datasetId, rules) => async ({ Datasets }) => {
+  await Datasets.deleteAllAccessFilters(datasetId);
+  for (const { datasetProperty, actorProperty } of rules) {
+    // eslint-disable-next-line no-await-in-loop
+    await Datasets.setAccessFilter(datasetId, datasetProperty, actorProperty);
+  }
+};
+
 module.exports = {
   createPublishedDataset, createPublishedProperty,
   createOrMerge, publishIfExists,
@@ -987,5 +1054,6 @@ module.exports = {
   getDatasetActivity, computeHashes, canReadForOpenRosa,
   del, purge, deleteProperty,
   getTargetDatasetsAndProperties, getLinkedDatasets, getRelatedDatasetsOfForm,
-  getListWithProperties
+  getListWithProperties,
+  setAccessFilter, getAccessFilter, deleteAllAccessFilters, setAccessFilters
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -1009,7 +1009,7 @@ WITH ds_prop AS (
 ), inserted AS (
   INSERT INTO dataset_access_filters ("datasetId", "datasetPropertyId", "actorPropertyId")
   SELECT ${datasetId}, ds_prop.id, actor_prop.id FROM ds_prop, actor_prop
-  ON CONFLICT ("datasetPropertyId") DO UPDATE SET "actorPropertyId" = EXCLUDED."actorPropertyId"
+  ON CONFLICT ("datasetPropertyId", "actorPropertyId") DO NOTHING
   RETURNING *
 )
 SELECT * FROM inserted`)

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -33,6 +33,7 @@ module.exports = (service, endpoint) => {
   service.patch('/projects/:projectId/datasets/:name', endpoint(async ({ Datasets }, { params, body, auth, query }) => {
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
     await auth.canOrReject('dataset.update', dataset);
+
     const newDataset = Dataset.fromApi(body);
 
     // validate value of convert query parameter
@@ -40,6 +41,7 @@ module.exports = (service, endpoint) => {
       return Problem.user.unexpectedValue({ field: 'convert', value: query.convert });
 
     // return warning if approvalRequired is false and there are pending submissions
+    // and the caller hasn't acknowledged with convert=true/false
     if (newDataset.approvalRequired === false && query.convert === undefined) {
       const unprocessedSubmissions = await Datasets.countUnprocessedSubmissions(dataset.id);
       if (unprocessedSubmissions > 0) {
@@ -47,32 +49,31 @@ module.exports = (service, endpoint) => {
       }
     }
 
+    // autoConvert only applies when disabling approvalRequired
     const autoConvert = newDataset.approvalRequired === false
       ? query.convert === 'true'
       : undefined;
 
-    // Collect all column updates into one object to call Datasets.update once.
-    // accessFilter wins over the legacy ownerOnly field if both are present.
+    // Collect all updates into one object to call Datasets.update once
     const updates = {};
-    if (newDataset.approvalRequired !== undefined) updates.approvalRequired = newDataset.approvalRequired;
-    if (newDataset.ownerOnly !== undefined) {
-      updates.ownerOnly = newDataset.ownerOnly;
-      // Clear property rules when enabling ownerOnly so the two filter types don't coexist.
-      if (newDataset.ownerOnly) await Datasets.deleteAllAccessFilters(dataset.id);
-    }
+    if (newDataset.approvalRequired !== undefined)
+      updates.approvalRequired = newDataset.approvalRequired;
 
-    // Handle accessFilter transitions if present in body (takes precedence over ownerOnly above).
+    // Handle access filter changes.
+    // accessFilter in the body takes precedence over the legacy ownerOnly field.
     if (Object.hasOwn(body, 'accessFilter')) {
       const { accessFilter } = body;
 
       if (accessFilter === null) {
-        // Clear any existing filter (both ownerOnly and property rules)
-        if (dataset.ownerOnly) updates.ownerOnly = false;
+        // Remove all access restrictions
+        updates.ownerOnly = false;
         await Datasets.deleteAllAccessFilters(dataset.id);
+
       } else if (accessFilter.type === 'ownerOnly') {
-        // Switch to ownerOnly: clear property rules first
+        // Switch to ownerOnly mode; clear any property rules first
         await Datasets.deleteAllAccessFilters(dataset.id);
-        if (!dataset.ownerOnly) updates.ownerOnly = true;
+        updates.ownerOnly = true;
+
       } else if (accessFilter.type === 'property') {
         const { rules } = accessFilter;
         if (!Array.isArray(rules) || rules.length === 0)
@@ -81,12 +82,19 @@ module.exports = (service, endpoint) => {
           if (!rule.datasetProperty || !rule.actorProperty)
             throw Problem.user.unexpectedValue({ field: 'accessFilter.rules', value: rule, reason: 'Each rule must have datasetProperty and actorProperty.' });
         }
-        // Clear ownerOnly if set, then replace all property rules atomically
-        if (dataset.ownerOnly) updates.ownerOnly = false;
+        // Disable ownerOnly if set, then replace all property rules
+        updates.ownerOnly = false;
         await Datasets.setAccessFilters(dataset.id, rules);
+
       } else {
         throw Problem.user.unexpectedValue({ field: 'accessFilter.type', value: accessFilter.type, reason: 'type must be ownerOnly or property.' });
       }
+
+    } else if (newDataset.ownerOnly !== undefined) {
+      // Legacy ownerOnly field (only used when accessFilter is absent)
+      updates.ownerOnly = newDataset.ownerOnly;
+      // Clear property rules when enabling ownerOnly
+      if (newDataset.ownerOnly) await Datasets.deleteAllAccessFilters(dataset.id);
     }
 
     const updatedDataset = Object.keys(updates).length > 0

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -50,7 +50,49 @@ module.exports = (service, endpoint) => {
     const autoConvert = newDataset.approvalRequired === false
       ? query.convert === 'true'
       : undefined;
-    const updatedDataset = await Datasets.update(dataset, newDataset, autoConvert);
+
+    // Collect all column updates into one object to call Datasets.update once.
+    // accessFilter wins over the legacy ownerOnly field if both are present.
+    const updates = {};
+    if (newDataset.approvalRequired !== undefined) updates.approvalRequired = newDataset.approvalRequired;
+    if (newDataset.ownerOnly !== undefined) {
+      updates.ownerOnly = newDataset.ownerOnly;
+      // Clear property rules when enabling ownerOnly so the two filter types don't coexist.
+      if (newDataset.ownerOnly) await Datasets.deleteAllAccessFilters(dataset.id);
+    }
+
+    // Handle accessFilter transitions if present in body (takes precedence over ownerOnly above).
+    if (Object.hasOwn(body, 'accessFilter')) {
+      const { accessFilter } = body;
+
+      if (accessFilter === null) {
+        // Clear any existing filter (both ownerOnly and property rules)
+        if (dataset.ownerOnly) updates.ownerOnly = false;
+        await Datasets.deleteAllAccessFilters(dataset.id);
+      } else if (accessFilter.type === 'ownerOnly') {
+        // Switch to ownerOnly: clear property rules first
+        await Datasets.deleteAllAccessFilters(dataset.id);
+        if (!dataset.ownerOnly) updates.ownerOnly = true;
+      } else if (accessFilter.type === 'property') {
+        const { rules } = accessFilter;
+        if (!Array.isArray(rules) || rules.length === 0)
+          throw Problem.user.unexpectedValue({ field: 'accessFilter.rules', value: rules, reason: 'rules must be a non-empty array.' });
+        for (const rule of rules) {
+          if (!rule.datasetProperty || !rule.actorProperty)
+            throw Problem.user.unexpectedValue({ field: 'accessFilter.rules', value: rule, reason: 'Each rule must have datasetProperty and actorProperty.' });
+        }
+        // Clear ownerOnly if set, then replace all property rules atomically
+        if (dataset.ownerOnly) updates.ownerOnly = false;
+        await Datasets.setAccessFilters(dataset.id, rules);
+      } else {
+        throw Problem.user.unexpectedValue({ field: 'accessFilter.type', value: accessFilter.type, reason: 'type must be ownerOnly or property.' });
+      }
+    }
+
+    const updatedDataset = Object.keys(updates).length > 0
+      ? await Datasets.update(dataset, updates, autoConvert)
+      : dataset;
+
     return Datasets.getMetadata(updatedDataset);
   }));
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -376,6 +376,7 @@ should.Assertion.add('Dataset', function assertDataset(extraKeys = []) {
     'projectId', 'name', 'approvalRequired', 'ownerOnly', 'createdAt', 'deletedAt',
     // Optional metadata
     'properties', 'linkedForms', 'sourceForms', 'lastUpdate', 'draftLinkedForms', 'draftSourceForms',
+    'accessFilter',
     ...extraKeys
   ]);
   this.obj.projectId.should.be.a.Number();

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -8,6 +8,7 @@ const should = require('should');
 const { sql } = require('slonik');
 const { QueryOptions } = require('../../../lib/util/db');
 const { createConflict } = require('../../util/scenarios');
+const { createDataset } = require('../../util/entities');
 const { omit, last } = require('ramda');
 const xml2js = require('xml2js');
 const { v4: uuid } = require('uuid');
@@ -5586,7 +5587,7 @@ describe('datasets and entities', () => {
   // endpoint as a whole for updating dataset settings, including ownerOnly. We
   // test the specific behavior of ownerOnly in a separate test suite below, but
   // in this test suite, we test that ownerOnly can be updated.
-  describe('approvalRequired and updating dataset settings', () => {
+  describe('updating dataset settings via PATCH (approvalRequired, ownerOnly, property filters)', () => {
     describe('PATCH /datasets/:name', () => {
 
       it('should return notfound if the dataset does not exist', testService(async (service) => {
@@ -6282,6 +6283,195 @@ describe('datasets and entities', () => {
         const parentEvent = await container.one(sql`select * from audits where id = ${parentEventId}`);
         parentEvent.action.should.equal('dataset.update');
       }));
+
+      describe('PATCH /projects/:id/datasets/:name accessFilter', () => {
+        it('should set a property access filter', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['plot_id']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'plot_id' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'plot_id', actorProperty: 'plot_id' }] } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'property', rules: [{ datasetProperty: 'plot_id', actorProperty: 'plot_id' }] });
+            });
+        }));
+
+        it('should replace all existing rules atomically', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['plot_id', 'region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'plot_id' }).expect(200);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'plot_id', actorProperty: 'plot_id' }] } })
+            .expect(200);
+
+          // Replace with a different set of rules
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] });
+            });
+        }));
+
+        it('should set multiple rules at once', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['plot_id', 'region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'plot_id' }).expect(200);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [
+              { datasetProperty: 'plot_id', actorProperty: 'plot_id' },
+              { datasetProperty: 'region', actorProperty: 'region' }
+            ] } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.type.should.equal('property');
+              body.accessFilter.rules.length.should.equal(2);
+            });
+        }));
+
+        it('should clear the filter when sent accessFilter: null', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['plot_id']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'plot_id' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'plot_id', actorProperty: 'plot_id' }] } })
+            .expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: null })
+            .expect(200)
+            .then(({ body }) => {
+              should.not.exist(body.accessFilter);
+            });
+        }));
+
+        it('should set ownerOnly filter', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['plot_id']);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'ownerOnly' } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'ownerOnly' });
+            });
+        }));
+
+        it('should switch from ownerOnly to property rules', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'ownerOnly' } })
+            .expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] });
+              body.ownerOnly.should.be.false();
+            });
+        }));
+
+        it('should switch from property rules to ownerOnly', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+            .expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'ownerOnly' } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'ownerOnly' });
+            });
+        }));
+
+        it('should leave filter unchanged when accessFilter absent from body', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+            .expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ approvalRequired: false })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] });
+            });
+        }));
+
+        it('should reject empty rules array', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [] } })
+            .expect(400);
+        }));
+
+        it('should reject rule missing datasetProperty', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ actorProperty: 'region' }] } })
+            .expect(400);
+        }));
+
+        it('should clear property rules when legacy ownerOnly: true is sent', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          // Set property rules first
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+            .expect(200);
+
+          // Switch to ownerOnly via legacy field — property rules should be cleared
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ ownerOnly: true })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'ownerOnly' });
+            });
+        }));
+
+        it('should leave property rules unchanged when legacy ownerOnly: false is sent', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          // Set property rules first
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+            .expect(200);
+
+          // ownerOnly: false is a noop when ownerOnly is already off — property rules should be untouched
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ ownerOnly: false })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] });
+            });
+        }));
+      });
     });
 
     it('should not let submission edits get caught in pending submission count', testService(async (service, container) => {

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -6335,6 +6335,61 @@ describe('datasets and entities', () => {
             });
         }));
 
+        it('should allow multiple rules using same dataset property', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['district']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'primaryDistrict' }).expect(200);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'secondaryDistrict' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [
+              { datasetProperty: 'district', actorProperty: 'primaryDistrict' },
+              { datasetProperty: 'district', actorProperty: 'secondaryDistrict' }
+            ] } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.type.should.equal('property');
+              body.accessFilter.rules.length.should.equal(2);
+            });
+        }));
+
+        it('should allow multiple rules using same actor property', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['assignedWorker', 'supervisor']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'staffId' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [
+              { datasetProperty: 'assignedWorker', actorProperty: 'staffId' },
+              { datasetProperty: 'supervisor', actorProperty: 'staffId' }
+            ] } })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.type.should.equal('property');
+              body.accessFilter.rules.length.should.equal(2);
+            });
+        }));
+
+        it('should collapse duplicate rules', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [
+              { datasetProperty: 'region', actorProperty: 'region' },
+              { datasetProperty: 'region', actorProperty: 'region' }
+            ] } })
+            .expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ approvalRequired: false })
+            .expect(200)
+            .then(({ body }) => {
+              body.accessFilter.should.eql({ type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] });
+            });
+        }));
+
         it('should clear the filter when sent accessFilter: null', testService(async (service) => {
           const asAlice = await service.login('alice');
           await createDataset(asAlice, 1, 'trees', ['plot_id']);


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1878 and does most of https://github.com/getodk/central/issues/1877
(Applying the access filter to come in a follow-up PR.)

## Summary: 

Adds an `accessFilter` field to dataset metadata responses and the dataset settings PATCH endpoint.

**GET response** — `accessFilter` added when a filter is set:
```json
{ "ownerOnly": true, "accessFilter": { "type": "ownerOnly" } }

{ "ownerOnly": false, "accessFilter": { "type": "property", "rules": [
  { "datasetProperty": "region", "actorProperty": "zone" }
]}}

{ "ownerOnly": false }  // no accessFilter field when no filter
```

**PATCH request body:**
```json
{ "ownerOnly": true }                    // legacy, still works
{ "accessFilter": null }                 // clears all filters
{ "accessFilter": { "type": "ownerOnly" } }
{ "accessFilter": { "type": "property", "rules": [
  { "datasetProperty": "region", "actorProperty": "zone" }
]}}
```

- If both `ownerOnly` and `accessFilter` are sent, `accessFilter` wins silently
- Setting `ownerOnly: true` clears any existing property rules
- `ownerOnly` boolean in DB; property rules in separate `dataset_access_filters` table



`rules` must be a non-empty array; each rule requires `datasetProperty` (a published dataset property name) and `actorProperty` (an actor property name in the same project). Replaces all existing rules atomically.

The legacy `ownerOnly` boolean field continues to work. If both `ownerOnly` and `accessFilter` are sent in the same request, `accessFilter` takes precedence.

-----

### Database schema:

**New table: `dataset_access_filters`**

Stores one row per filter rule, mapping a published dataset property to an actor property.

| Column | Type | Notes |
|---|---|---|
| `datasetId` | integer | FK to dataset (redundant, required for composite FK) |
| `datasetPropertyId` | integer PK | FK to `ds_properties` |
| `actorPropertyId` | integer | FK to `actor_properties`, cascades on delete |

A composite FK on `(datasetId, datasetPropertyId)` → `ds_properties(datasetId, id)` prevents `datasetId` from being inconsistent with `datasetPropertyId`. A unique index on `(datasetPropertyId, actorPropertyId)` ensures each actor property is used at most once per dataset property.

**New view: `actor_dataset_filter`**

Joins `dataset_access_filters` with `ds_properties` and `actor_property_values` to produce one row per `(datasetId, actorId)` pair, containing a `jsonb` filter object (keyed by dataset property name, valued by the actor's value for the mapped actor property).

Also contains an MD5 hash of that object that can be used as an ETag component in incremental entity list downloads. See issue: https://github.com/getodk/central/issues/1880

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Integration tests cover the new `accessFilter` field on `PATCH /projects/:id/datasets/:name`, including setting property-based rules, switching to `ownerOnly`, clearing filters, and error cases for invalid input (bad type, empty rules array, missing rule fields). 

#### Why is this the best possible solution? Were any other approaches considered?

The `accessFilter` field is a unified, structured alternative to the bare `ownerOnly` boolean, making it easier to add new filter types in the future without introducing more top-level fields. Adding a separate `propertyFilter` field alongside `ownerOnly` was considered but rejected — it would leave two independent filter fields that could contradict each other.

The legacy `ownerOnly` field is preserved for backward compatibility. `accessFilter` takes precedence if both are sent in the same request.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

**Intentional changes:**
- Dataset metadata responses now include an `accessFilter` field when a filter is active. This is additive and should not affect existing clients.
- `PATCH /projects/:id/datasets/:name` accepts a new `accessFilter` body field.
- Setting `accessFilter: { type: 'ownerOnly' }` clears any existing property rules, and setting `accessFilter: { type: 'property', ... }` clears `ownerOnly` if it was set. The two filter types cannot coexist.

**Regression risks:**
- If a client sends both `ownerOnly` and `accessFilter` in the same PATCH request, `accessFilter` silently wins. This could be surprising if a client is unaware of the new field.
- `Datasets.update` is now only called when there are column-level changes to make. If the request only touches `accessFilter` (no `approvalRequired` or `ownerOnly` changes), the dataset row is returned as-is without a DB write and won't make an audit log entry.  This needs to be fixed in a follow up issue: https://github.com/getodk/central/issues/1882 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes. `docs/api.yaml` should be updated to document:

1. The `accessFilter` field in the dataset metadata response schema (optional, present when a filter is set).
2. The `accessFilter` field in the `PATCH /projects/{projectId}/datasets/{name}` request body schema.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
