### PR TITLE
ci: use run-docker-postgres make target

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -25,20 +25,6 @@ jobs:
     timeout-minutes: 2
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
-    services:
-      # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
-      postgres:
-        image: postgres:14.20
-        env:
-          POSTGRES_PASSWORD: odktest
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version
@@ -47,5 +33,5 @@ jobs:
         node-version-file: package.json
         cache: 'npm'
     - run: npm ci
-    - run: node lib/bin/create-docker-databases.js
+    - run: make run-docker-postgres
     - run: make test-db-migrations

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -13,20 +13,6 @@ jobs:
     timeout-minutes: 6
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
-    services:
-      # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
-      postgres:
-        image: postgres:14.20
-        env:
-          POSTGRES_PASSWORD: odktest
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 50
     steps:
 
     # This one weird trick speeds up every build!
@@ -41,7 +27,7 @@ jobs:
         node-version-file: package.json
         cache: 'npm'
     - run: npm ci
-    - run: node lib/bin/create-docker-databases.js
+    - run: make run-docker-postgres
     - run: sudo apt-get install wait-for-it
 	- run: ./test/e2e/oidc/run-tests.sh
     - name: Archive Playwright Test Report

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -29,7 +29,7 @@ jobs:
     - run: npm ci
     - run: make run-docker-postgres
     - run: sudo apt-get install wait-for-it
-	- run: ./test/e2e/oidc/run-tests.sh
+    - run: ./test/e2e/oidc/run-tests.sh
     - name: Archive Playwright Test Report
       if: failure()
       uses: actions/upload-artifact@v7

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -9,20 +9,6 @@ jobs:
     timeout-minutes: 6
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
-    services:
-      # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
-      postgres:
-        image: postgres:14.20
-        env:
-          POSTGRES_PASSWORD: odktest
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version
@@ -32,7 +18,7 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: FAKE_OIDC_ROOT_URL=http://localhost:9898 make fake-oidc-server-ci > fake-oidc-server.log &
-    - run: node lib/bin/create-docker-databases.js
+    - run: make run-docker-postgres
     - run: make test-oidc-integration
     - name: Fake OIDC Server Logs
       if: always()

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -9,20 +9,6 @@ jobs:
     timeout-minutes: 15
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
-    services:
-      # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
-      postgres:
-        image: postgres:14.20
-        env:
-          POSTGRES_PASSWORD: odktest
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - run: make fake-s3-server-persistent
@@ -32,7 +18,7 @@ jobs:
         node-version-file: package.json
         cache: 'npm'
     - run: npm ci
-    - run: node lib/bin/create-docker-databases.js
+    - run: make run-docker-postgres
     - run: sudo apt-get install wait-for-it
     - name: E2E Test
       timeout-minutes: 10

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -9,20 +9,6 @@ jobs:
     timeout-minutes: 15
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
-    services:
-      # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
-      postgres:
-        image: postgres:14.20
-        env:
-          POSTGRES_PASSWORD: odktest
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - run: ./test/e2e/soak/ci/prepare-postgres.sh
@@ -32,7 +18,7 @@ jobs:
         node-version-file: package.json
         cache: 'npm'
     - run: npm ci
-    - run: node lib/bin/create-docker-databases.js
+    - run: make run-docker-postgres
     - name: Soak Test
       timeout-minutes: 10
       run: ./test/e2e/soak/ci/run-tests.sh

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -12,20 +12,6 @@ jobs:
     timeout-minutes: 15
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
-    services:
-      # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
-      postgres:
-        image: postgres:14.20
-        env:
-          POSTGRES_PASSWORD: odktest
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version
@@ -34,7 +20,7 @@ jobs:
         node-version-file: package.json
         cache: 'npm'
     - run: npm ci
-    - run: node lib/bin/create-docker-databases.js
+    - run: make run-docker-postgres
 
     - name: E2E Test
       timeout-minutes: 10

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -9,20 +9,6 @@ jobs:
     timeout-minutes: 20
     # TODO should we use the same container as circle & central?
     runs-on: ubuntu-latest
-    services:
-      # see: https://docs.github.com/en/enterprise-server@3.5/actions/using-containerized-services/creating-postgresql-service-containers
-      postgres:
-        image: postgres:14.20
-        env:
-          POSTGRES_PASSWORD: odktest
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 50
     steps:
     - uses: actions/checkout@v6
     - name: Set node version
@@ -33,5 +19,5 @@ jobs:
     - run: make check-for-large-files
     - run: npm ci
     - run: make api-docs-lint
-    - run: node lib/bin/create-docker-databases.js
+    - run: make run-docker-postgres
     - run: make test

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ run-docker-postgres: stop-docker-postgres
 			postgres:14.20-alpine \
 		&& sleep 2 \
 		&& docker exec odk-postgres14 pg_isready --username=postgres --timeout=10 \
-		&& node lib/bin/create-docker-databases.js --log \
+		&& node lib/bin/create-docker-databases.js $(if $(CI),,--log) \
 	)
 
 .PHONY: stop-docker-postgres


### PR DESCRIPTION
Replace GitHub Actions postgres service with a straight docker approach.

Advantages:

* simpler code
* merges dev & ci code paths:
  * better test coverage of dev code
  * more similar dev & test environments

This also allows for future changes to postgres extensions, e.g. enabling `pg_stat_statements` in CI.

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

* simpler code
* merges dev & ci code paths:
  * better test coverage of dev code
  * more similar dev & test environments

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just test code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.