### PR TITLE
Usage metrics for 2026.2: User/actor properties for filtering datasets

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/forms/odk-analytics/submissions",
         "formId": "odk-analytics",
-        "version": "v2026.1.0_1"
+        "version": "v2026.2.0_1"
       },
       "mailingListOptIn": {
         "url": "https://data.getodk.cloud/v1/key/Dd0XJq$!skdvUmMLUO1!srDmrxePJSIiGuj3ttbzlayelMxxXMQF3hmeJ24rcT8N/projects/8/forms/mailing_list_opt_in/submissions",

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -177,6 +177,9 @@ const metricsTemplate = {
         "description_length": 0,
         "num_datasets_deleted": 0,
         "num_dataset_properties_deleted": 0,
+        "num_owner_only_datasets_per_project": 0,
+        "num_custom_user_properties": 0,
+        "num_user_property_filtered_datasets": 0,
       },
       "datasets": [{
         "id": 0,

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -795,6 +795,9 @@ const projectMetrics = () => (({ Analytics }) => runSequentially([
   Analytics.countSubmissionsByUserType,
   Analytics.getProjectsWithDescriptions,
   Analytics.countDeletedDatasetAndPropertiesByProject,
+  Analytics.countOwnerOnlyDatasetsPerProject,
+  Analytics.countUserFilteredDatasetsPerProject,
+  Analytics.countCustomPropertiesPerProject,
   Analytics.getDatasets,
   Analytics.getDatasetEvents,
   Analytics.getDatasetProperties,
@@ -802,7 +805,9 @@ const projectMetrics = () => (({ Analytics }) => runSequentially([
 ]).then(([ userRoles, appUsers, deviceIds, pubLinks,
   forms, formGeoRepeats, formsEncrypt, formStates, webforms, reusedIds, entityForms,
   subs, subStates, subEdited, subComments, subUsers,
-  projWithDesc, deletedDatasetCounts, datasets, datasetEvents, datasetProperties, entitiesWithGeometry ]) => {
+  projWithDesc, deletedDatasetCounts,
+  ownerOnlyPerProject, filteredDatasets, customProperties,
+  datasets, datasetEvents, datasetProperties, entitiesWithGeometry ]) => {
   const projects = {};
 
   // users
@@ -974,6 +979,21 @@ const projectMetrics = () => (({ Analytics }) => runSequentially([
     const project = _getProject(projects, row.projectId);
     project.other.num_datasets_deleted = row.dataset_count;
     project.other.num_dataset_properties_deleted = row.property_count;
+  }
+
+  for (const row of ownerOnlyPerProject) {
+    const project = _getProject(projects, row.projectId);
+    project.other.num_owner_only_datasets_per_project = row.dataset_count;
+  }
+
+  for (const row of filteredDatasets) {
+    const project = _getProject(projects, row.projectId);
+    project.other.num_user_property_filtered_datasets = row.dataset_count;
+  }
+
+  for (const row of customProperties) {
+    const project = _getProject(projects, row.projectId);
+    project.other.num_custom_user_properties = row.property_count;
   }
 
   // Order projects by ID

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -757,6 +757,25 @@ const countDeletedDatasetAndPropertiesByProject = () => ({ all }) =>
         AND actees.species = 'dataset'
     GROUP BY projects.id`);
 
+const countOwnerOnlyDatasetsPerProject = () => ({ all }) => all(sql`
+  SELECT COUNT(*) as dataset_count, "projectId" FROM datasets
+  WHERE "ownerOnly" = true
+  GROUP BY "projectId";
+`);
+
+const countUserFilteredDatasetsPerProject = () => ({ all }) => all(sql`
+  SELECT COUNT(DISTINCT d.id) as dataset_count, d."projectId"
+  FROM datasets d
+  JOIN dataset_access_filters daf ON d.id = daf."datasetId"
+  GROUP BY d."projectId";
+`);
+
+const countCustomPropertiesPerProject = () => ({ all }) => all(sql`
+  SELECT COUNT(*) as property_count, "projectId"
+  FROM actor_properties
+  GROUP BY "projectId";
+`);
+
 const projectMetrics = () => (({ Analytics }) => runSequentially([
   Analytics.countUsersPerRole,
   Analytics.countAppUsers,
@@ -1138,5 +1157,8 @@ module.exports = {
   countMultiEntityErrors,
   countEntityBulkDeletes,
   checkLoginCustomization,
-  countDeletedDatasetAndPropertiesByProject
+  countDeletedDatasetAndPropertiesByProject,
+  countOwnerOnlyDatasetsPerProject,
+  countUserFilteredDatasetsPerProject,
+  countCustomPropertiesPerProject
 };

--- a/test/data/odk-analytics.xml
+++ b/test/data/odk-analytics.xml
@@ -4,7 +4,7 @@
     <h:title>ODK Analytics</h:title>
     <model odk:xforms-version="1.0.0">
       <instance>
-        <data id="odk-analytics" version="v2026.1.0_1">
+        <data id="odk-analytics" version="v2026.2.0_1">
           <config>
             <email/>
             <organization/>
@@ -229,6 +229,9 @@
               <description_length/>
               <num_datasets_deleted/>
               <num_dataset_properties_deleted/>
+              <num_owner_only_datasets_per_project/>
+              <num_custom_user_properties/>
+              <num_user_property_filtered_datasets/>
             </other>
           </projects>
           <projects>
@@ -399,6 +402,9 @@
               <description_length/>
               <num_datasets_deleted/>
               <num_dataset_properties_deleted/>
+              <num_owner_only_datasets_per_project/>
+              <num_custom_user_properties/>
+              <num_user_property_filtered_datasets/>
             </other>
           </projects>
           <meta>
@@ -538,6 +544,9 @@
       <bind nodeset="/data/projects/other/description_length" type="int"/>
       <bind nodeset="/data/projects/other/num_datasets_deleted" type="int"/>
       <bind nodeset="/data/projects/other/num_dataset_properties_deleted" type="int"/>
+      <bind nodeset="/data/projects/other/num_owner_only_datasets_per_project" type="int"/>
+      <bind nodeset="/data/projects/other/num_custom_user_properties" type="int"/>
+      <bind nodeset="/data/projects/other/num_user_property_filtered_datasets" type="int"/>
       <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
     </model>
   </h:head>
@@ -1079,6 +1088,15 @@
           </input>
           <input ref="/data/projects/other/num_dataset_properties_deleted">
             <label>Number of dataset property delete events</label>
+          </input>
+          <input ref="/data/projects/other/num_owner_only_datasets_per_project">
+            <label>Number of Entity Lists restricted to Owner Only</label>
+          </input>
+          <input ref="/data/projects/other/num_custom_user_properties">
+            <label>Number of custom user properties</label>
+          </input>
+          <input ref="/data/projects/other/num_user_property_filtered_datasets">
+            <label>Number of Entity Lists restricted by User Properties</label>
           </input>
         </group>
       </repeat>

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -3032,6 +3032,28 @@ describe('analytics task queries @slow', function () {
       await asAlice.delete('/v1/projects/1/datasets/trees')
         .expect(200);
 
+      // Add owner only dataset
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'patients', ownerOnly: true })
+        .expect(200);
+
+      // Add a new actor_property, dataset, and filter
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'households' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/households/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.patch('/v1/projects/1/datasets/households')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
       const res = await container.Analytics.previewMetrics();
 
       // check everything is non-zero

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -2588,7 +2588,6 @@ describe('analytics task queries @slow', function () {
         .expect(200)
         .then(({ body }) => body.id);
 
-      // Create a dataset in new project to be deleted
       await asAlice.post(`/v1/projects/${newProjectId}/datasets`)
         .send({ name: 'people', ownerOnly: true })
         .expect(200);

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -2547,13 +2547,131 @@ describe('analytics task queries @slow', function () {
       await Datasets.purge(true, newProjectId);
 
       const res = await Analytics.countDeletedDatasetAndPropertiesByProject();
-      for (const row in res) {
+      for (const row of res) {
         if (row.projectId === 1) {
           row.dataset_count.should.equal(2);
           row.property_count.should.equal(1);
         } else if (row.projectId === newProjectId) {
           row.dataset_count.should.equal(1);
           row.property_count.should.equal(0);
+        }
+      }
+    }));
+
+    it('should count how many datasets are ownerOnly per project', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'trees' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'households' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'patients' })
+        .expect(200);
+
+      await asAlice.patch('/v1/projects/1/datasets/patients')
+        .send({ ownerOnly: true })
+        .expect(200);
+
+      await asAlice.patch('/v1/projects/1/datasets/households')
+        .send({ ownerOnly: true })
+        .expect(200);
+
+      // Create another project
+      const newProjectId = await asAlice.post('/v1/projects')
+        .set('Content-Type', 'application/json')
+        .send({ name: 'Test Project' })
+        .expect(200)
+        .then(({ body }) => body.id);
+
+      // Create a dataset in new project to be deleted
+      await asAlice.post(`/v1/projects/${newProjectId}/datasets`)
+        .send({ name: 'people', ownerOnly: true })
+        .expect(200);
+
+      // count datasets
+      const res = await container.Analytics.countOwnerOnlyDatasetsPerProject();
+      for (const row of res) {
+        if (row.projectId === 1) {
+          row.dataset_count.should.equal(2);
+        } else if (row.projectId === newProjectId) {
+          row.dataset_count.should.equal(1);
+        }
+      }
+    }));
+
+    it('should count user properties and filtered datasets per project', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'trees' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/trees/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'households' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/households/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/')
+        .send({ name: 'patients' })
+        .expect(200);
+
+      await asAlice.patch('/v1/projects/1/datasets/trees')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      await asAlice.patch('/v1/projects/1/datasets/households')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      // Create another project
+      const newProjectId = await asAlice.post('/v1/projects')
+        .set('Content-Type', 'application/json')
+        .send({ name: 'Test Project' })
+        .expect(200)
+        .then(({ body }) => body.id);
+
+      await asAlice.post(`/v1/projects/${newProjectId}/datasets`)
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.post(`/v1/projects/${newProjectId}/actor-properties`)
+        .send({ name: 'prop1' })
+        .expect(200);
+
+      await asAlice.post(`/v1/projects/${newProjectId}/actor-properties`)
+        .send({ name: 'prop2' })
+        .expect(200);
+
+      await asAlice.post(`/v1/projects/${newProjectId}/actor-properties`)
+        .send({ name: 'prop3' })
+        .expect(200);
+
+      // count datasets
+      const res = await container.Analytics.countUserFilteredDatasetsPerProject();
+      res.should.eql([ { dataset_count: 2, projectId: 1 } ]);
+
+      const properties = await container.Analytics.countCustomPropertiesPerProject();
+      for (const row of properties) {
+        if (row.projectId === 1) {
+          row.property_count.should.equal(1);
+        } else if (row.projectId === newProjectId) {
+          row.property_count.should.equal(3);
         }
       }
     }));


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1846

Adds: 
- "num_owner_only_datasets_per_project"
- "num_custom_user_properties"
- "num_user_property_filtered_datasets"

I noticed the previous ownerOnly dataset count was at the whole system level. Maybe I was in a rush and didn't want to scope it to per-project or I forgot about the "projects.other" category and knew it didn't fit into the other project categories when adding it to the form. This time, I added a new ownerOnly count at the project level. I added the other counts (number of filtered datasets, number of custom properties on a project) to the project.other group, too.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests. Also fixed an existing test I noticed that wasn't iterating correctly.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

#### Before submitting this PR, please make sure you have:

- [ ] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [ ] verified that any code from external sources are properly credited in comments or that everything is internally sourced
