### PR TITLE
test/offline-entities: double timeout

### DIFF
--- a/test/integration/api/offline-entities.js
+++ b/test/integration/api/offline-entities.js
@@ -1924,7 +1924,7 @@ describe('Offline Entities', () => {
   });
 
   describe('locking an entity while processing a related submission @slow', function() {
-    this.timeout(16_000);
+    this.timeout(32_000);
 
     // https://github.com/getodk/central/issues/705
     it('should concurrently process an offline create + update', testServiceFullTrx(async (service, container) => {


### PR DESCRIPTION
Closes getodk/central#2027

#### What has been done to verify that this works as intended?

- [x] ran tests in CI
- [ ] run tests A LOT to ensure that the problem really is a timeout vs a logic failure or deadlock or something

#### Why is this the best possible solution? Were any other approaches considered?

It might be good to understand why such a huge timeout is required.  But it's also good if an intermittent failure can easily be avoided, or at least may to occur less frequently.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just test code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `make test` and confirmed all checks still pass, or witnessed Github completing all checks with success
- [x] verified that any code from external sources are properly credited in comments or that everything is internally sourced
