### PR TITLE
test/http/preprocessors: test for colons in basic auth password

### DIFF
--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -135,6 +135,21 @@ describe('preprocessors', () => {
           )).then((context) => {
             context.auth.actor.should.eql(Option.of(new Actor({ displayName: 'test' })));
           })));
+
+      it('should treat additional colons as part of password', () =>
+        hashPassword('password:4alice').then((hashed) =>
+          Promise.resolve(authHandler(
+            { Auth, Users: mockUsers('alice@getodk.org', hashed) },
+            new Context(
+              createRequest({ headers: {
+                Authorization: `Basic ${Buffer.from('alice@getodk.org:password:4alice', 'utf8').toString('base64')}`,
+                'X-Forwarded-Proto': 'https'
+              } }),
+              { fieldKey: Option.none() }
+            )
+          )).then((context) => {
+            context.auth.actor.should.eql(Option.of(new Actor({ displayName: 'test' })));
+          })));
     });
 
     describe('by cookie', () => {

--- a/test/unit/http/preprocessors.js
+++ b/test/unit/http/preprocessors.js
@@ -136,7 +136,7 @@ describe('preprocessors', () => {
             context.auth.actor.should.eql(Option.of(new Actor({ displayName: 'test' })));
           })));
 
-      it('should treat additional colons as part of password', () =>
+      it('should handle colons-in-password as part of password (not username)', () =>
         hashPassword('password:4alice').then((hashed) =>
           Promise.resolve(authHandler(
             { Auth, Users: mockUsers('alice@getodk.org', hashed) },


### PR DESCRIPTION
Add test to demonstrate assertion made in https://github.com/getodk/central-backend/pull/1246.

Basic Auth isn't very well specified, and currently this codebase implements its own decoding.  It seems sensible to test for documented behaviours.

#### What has been done to verify that this works as intended?

A new test.

#### Why is this the best possible solution? Were any other approaches considered?

It seems sensible to test for documented behaviours.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just a new test to prevent regression.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.