### PR TITLE
/users?q: make search more user-friendly

### DIFF
--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -71,16 +71,16 @@ ${options.ifArg('q', (q) => sql`
     greatest(word_similarity("displayName", ${q}) + similarity("displayName", ${q}),
       word_similarity(email, ${q}) + similarity(email, ${q})) as score on true`)}
 where ${sqlEquals(options.condition)} and actors."deletedAt" is null
-${options.ifArg('q', (q) => {
-  const qMatcher = `%${q.replaceAll(/[_%\\\\]/g, 'g$&')}%`;
-  return sql`
-    AND (
-      score > 0.5 OR
-      "email"       ILIKE ${qMatcher} ESCAPE 'g' OR
-      "displayName" ILIKE ${qMatcher} ESCAPE 'g'
-    )
-  `;
-})}
+  ${options.ifArg('q', (q) => {
+    const qMatcher = `%${q.replaceAll(/[_%\\\\]/g, 'g$&')}%`;
+    return sql`
+      AND (
+        score > 0.5 OR
+        "email"       ILIKE ${qMatcher} ESCAPE 'g' OR
+        "displayName" ILIKE ${qMatcher} ESCAPE 'g'
+      )
+    `;
+  })}
 order by ${options.ifArg('q', () => sql`score desc,`)} email asc 
 ${page(options)}`;
 

--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -72,7 +72,7 @@ ${options.ifArg('q', (q) => sql`
       word_similarity(email, ${q}) + similarity(email, ${q})) as score on true`)}
 where ${sqlEquals(options.condition)} and actors."deletedAt" is null
   ${options.ifArg('q', (q) => {
-    const qMatcher = `%${q.replaceAll(/[_%\\\\]/g, 'g$&')}%`;
+    const qMatcher = `%${q.replaceAll(/[_%\\\\g]/g, 'g$&')}%`;
     return sql`
       AND (
         score > 0.5 OR

--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -72,7 +72,7 @@ ${options.ifArg('q', (q) => sql`
       word_similarity(email, ${q}) + similarity(email, ${q})) as score on true`)}
 where ${sqlEquals(options.condition)} and actors."deletedAt" is null
   ${options.ifArg('q', (q) => {
-    const qMatcher = `%${q.replaceAll(/[_%\\\\g]/g, 'g$&')}%`;
+    const qMatcher = `%${q.replaceAll(/[_%\\g]/g, 'g$&')}%`;
     return sql`
       AND (
         score > 0.5 OR

--- a/lib/model/query/users.js
+++ b/lib/model/query/users.js
@@ -71,7 +71,16 @@ ${options.ifArg('q', (q) => sql`
     greatest(word_similarity("displayName", ${q}) + similarity("displayName", ${q}),
       word_similarity(email, ${q}) + similarity(email, ${q})) as score on true`)}
 where ${sqlEquals(options.condition)} and actors."deletedAt" is null
-  ${options.ifArg('q', () => sql`and score > 0.5`)}
+${options.ifArg('q', (q) => {
+  const qMatcher = `%${q.replaceAll(/[_%\\\\]/g, 'g$&')}%`;
+  return sql`
+    AND (
+      score > 0.5 OR
+      "email"       ILIKE ${qMatcher} ESCAPE 'g' OR
+      "displayName" ILIKE ${qMatcher} ESCAPE 'g'
+    )
+  `;
+})}
 order by ${options.ifArg('q', () => sql`score desc,`)} email asc 
 ${page(options)}`;
 

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -84,7 +84,6 @@ describe('api: /users', () => {
           .then(() => asAlice.get('/v1/users?q=GETO')
             .expect(200)
             .then(({ body }) => {
-              console.log(body);
               body.length.should.equal(4);
               body.forEach((user) => user.should.be.a.User());
               body.map((user) => user.displayName).should.containDeep([ 'Alice', 'Bob', 'Chelsea', 'David' ]);
@@ -99,7 +98,6 @@ describe('api: /users', () => {
           .then(() => asAlice.get('/v1/users?q=GETO')
             .expect(200)
             .then(({ body }) => {
-              console.log(body);
               body.length.should.equal(4);
               body.forEach((user) => user.should.be.a.User());
               body.map((user) => user.displayName).should.containDeep([ 'Alice', 'Bob', 'Chelsea', 'getouttahererightnow!' ]);
@@ -111,12 +109,9 @@ describe('api: /users', () => {
         asAlice.post('/v1/users')
           .send({ email: 'david@closeddatakit.org', displayName: 'geto\\uttahererightnow!' })
           .expect(200)
-          .then(() => all(sql`SELECT * FROM actors`))
-          .then(users => console.log(users))
           .then(() => asAlice.get('/v1/users?q=GETO\\')
             .expect(200)
             .then(({ body }) => {
-              console.log(body);
               body.length.should.equal(2);
               body.forEach((user) => user.should.be.a.User());
               body.map((user) => user.displayName).should.containDeep([ 'Bob', 'geto\\uttahererightnow!' ]);

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -26,6 +26,28 @@ describe('api: /users', () => {
             body.slice(1).map((user) => user.lastLoginAt).should.eql([ null, null]);
           }))));
 
+    it('should escape % in search string', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/users')
+          .send({ email: 'test@email.org', displayName: 'alicia' })
+          .expect(200)
+          .then(() => asAlice.get('/v1/users?q=%')
+            .expect(200)
+            .then(({ body }) => {
+              body.length.should.equal(0);
+            })))));
+
+    it('should escape _ in search string', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/users')
+          .send({ email: 'test@email.org', displayName: 'alicia' })
+          .expect(200)
+          .then(() => asAlice.get('/v1/users?q=_')
+            .expect(200)
+            .then(({ body }) => {
+              body.length.should.equal(0);
+            })))));
+
     it('should search user display names if a query is given', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
@@ -52,6 +74,53 @@ describe('api: /users', () => {
               body.forEach((user) => user.should.be.a.User());
               body.map((user) => user.displayName).should.containDeep([ 'Alice', 'Bob', 'Chelsea' ]);
               body.map((user) => user.email).should.containDeep([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org' ]);
+            })))));
+
+    it('should return sane email matches', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/users')
+          .send({ email: 'getouttahere@closeddatakit.org', displayName: 'David' })
+          .expect(200)
+          .then(() => asAlice.get('/v1/users?q=GETO')
+            .expect(200)
+            .then(({ body }) => {
+              console.log(body);
+              body.length.should.equal(4);
+              body.forEach((user) => user.should.be.a.User());
+              body.map((user) => user.displayName).should.containDeep([ 'Alice', 'Bob', 'Chelsea', 'David' ]);
+              body.map((user) => user.email).should.containDeep([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org', 'getouttahere@closeddatakit.org' ]);
+            })))));
+
+    it('should return sane displayName matches', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/users')
+          .send({ email: 'david@closeddatakit.org', displayName: 'getouttahererightnow!' })
+          .expect(200)
+          .then(() => asAlice.get('/v1/users?q=GETO')
+            .expect(200)
+            .then(({ body }) => {
+              console.log(body);
+              body.length.should.equal(4);
+              body.forEach((user) => user.should.be.a.User());
+              body.map((user) => user.displayName).should.containDeep([ 'Alice', 'Bob', 'Chelsea', 'getouttahererightnow!' ]);
+              body.map((user) => user.email).should.containDeep([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org', 'david@closeddatakit.org' ]);
+            })))));
+
+    it('should escape backslashes in search string', testService((service, { all }) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/users')
+          .send({ email: 'david@closeddatakit.org', displayName: 'geto\\uttahererightnow!' })
+          .expect(200)
+          .then(() => all(sql`SELECT * FROM actors`))
+          .then(users => console.log(users))
+          .then(() => asAlice.get('/v1/users?q=GETO\\')
+            .expect(200)
+            .then(({ body }) => {
+              console.log(body);
+              body.length.should.equal(2);
+              body.forEach((user) => user.should.be.a.User());
+              body.map((user) => user.displayName).should.containDeep([ 'Bob', 'geto\\uttahererightnow!' ]);
+              body.map((user) => user.email).should.containDeep([ 'bob@getodk.org', 'david@closeddatakit.org' ]);
             })))));
 
     it('should search with compound phrases if given', testService((service) =>

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -76,6 +76,20 @@ describe('api: /users', () => {
               body.map((user) => user.email).should.containDeep([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org' ]);
             })))));
 
+    it('should not have a problem with the postgres escape character in searches', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/users')
+          .send({ email: 'abcdef_hijklmnopqrstuvwxyz@example.com', displayName: 'David' })
+          .expect(200)
+          .then(() => asAlice.get('/v1/users?q=g')
+            .expect(200)
+            .then(({ body }) => {
+              body.length.should.equal(3);
+              body.forEach((user) => user.should.be.a.User());
+              body.map((user) => user.displayName).should.containDeep([ 'Alice', 'Bob', 'Chelsea' ]);
+              body.map((user) => user.email).should.containDeep([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org' ]);
+            })))));
+
     it('should return sane email matches', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -104,7 +104,7 @@ describe('api: /users', () => {
               body.map((user) => user.email).should.containDeep([ 'alice@getodk.org', 'bob@getodk.org', 'chelsea@getodk.org', 'david@closeddatakit.org' ]);
             })))));
 
-    it('should escape backslashes in search string', testService((service, { all }) =>
+    it('should escape backslashes in search string', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/users')
           .send({ email: 'david@closeddatakit.org', displayName: 'geto\\uttahererightnow!' })


### PR DESCRIPTION
Closes getodk/central#2053

#### What has been done to verify that this works as intended?

New tests, which pass on this branch.

With `lib/model/query/users.js` from master:

```
  78 passing (3s)
  3 failing

  1) api: /users
       GET
         should return sane email matches:

      AssertionError: expected 1 to be 4
      + expected - actual

      -1
      +4

  2) api: /users
       GET
         should return sane displayName matches:

      AssertionError: expected 1 to be 4
      + expected - actual

      -1
      +4

  3) api: /users
       GET
         should escape backslashes in search string:

      AssertionError: expected 1 to be 2
      + expected - actual

      -1
      +2

```

#### Why is this the best possible solution? Were any other approaches considered?

The search is quite confusing.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Should make life a bit better.  Unlikely to confuse or annoy.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.