### PR TITLE
remove unused dependency: pg-query-stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "openid-client": "^6.8.4",
         "path-to-regexp": "^8.3.0",
         "pg": "~8.8.0",
-        "pg-query-stream": "^4.14.0",
         "pm2": "~5.4",
         "prompt": "~1",
         "ramda": "^0.32.0",
@@ -10773,18 +10772,6 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
       "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
       "license": "MIT"
-    },
-    "node_modules/pg-query-stream": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.14.0.tgz",
-      "integrity": "sha512-B1LLxgqngAATPciOPYYKyaQfsw5wyP6BZq6nHqQOC5QaaEBsfW/0OBwWUga+knCAqENMeoow9I8Zgi2m3P9rWw==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-cursor": "^2.19.0"
-      },
-      "peerDependencies": {
-        "pg": "^8"
-      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -22501,14 +22488,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
       "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q=="
-    },
-    "pg-query-stream": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.14.0.tgz",
-      "integrity": "sha512-B1LLxgqngAATPciOPYYKyaQfsw5wyP6BZq6nHqQOC5QaaEBsfW/0OBwWUga+knCAqENMeoow9I8Zgi2m3P9rWw==",
-      "requires": {
-        "pg-cursor": "^2.19.0"
-      }
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "openid-client": "^6.8.4",
     "path-to-regexp": "^8.3.0",
     "pg": "~8.8.0",
-    "pg-query-stream": "^4.14.0",
     "pm2": "~5.4",
     "prompt": "~1",
     "ramda": "^0.32.0",


### PR DESCRIPTION
* not used directly in this project
* not used indirectly by dependencies

Noticed while looking into https://github.com/getodk/central/issues/1090

#### What has been done to verify that this works as intended?

- [ ] checked `package-lock.json` updates
- [ ] searched for dependency references in `node_modules` directory
- [ ] ci

#### Why is this the best possible solution? Were any other approaches considered?

It's not used, so why include it?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.