### PR TITLE
test-integration: mark FullTrx tests as slow

### DIFF
--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -4704,7 +4704,7 @@ describe('datasets and entities', () => {
 
       describe('dataset-specific verbs', () => {
         describe('dataset.create', () => {
-          it('should NOT allow a new form that creates a dataset without user having dataset.create verb', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow a new form that creates a dataset without user having dataset.create verb @slow', testServiceFullTrx(async (service, { run }) => {
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.create') WHERE system in ('manager')`);
 
             const asBob = await service.login('bob');
@@ -4721,7 +4721,7 @@ describe('datasets and entities', () => {
               .expect(403);
           }));
 
-          it('should NOT allow "creating" of a dataset when the dataset exists but unpublished', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow "creating" of a dataset when the dataset exists but unpublished @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.create') WHERE system in ('manager')`);
@@ -4740,7 +4740,7 @@ describe('datasets and entities', () => {
               .expect(403);
           }));
 
-          it('should NOT allow updating a form about an unpublished dataset, which is similar to creating that dataset', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow updating a form about an unpublished dataset, which is similar to creating that dataset @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.create') WHERE system in ('manager')`);
@@ -4758,7 +4758,7 @@ describe('datasets and entities', () => {
               .expect(403);
           }));
 
-          it('should NOT allow updating a draft that creates a dataset without user having dataset.create verb', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow updating a draft that creates a dataset without user having dataset.create verb @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.create') WHERE system in ('manager')`);
@@ -4776,7 +4776,7 @@ describe('datasets and entities', () => {
               .expect(403);
           }));
 
-          it('should NOT allow unpublished dataset to be published on form publish if user does not have dataset.create verb', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow unpublished dataset to be published on form publish if user does not have dataset.create verb @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.create') WHERE system in ('manager')`);
@@ -4794,7 +4794,7 @@ describe('datasets and entities', () => {
         });
 
         describe('dataset.update', () => {
-          it('should NOT allow a new form that updates a dataset without user having dataset.update verb', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow a new form that updates a dataset without user having dataset.update verb @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
 
@@ -4818,7 +4818,7 @@ describe('datasets and entities', () => {
               .expect(403);
           }));
 
-          it('should NOT allow update draft that updates a dataset without user having dataset.update verb', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow update draft that updates a dataset without user having dataset.update verb @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.update') WHERE system in ('manager')`);
@@ -4835,7 +4835,7 @@ describe('datasets and entities', () => {
               .expect(403);
           }));
 
-          it('should NOT allow unpublished properties to be published on form publish if user does not have dataset.update verb', testServiceFullTrx(async (service, { run }) => {
+          it('should NOT allow unpublished properties to be published on form publish if user does not have dataset.update verb @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.update') WHERE system in ('manager')`);
@@ -4860,7 +4860,7 @@ describe('datasets and entities', () => {
               .expect(403);
           }));
 
-          it('should ALLOW update of form draft that does not modify existing dataset', testServiceFullTrx(async (service, { run }) => {
+          it('should ALLOW update of form draft that does not modify existing dataset @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.update') WHERE system in ('manager')`);
@@ -4878,7 +4878,7 @@ describe('datasets and entities', () => {
               .expect(200);
           }));
 
-          it('should ALLOW new form about existing dataset that does not update it', testServiceFullTrx(async (service, { run }) => {
+          it('should ALLOW new form about existing dataset that does not update it @slow', testServiceFullTrx(async (service, { run }) => {
             const asAlice = await service.login('alice');
             const asBob = await service.login('bob');
             await run(sql`UPDATE roles SET verbs = (verbs - 'dataset.update') WHERE system in ('manager')`);
@@ -7327,7 +7327,7 @@ describe('datasets and entities', () => {
         treeETagForAlice.should.equal(treeETagForChelsea);
       }));
 
-      it('changes hash after a data collector creates an entity', testServiceFullTrx(async (service, container) => {
+      it('changes hash after a data collector creates an entity @slow', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7343,7 +7343,7 @@ describe('datasets and entities', () => {
         (await getHash(asChelsea)).should.not.equal(originalHash);
       }));
 
-      it('does not change hash after someone else creates an entity', testServiceFullTrx(async (service) => {
+      it('does not change hash after someone else creates an entity @slow', testServiceFullTrx(async (service) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7360,7 +7360,7 @@ describe('datasets and entities', () => {
         (await getHash(asChelsea)).should.equal(originalHash);
       }));
 
-      it('changes hash after an entity is updated', testServiceFullTrx(async (service, container) => {
+      it('changes hash after an entity is updated @slow', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7380,7 +7380,7 @@ describe('datasets and entities', () => {
         (await getHash(asChelsea)).should.not.equal(originalHash);
       }));
 
-      it('changes hash after an entity is deleted', testServiceFullTrx(async (service, container) => {
+      it('changes hash after an entity is deleted @slow', testServiceFullTrx(async (service, container) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7482,7 +7482,7 @@ describe('datasets and entities', () => {
         [hash1, hash2, hash3].should.be.unique();
       }));
 
-      it('changes hash after a dataset property is added', testServiceFullTrx(async (service) => {
+      it('changes hash after a dataset property is added @slow', testServiceFullTrx(async (service) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7496,7 +7496,7 @@ describe('datasets and entities', () => {
         (await getHash(asChelsea)).should.not.equal(originalHash);
       }));
 
-      it('changes hash after a dataset property is deleted', testServiceFullTrx(async (service) => {
+      it('changes hash after a dataset property is deleted @slow', testServiceFullTrx(async (service) => {
         const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
         await createData(asAlice);
         await assignToProject(asAlice, asChelsea, 'formfill');
@@ -7970,7 +7970,7 @@ describe('datasets and entities', () => {
         return { asAlice, appUser };
       };
 
-      it('hash changes for alice AND for app user when entity outside segment is added', testServiceFullTrx(async (service) => {
+      it('hash changes for alice AND for app user when entity outside segment is added @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Before the filter is applied, both see the same hash and all entities
@@ -8011,7 +8011,7 @@ describe('datasets and entities', () => {
         (await getHashAppUser(service, appUser.token)).should.not.equal(appUserHashAfterFilter);
       }));
 
-      it('hash changes for app user when filter rules are first added', testServiceFullTrx(async (service) => {
+      it('hash changes for app user when filter rules are first added @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties and assign region 'north' to the app user (no filter yet)
@@ -8038,7 +8038,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(1);
       }));
 
-      it('hash changes for app user when filter rules are removed', testServiceFullTrx(async (service) => {
+      it('hash changes for app user when filter rules are removed @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties, assign region 'north' to the app user, and apply filter
@@ -8068,7 +8068,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(2);
       }));
 
-      it('hash changes for app user when their actor property value changes', testServiceFullTrx(async (service) => {
+      it('hash changes for app user when their actor property value changes @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         await asAlice.post('/v1/projects/1/datasets/people/properties')
@@ -8105,7 +8105,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(1);
       }));
 
-      it('hash changes for app user when their actor property value is assigned for the first time', testServiceFullTrx(async (service) => {
+      it('hash changes for app user when their actor property value is assigned for the first time @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties and apply filter — but do NOT assign a value to the app user yet
@@ -8133,7 +8133,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(1);
       }));
 
-      it('two app users with different property values get different hashes', testServiceFullTrx(async (service) => {
+      it('two app users with different property values get different hashes @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser: northUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Create a second app user assigned to the same form
@@ -8163,7 +8163,7 @@ describe('datasets and entities', () => {
         northHash.should.not.equal(southHash);
       }));
 
-      it('when user has no property set, hash changes when filter is added AND ALSO when entities are added outside the empty segment', testServiceFullTrx(async (service) => {
+      it('when user has no property set, hash changes when filter is added AND ALSO when entities are added outside the empty segment @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Before filter: app user sees all entities
@@ -8194,7 +8194,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(0);
       }));
 
-      it('hash changes when an entity in the app user segment is updated', testServiceFullTrx(async (service) => {
+      it('hash changes when an entity in the app user segment is updated @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties, apply filter, assign 'north' to app user
@@ -8222,7 +8222,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(1);
       }));
 
-      it('hash DOES change when an entity outside the app user segment is updated', testServiceFullTrx(async (service) => {
+      it('hash DOES change when an entity outside the app user segment is updated @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties, apply filter, assign 'north' to app user
@@ -8250,7 +8250,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(1);
       }));
 
-      it('hash changes when the filter rule mapping is changed', testServiceFullTrx(async (service) => {
+      it('hash changes when the filter rule mapping is changed @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Add a second dataset property 'district' and a second actor property 'district'
@@ -8282,7 +8282,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(0);
       }));
 
-      it('hash changes for filtered app user when a new dataset property is added', testServiceFullTrx(async (service) => {
+      it('hash changes for filtered app user when a new dataset property is added @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up filter: region → region, assign 'north' to app user
@@ -8358,7 +8358,7 @@ describe('datasets and entities', () => {
         })));
       }));
 
-      it('changes hash in property-filtered after a dataset property is added', testServiceFullTrx(async (service) => {
+      it('changes hash in property-filtered after a dataset property is added @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties, assign region 'north' to the app user, and apply filter
@@ -8381,7 +8381,7 @@ describe('datasets and entities', () => {
         (await getHashAppUser(service, appUser.token)).should.not.equal(originalHashWithFilter);
       }));
 
-      it('changes hash in property-filtered after a dataset property is deleted', testServiceFullTrx(async (service) => {
+      it('changes hash in property-filtered after a dataset property is deleted @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties, assign region 'north' to the app user, and apply filter
@@ -8407,7 +8407,7 @@ describe('datasets and entities', () => {
         (await getHashAppUser(service, appUser.token)).should.not.equal(originalHashWithFilter);
       }));
 
-      it('hash changes and count changes when an entity in the segment is deleted', testServiceFullTrx(async (service) => {
+      it('hash changes and count changes when an entity in the segment is deleted @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties, apply filter, assign 'north' to app user
@@ -8434,7 +8434,7 @@ describe('datasets and entities', () => {
         (await countEntities(service, null, appUser.token)).should.equal(0);
       }));
 
-      it('hash changes even when count stays the same (delete one, add one in segment)', testServiceFullTrx(async (service) => {
+      it('hash changes even when count stays the same (delete one, add one in segment) @slow', testServiceFullTrx(async (service) => {
         const { asAlice, appUser } = await setupPeopleDatasetWithAppUser(service);
 
         // Set up actor properties, apply filter, assign 'north' to app user
@@ -8505,7 +8505,7 @@ describe('datasets and entities', () => {
       return hash;
     };
 
-    it('hash changes when an entity is added', testServiceFullTrx(async (service) => {
+    it('hash changes when an entity is added @slow', testServiceFullTrx(async (service) => {
       const { asAlice } = await setup(service);
 
       const hashBefore = await getHash(asAlice);
@@ -8517,7 +8517,7 @@ describe('datasets and entities', () => {
       (await getHash(asAlice)).should.not.equal(hashBefore);
     }));
 
-    it('hash changes when an entity is updated', testServiceFullTrx(async (service) => {
+    it('hash changes when an entity is updated @slow', testServiceFullTrx(async (service) => {
       const { asAlice, entityUuid } = await setup(service);
 
       const hashBefore = await getHash(asAlice);
@@ -8529,7 +8529,7 @@ describe('datasets and entities', () => {
       (await getHash(asAlice)).should.not.equal(hashBefore);
     }));
 
-    it('hash changes when an entity is deleted', testServiceFullTrx(async (service) => {
+    it('hash changes when an entity is deleted @slow', testServiceFullTrx(async (service) => {
       const { asAlice, entityUuid } = await setup(service);
 
       const hashBefore = await getHash(asAlice);
@@ -8540,7 +8540,7 @@ describe('datasets and entities', () => {
       (await getHash(asAlice)).should.not.equal(hashBefore);
     }));
 
-    it('two app users with no filter get the same hash', testServiceFullTrx(async (service) => {
+    it('two app users with no filter get the same hash @slow', testServiceFullTrx(async (service) => {
       const { asAlice } = await setup(service);
 
       const { body: appUserA } = await asAlice.post('/v1/projects/1/app-users')
@@ -8559,7 +8559,7 @@ describe('datasets and entities', () => {
       hashA.should.equal(hashB);
     }));
 
-    it('alice (manager) and an app user get the same hash when there is no filter', testServiceFullTrx(async (service) => {
+    it('alice (manager) and an app user get the same hash when there is no filter @slow', testServiceFullTrx(async (service) => {
       const { asAlice } = await setup(service);
 
       const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
@@ -9286,7 +9286,7 @@ describe('datasets and entities', () => {
         });
     }));
 
-    it('should reject if there is a draft Form consuming the dataset', testServiceFullTrx(async (service) => {
+    it('should reject if there is a draft Form consuming the dataset @slow', testServiceFullTrx(async (service) => {
       const asAlice = await service.login('alice');
 
       await asAlice.post('/v1/projects/1/datasets')

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -2003,7 +2003,7 @@ describe('Entities API', () => {
     // `getById` creates an advisory lock which blocks other transactions to do the same.
     // Once first transaction updates the Entity, only then second transaction is able
     // to get the Entity.
-    it('should not allow parallel updates to the same Entity', testServiceFullTrx(async (service, container) => {
+    it('should not allow parallel updates to the same Entity @slow', testServiceFullTrx(async (service, container) => {
 
       const asAlice = await service.login('alice');
 
@@ -2554,7 +2554,7 @@ describe('Entities API', () => {
           });
       }));
 
-      it('should not create any entities there is a UUID collision', testServiceFullTrx(async (service) => {
+      it('should not create any entities there is a UUID collision @slow', testServiceFullTrx(async (service) => {
         const asAlice = await service.login('alice');
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
@@ -2621,7 +2621,7 @@ describe('Entities API', () => {
           });
       }));
 
-      it('should not create any entities if there is a UUID collision with soft deleted Entity', testServiceFullTrx(async (service) => {
+      it('should not create any entities if there is a UUID collision with soft deleted Entity @slow', testServiceFullTrx(async (service) => {
         const asAlice = await service.login('alice');
 
         await asAlice.post('/v1/projects/1/forms?publish=true')

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1693,7 +1693,7 @@ describe('api: /forms/:id/submissions', () => {
         .expect(404);
     }));
 
-    it('should not let a submission with the same instanceId as a deleted submission be sent', testServiceFullTrx(async (service, { Submissions }) => {
+    it('should not let a submission with the same instanceId as a deleted submission be sent @slow', testServiceFullTrx(async (service, { Submissions }) => {
       const asAlice = await service.login('alice');
 
       await asAlice.post('/v1/projects/1/forms/simple/submissions')

--- a/test/integration/task/log-upgrade.js
+++ b/test/integration/task/log-upgrade.js
@@ -3,7 +3,7 @@ const { sql } = require('slonik');
 const { testTaskFullTrx, } = require('../setup');
 const { logUpgrade } = require(appRoot + '/lib/task/log-upgrade');
 
-describe('task: log-upgrade', () => {
+describe('task: log-upgrade @slow', () => {
   it('should log upgrade if no previous upgrade event exists', testTaskFullTrx(async ({ Audits }) => {
     await logUpgrade({ version: '1234', server: 'cb1', client: 'cf1' });
     const audit = await Audits.getLatestByAction('upgrade.server').then(o => o.get());

--- a/test/integration/task/s3.js
+++ b/test/integration/task/s3.js
@@ -218,7 +218,7 @@ describe('task: s3', () => {
           restoreS3mock();
         });
 
-        it('should not attempt to upload an in-progress blob', testTaskFullTrx(async (container) => {
+        it('should not attempt to upload an in-progress blob @slow', testTaskFullTrx(async (container) => {
           await aBlobExistsWith(container, { status: 'pending' });
 
           // when

--- a/test/integration/worker/worker.js
+++ b/test/integration/worker/worker.js
@@ -36,7 +36,7 @@ describe('worker', () => {
       queue.run({ action: 'test.event' }, done).should.equal(true);
     });
 
-    it('should pass the container and event details to the job', testContainerFullTrx(async (container) => {
+    it('should pass the container and event details to the job @slow', testContainerFullTrx(async (container) => {
       const sentineledContainer = container.with({ testSentinel: 108 });
       const event = { id: -1, action: 'test.event', details: { x: 42 } };
 
@@ -54,7 +54,7 @@ describe('worker', () => {
       checked.should.equal(true);
     }));
 
-    it('should run all matched jobs', testContainerFullTrx(async (container) => {
+    it('should run all matched jobs @slow', testContainerFullTrx(async (container) => {
       let count = 0;
       const jobMap = { 'test.event': [
         // eslint-disable-next-line no-return-assign
@@ -68,7 +68,7 @@ describe('worker', () => {
       count.should.equal(2);
     }));
 
-    it('should mark the event as processed after on job completion', testContainerFullTrx(async (container) => {
+    it('should mark the event as processed after on job completion @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.create', alice.actor);
@@ -80,7 +80,7 @@ describe('worker', () => {
       after.processed.should.be.a.recentDate();
     }));
 
-    it('should log to Sentry if a worker goes wrong', testContainerFullTrx(async (container) => {
+    it('should log to Sentry if a worker goes wrong @slow', testContainerFullTrx(async (container) => {
       let captured = null;
       const Sentry = { captureException(err) { captured = err; } };
       const hijackedContainer = container.with({ Sentry });
@@ -94,7 +94,7 @@ describe('worker', () => {
 
     // ideally we'd test that the error gets written to stderr but i don't like
     // hijacking globals in tests.
-    it('should still survive and reschedule if Sentry goes wrong', testContainerFullTrx(async (container) => {
+    it('should still survive and reschedule if Sentry goes wrong @slow', testContainerFullTrx(async (container) => {
       // eslint-disable-next-line no-throw-literal
       const Sentry = { captureException() { throw 'no sentry for you'; } };
       const hijackedContainer = container.with({ Sentry });
@@ -108,7 +108,7 @@ describe('worker', () => {
     // we need to use a real event here that doesn't get auto-marked as processed, so
     // we can test that it is not indeed processed afterwards.
     // TODO: we should be able to not do this as of block 8.
-    it('should unclaim the event and mark failure in case of failure', testContainerFullTrx(async (container) => {
+    it('should unclaim the event and mark failure in case of failure @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -123,7 +123,7 @@ describe('worker', () => {
       after.lastFailure.should.be.a.recentDate();
     }));
 
-    it('should roll back changes in case of error in any job', testContainerFullTrx(async (container) => {
+    it('should roll back changes in case of error in any job @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -256,7 +256,7 @@ describe('worker', () => {
   describe('loop', () => {
     const millis = (x) => new Promise((done) => { setTimeout(done, x); });
 
-    it('should run a full loop right away', testContainerFullTrx(async (container) => {
+    it('should run a full loop right away @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -275,7 +275,7 @@ describe('worker', () => {
       ran.should.equal(true);
     }));
 
-    it('should run two full loops right away', testContainerFullTrx(async (container) => {
+    it('should run two full loops right away @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -294,7 +294,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
       await millis(20); // ditto above
     }));
 
-    it('should run two full loops with an idle cycle in between', testContainerFullTrx(async (container) => {
+    it('should run two full loops with an idle cycle in between @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -319,7 +319,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
       await millis(20); // ditto above
     }));
 
-    it('should restart if the check fails prequery', testContainerFullTrx(async (container) => {
+    it('should restart if the check fails prequery @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -348,7 +348,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
       failed.should.equal(true);
     }));
 
-    it('should restart if the check fails in-query', testContainerFullTrx(async (container) => {
+    it('should restart if the check fails in-query @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);
@@ -378,7 +378,7 @@ select count(*) from audits where action='submission.attachment.update' and proc
       failed.should.equal(true);
     }));
 
-    it('should restart if the process itself fails', testContainerFullTrx(async (container) => {
+    it('should restart if the process itself fails @slow', testContainerFullTrx(async (container) => {
       const { Audits, Users } = container;
       const alice = (await Users.getByEmail('alice@getodk.org')).get();
       await Audits.log(alice.actor, 'submission.attachment.update', alice.actor);


### PR DESCRIPTION
Closes getodk/central#2076

#### What has been done to verify that this works as intended?

##### This branch

```sh
time make test-fast
...
2323 passing (2m)
...
real	1m34.940s
```

##### `master`

```sh
time make test-fast
...
2375 passing (3m)
...
real	3m13.746s
```

#### Why is this the best possible solution? Were any other approaches considered?

Makes `make test-fast` faster.

Specifically on my machine, this halves the time taken for `make test-fast`.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just test code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.