### PR TITLE
ci: use non-alpine postgres docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ run-docker-postgres: stop-docker-postgres
 			--name odk-postgres14 \
 			--publish 127.0.0.1:5432:5432 \
 			--env POSTGRES_PASSWORD=odktest \
-			postgres:14.20-alpine \
+			postgres:14.20 \
 		&& sleep 2 \
 		&& docker exec odk-postgres14 pg_isready --username=postgres --timeout=10 \
 		&& node lib/bin/create-docker-databases.js $(if $(CI),,--log) \


### PR DESCRIPTION
This significantly speeds up test run times (~6 minutes -> ~4:15 minutes).

Closes https://github.com/getodk/central/issues/2083

#### What has been done to verify that this works as intended?

CI runs:

* with this change: https://github.com/alxndrsn/odk-central-backend/actions/runs/30003996026
* without this change: https://github.com/alxndrsn/odk-central-backend/actions/runs/29998322925

#### Why is this the best possible solution? Were any other approaches considered?

It does have implications for dev use of `make run-docker-postgres` - perhaps higher resource usage, and faster test runs.  An alternative would be to keep `-alpine` if the `CI` env var is not set.  But simpler to use non-alpine everywhere, and change back in dev if there are issues.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just tests.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.