### PR TITLE
Makefile/run-docker-postgres: use long-form args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ run-docker-postgres: stop-docker-postgres
 			--name odk-postgres14 \
 			--publish 127.0.0.1:5432:5432 \
 			--env POSTGRES_PASSWORD=odktest \
-			postgres:14.20-alpine
+			postgres:14.20-alpine \
 		&& sleep 5 \
 		&& node lib/bin/create-docker-databases.js --log \
 	)

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,11 @@ lint: node_version
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres
 	docker start odk-postgres14 || (\
-		docker run -d --name odk-postgres14 -p 127.0.0.1:5432:5432 -e POSTGRES_PASSWORD=odktest postgres:14.20-alpine \
+		docker run -d \
+			--name odk-postgres14 \
+			--publish 127.0.0.1:5432:5432 \
+			--env POSTGRES_PASSWORD=odktest \
+			postgres:14.20-alpine
 		&& sleep 5 \
 		&& node lib/bin/create-docker-databases.js --log \
 	)


### PR DESCRIPTION
This will simplify:

* tracking changes to the container config over time
* understanding specific flags used

This also sets up for a simpler changeset in https://github.com/getodk/central-backend/pull/1882.

#### What has been done to verify that this works as intended?

Tested locally, which is the only place this is used.

#### Why is this the best possible solution? Were any other approaches considered?

No.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.