### PR TITLE
Fixes: skip etag calc if top=0 and count is true

### DIFF
--- a/lib/formats/odata.js
+++ b/lib/formats/odata.js
@@ -678,9 +678,19 @@ const filterFields = (formFields, select, table) => {
 
 const selectFields = (query, table) => (fields) => (query.$select && query.$select !== '*' ? filterFields(fields, query.$select, table) : fields);
 
+// Returns OData response with empty value array and count (used when $top=0)
+const countOnlyToOData = (table, domain, originalUrl, count) =>
+  `{"value":[],${jsonDataFooter({
+    table,
+    domain,
+    serviceRoot: getServiceRoot(originalUrl),
+    nextUrl: null,
+    count: count != null ? count.toString() : null
+  })}`;
+
 module.exports = {
   odataXmlError, serviceDocumentFor, edmxFor,
-  rowStreamToOData, singleRowToOData,
+  rowStreamToOData, singleRowToOData, countOnlyToOData,
   selectFields, getTableFromOriginalUrl,
   edmxForEntities,
   // exporting for unit tests

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -11,9 +11,9 @@ const { Form } = require('../model/frames');
 const { ensureDef } = require('../model/frame');
 const { getOrNotFound, resolve } = require('../util/promise');
 const { QueryOptions } = require('../util/db');
-const { contentType, xml, json, withEtag } = require('../util/http');
+const { contentType, xml, json, withEtag, isTrue } = require('../util/http');
 const Problem = require('../util/problem');
-const { serviceDocumentFor, edmxFor, rowStreamToOData, singleRowToOData, selectFields, getTableFromOriginalUrl } = require('../formats/odata');
+const { serviceDocumentFor, edmxFor, rowStreamToOData, singleRowToOData, countOnlyToOData, selectFields, getTableFromOriginalUrl } = require('../formats/odata');
 
 module.exports = (service, endpoint) => {
 
@@ -61,7 +61,10 @@ module.exports = (service, endpoint) => {
     service.get(`${base}/:table`, endpoint.odata.json(async ({ Forms, Submissions, env }, { auth, params, originalUrl, query }) => {
       const form = await getForm(Forms, auth, params);
       const options = QueryOptions.fromODataRequest(params, query);
-      const etag = await Submissions.getODataSelectionEtag(form.id, draft, options);
+
+      if (options.limit === 0 && !isTrue(query.$count)) {
+        return json(countOnlyToOData(params.table, env.domain, originalUrl, null));
+      }
 
       const createResponse = () => Promise.all([
         Forms.getFields(form.def.id).then(selectFields(query, params.table)),
@@ -71,6 +74,19 @@ module.exports = (service, endpoint) => {
       ])
         .then(([fields, stream, { count, remaining }]) =>
           json(rowStreamToOData(fields, params.table, env.domain, originalUrl, query, stream, count, remaining)));
+
+      // if $top=0 with $count then just return the count; no need to calculate Etag
+      if (query.$top != null && parseInt(query.$top, 10) === 0 && isTrue(query.$count)) {
+        if (params.table === 'Submissions') {
+          const { count } = await Submissions.countByFormId(form.id, draft, options);
+          return json(countOnlyToOData(params.table, env.domain, originalUrl, count));
+        } else {
+          // For subtable we need to read submission xmls to count
+          return createResponse();
+        }
+      }
+
+      const etag = await Submissions.getODataSelectionEtag(form.id, draft, options);
 
       return withEtag(etag, createResponse, true);
     }));

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -1080,6 +1080,46 @@ describe('api: /forms/:id.svc', () => {
             body['@odata.nextLink'].should.have.skiptoken({ instanceId: 'rthree' });
           }))));
 
+    it('should not use eventhash for ETag when $top=0 with $count on Submissions table', testService((service) =>
+      withSubmissions(service, (asAlice) =>
+        asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions?$top=0&$count=true')
+          .expect(200)
+          .then(({ body, headers }) => {
+            headers.etag.should.not.startWith('W/"eventhash');
+            body.should.eql({
+              '@odata.context': 'http://localhost:8989/v1/projects/1/forms/withrepeat.svc/$metadata#Submissions',
+              '@odata.count': 3,
+              value: []
+            });
+          }))));
+
+    it('should not use eventhash for ETag when $top=0 with $count on subtable', testService((service) =>
+      withSubmissions(service, (asAlice) =>
+        asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions.children.child?$top=0&$count=true')
+          .expect(200)
+          .then(({ body, headers }) => {
+            // expressjs can't add etag for "streaming" response
+            should.not.exist(headers.etag);
+            body.should.eql({
+              '@odata.context': 'http://localhost:8989/v1/projects/1/forms/withrepeat.svc/$metadata#Submissions.children.child',
+              '@odata.nextLink': 'http://localhost:8989/v1/projects/1/forms/withrepeat.svc/Submissions.children.child?%24top=0&%24count=true&%24skiptoken=01eyJyZXBlYXRJZCI6bnVsbH0%3D',
+              '@odata.count': 3,
+              value: []
+            });
+          }))));
+
+    it('should not use eventhash for ETag when $top=0 without $count', testService((service) =>
+      withSubmissions(service, (asAlice) =>
+        asAlice.get('/v1/projects/1/forms/withrepeat.svc/Submissions?$top=0')
+          .expect(200)
+          .then(({ body, headers }) => {
+            headers.etag.should.not.startWith('W/"eventhash');
+            body.should.eql({
+              '@odata.context': 'http://localhost:8989/v1/projects/1/forms/withrepeat.svc/$metadata#Submissions',
+              value: []
+            });
+          }))));
+
     it('should return id-filtered toplevel rows if requested', testService((service) =>
       service.login('alice', (asAlice) =>
         service.login('bob', (asBob) =>


### PR DESCRIPTION
Closes getodk/central#2028

#### What has been done to verify that this works as intended?

Added tests

#### Why is this the best possible solution? Were any other approaches considered?

When $top=0, we can't calculate etag with `getODataSelectionEtag` which relies on the response payload. For count only requests we don't save any computation by having an etag hence removing it seems our best bet.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No