### PR TITLE
migrations/s3-add-skipped-status: remove broken down()

### DIFF
--- a/lib/model/migrations/20251118-01-s3-add-skipped-status.js
+++ b/lib/model/migrations/20251118-01-s3-add-skipped-status.js
@@ -11,8 +11,6 @@ const up = db => db.raw(`
   ALTER TYPE S3_UPLOAD_STATUS ADD VALUE 'skipped'
 `);
 
-const down = db => db.raw(`
-  ALTER TYPE S3_UPLOAD_STATUS DROP VALUE 'skipped'
-`);
+const down = db => {};
 
 module.exports = { up, down };

--- a/lib/model/migrations/20251118-01-s3-add-skipped-status.js
+++ b/lib/model/migrations/20251118-01-s3-add-skipped-status.js
@@ -11,6 +11,6 @@ const up = db => db.raw(`
   ALTER TYPE S3_UPLOAD_STATUS ADD VALUE 'skipped'
 `);
 
-const down = db => {};
+const down = () => {};
 
 module.exports = { up, down };


### PR DESCRIPTION
* down migrations are for dev only
* down migrations are not required
* this migration is more than 6 months old, so unlikely to be reversed

Closes https://github.com/getodk/central/issues/1510

#### What has been done to verify that this works as intended?

Nothing specifically beyond CI - the new version should be a no-op, so it would be hard for it to break.

#### Why is this the best possible solution? Were any other approaches considered?

Given:

* down migrations are for dev only
* down migrations are not required
* this migration is more than 6 months old, so unlikely to be reversed

it doesn't seem worth trying to understand and fix the reverse migration, especially if it's only broken on PG18, which isn't yet supported in this repo.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect - this code is only for devs.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.