### PR TITLE
sentry: ignore known REPL issue

### DIFF
--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -14,6 +14,8 @@ const container = require('../util/default-container');
 const Problem = require('../util/problem');
 
 (async () => {
+  container.Sentry.setTag('entrypoint', 'repl');
+
   const context = {
     ..._.omit(container, 'with'),
     container,

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -206,7 +206,7 @@ const _init = (config) => { // eslint-disable-line no-shadow
       const error = hint.originalException;
       if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
 
-      if (process.argv[1]?.match(/lib\/bin\/repl(.js)?$/)) {
+      if (process.argv[1]?.match(/lib\/bin\/repl(\.js)?$/)) {
         // Ignore REPL crashes caused by corrupted history.  See:
         // * https://github.com/getodk/central/issues/2057
         // * https://github.com/nodejs/node/issues/59431

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -205,7 +205,7 @@ const _init = (config) => { // eslint-disable-line no-shadow
       const error = hint.originalException;
       if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
 
-      if (process.argv[1]?.match(/lib\/bin\/repl(\.js)?$/)) {
+      if (event.tags?.entrypoint === 'repl') {
         // Ignore REPL crashes caused by corrupted history.  See:
         // * https://github.com/getodk/central/issues/2057
         // * https://github.com/nodejs/node/issues/59431

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -202,7 +202,6 @@ const _init = (config) => { // eslint-disable-line no-shadow
         sanitizedEvent.extra.duration = Date.now() - sanitizedEvent.extra.startTimestamp;
       }
 
-      // only file the event if it is a bare exception or it is a true 500.x Problem.
       const error = hint.originalException;
       if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
 
@@ -215,6 +214,7 @@ const _init = (config) => { // eslint-disable-line no-shadow
             error.stack.includes('_moveUpOrHistoryPrev')) return null;
       }
 
+      // only file the event if it is a bare exception or it is a true 500.x Problem.
       if ((error.isProblem !== true) || (error.httpCode === 500)) return sanitizedEvent; // throw exceptions.
       return null; // we have a user-space problem.
     }

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -205,6 +205,16 @@ const _init = (config) => { // eslint-disable-line no-shadow
       // only file the event if it is a bare exception or it is a true 500.x Problem.
       const error = hint.originalException;
       if (error == null) return sanitizedEvent; // we aren't sure why there isn't an exception; pass through.
+
+      if (process.argv[1]?.match(/lib\/bin\/repl(.js)?$/)) {
+        // Ignore REPL crashes caused by corrupted history.  See:
+        // * https://github.com/getodk/central/issues/2057
+        // * https://github.com/nodejs/node/issues/59431
+        if (error instanceof TypeError &&
+            error.message === `Cannot read properties of undefined (reading 'length')` &&
+            error.stack.includes('_moveUpOrHistoryPrev')) return null;
+      }
+
       if ((error.isProblem !== true) || (error.httpCode === 500)) return sanitizedEvent; // throw exceptions.
       return null; // we have a user-space problem.
     }


### PR DESCRIPTION
Closes getodk/central#2057

#### What has been done to verify that this works as intended?

- [x] ci
- [x] tested on dev.getodk.cloud

#### Why is this the best possible solution? Were any other approaches considered?

Also considered trying to do something with `uncaughtException` handler in `repl.js`.  This seems more direct, but there are loads of issues with it.  Could also invalidate the user's history once it's corrupt, or prompt them to, but those both seem like a lot of work for a rare case, which should be reasonably well understood.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact expected - should only affect Sentry reporting, and only for a very specific case.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.