### PR TITLE
sentry: reduce ERR_STREAM_PREMATURE_CLOSE noise

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -149,6 +149,11 @@ module.exports = (container) => {
   const { defaultErrorWriter } = require('./endpoint');
   service.use((error, request, response, next) => {
     if (response.headersSent === true) {
+      if (error.code === 'ERR_STREAM_PREMATURE_CLOSE' && request.signal.aborted && !error.cause) {
+        console.debug('DEBUG', request.method, request.originalUrl, error.code, 'request aborted, which caused stream(s) to close'); // eslint-disable-line no-console
+        return;
+      }
+
       // In this case, we'll just let Express fail the request out.
       return next(error);
     }


### PR DESCRIPTION
These Errors aren't very interesting - they're likely the result of a request being terminated by the client.  They happen a lot, and are surfaced in Sentry.  This reduces them from Sentry-logged to console-logged at level DEBUG.

Closes getodk/central#1241

#### What has been done to verify that this works as intended?

Tested locally with cutting a connection midway.

#### Why is this the best possible solution? Were any other approaches considered?

It's the first bit of logging in backend.  It seems like a reasonable thing to log.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No change.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.