### PR TITLE
repl: add db & promise globals

### DIFF
--- a/lib/bin/repl.js
+++ b/lib/bin/repl.js
@@ -10,8 +10,21 @@
 const _ = require('lodash'); // eslint-disable-line import/no-extraneous-dependencies
 const { sql } = require('slonik');
 
+const { // eslint-disable-line object-curly-newline
+  sqlEquals,
+  sqlInArray,
+  QueryOptions,
+} = require('../util/db'); // eslint-disable-line object-curly-newline
 const container = require('../util/default-container');
 const Problem = require('../util/problem');
+const { // eslint-disable-line object-curly-newline
+  getOrElse,
+  getOrNotFound,
+  getOrReject,
+  ignoringResult,
+  rejectIf,
+  rejectIfError,
+} = require('../util/promise'); // eslint-disable-line object-curly-newline
 
 (async () => {
   container.Sentry.setTag('entrypoint', 'repl');
@@ -20,7 +33,22 @@ const Problem = require('../util/problem');
     ..._.omit(container, 'with'),
     container,
     sql,
+
+    // util/db
+    sqlEquals,
+    sqlInArray,
+    QueryOptions,
+
+    // util/problem
     Problem,
+
+    // util/promise
+    getOrElse,
+    getOrNotFound,
+    getOrReject,
+    ignoringResult,
+    rejectIf,
+    rejectIfError,
   };
   const replGlobals = Object.keys(context);
 


### PR DESCRIPTION
Simplify debugging/testing code from `lib/model/query/`.

Closes getodk/central#2087

#### What has been done to verify that this works as intended?

- [x] tested locally

#### Why is this the best possible solution? Were any other approaches considered?

Helpful for debugging `lib/model/query` code.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.