### PR TITLE
Test OpenRosa hash changes when property is added

### DIFF
--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -8358,6 +8358,29 @@ describe('datasets and entities', () => {
         })));
       }));
 
+      it('changes hash in property-filtered after a dataset property is added', testServiceFullTrx(async (service) => {
+        const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
+
+        // Set up actor properties, assign region 'north' to the app user, and apply filter
+        await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+        await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+          .send({ properties: { region: 'north' } })
+          .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+          .expect(200);
+
+        // Get original hash with
+        const originalHashWithFilter = await getHashAppUser(service, appUser.token);
+
+        // Add an entity property.
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'foo' })
+          .expect(200);
+
+        (await getHashAppUser(service, appUser.token)).should.not.equal(originalHashWithFilter);
+      }));
+
       it('changes hash in property-filtered after a dataset property is deleted', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2024 

There are 3 cases where we check OpenRosa hashes on entity lists:
1. No filters applied
2. OwnerOnly filtering
3. Property filtering

Only the 3rd case was missing a test that the hash changes when a property is added. It had a test for when a property was deleted. 

#### What has been done to verify that this works as intended?

Added a new test that should pass. 

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No changes to code. 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No changes to code.