### PR TITLE
postgres: fix references to old image name

### DIFF
--- a/test/e2e/s3/run-tests.sh
+++ b/test/e2e/s3/run-tests.sh
@@ -44,7 +44,7 @@ if [[ "${CI-}" = '' ]]; then
     !
     ! A quick fix for this could be:
     !
-    !   docker exec odk-postgres14 psql -U jubilant jubilant -c "TRUNCATE blobs CASCADE"
+    !   docker exec odk-central-backend-dev-postgres psql -U jubilant jubilant -c "TRUNCATE blobs CASCADE"
     !
     ! Press <enter> to continue...
 

--- a/test/e2e/soak/ci/prepare-postgres.sh
+++ b/test/e2e/soak/ci/prepare-postgres.sh
@@ -24,7 +24,7 @@ pg_exec "ALTER SYSTEM SET track_activity_query_size = 16384"
 # Postgres must be restarted to apply change to track_activity_query_size
 # See: https://www.postgresql.org/docs/14/runtime-config-statistics.html#GUC-TRACK-ACTIVITY-QUERY-SIZE
 log "  Restarting postgres..."
-pgImg=odk-postgres14
+pgImg=odk-central-backend-dev-postgres
 docker restart "$pgImg" >/dev/null
 timeout 10 bash -c "while ! docker exec $pgImg pg_isready --timeout=1; do sleep 1; done"
 log "  Restarted OK."


### PR DESCRIPTION
Image name changed in f909b2ad9dce10c3105f77d9b95e697cf60f6c2b (#1872), but some references were missed.

#### What has been done to verify that this works as intended?

- [x] grepped for other mentions
- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

:shrug: 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.