### PR TITLE
test/oidc-e2e: align setup with other e2e workflows

### DIFF
--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -43,7 +43,7 @@ jobs:
     - run: npm ci
     - run: node lib/bin/create-docker-databases.js
     - run: sudo apt-get install wait-for-it
-	  - run: ./test/e2e/oidc/run-tests.sh
+	- run: ./test/e2e/oidc/run-tests.sh
     - name: Archive Playwright Test Report
       if: failure()
       uses: actions/upload-artifact@v7

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -40,7 +40,10 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: make test-oidc-e2e
+    - run: npm ci
+    - run: node lib/bin/create-docker-databases.js
+    - run: sudo apt-get install wait-for-it
+	  - run: ./test/e2e/oidc/run-tests.sh
     - name: Archive Playwright Test Report
       if: failure()
       uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,6 @@ node_version: node_modules
 test-oidc-integration: node_version
 	TEST_AUTH=oidc NODE_CONFIG_ENV=oidc-integration-test make test-integration
 
-.PHONY: test-oidc-e2e
-test-oidc-e2e: node_version
-	test/e2e/oidc/run-tests.sh
-
 .PHONY: dev-oidc
 dev-oidc: base
 	NODE_CONFIG_ENV=oidc-development npx nodemon --watch lib --watch config lib/bin/run-server.js

--- a/test/e2e/oidc/run-tests.sh
+++ b/test/e2e/oidc/run-tests.sh
@@ -11,13 +11,6 @@ if [[ ${CI-} = true ]]; then
   echo '127.0.0.1 fake-oidc-server.example.net' | sudo tee --append /etc/hosts
   echo '127.0.0.1      odk-central.example.org' | sudo tee --append /etc/hosts
 
-  log "Installing apt dependencies..."
-  sudo apt-get install -y wait-for-it
-
-  log "Creating database users..."
-  npm ci
-  node lib/bin/create-docker-databases.js
-
   START_SERVICES=true
   INSTALL_PLAYWRIGHT_DEPS=true
 fi


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

Aligns with other suites:

1. `standard-e2e`:
    i. workflow yaml: https://github.com/getodk/central-backend/blob/69453854eb4ea501f9492489d6db5cd179c5050d/.github/workflows/standard-e2e.yml#L36-L41
    ii. `run-tests.sh`: https://github.com/getodk/central-backend/blob/69453854eb4ea501f9492489d6db5cd179c5050d/test/e2e/standard/run-tests.sh
2. `s3-e2e`:
    i. workflow yaml: https://github.com/getodk/central-backend/blob/69453854eb4ea501f9492489d6db5cd179c5050d/.github/workflows/s3-e2e.yml#L34-L39
    ii. https://github.com/getodk/central-backend/blob/69453854eb4ea501f9492489d6db5cd179c5050d/test/e2e/s3/run-tests.sh

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just tests.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.