### PR TITLE
query/entities/streamForExport(): disable hashjoins

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -10,7 +10,7 @@
 const config = require('config');
 const { sql } = require('slonik');
 const { Actor, Audit, Entity, Submission, Form } = require('../frames');
-const { sqlEquals, extender, unjoiner, page, markDeleted, insertMany, queryFuncs } = require('../../util/db');
+const { sqlEquals, extender, unjoiner, page, markDeleted, insertMany } = require('../../util/db');
 const { map, mergeRight, pickAll } = require('ramda');
 const { blankStringToNull, construct } = require('../../util/util');
 const { QueryOptions } = require('../../util/db');

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -10,7 +10,7 @@
 const config = require('config');
 const { sql } = require('slonik');
 const { Actor, Audit, Entity, Submission, Form } = require('../frames');
-const { sqlEquals, extender, unjoiner, page, markDeleted, insertMany } = require('../../util/db');
+const { sqlEquals, extender, unjoiner, page, markDeleted, insertMany, queryFuncs } = require('../../util/db');
 const { map, mergeRight, pickAll } = require('ramda');
 const { blankStringToNull, construct } = require('../../util/util');
 const { QueryOptions } = require('../../util/db');
@@ -929,12 +929,14 @@ const _actorHasAccess = (actorId) => sql`
   )
 `;
 
-const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async ({ run, stream, isTransacting }) => {
-  if (!isTransacting) throw new Error('This function must be called inside a transaction.');
+const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async (container) =>
+  container.db.transaction(async _tx => {
+    const tx = {};
+    queryFuncs(tx, _tx);
 
-  await run(sql`SET LOCAL enable_hashjoin = off`);
-  await run(sql`SET LOCAL enable_mergejoin = off`);
-  const _stream = await stream(sql`
+    await tx.run(sql`SET LOCAL enable_hashjoin = off`);
+    await tx.run(sql`SET LOCAL enable_mergejoin = off`);
+    return tx.stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"
 LEFT JOIN actors ON entities."creatorId"=actors.id
@@ -955,10 +957,8 @@ ${options.orderby ? sql`
   ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}
   `: sql`ORDER BY entities."createdAt" DESC, entities.id DESC`}
 ${page(options)}`)
-    .then(stream.map(_exportUnjoiner));
-  await run(sql`SET LOCAL enable_hashjoin = on`);
-  return _stream;
-};
+      .then(tx.stream.map(_exportUnjoiner));
+  });
 
 const countByDatasetId = (datasetId, options = QueryOptions.none) => ({ one }) => one(sql`
 SELECT * FROM

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -929,7 +929,9 @@ const _actorHasAccess = (actorId) => sql`
   )
 `;
 
-const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async ({ run, stream }) => {
+const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async ({ run, stream, isTransacting }) => {
+  if (!isTransacting) throw new Error('This function must be called inside a transaction.');
+
   await run(sql`SET LOCAL enable_hashjoin = off`);
   await run(sql`SET LOCAL enable_mergejoin = off`);
   const _stream = await stream(sql`

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -934,8 +934,8 @@ const streamForExport = (datasetId, options = QueryOptions.none, actorId) => asy
     const tx = {};
     queryFuncs(_tx, tx);
 
-    await tx.run(sql`SET LOCAL enable_hashjoin = off`);
-    await tx.run(sql`SET LOCAL enable_mergejoin = off`);
+    await _tx.query(sql`SET LOCAL enable_hashjoin = off`);
+    await _tx.query(sql`SET LOCAL enable_mergejoin = off`);
     return tx.stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -929,8 +929,9 @@ const _actorHasAccess = (actorId) => sql`
   )
 `;
 
-const streamForExport = (datasetId, options = QueryOptions.none, actorId) => ({ stream }) =>
-  stream(sql`
+const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async ({ run, stream }) => {
+  await run(sql`SET LOCAL enable_hashjoin = off`);
+  const _stream = await stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"
 LEFT JOIN actors ON entities."creatorId"=actors.id
@@ -952,6 +953,9 @@ ${options.orderby ? sql`
   `: sql`ORDER BY entities."createdAt" DESC, entities.id DESC`}
 ${page(options)}`)
     .then(stream.map(_exportUnjoiner));
+  await run(sql`SET LOCAL enable_hashjoin = on`);
+  return _stream;
+};
 
 const countByDatasetId = (datasetId, options = QueryOptions.none) => ({ one }) => one(sql`
 SELECT * FROM

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -931,6 +931,7 @@ const _actorHasAccess = (actorId) => sql`
 
 const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async ({ run, stream }) => {
   await run(sql`SET LOCAL enable_hashjoin = off`);
+  await run(sql`SET LOCAL enable_mergejoin = off`);
   const _stream = await stream(sql`
 SELECT ${_exportUnjoiner.fields} FROM entity_defs
 INNER JOIN entities ON entities.id = entity_defs."entityId"

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -932,7 +932,7 @@ const _actorHasAccess = (actorId) => sql`
 const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async (container) =>
   container.db.transaction(async _tx => {
     const tx = {};
-    queryFuncs(tx, _tx);
+    queryFuncs(_tx, tx);
 
     await tx.run(sql`SET LOCAL enable_hashjoin = off`);
     await tx.run(sql`SET LOCAL enable_mergejoin = off`);

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -929,36 +929,28 @@ const _actorHasAccess = (actorId) => sql`
   )
 `;
 
-const streamForExport = (datasetId, options = QueryOptions.none, actorId) => async (container) =>
-  container.db.transaction(async _tx => {
-    const tx = {};
-    queryFuncs(_tx, tx);
-
-    await _tx.query(sql`SET LOCAL enable_hashjoin = off`);
-    await _tx.query(sql`SET LOCAL enable_mergejoin = off`);
-    return tx.stream(sql`
-SELECT ${_exportUnjoiner.fields} FROM entity_defs
-INNER JOIN entities ON entities.id = entity_defs."entityId"
-LEFT JOIN actors ON entities."creatorId"=actors.id
-${options.skiptoken ? sql`
-  INNER JOIN
-  ( SELECT id, "createdAt" FROM entities WHERE "uuid" = ${options.skiptoken.uuid}::uuid) AS cursor
-  ON entities."createdAt" <= cursor."createdAt" AND entities.id < cursor.id
-  `: sql``} 
-WHERE
-  entities."datasetId" = ${datasetId}
-  AND ${sqlEquals(options.condition)}
-  AND ${odataExcludeDeleted(options.filter, odataToColumnMap)}
-  AND entity_defs.current=true
-  AND ${odataFilter(options.filter, odataToColumnMap)}
-  AND ${searchClause(options.search)}
-${actorId != null ? sql`AND ${_actorHasAccess(actorId)}` : sql``}
-${options.orderby ? sql`
-  ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}
+const streamForExport = (datasetId, options = QueryOptions.none, actorId) => ({ stream }) =>
+  stream(sql`
+WITH target_entities AS NOT MATERIALIZED (
+  SELECT entities.id, entities."createdAt", entities."creatorId"
+  FROM entities
+  WHERE entities."datasetId" = ${datasetId}
+    AND ${sqlEquals(options.condition)}
+    AND ${odataExcludeDeleted(options.filter, odataToColumnMap)}
+    AND ${odataFilter(options.filter, odataToColumnMap)}
+    AND ${searchClause(options.search)}
+  ${options.orderby ? sql`
+    ${odataOrderBy(options.orderby, odataToColumnMap, 'entities.id')}
   `: sql`ORDER BY entities."createdAt" DESC, entities.id DESC`}
-${page(options)}`)
-      .then(tx.stream.map(_exportUnjoiner));
-  });
+  ${page(options)}
+)
+SELECT ${_exportUnjoiner.fields}
+FROM target_entities entities
+INNER JOIN entity_defs ON entity_defs."entityId" = entities.id AND entity_defs.current = true
+LEFT JOIN actors ON entities."creatorId" = actors.id
+${actorId != null ? sql`WHERE ${_actorHasAccess(actorId)}` : sql``}
+`)
+    .then(stream.map(_exportUnjoiner));
 
 const countByDatasetId = (datasetId, options = QueryOptions.none) => ({ one }) => one(sql`
 SELECT * FROM


### PR DESCRIPTION
TODO why?
TODO link to issue, e.g. Closes getodk/central#

#### What has been done to verify that this works as intended?

- [x] tested locally
- [ ] tested manually in dev env
- [ ] ci
- [ ] tested patched in dev env

#### Why is this the best possible solution? Were any other approaches considered?

TODO why _is it_ the best?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Should make their lives better.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.