### PR TITLE
problem/fieldTypeConflict: make message less ambiguous

### DIFF
--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -91,7 +91,7 @@ const problems = {
 
     formWarnings: problem(400.16, () => 'The Form is valid, but with warnings. Please check the warnings and if they are acceptable resubmit with ?ignoreWarnings=true'),
 
-    fieldTypeConflict: problem(400.17, ({ path, type }) => `The form you have uploaded attempts to change the type of the field at ${path}. In a previous version, it had the type ${type}. Please either return that field to its previous type, or rename the field so it lives at a new path.`),
+    fieldTypeConflict: problem(400.17, ({ path, type }) => `The form you have uploaded attempts to change the type of the field at ${path}. In a previous version, it had the type "${type}". Please either return that field to its previous type, or rename the field so it lives at a new path.`),
 
     unparseableODataExpression: problem(400.18, (({ reason }) => `The OData filter expression you provided could not be parsed: ${reason}`)),
 


### PR DESCRIPTION
Partially closes getodk/central#1205

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

Definitely makes the error less ambiguous.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

If users are parsing these error messages (hopefully not), then they might find something breaks.  Seems unlikely t have a significant effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.