### PR TITLE
postgres: use same version as in prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ run-docker-postgres: stop-docker-postgres
 			--name odk-postgres14 \
 			--publish 127.0.0.1:5432:5432 \
 			--env POSTGRES_PASSWORD=odktest \
-			postgres:14.20-alpine \
+			postgres:14.23-alpine \
 		&& sleep 2 \
 		&& docker exec odk-postgres14 pg_isready --username=postgres --timeout=10 \
 		&& node lib/bin/create-docker-databases.js $(if $(CI),,--log) \


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

- [x] ci
- [x] checked in central repo: https://github.com/getodk/central/blob/3e9b78f4c7d1636982643585759c3d8a904904e3/postgres14.dockerfile#L1

#### Why is this the best possible solution? Were any other approaches considered?

Testing on the same version as used in prod is generally a good idea.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.