### PR TITLE
Add size field to blobs and compute from content length (and backfill)

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -45,6 +45,7 @@ info:
 
     **Changed**:
     - [GET /audits](/central-api-system-endpoints/#getting-audit-log-entries) now uses less-than when filtering with the `end` parameter.
+    - [Form Attachment](/central-api-form-management/#listing-form-attachments) objects now include a `size` field (in bytes) when a file has been uploaded. The field is absent for dataset-linked attachments and empty slots, and may be `null` for blobs uploaded before this version.
 
     ## ODK Central v2026.2
 
@@ -3940,6 +3941,7 @@ paths:
                 exists: true
                 blobExists: true
                 datasetExists: false
+                size: 4096
                 hash: 'd41d8cd98f00b204e9800998ecf8427e'
                 updatedAt: 2018-03-21T12:45:02.312Z
   /v1/projects/{projectId}/forms/{xmlFormId}/attachments/{filename}:
@@ -4419,6 +4421,7 @@ paths:
                 exists: true
                 blobExists: true
                 datasetExists: false
+                size: 4096
                 hash: 'd41d8cd98f00b204e9800998ecf8427e'
                 updatedAt: 2018-03-21T12:45:02.312Z
   /v1/projects/{projectId}/forms/{xmlFormId}/draft/attachments/{filename}:
@@ -5029,6 +5032,7 @@ paths:
                 exists: true
                 blobExists: true
                 datasetExists: false
+                size: 4096
                 hash: 'd41d8cd98f00b204e9800998ecf8427e'
                 updatedAt: 2018-03-21T12:45:02.312Z
   /v1/projects/{projectId}/forms/{xmlFormId}/versions/{version}/attachments/{filename}:
@@ -13033,11 +13037,16 @@ components:
         blobExists:
           type: boolean
           example: true
-          description: Whether the server has the file or not.
+          description: True only when a file has been uploaded for this attachment slot. False when no file has been uploaded, or when the attachment is linked to a Dataset instead of a file.
         datasetExists:
           type: boolean
           example: true
           description: Whether attachment is linked to a Dataset.
+        size:
+          type: integer
+          nullable: true
+          example: 4096
+          description: The size of the uploaded file in bytes. Only present when `blobExists` is `true`. May be `null` for files on external blob store uploaded before version 2026.3.
         updatedAt:
           type: string
           example: '2018-03-21T12:45:02.312Z'

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -132,7 +132,7 @@ Form.Attachment = class extends Frame.define(
       datasetExists: this.datasetId != null
     };
     if (this.updatedAt != null) data.updatedAt = this.updatedAt;
-    if (this.blobId != null) data.size = this.aux.blob?.size; // computed from octet_length(content) on blob table
+    if (this.blobId != null) data.size = this.aux.blob?.size;
     return data;
   }
 };

--- a/lib/model/frames.js
+++ b/lib/model/frames.js
@@ -113,10 +113,13 @@ FieldKey.Extended = Frame.define('lastUsed', readable);
 const { Form } = require('./frames/form');
 Form.Attachment = class extends Frame.define(
   table('form_attachments'),
-  'formId',                             'formDefId',
-  'blobId',                             'datasetId',
-  'name',         readable,             'type',       readable,
-  'updatedAt',    readable,
+  'formId',
+  'formDefId',
+  'blobId',
+  'datasetId',
+  'name', readable,
+  'type', readable,
+  'updatedAt', readable,
   fieldTypes(['int4', 'int4', 'int4', 'int4', 'text', 'text', 'timestamptz'])
 ) {
   forApi() {
@@ -129,6 +132,7 @@ Form.Attachment = class extends Frame.define(
       datasetExists: this.datasetId != null
     };
     if (this.updatedAt != null) data.updatedAt = this.updatedAt;
+    if (this.blobId != null) data.size = this.aux.blob?.size; // computed from octet_length(content) on blob table
     return data;
   }
 };

--- a/lib/model/frames/blob.js
+++ b/lib/model/frames/blob.js
@@ -16,7 +16,7 @@ const { digestWith, md5sum, shasum } = require('../../util/crypto');
 const { pipethroughAndBuffer } = require('../../util/stream');
 
 
-class Blob extends Frame.define(table('blobs'), 'id', 'sha', 'content', 'contentType', 'md5', 's3_status') {
+class Blob extends Frame.define(table('blobs'), 'id', 'sha', 'content', 'contentType', 'md5', 's3_status', 'size') {
   // Given a path to a file on disk (typically written to a temporary location for the
   // duration of the request), will do the work to generate a Blob instance with the
   // appropriate SHA and binary content information. Does _not_ save it to the database;

--- a/lib/model/migrations/20260717-01-add-blob-size.js
+++ b/lib/model/migrations/20260717-01-add-blob-size.js
@@ -1,0 +1,13 @@
+const up = async (db) => {
+  await db.raw('ALTER TABLE blobs ADD COLUMN size integer');
+  // backfill size for blobs whose content is still stored locally. blobs whose
+  // content has already been offloaded to S3 (content IS NULL) cannot be
+  // backfilled and will have a null size.
+  await db.raw('UPDATE blobs SET size = octet_length(content) WHERE content IS NOT NULL');
+};
+
+const down = async (db) => {
+  await db.raw('ALTER TABLE blobs DROP COLUMN size');
+};
+
+module.exports = { up, down };

--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -19,8 +19,8 @@ const ensure = (blob) => ({ oneFirst }) => oneFirst(sql`
     SELECT id FROM blobs WHERE (sha, "contentType") = (${blob.sha}, ${blob.contentType || DEFAULT_CONTENT_TYPE})
   ),
   ensured AS (
-    INSERT INTO blobs (sha, md5, content, "contentType") VALUES (
-      ${blob.sha}, ${blob.md5}, ${sql.binary(blob.content)}, ${blob.contentType || sql`DEFAULT`}
+    INSERT INTO blobs (sha, md5, content, "contentType", size) VALUES (
+      ${blob.sha}, ${blob.md5}, ${sql.binary(blob.content)}, ${blob.contentType || sql`DEFAULT`}, ${blob.content.length}
     )
     ON CONFLICT (sha, "contentType") DO NOTHING
     RETURNING id

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -129,11 +129,11 @@ const autoLinkWithDataset = (form, datasetId) => async ({ FormAttachments, Datas
 // GETTERS
 
 // This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
-const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5'));
+const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5', 'size'));
 
 const _get = (exec, options) =>
   exec(sql`select ${_unjoinMd5.fields} from form_attachments
-  left outer join (select id, md5 from blobs) as blobs on form_attachments."blobId"=blobs.id
+  left outer join (select id, md5, size from blobs) as blobs on form_attachments."blobId"=blobs.id
   where ${sqlEquals(options.condition)} order by name asc`)
     .then(map(_unjoinMd5));
 

--- a/lib/model/query/form-attachments.js
+++ b/lib/model/query/form-attachments.js
@@ -128,14 +128,14 @@ const autoLinkWithDataset = (form, datasetId) => async ({ FormAttachments, Datas
 ////////////////////////////////////////////////////////////////////////////////
 // GETTERS
 
-// This unjoiner pulls md5 from blob table (if it exists) and adds it to attachment frame
-const _unjoinMd5 = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5', 'size'));
+// This unjoiner pulls md5 and size from blob table (if it exists) and adds it to attachment frame
+const _unjoinBlobs = unjoiner(Form.Attachment, Frame.define(into('blob'), 'md5', 'size'));
 
 const _get = (exec, options) =>
-  exec(sql`select ${_unjoinMd5.fields} from form_attachments
+  exec(sql`select ${_unjoinBlobs.fields} from form_attachments
   left outer join (select id, md5, size from blobs) as blobs on form_attachments."blobId"=blobs.id
   where ${sqlEquals(options.condition)} order by name asc`)
-    .then(map(_unjoinMd5));
+    .then(map(_unjoinBlobs));
 
 const getAllByFormDefId = (formDefId, options = QueryOptions.none) => ({ all }) =>
   _get(all, options.withCondition({ formDefId }));

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -217,7 +217,7 @@ should.Assertion.add('ExtendedForm', function() {
 should.Assertion.add('FormAttachment', function() {
   this.params = { operator: 'to be a Form Attachment' };
 
-  Object.keys(this.obj).should.be.a.subsetOf([ 'name', 'type', 'blobExists', 'datasetExists', 'exists', 'hash', 'updatedAt' ]);
+  Object.keys(this.obj).should.be.a.subsetOf([ 'name', 'type', 'blobExists', 'datasetExists', 'exists', 'size', 'hash', 'updatedAt' ]);
   this.obj.name.should.be.a.String();
   this.obj.type.should.be.a.String();
   const { blobExists, datasetExists, exists, hash } = this.obj;

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -227,7 +227,10 @@ should.Assertion.add('FormAttachment', function() {
   exists.should.equal(blobExists || datasetExists);
   (hash != null).should.equal(blobExists);
   if (hash != null) hash.should.be.an.md5Sum();
-  if (this.obj.size != null) this.obj.size.should.be.a.Number();
+  if (this.obj.size != null) {
+    this.obj.size.should.be.a.Number();
+    this.obj.blobExists.should.be.true();
+  }
   if (this.obj.updatedAt != null) this.obj.updatedAt.should.be.an.isoDate();
 });
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -227,6 +227,7 @@ should.Assertion.add('FormAttachment', function() {
   exists.should.equal(blobExists || datasetExists);
   (hash != null).should.equal(blobExists);
   if (hash != null) hash.should.be.an.md5Sum();
+  if (this.obj.size != null) this.obj.size.should.be.a.Number();
   if (this.obj.updatedAt != null) this.obj.updatedAt.should.be.an.isoDate();
 });
 

--- a/test/db-migrations/20260717-01-add-blob-size.spec.js
+++ b/test/db-migrations/20260717-01-add-blob-size.spec.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+
+const { describeMigration } = require('./utils');
+const { aBlobWith } = require('./fixtures');
+
+describeMigration('20260717-01-add-blob-size', ({ runMigrationBeingTested }) => {
+  const localContent = Buffer.from('hello world');
+  const localBlob = aBlobWith({ contentType: 'text/plain' });
+  const s3Blob = aBlobWith({ contentType: 'text/plain' });
+
+  before(async () => {
+    // Insert a blob with local content (not on S3)
+    await db.query(sql`
+      INSERT INTO blobs (md5, sha, "contentType", content, s3_status)
+        VALUES (${localBlob.md5}, ${localBlob.sha}, ${localBlob.contentType}, ${sql.binary(localContent)}, 'pending')
+    `);
+
+    // Insert a blob whose content has been offloaded to S3 (content IS NULL)
+    await db.query(sql`
+      INSERT INTO blobs (md5, sha, "contentType", content, s3_status)
+        VALUES (${s3Blob.md5}, ${s3Blob.sha}, ${s3Blob.contentType}, NULL, 'uploaded')
+    `);
+
+    await runMigrationBeingTested();
+  });
+
+  it('should backfill size for blobs with local content', async () => {
+    const { size } = await db.one(sql`SELECT size FROM blobs WHERE sha=${localBlob.sha}`);
+    assert.equal(size, localContent.length);
+  });
+
+  it('should not backfill size for blobs already uploaded to S3', async () => {
+    const { size } = await db.one(sql`SELECT size FROM blobs WHERE sha=${s3Blob.sha}`);
+    assert.equal(size, null);
+  });
+});

--- a/test/integration/api/forms/draft.js
+++ b/test/integration/api/forms/draft.js
@@ -572,7 +572,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2af2751b79eccfaa8f452331e76e679e' },
+                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 19, hash: '2af2751b79eccfaa8f452331e76e679e' },
                   { name: 'greattwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
                 ]);
               })))));
@@ -604,7 +604,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2af2751b79eccfaa8f452331e76e679e' },
+                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 19, hash: '2af2751b79eccfaa8f452331e76e679e' },
                   { name: 'greattwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
                 ]);
               })))));
@@ -1744,7 +1744,7 @@ describe('api: /projects/:id/forms (drafts)', () => {
                 // eslint-disable-next-line no-param-reassign
                 delete body[0].updatedAt;
                 body.should.eql([
-                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2af2751b79eccfaa8f452331e76e679e' },
+                  { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 19, hash: '2af2751b79eccfaa8f452331e76e679e' },
                   { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
                 ]);
               })))));

--- a/test/integration/api/forms/forms.js
+++ b/test/integration/api/forms/forms.js
@@ -1397,9 +1397,8 @@ describe('api: /projects/:id/forms (create, read, update)', () => {
                   body[0].updatedAt.should.be.a.recentIsoDate();
                   // eslint-disable-next-line no-param-reassign
                   delete body[0].updatedAt;
-
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
+                    { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 12, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
                     { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
                   ]);
                 })))));

--- a/test/integration/api/forms/versions.js
+++ b/test/integration/api/forms/versions.js
@@ -454,7 +454,7 @@ describe('api: /projects/:id/forms (versions)', () => {
                   delete body[0].updatedAt;
 
                   body.should.eql([
-                    { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2af2751b79eccfaa8f452331e76e679e' },
+                    { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 19, hash: '2af2751b79eccfaa8f452331e76e679e' },
                     { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
                   ]);
                 })))));

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -151,9 +151,9 @@ describe('blob query module', () => {
         .then(() => container.oneFirst(sql`select count(*) from blobs`))
         .then((count) => count.should.equal(1))))); //
 
-  it('should store size as byte length when a blob is created via form attachment', testService(async (service, container) => {
+  it('should store size as byte length when a blob is created via form attachment', testService(async (service) => {
     const asAlice = await service.login('alice');
-    const bufferContent = Buffer.from('some,csv,data');
+    const bufferContent = Buffer.from('📊');
 
     await asAlice.post('/v1/projects/1/forms')
       .set('Content-Type', 'application/xml')
@@ -163,9 +163,9 @@ describe('blob query module', () => {
     await asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
       .set('Content-Type', 'text/csv')
       .send(bufferContent)
-      .expect(200);
-
-    const { size } = await container.one(sql`SELECT size FROM blobs LIMIT 1`);
-    size.should.equal(bufferContent.length);
+      .expect(200)
+      .then(({ body }) => {
+        body.size.should.equal(4);
+      });
   }));
 });

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -1,3 +1,5 @@
+const should = require('should');
+
 const { readFileSync } = require('fs');
 const appPath = require('app-root-path');
 const { sql } = require('slonik');
@@ -166,6 +168,56 @@ describe('blob query module', () => {
       .expect(200)
       .then(({ body }) => {
         body.size.should.equal(4);
+      });
+  }));
+
+  it('should not recompute size when blob with same hash comes in', testService(async (service, container) => {
+    const asAlice = await service.login('alice');
+    const bufferContent = Buffer.from('some,csv,data');
+
+    await asAlice.post('/v1/projects/1/forms')
+      .set('Content-Type', 'application/xml')
+      .send(testData.forms.withAttachments)
+      .expect(200);
+
+    await asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+      .set('Content-Type', 'text/csv')
+      .send(bufferContent)
+      .expect(200)
+      .then(({ body }) => {
+        body.size.should.equal(13);
+      });
+
+    // simulate uploading to s3 before migration: content is set to null, status set to uploaded, size is not filled in
+    await container.run(sql`update blobs set size = null, content = null, s3_status = 'uploaded'`);
+    await asAlice.get('/v1/projects/1/forms/withAttachments/draft/attachments')
+      .expect(200)
+      .then(({ body }) => {
+        body[0].name.should.equal('goodone.csv');
+        should.not.exist(body[0].size);
+      });
+
+    // create a new form with a new attachment that uses the same underlying blob
+    await asAlice.post('/v1/projects/1/forms')
+      .set('Content-Type', 'application/xml')
+      .send(testData.forms.consumeDatasets)
+      .expect(200);
+
+    // reupload the file to new form attachment
+    // hash of contents will match with existing blob and blob will not be re-written, causing size to remain null
+    await asAlice.post('/v1/projects/1/forms/consumeDatasets/draft/attachments/people.csv')
+      .set('Content-Type', 'text/csv')
+      .send(bufferContent)
+      .expect(200)
+      .then(({ body }) => {
+        should.not.exist(body.size);
+      });
+
+    await asAlice.get('/v1/projects/1/forms/consumeDatasets/draft/attachments')
+      .expect(200)
+      .then(({ body }) => {
+        body[0].name.should.equal('people.csv');
+        should.not.exist(body[0].size);
       });
   }));
 });

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -150,4 +150,22 @@ describe('blob query module', () => {
         .then(() => container.Blobs.purgeUnattached())
         .then(() => container.oneFirst(sql`select count(*) from blobs`))
         .then((count) => count.should.equal(1))))); //
+
+  it('should store size as byte length when a blob is created via form attachment', testService(async (service, container) => {
+    const asAlice = await service.login('alice');
+    const bufferContent = Buffer.from('some,csv,data');
+
+    await asAlice.post('/v1/projects/1/forms')
+      .set('Content-Type', 'application/xml')
+      .send(testData.forms.withAttachments)
+      .expect(200);
+
+    await asAlice.post('/v1/projects/1/forms/withAttachments/draft/attachments/goodone.csv')
+      .set('Content-Type', 'text/csv')
+      .send(bufferContent)
+      .expect(200);
+
+    const { size } = await container.one(sql`SELECT size FROM blobs LIMIT 1`);
+    size.should.equal(bufferContent.length);
+  }));
 });

--- a/test/integration/other/form-entities-version.js
+++ b/test/integration/other/form-entities-version.js
@@ -303,7 +303,7 @@ describe('Update / migrate entities-version within form', () => {
           // eslint-disable-next-line no-param-reassign
           delete body[0].updatedAt;
           body.should.eql([
-            { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
+            { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 12, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
             { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
           ]);
         });
@@ -339,7 +339,7 @@ describe('Update / migrate entities-version within form', () => {
           // eslint-disable-next-line no-param-reassign
           delete body[0].updatedAt;
           body.should.eql([
-            { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
+            { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 12, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
             { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
           ]);
         });
@@ -350,7 +350,7 @@ describe('Update / migrate entities-version within form', () => {
           // eslint-disable-next-line no-param-reassign
           delete body[0].updatedAt;
           body.should.eql([
-            { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
+            { name: 'goodone.csv', type: 'file', exists: true, blobExists: true, datasetExists: false, size: 12, hash: '2241de57bbec8144c8ad387e69b3a3ba' },
             { name: 'goodtwo.mp3', type: 'audio', exists: false, blobExists: false, datasetExists: false, hash: null }
           ]);
         });

--- a/test/integration/task/s3.js
+++ b/test/integration/task/s3.js
@@ -198,6 +198,26 @@ describe('task: s3', () => {
         (await container.Audits.getLatestByAction('blobs.s3.upload')).get().details.should.containEql({ uploaded: 1, failed: 0 });
       }));
 
+      it('should retain blob size after content is offloaded to s3', testTask(async (container) => {
+        // given
+        const blob = await Blob.fromBuffer(crypto.randomBytes(100));
+        const blobId = await container.Blobs.ensure(blob);
+
+        // expect: size is populated and content is present before upload
+        const before = await container.one(sql`SELECT size, (content IS NOT NULL) AS "hasContent" FROM blobs WHERE id=${blobId}`);
+        before.size.should.equal(100);
+        before.hasContent.should.equal(true);
+
+        // when
+        await uploadPending();
+
+        // then: content has been offloaded to s3 but size is retained
+        assertUploadCount(1);
+        const after = await container.one(sql`SELECT size, (content IS NOT NULL) AS "hasContent" FROM blobs WHERE id=${blobId}`);
+        after.size.should.equal(100);
+        after.hasContent.should.equal(false);
+      }));
+
       describe('with delayed s3 upload', () => {
         let restoreS3mock;
         let resumeFirstUpload;


### PR DESCRIPTION
Part of closing https://github.com/getodk/central/issues/1895 

I was first considering just computing the size of every blob with `octet_length(content)` because I believe it just looks up `bytea` metadata and isn't an expensive query. 

But I wanted to also track the size for blobs that were uploaded to S3, so I went with this other approach of adding a `size` column and populating it on insert. Blobs that have already been moved to S3 won't have size information. Blobs that are later uploaded but match a blob on S3 also won't go through this insert path so they also wont have size information. 

The only place the blob size is returned in the API is through form attachments because I think that's the only place it's currently needed..

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests and trying it with frontend.

#### Why is this the best possible solution? Were any other approaches considered?

The issue [mentioned](https://github.com/getodk/central/issues/1895#issuecomment-4455644381) some other ways of capturing the content size but we can get it pretty easily from the content itself as it comes in. Those comments might be more about backfilling S3 blobs, but the overall consensus is that that doesn't seem worth it, just handling regular blobs and new blobs is good enough. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Touches blob upload path but I don't think it will hurt anything for users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Made small change to API docs in this PR.