### PR TITLE
Fixes: dont change etag if submission is made to a different form

### DIFF
--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -558,6 +558,8 @@ const getODataSelectionEtag = (formId, draft, options = QueryOptions.none) => ({
         ${sqlEquals(options.condition)}
         AND
         ${odataExcludeDeleted(options.filter, options.isSubmissionsTable ? odataToColumnMap : odataSubTableToColumnMap)}
+        AND
+        "formId"=${formId}
       )
       ${options.orderby
     ? sql`${odataOrderBy(options.orderby, odataToColumnMap, 'submissions.id')}`

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -659,6 +659,27 @@ describe('api: /forms/:id.svc', () => {
             });
           }))));
 
+    it('should update Etag if a new submission is made', testService(async (service) => {
+      const asAlice = await withSubmissions(service, identity);
+
+      const firstResult = await asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions')
+        .expect(200);
+
+      const etag = firstResult.get('ETag');
+      should.exist(etag);
+
+      await asAlice.post('/v1/projects/1/forms/withrepeat/submissions')
+        .send(testData.instances.withrepeat.three.replaceAll('rthree', 'rfour'))
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      const secondResult = await asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions')
+        .expect(200);
+      should.exist(secondResult);
+
+      secondResult.get('ETag').should.not.equal(etag);
+    }));
+
     it('should not update Etag if submission is made to another form', testService(async (service) => {
       const asAlice = await withSubmissions(service, identity);
 

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -659,6 +659,26 @@ describe('api: /forms/:id.svc', () => {
             });
           }))));
 
+    it('should not update Etag if submission is made to another form', testService(async (service) => {
+      const asAlice = await withSubmissions(service, identity);
+
+      const firstResult = await asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions')
+        .expect(200);
+
+      const etag = firstResult.get('ETag');
+      should.exist(etag);
+
+      await asAlice.post('/v1/projects/1/forms/simple/submissions')
+        .send(testData.instances.simple.one)
+        .set('Content-Type', 'text/xml')
+        .expect(200);
+
+      const secondResult = await asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions')
+        .expect(200);
+
+      secondResult.get('ETag').should.equal(etag);
+    }));
+
     it('should exclude a deleted submission from rows', testService((service) =>
       withSubmissions(service, (asAlice) =>
         asAlice.delete('/v1/projects/1/forms/withrepeat/submissions/rthree')


### PR DESCRIPTION
Towards https://github.com/getodk/central/issues/2028

#### What has been done to verify that this works as intended?

Added a test that fails without the fix.

#### Why is this the best possible solution? Were any other approaches considered?

Added the missing where clause in the sql.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No