### PR TITLE
Apply dataset access filter to streaming entity export form attachments

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -931,6 +931,18 @@ ${actorId != null ? sql`
     -- ownerOnly: if the dataset is ownerOnly, restrict to entities created by this actor
     NOT EXISTS (SELECT 1 FROM datasets WHERE datasets.id = entities."datasetId" AND datasets."ownerOnly")
     OR entities."creatorId" = ${actorId}
+  )
+  AND (
+    -- property filters: if the dataset has access filters, restrict to matching entities
+    NOT EXISTS (SELECT 1 FROM dataset_access_filters WHERE "datasetId" = entities."datasetId")
+    OR EXISTS (
+      SELECT 1 FROM dataset_access_filters daf
+      JOIN ds_properties dp ON dp.id = daf."datasetPropertyId"
+      JOIN actor_property_values apv ON apv."actorPropertyId" = daf."actorPropertyId"
+      WHERE daf."datasetId" = entities."datasetId"
+        AND apv."actorId" = ${actorId}
+        AND entity_defs.data ->> dp."name" = apv."value"
+    )
   )` : sql``}
 ${options.orderby ? sql`
   ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -8,7 +8,7 @@ const should = require('should');
 const { sql } = require('slonik');
 const { QueryOptions } = require('../../../lib/util/db');
 const { createConflict } = require('../../util/scenarios');
-const { createDataset } = require('../../util/entities');
+const { createDataset, createEntities } = require('../../util/entities');
 const { omit, last } = require('ramda');
 const xml2js = require('xml2js');
 const { v4: uuid } = require('uuid');
@@ -7376,6 +7376,202 @@ describe('datasets and entities', () => {
         chelseaHash.should.not.equal(bobHash);
       }));
     });
+  });
+
+  describe('filter attached dataset', () => {
+    async function setupDatasetsAndProperties(asAlice) {
+      // Create trees dataset with "region" and "species" and 5 trees
+      // 3 north + oak trees
+      // 2 south + pine trees
+      await createDataset(asAlice, 1, 'trees', ['region', 'species']);
+      await createEntities(asAlice, 3, 1, 'trees', [], { region: 'north', species: 'oak' }, 'North Oak Tree');
+      await createEntities(asAlice, 2, 1, 'trees', [], { region: 'south', species: 'pine' }, 'South Pine Tree');
+
+      // Create people dataset
+      await createDataset(asAlice, 1, 'people', ['species']);
+      await createEntities(asAlice, 1, 1, 'people', [], { species: 'oak' }, 'Oak Specialist');
+      await createEntities(asAlice, 1, 1, 'people', [], { species: 'pine' }, 'Pine Specialist');
+
+      // Publish a form that consumes trees and people datasets
+      await asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.consumeDatasets)
+        .set('Content-Type', 'application/xml').expect(200);
+      await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/publish').expect(200);
+
+      // Set up actor properties region and expertise
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'expertise' }).expect(200);
+
+      // Set up dataset filter on trees mapping region to region
+      await asAlice.patch('/v1/projects/1/datasets/trees')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      // Create two app users and assign them to the form
+      const { body: appUserA } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'Survey Worker A' }).expect(200);
+      await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUserA.id}`).expect(200);
+
+      const { body: appUserB } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'Survey Worker B' }).expect(200);
+      await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUserB.id}`).expect(200);
+
+      return { appUserA, appUserB };
+    }
+
+    it('should only return the entities that the user has access to based on property filter', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { appUserA } = await setupDatasetsAndProperties(asAlice);
+
+      // Set actor properties on the app user: region = "north", expertise = "oak"
+      await asAlice.patch(`/v1/projects/1/app-users/${appUserA.id}`)
+        .send({ properties: { region: 'north', expertise: 'oak' } })
+        .expect(200);
+
+      // Fetch trees.csv as the app user
+      await service.get(`/v1/key/${appUserA.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(4); // 1 header + 3 north trees
+          text.should.containEql('north');
+          text.should.not.containEql('south');
+        });
+    }));
+
+    it('should only segment entities if filter is set', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      // access filter is on trees only, not set up on people
+      const { appUserA } = await setupDatasetsAndProperties(asAlice);
+
+      // Set actor properties on the app user: region = "north", expertise = "oak"
+      await asAlice.patch(`/v1/projects/1/app-users/${appUserA.id}`)
+        .send({ properties: { region: 'north', expertise: 'oak' } })
+        .expect(200);
+
+      // Fetch people.csv as the app user before applying filter
+      await service.get(`/v1/key/${appUserA.token}/projects/1/forms/consumeDatasets/attachments/people.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(3); // 1 header + 2 people with both species specialties
+          text.should.containEql('oak');
+          text.should.containEql('pine');
+        });
+
+      // Set up dataset filter on people: people.species to actor.expertise
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'species', actorProperty: 'expertise' }] } })
+        .expect(200);
+
+      // Fetch people.csv as the app user after applying filter
+      await service.get(`/v1/key/${appUserA.token}/projects/1/forms/consumeDatasets/attachments/people.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(2); // 1 header + 1 oak
+          text.should.containEql('oak');
+          text.should.not.containEql('pine');
+        });
+    }));
+
+    it('should return null set of entities if actor property is not set', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { appUserA } = await setupDatasetsAndProperties(asAlice);
+
+      // Don't set any properties on the app user
+
+      // Fetch trees.csv as the app user
+      await service.get(`/v1/key/${appUserA.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(1); // 1 header only
+        });
+    }));
+
+    it('should not return entities with property not set or if property does not match', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const { appUserA, appUserB } = await setupDatasetsAndProperties(asAlice);
+
+      // Only set region on one of the app users
+      await asAlice.patch(`/v1/projects/1/app-users/${appUserA.id}`)
+        .send({ properties: { region: 'west' } })
+        .expect(200);
+
+      // Add entities with null region property
+      await createEntities(asAlice, 2, 1, 'trees', [], { species: 'willow' }, 'Willow Seedling');
+
+      // Fetch trees.csv as the app user
+      await service.get(`/v1/key/${appUserA.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(1); // 1 header only (no west trees, shouldn't include blank tree)
+        });
+
+      await service.get(`/v1/key/${appUserB.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(1); // 1 header only (no blank region trees even if app user region is empty)
+        });
+    }));
+
+    it('should return entities where any rule matches (OR semantics)', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      // Create trees dataset with worker_id and supervisor_id properties
+      await createDataset(asAlice, 1, 'trees', ['region', 'worker_id', 'supervisor_id']);
+
+      // Entities assigned to different workers/supervisors (bob is supervisor of others)
+      await createEntities(asAlice, 1, 1, 'trees', [], { region: 'north', worker_id: 'alice', supervisor_id: 'bob' }, 'Alice North Tree');
+      await createEntities(asAlice, 1, 1, 'trees', [], { region: 'south', worker_id: 'bob', supervisor_id: 'diane' }, 'Bob South Tree');
+      await createEntities(asAlice, 1, 1, 'trees', [], { region: 'east', worker_id: 'carol', supervisor_id: 'bob' }, 'Carol East Tree');
+      await createEntities(asAlice, 1, 1, 'trees', [], { region: 'west', worker_id: 'diane', supervisor_id: 'alice' }, 'Diane West Tree');
+
+
+      // Publish the form that consumes trees
+      await asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.consumeDatasets)
+        .set('Content-Type', 'application/xml').expect(200);
+      await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/publish').expect(200);
+
+      // Set up actor property: staff_id
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'staff_id' }).expect(200);
+
+      // Set up two filter rules (OR): worker_id → staff_id, supervisor_id → staff_id
+      await asAlice.patch('/v1/projects/1/datasets/trees')
+        .send({ accessFilter: { type: 'property', rules: [
+          { datasetProperty: 'worker_id', actorProperty: 'staff_id' },
+          { datasetProperty: 'supervisor_id', actorProperty: 'staff_id' }
+        ] } })
+        .expect(200);
+
+      // Create app user Bob with staff_id = "bob"
+      const { body: appUserBob } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'Bob' }).expect(200);
+      await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUserBob.id}`).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUserBob.id}`)
+        .send({ properties: { staff_id: 'bob' } })
+        .expect(200);
+
+      // Bob should see:
+      // - 1 "Alice North Tree" entities (supervisor_id = 'bob')
+      // - 1 "Bob South Tree" entities (worker_id = 'bob')
+      // - 1 "Carol East Tree" entities (supervisor_id = 'bob')
+      // But NOT "Diane West Tree" (worker_id = 'diane', supervisor_id = 'alice')
+      await service.get(`/v1/key/${appUserBob.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(4); // 1 header + 3 entities
+          text.should.containEql('Alice North Tree');
+          text.should.containEql('Bob South Tree');
+          text.should.containEql('Carol East Tree');
+          text.should.not.containEql('Diane West Tree');
+        });
+    }));
   });
 
   // OpenRosa endpoint

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -7572,6 +7572,171 @@ describe('datasets and entities', () => {
           text.should.not.containEql('Diane West Tree');
         });
     }));
+
+    it('should filter with same actor property mapped to different entity properties (supervisor vs. worker)', testService(async (service) => {
+      // A community health program tracks household visits as entities.
+      // Every actor has one property: staffId.
+      // Each visit entity records:
+      //   - assignedWorker: the staff ID of the field worker who owns the visit
+      //   - supervisor: the staff ID of that worker's supervisor
+      // Rule 1: entity.assignedWorker = actor.staffId  (worker sees their own visits)
+      // Rule 2: entity.supervisor = actor.staffId      (supervisor sees all visits they oversee)
+      const asAlice = await service.login('alice');
+
+      await createDataset(asAlice, 1, 'visits', ['assignedWorker', 'supervisor']);
+
+      // Visit 1: assigned to worker1, supervised by supervisor1
+      await createEntities(asAlice, 1, 1, 'visits', [], { assignedWorker: 'worker1', supervisor: 'supervisor1' }, 'Visit by worker1');
+      // Visit 2: assigned to worker2, supervised by supervisor1
+      await createEntities(asAlice, 1, 1, 'visits', [], { assignedWorker: 'worker2', supervisor: 'supervisor1' }, 'Visit by worker2');
+      // Visit 3: assigned to worker3, supervised by supervisor2
+      await createEntities(asAlice, 1, 1, 'visits', [], { assignedWorker: 'worker3', supervisor: 'supervisor2' }, 'Visit by worker3');
+
+      await asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.consumeDatasets.replace('people.csv', 'visits.csv'))
+        .set('Content-Type', 'application/xml').expect(200);
+      await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/publish').expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'staffId' }).expect(200);
+
+      // Two filter rules using the same actor property (staffId) but different entity properties
+      await asAlice.patch('/v1/projects/1/datasets/visits')
+        .send({ accessFilter: { type: 'property', rules: [
+          { datasetProperty: 'assignedWorker', actorProperty: 'staffId' },
+          { datasetProperty: 'supervisor', actorProperty: 'staffId' }
+        ] } })
+        .expect(200);
+
+      // worker1 sees only their own visit (matched via assignedWorker)
+      const { body: appUserWorker1 } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'Worker 1' }).expect(200);
+      await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUserWorker1.id}`).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUserWorker1.id}`)
+        .send({ properties: { staffId: 'worker1' } }).expect(200);
+
+      await service.get(`/v1/key/${appUserWorker1.token}/projects/1/forms/consumeDatasets/attachments/visits.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(2); // 1 header + 1 visit
+          text.should.containEql('Visit by worker1');
+          text.should.not.containEql('Visit by worker2');
+          text.should.not.containEql('Visit by worker3');
+        });
+
+      // supervisor1 sees visits by worker1 and worker2 (matched via supervisor)
+      const { body: appUserSupervisor1 } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'Supervisor 1' }).expect(200);
+      await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUserSupervisor1.id}`).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUserSupervisor1.id}`)
+        .send({ properties: { staffId: 'supervisor1' } }).expect(200);
+
+      await service.get(`/v1/key/${appUserSupervisor1.token}/projects/1/forms/consumeDatasets/attachments/visits.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(3); // 1 header + 2 visits
+          text.should.containEql('Visit by worker1');
+          text.should.containEql('Visit by worker2');
+          text.should.not.containEql('Visit by worker3');
+        });
+    }));
+
+    it('should filter with different actor properties mapped to different entity properties', testService(async (service) => {
+      // An actor has actor.homeDistrict = "east" and actor.assignedRegion = "north".
+      // Entities have two properties: entity.district and entity.region.
+      // Rule 1: entity.district = actor.homeDistrict
+      // Rule 2: entity.region = actor.assignedRegion
+      // Actor sees any entity where their home district matches OR their assigned region matches.
+      const asAlice = await service.login('alice');
+
+      await createDataset(asAlice, 1, 'trees', ['district', 'region']);
+
+      await createEntities(asAlice, 1, 1, 'trees', [], { district: 'east', region: 'south' }, 'East District Tree'); // matches Rule 1
+      await createEntities(asAlice, 1, 1, 'trees', [], { district: 'west', region: 'north' }, 'North Region Tree'); // matches Rule 2
+      await createEntities(asAlice, 1, 1, 'trees', [], { district: 'east', region: 'north' }, 'East+North Tree'); // matches both rules
+      await createEntities(asAlice, 1, 1, 'trees', [], { district: 'west', region: 'south' }, 'West South Tree'); // matches neither
+
+      await asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.consumeDatasets)
+        .set('Content-Type', 'application/xml').expect(200);
+      await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/publish').expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'homeDistrict' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'assignedRegion' }).expect(200);
+
+      // Two rules: different actor properties AND different entity properties
+      await asAlice.patch('/v1/projects/1/datasets/trees')
+        .send({ accessFilter: { type: 'property', rules: [
+          { datasetProperty: 'district', actorProperty: 'homeDistrict' },
+          { datasetProperty: 'region', actorProperty: 'assignedRegion' }
+        ] } })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'East/North Worker' }).expect(200);
+      await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUser.id}`).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { homeDistrict: 'east', assignedRegion: 'north' } }).expect(200);
+
+      await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(4); // 1 header + 3 matching entities
+          text.should.containEql('East District Tree');
+          text.should.containEql('North Region Tree');
+          text.should.containEql('East+North Tree');
+          text.should.not.containEql('West South Tree');
+        });
+    }));
+
+    it('should filter with different actor properties mapped to the same entity property (multi-territory)', testService(async (service) => {
+      // An actor has actor.primaryDistrict = "east" and actor.secondaryDistrict = "north".
+      // Entities have one property: entity.district.
+      // Rule 1: entity.district = actor.primaryDistrict
+      // Rule 2: entity.district = actor.secondaryDistrict
+      // Actor sees entities from their primary OR secondary district.
+      const asAlice = await service.login('alice');
+
+      await createDataset(asAlice, 1, 'trees', ['district']);
+
+      await createEntities(asAlice, 1, 1, 'trees', [], { district: 'east' }, 'East Tree'); // matches Rule 1 (primaryDistrict)
+      await createEntities(asAlice, 1, 1, 'trees', [], { district: 'north' }, 'North Tree'); // matches Rule 2 (secondaryDistrict)
+      await createEntities(asAlice, 1, 1, 'trees', [], { district: 'west' }, 'West Tree'); // matches neither
+
+      await asAlice.post('/v1/projects/1/forms')
+        .send(testData.forms.consumeDatasets)
+        .set('Content-Type', 'application/xml').expect(200);
+      await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/publish').expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'primaryDistrict' }).expect(200);
+      await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'secondaryDistrict' }).expect(200);
+
+      // Two rules: different actor properties, same entity property
+      await asAlice.patch('/v1/projects/1/datasets/trees')
+        .send({ accessFilter: { type: 'property', rules: [
+          { datasetProperty: 'district', actorProperty: 'primaryDistrict' },
+          { datasetProperty: 'district', actorProperty: 'secondaryDistrict' }
+        ] } })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'Multi-territory Worker' }).expect(200);
+      await asAlice.post(`/v1/projects/1/forms/consumeDatasets/assignments/app-user/${appUser.id}`).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { primaryDistrict: 'east', secondaryDistrict: 'north' } }).expect(200);
+
+      await service.get(`/v1/key/${appUser.token}/projects/1/forms/consumeDatasets/attachments/trees.csv`)
+        .expect(200)
+        .then(({ text }) => {
+          const rows = text.trim().split('\n');
+          rows.length.should.equal(3); // 1 header + 2 matching entities
+          text.should.containEql('East Tree');
+          text.should.containEql('North Tree');
+          text.should.not.containEql('West Tree');
+        });
+    }));
   });
 
   // OpenRosa endpoint

--- a/test/util/entities.js
+++ b/test/util/entities.js
@@ -51,18 +51,14 @@ const deleteDatasets = async (user, names, projectId) => {
   }
 };
 
-const createEntities = async (user, count, projectId, datasetName, properties = []) => {
+const createEntities = async (user, count, projectId, datasetName, properties = [], data = null, label = 'John Doe') => {
   const uuids = [];
+  const entityData = data ?? Object.fromEntries(properties.map((property) => [property, 'foo']));
   for (let i = 0; i < count; i += 1) {
     const _uuid = uuid();
-    const data = Object.fromEntries(properties.map((property) => [property, 'foo']));
     // eslint-disable-next-line no-await-in-loop
     await user.post(`/v1/projects/${projectId}/datasets/${datasetName}/entities`)
-      .send({
-        uuid: _uuid,
-        label: 'John Doe',
-        ...(properties.length ? { data } : {})
-      })
+      .send({ uuid: _uuid, label, data: entityData })
       .expect(200);
     uuids.push(_uuid);
   }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1877

## Summary

This PR applies dataset access filters to the streaming entity export used for form attachments.

Before this change, this query path already respected `ownerOnly` datasets, but it did not apply dataset property-based access filters.

## Where the filtering happens

The filtering is added in `lib/model/query/entities.js`, in the SQL predicate used when building the entity query for the streaming export path.

It is added alongside the existing actor-scoped dataset checks, so the query now enforces both:

- `ownerOnly` restrictions
- dataset access filters from `dataset_access_filters`

## When the filtering applies

This logic applies when the query is executed with an `actorId`, meaning the export is being evaluated in the context of a specific actor whose dataset access should be restricted.

This is not applied when `actorId` is not set, including the case where the requester is an admin or manager who has access to all entities in a dataset via the `entity.list` project verb.

## How the query works

The new condition does the following:

- if the dataset has no access filters, allow the entity through
- otherwise, require at least one matching access-filter rule for the current actor

More specifically, the query:

- checks whether any rows exist in `dataset_access_filters` for the entity's dataset
- if no rows exist, the entity is allowed
- if filters do exist, it joins:
  - `dataset_access_filters`
  - `ds_properties`
  - `actor_property_values`
- then requires:
  - a filter configured for this dataset
  - an `actor_property_values` row for the current `actorId`
  - a match between the entity property value in `entity_defs.data` and the actor property value

In effect, an entity is returned only if:

- the dataset has no access filters, or
- the actor has at least one configured property-value match for that dataset and entity

If multiple access-filter rules are configured for the dataset, this query treats them as ORed together: an entity is included as soon as one configured rule matches the actor's property value.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main regression risk is query cost, since this adds additional existence and join checks during entity selection, although it should still be preferable to exporting a larger unfiltered result set.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No. The API behavior is being brought into line with existing dataset access rules rather than introducing a new API surface.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass, or witnessed GitHub completing all checks with success
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced