### PR TITLE
make run-docker-postgres: wait more robustly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ run-docker-postgres: stop-docker-postgres
 			--publish 127.0.0.1:5432:5432 \
 			--env POSTGRES_PASSWORD=odktest \
 			postgres:14.20-alpine \
-		&& sleep 5 \
+		&& sleep 2 \
+		&& docker exec odk-postgres14 pg_isready --username=postgres --timeout=10 \
 		&& node lib/bin/create-docker-databases.js --log \
 	)
 


### PR DESCRIPTION
Use a shorter sleep + `pg_isready`.

* faster to respond if postgres starts quickly
* more reliable if postgres starts slowly

#### What has been done to verify that this works as intended?

Tested locally, which is all it's used for.

#### Why is this the best possible solution? Were any other approaches considered?

* faster to respond if postgres starts quickly
* more reliable if postgres starts slowly

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just dev code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.