### PR TITLE
remove body-parser dependency

### DIFF
--- a/lib/http/service.js
+++ b/lib/http/service.js
@@ -10,12 +10,13 @@
 // This file glues together all the middleware and the HTTP REST resources we have
 // defined elsewhere into an actual Express service. The only thing it needs in
 // order to do this is a valid dependency injection context container.
+const express = require('express');
 const { match } = require('path-to-regexp');
 
 const { cachePolicy, setCachePolicy } = require('../util/http');
 
 module.exports = (container) => {
-  const service = require('express')();
+  const service = express();
   service.set('case sensitive routing', true);
   service.set('query parser', 'simple');
   service.disable('x-powered-by');
@@ -30,11 +31,10 @@ module.exports = (container) => {
 
   // automatically parse JSON if it is marked as such. otherwise, just pull the
   // plain-text body contents.
-  const bodyParser = require('body-parser');
 
   // use a default json limit except for URLs that explicitly need a larger limit.
-  const defaultJsonLimit = bodyParser.json({ type: 'application/json', limit: '250kb' });
-  const largeJsonLimit = bodyParser.json({ type: 'application/json', limit: '100mb' });
+  const defaultJsonLimit = express.json({ type: 'application/json', limit: '250kb' });
+  const largeJsonLimit = express.json({ type: 'application/json', limit: '100mb' });
   const largeJsonUrlMatch = match('/:apiVersion/projects/:id/datasets/:name/entities');
   // only apply body-parser middleware to request types which should have a body.
   service.patch('/*', defaultJsonLimit);

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -52,8 +52,8 @@ const multipartErrorHandler = (err, req, res, next) => {
 };
 
 // formbody things:
-const bodyParser = require('body-parser');
-const formParser = bodyParser.urlencoded({ extended: false });
+const express = require('express');
+const formParser = express.urlencoded({ extended: false });
 
 // util funcs for openRosaSubmission below, mostly just moving baked logic/data off for perf.
 const missingXmlProblem = Problem.user.missingMultipartField({ field: XML_SUBMISSION_FILE });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@sentry/node": "^10.46.0",
         "archiver": "^7.0.1",
         "bcrypt": "^6.0.0",
-        "body-parser": "~1.20",
         "buffer-peek-stream": "^1.1.0",
         "cloneable-readable": "^3.0.0",
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@sentry/node": "^10.46.0",
     "archiver": "^7.0.1",
     "bcrypt": "^6.0.0",
-    "body-parser": "~1.20",
     "buffer-peek-stream": "^1.1.0",
     "cloneable-readable": "^3.0.0",
     "commander": "^14.0.3",


### PR DESCRIPTION
Ref https://github.com/getodk/central/issues/1090

#### What has been done to verify that this works as intended?

- [x] tested locally
- [x] tested in CI

#### Why is this the best possible solution? Were any other approaches considered?

Body parser now built into express, so no need to maintain a separate dependency.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect, hopefully.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.