### PR TITLE
Add "viewAs" query param to OData and REST entities endpoints

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -9090,7 +9090,7 @@ paths:
           This is intended for previewing what a particular App User or Public Link would receive when downloading the Dataset via a linked Form Attachment.
         schema:
           type: number
-        example: "42"
+        example: 42
       responses:        
         "200":
           description: OK

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -44,7 +44,7 @@ info:
     ## ODK Central v2026.3
 
     **Added**:
-    - [Entities OData](/central-api-odata-endpoints/#data-document-1) now supports a `viewAs` query parameter to preview the filtered Entity list for a specific Actor.
+    - [Entities OData](/central-api-odata-endpoints/#odata-dataset-service) and [GET Entities Metadata](/central-api-entity-management/#entities-metadata) now support a `viewAs` query parameter to preview the filtered Entity list for a specific Actor.
 
     **Changed**:
     - [GET /audits](/central-api-system-endpoints/#getting-audit-log-entries) now uses less-than when filtering with the `end` parameter.
@@ -9063,7 +9063,7 @@ paths:
       - Entity Management
       summary: Entities Metadata
       description: |-
-        This endpoint returns a list of the Entities of a Dataset. Please note that this endpoint only returns metadata of the entities not the data. If you want to get the data of all entities then please refer to [OData Dataset Service](/central-api-odata-endpoints/#odata-form-service)
+        This endpoint returns a list of the Entities of a Dataset. Please note that this endpoint only returns metadata of the entities not the data. If you want to get the data of all entities then please refer to [OData Dataset Service](/central-api-odata-endpoints/#odata-dataset-service)
         You can provide `?deleted=true` to get only deleted entities.
       
       operationId: entitiesMetadata
@@ -9082,6 +9082,15 @@ paths:
         schema:
           type: string
         example: people
+      - name: viewAs
+        in: query
+        description: |-
+          If provided, filters the response to only the Entities that the specified Actor would be able to see, based on the Dataset's access filter (`ownerOnly` or property rules). The value must be a numeric Actor ID.
+
+          This is intended for previewing what a particular App User or Public Link would receive when downloading the Dataset via a linked Form Attachment.
+        schema:
+          type: number
+        example: "42"
       responses:        
         "200":
           description: OK
@@ -11405,6 +11414,8 @@ paths:
         - The `OR` keyword can be used to find entities that contain **any** of the searched words.
         - Quoted text (e.g., `"quoted text"`) searches for entities containing the **exact** phrase.
         - A dash (`-`) before a word excludes entities that contain that word (logical NOT).
+
+        The `viewAs` query parameter can be used to preview what a specific Actor would receive, based on the Dataset's access filter (`ownerOnly` or property rules). Pass a numeric Actor ID as the value. This is intended to preview what an App User or Public Link would see when fetching these Entities as a Form Attachment. This parameter can be combined with other filters, e.g. to see the subset of an Actor's Entities that also match a given `$filter` or `$search` expression.
 
         As the vast majority of clients only support the JSON OData format, that is the only format ODK Central offers.
       operationId: dataDocumentForDataset

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -43,6 +43,9 @@ info:
 
     ## ODK Central v2026.3
 
+    **Added**:
+    - [Entities OData](/central-api-odata-endpoints/#data-document-1) now supports a `viewAs` query parameter to preview the filtered Entity list for a specific Actor.
+
     **Changed**:
     - [GET /audits](/central-api-system-endpoints/#getting-audit-log-entries) now uses less-than when filtering with the `end` parameter.
     - [Form Attachment](/central-api-form-management/#listing-form-attachments) objects now include a `size` field (in bytes) when a file has been uploaded. The field is absent for dataset-linked attachments and empty slots, and may be `null` for blobs uploaded before this version.
@@ -11468,6 +11471,15 @@ paths:
         description: Opaque cursor from `@odata.nextLink` used for paging.
         schema:
           type: string
+      - name: viewAs
+        in: query
+        description: |-
+          If provided, filters the response to only the Entities that the specified Actor would be able to see, based on the Dataset's access filter (`ownerOnly` or property rules). The value must be a numeric Actor ID.
+
+          This is intended for previewing what a particular App User or Public Link would receive when downloading the Dataset via a linked Form Attachment.
+        schema:
+          type: number
+        example: "42"
       responses:
         "200":
           description: Ok

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -350,7 +350,7 @@ const openRosaEndpoint = endpointBase({
 // ODATA
 
 // various supported odata constants:
-const supportedParams = [ '$format', '$count', '$skip', '$top', '$filter', '$wkt', '$expand', '$select', '$skiptoken', '$orderby', '$search' ];
+const supportedParams = [ '$format', '$count', '$skip', '$top', '$filter', '$wkt', '$expand', '$select', '$skiptoken', '$orderby', '$search', 'viewAs' ];
 const supportedFormats = {
   json: [ 'application/json', 'json' ],
   xml: [ 'application/xml', 'atom' ]

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -776,10 +776,30 @@ const createEntitiesFromPendingSubmissions = (submissionEvents, parentEvent) => 
 ////////////////////////////////////////////////////////////////////////////////
 // GETTING ENTITIES
 
+const _actorHasAccess = (actorId) => sql`
+  (
+    -- ownerOnly: if the dataset is ownerOnly, restrict to entities created by this actor
+    NOT EXISTS (SELECT 1 FROM datasets WHERE datasets.id = entities."datasetId" AND datasets."ownerOnly")
+    OR entities."creatorId" = ${actorId}
+  )
+  AND (
+    -- property filters: if the dataset has access filters, restrict to matching entities
+    NOT EXISTS (SELECT 1 FROM dataset_access_filters WHERE "datasetId" = entities."datasetId")
+    OR EXISTS (
+      SELECT 1 FROM dataset_access_filters daf
+      JOIN ds_properties dp ON dp.id = daf."datasetPropertyId"
+      JOIN actor_property_values apv ON apv."actorPropertyId" = daf."actorPropertyId"
+      WHERE daf."datasetId" = entities."datasetId"
+        AND apv."actorId" = ${actorId}
+        AND entity_defs.data ->> dp."name" = apv."value"
+    )
+  )
+`;
+
 // There is plumbing here for including the entity source submission, but it
 // is not currently in use. Leaving it in place for when we do want to include
 // source information again.
-const _get = (includeSource) => {
+const _get = (includeSource, filterActorId = null) => {
   const frames = [Entity];
   if (includeSource) {
     frames.push(Entity.Def.into('currentVersion'), Submission, Submission.Def.into('submissionDef'), Form);
@@ -810,6 +830,7 @@ const _get = (includeSource) => {
     LEFT JOIN forms ON submissions."formId" = forms.id
   `} 
   WHERE ${sqlEquals(options.condition, { uuid: 'uuid' })} AND entities."deletedAt" is ${deleted ? sql`not` : sql``} null
+  ${filterActorId != null ? sql`AND ${_actorHasAccess(filterActorId)}` : sql``}
   ORDER BY entities."createdAt" DESC, entities.id DESC
 `);
 };
@@ -828,8 +849,10 @@ const getById = (datasetId, wildtypeUuid, options = QueryOptions.none) => async 
     .then(map(assignCurrentVersionCreator));
 };
 
-const getAll = (datasetId, options = QueryOptions.none) => ({ all }) =>
-  _get(false)(all, options.withCondition({ datasetId }), isTrue(options.argData.deleted))
+// filterActorId is set to apply dataset access filters (ownerOnly, property rules) for that actor
+// null filterActorId skips filtering (e.g. for project managers with full access)
+const getAll = (datasetId, options = QueryOptions.none, filterActorId = null) => ({ all }) =>
+  _get(false, filterActorId)(all, options.withCondition({ datasetId }), isTrue(options.argData.deleted))
     .then(map(assignCurrentVersionCreator));
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -912,26 +935,6 @@ const searchClause = (expr) => {
 
   return sql`(jsonb_to_tsvector('simple', entity_defs.data, '["string"]') || to_tsvector('simple', entity_defs.label)) @@ websearch_to_tsquery('simple', ${expr})`;
 };
-
-const _actorHasAccess = (actorId) => sql`
-  (
-    -- ownerOnly: if the dataset is ownerOnly, restrict to entities created by this actor
-    NOT EXISTS (SELECT 1 FROM datasets WHERE datasets.id = entities."datasetId" AND datasets."ownerOnly")
-    OR entities."creatorId" = ${actorId}
-  )
-  AND (
-    -- property filters: if the dataset has access filters, restrict to matching entities
-    NOT EXISTS (SELECT 1 FROM dataset_access_filters WHERE "datasetId" = entities."datasetId")
-    OR EXISTS (
-      SELECT 1 FROM dataset_access_filters daf
-      JOIN ds_properties dp ON dp.id = daf."datasetPropertyId"
-      JOIN actor_property_values apv ON apv."actorPropertyId" = daf."actorPropertyId"
-      WHERE daf."datasetId" = entities."datasetId"
-        AND apv."actorId" = ${actorId}
-        AND entity_defs.data ->> dp."name" = apv."value"
-    )
-  )
-`;
 
 const streamForExport = (datasetId, options = QueryOptions.none, actorId) => ({ stream }) =>
   stream(sql`

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -957,7 +957,7 @@ ${options.orderby ? sql`
 ${page(options)}`)
     .then(stream.map(_exportUnjoiner));
 
-const countByDatasetId = (datasetId, options = QueryOptions.none) => ({ one }) => one(sql`
+const countByDatasetId = (datasetId, options = QueryOptions.none, actorId) => ({ one }) => one(sql`
 SELECT * FROM
 
 (
@@ -968,6 +968,7 @@ SELECT * FROM
   AND ${odataExcludeDeleted(options.filter, odataToColumnMap)}
   AND  ${odataFilter(options.filter, odataToColumnMap)}
   AND ${searchClause(options.search)}
+${actorId != null ? sql`AND ${_actorHasAccess(actorId)}` : sql``}
 ) AS "all"
   
 CROSS JOIN 
@@ -984,6 +985,7 @@ CROSS JOIN
   AND ${odataExcludeDeleted(options.filter, odataToColumnMap)}
   AND  ${odataFilter(options.filter, odataToColumnMap)}
   AND ${searchClause(options.search)}
+${actorId != null ? sql`AND ${_actorHasAccess(actorId)}` : sql``}
 ) AS skiptoken`);
 
 

--- a/lib/resources/entities.js
+++ b/lib/resources/entities.js
@@ -18,13 +18,20 @@ const { pick } = require('ramda');
 
 module.exports = (service, endpoint) => {
 
-  service.get('/projects/:projectId/datasets/:name/entities', endpoint(async ({ Datasets, Entities }, { params, auth, queryOptions }) => {
+  service.get('/projects/:projectId/datasets/:name/entities', endpoint(async ({ Auth, Actors, Datasets, Entities }, { params, auth, query, queryOptions }) => {
 
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
 
     await auth.canOrReject('entity.list', dataset);
 
-    return Entities.getAll(dataset.id, queryOptions);
+    let filterActorId = null;
+    if (query.viewAs != null) {
+      const actor = await Actors.getById(parseInt(query.viewAs, 10)).then(getOrNotFound);
+      const targetCanList = await Auth.can(actor, 'entity.list', dataset);
+      filterActorId = targetCanList ? null : actor.id;
+    }
+
+    return Entities.getAll(dataset.id, queryOptions, filterActorId);
   }));
 
   service.get('/projects/:projectId/datasets/:name/entities/creators', endpoint(async ({ Datasets, Entities }, { params, auth }) => {

--- a/lib/resources/odata-entities.js
+++ b/lib/resources/odata-entities.js
@@ -14,6 +14,7 @@ const { json, contentType, xml } = require('../util/http');
 const { streamEntityOdata } = require('../data/entity');
 const { urlPathname } = require('../util/http');
 const { edmxForEntities } = require('../formats/odata');
+const Problem = require('../util/problem');
 
 module.exports = (service, endpoint) => {
 
@@ -49,7 +50,9 @@ module.exports = (service, endpoint) => {
 
     let actorId = null;
     if (query.viewAs != null) {
-      const actor = await Actors.getById(parseInt(query.viewAs, 10)).then(getOrNotFound);
+      const parsed = parseInt(query.viewAs, 10);
+      if (Number.isNaN(parsed)) return Problem.user.unexpectedValue({ field: 'viewAs', value: query.viewAs, reason: 'must be a numeric actor ID' });
+      const actor = await Actors.getById(parsed).then(getOrNotFound);
       actorId = actor.id;
     }
 

--- a/lib/resources/odata-entities.js
+++ b/lib/resources/odata-entities.js
@@ -40,14 +40,21 @@ module.exports = (service, endpoint) => {
   }));
 
   // serves the odata feed for the entities
-  service.get('/projects/:projectId/datasets/:name.svc/Entities', endpoint.odata.json(async ({ Datasets, Entities, Projects, env }, { auth, params, originalUrl, query }) => {
+  service.get('/projects/:projectId/datasets/:name.svc/Entities', endpoint.odata.json(async ({ Actors, Datasets, Entities, Projects, env }, { auth, params, originalUrl, query }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
     const properties = await Datasets.getProperties(dataset.id);
     const options = QueryOptions.fromODataRequestEntities(query);
-    const { count, remaining } = await Entities.countByDatasetId(dataset.id, options);
-    const entities = await Entities.streamForExport(dataset.id, options);
+
+    let actorId = null;
+    if (query.viewAs != null) {
+      const actor = await Actors.getById(parseInt(query.viewAs, 10)).then(getOrNotFound);
+      actorId = actor.id;
+    }
+
+    const { count, remaining } = await Entities.countByDatasetId(dataset.id, options, actorId);
+    const entities = await Entities.streamForExport(dataset.id, options, actorId);
     return json(streamEntityOdata(entities, properties, env.domain, originalUrl, query, count, remaining));
   }));
 

--- a/lib/resources/odata-entities.js
+++ b/lib/resources/odata-entities.js
@@ -47,15 +47,15 @@ module.exports = (service, endpoint) => {
     const properties = await Datasets.getProperties(dataset.id);
     const options = QueryOptions.fromODataRequestEntities(query);
 
-    let actorId = null;
+    let filterActorId = null;
     if (query.viewAs != null) {
       const actor = await Actors.getById(parseInt(query.viewAs, 10)).then(getOrNotFound);
       const targetCanList = await Auth.can(actor, 'entity.list', project);
-      actorId = targetCanList ? null : actor.id;
+      filterActorId = targetCanList ? null : actor.id;
     }
 
-    const { count, remaining } = await Entities.countByDatasetId(dataset.id, options, actorId);
-    const entities = await Entities.streamForExport(dataset.id, options, actorId);
+    const { count, remaining } = await Entities.countByDatasetId(dataset.id, options, filterActorId);
+    const entities = await Entities.streamForExport(dataset.id, options, filterActorId);
     return json(streamEntityOdata(entities, properties, env.domain, originalUrl, query, count, remaining));
   }));
 

--- a/lib/resources/odata-entities.js
+++ b/lib/resources/odata-entities.js
@@ -14,7 +14,6 @@ const { json, contentType, xml } = require('../util/http');
 const { streamEntityOdata } = require('../data/entity');
 const { urlPathname } = require('../util/http');
 const { edmxForEntities } = require('../formats/odata');
-const Problem = require('../util/problem');
 
 module.exports = (service, endpoint) => {
 
@@ -41,7 +40,7 @@ module.exports = (service, endpoint) => {
   }));
 
   // serves the odata feed for the entities
-  service.get('/projects/:projectId/datasets/:name.svc/Entities', endpoint.odata.json(async ({ Actors, Datasets, Entities, Projects, env }, { auth, params, originalUrl, query }) => {
+  service.get('/projects/:projectId/datasets/:name.svc/Entities', endpoint.odata.json(async ({ Auth, Actors, Datasets, Entities, Projects, env }, { auth, params, originalUrl, query }) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
     const dataset = await Datasets.get(params.projectId, params.name, true).then(getOrNotFound);
@@ -50,10 +49,9 @@ module.exports = (service, endpoint) => {
 
     let actorId = null;
     if (query.viewAs != null) {
-      const parsed = parseInt(query.viewAs, 10);
-      if (Number.isNaN(parsed)) return Problem.user.unexpectedValue({ field: 'viewAs', value: query.viewAs, reason: 'must be a numeric actor ID' });
-      const actor = await Actors.getById(parsed).then(getOrNotFound);
-      actorId = actor.id;
+      const actor = await Actors.getById(parseInt(query.viewAs, 10)).then(getOrNotFound);
+      const targetCanList = await Auth.can(actor, 'entity.list', project);
+      actorId = targetCanList ? null : actor.id;
     }
 
     const { count, remaining } = await Entities.countByDatasetId(dataset.id, options, actorId);

--- a/test/integration/api/entities.js
+++ b/test/integration/api/entities.js
@@ -241,6 +241,163 @@ describe('Entities API', () => {
     }));
   });
 
+  describe('GET /datasets/:name/entities with viewAs', () => {
+    it('should return all entities if dataset has no access filter', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'entity1' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'entity2' })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'App User' }).expect(200);
+
+      await asAlice.get(`/v1/projects/1/datasets/people/entities?viewAs=${appUser.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.length.should.eql(2);
+        });
+    }));
+
+    it('should return 404 if viewAs actor does not exist', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/datasets/people/entities?viewAs=99999')
+        .expect(404);
+    }));
+
+    it('should return 400 if viewAs is not a numeric ID', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/datasets/people/entities?viewAs=notanumber')
+        .expect(400)
+        .then(({ body }) => {
+          body.code.should.eql(400.11);
+        });
+    }));
+
+    it('should return all entities if viewAs actor has full access', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ ownerOnly: true })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'entity1' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'entity2' })
+        .expect(200);
+
+      // Bob is a project manager with full entity.list access so filtering is skipped
+      const asBob = await service.login('bob');
+      const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
+
+      await asAlice.get(`/v1/projects/1/datasets/people/entities?viewAs=${bobId}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.length.should.eql(2);
+        });
+    }));
+
+    it('should filter entities for ownerOnly dataset', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.simpleEntity)
+        .expect(200);
+
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ ownerOnly: true })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'App User' }).expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'alice entity' })
+        .expect(200);
+
+      await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
+        .expect(200);
+      await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
+        .send(testData.instances.simpleEntity.one.replace(
+          '<entities:label>Alice (88)</entities:label>',
+          '<entities:label>Made By App User</entities:label>'))
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+      await exhaust(container);
+
+      await asAlice.get(`/v1/projects/1/datasets/people/entities?viewAs=${appUser.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.length.should.eql(1);
+          body[0].currentVersion.label.should.eql('Made By App User');
+        });
+    }));
+
+    it('should filter entities based on actor property rules', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'north person 1', data: { region: 'north' } })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'north person 2', data: { region: 'north' } })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ label: 'south person', data: { region: 'south' } })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'North Worker' }).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      await asAlice.get(`/v1/projects/1/datasets/people/entities?viewAs=${appUser.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.length.should.eql(2);
+          body.map(e => e.currentVersion.label).should.containDeep(['north person 1', 'north person 2']);
+        });
+    }));
+  });
+
   describe('GET /datasets/:name/entities/:uuid', () => {
 
     it('should strip uuid: prefix from query param in entity requests', testEntities(async (service) => {

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -1273,6 +1273,41 @@ describe('api: /datasets/:name.svc', () => {
             body.value[0].label.should.eql('north entity 1');
           });
       }));
+
+      it('should not surface soft-deleted entities when using viewAs unless specified in the filter', testService(async (service) => {
+        const asAlice = await service.login('alice');
+        const appUser = await setupPropertyFilter(service, asAlice);
+
+        const uuids = [uuid(), uuid()];
+
+        // Add and delete a third entity that the app user would be able to see
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuids[0], label: 'north entity 3', data: { region: 'north' } }).expect(200);
+        await asAlice.delete(`/v1/projects/1/datasets/people/entities/${uuids[0]}`)
+          .expect(200);
+
+        // Add and delete another entity that the user cannot access
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuids[1], label: 'west entity 1', data: { region: 'west' } }).expect(200);
+        await asAlice.delete(`/v1/projects/1/datasets/people/entities/${uuids[1]}`)
+          .expect(200);
+
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(2);
+            body.value[0].label.should.eql('north entity 2');
+            body.value[1].label.should.eql('north entity 1');
+          });
+
+        // View only soft-deleted entities for the app user
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$filter=__system/deletedAt ne null`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(1);
+            body.value[0].label.should.eql('north entity 3');
+          });
+      }));
     });
   });
 

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -919,293 +919,302 @@ describe('api: /datasets/:name.svc', () => {
         });
     }));
 
-    it('should filter entities for ownerOnly dataset', testService(async (service, container) => {
-      const asAlice = await service.login('alice');
+    describe('invalid actorId', () => {
+      it('should return 404 if viewAs actor does not exist', testService(async (service) => {
+        const asAlice = await service.login('alice');
 
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .set('Content-Type', 'application/xml')
-        .send(testData.forms.simpleEntity)
-        .expect(200);
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
 
-      // Set ownerOnly on the dataset
-      await asAlice.patch('/v1/projects/1/datasets/people')
-        .send({ ownerOnly: true })
-        .expect(200);
+        await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=99999')
+          .expect(404);
+      }));
 
-      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
-        .send({ displayName: 'App User' }).expect(200);
+      it('should return 400 if viewAs is not a numeric ID', testService(async (service) => {
+        const asAlice = await service.login('alice');
 
-      // Create two entities as Alice (not the app user)
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'alice entity' })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
 
-      // Create one entity as the app user via submission
-      await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
-        .expect(200);
-      await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
-        .send(testData.instances.simpleEntity.one)
-        .set('Content-Type', 'application/xml')
-        .expect(200);
-      await exhaust(container);
+        await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=notanumber')
+          .expect(400)
+          .then(({ body }) => {
+            body.code.should.eql(400.8);
+          });
+      }));
+    });
 
-      // viewAs the app user — should only see the entity they created
-      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
-        .expect(200)
-        .then(({ body }) => {
-          body.value.length.should.eql(1);
-          body.value[0].label.should.eql('Alice (88)');
-        });
-    }));
+    describe('viewAs with ownerOnly filter', () => {
+      it('should filter entities for ownerOnly dataset', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
 
-    it('should return correct $count when filtered by ownerOnly', testService(async (service, container) => {
-      const asAlice = await service.login('alice');
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.simpleEntity)
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .set('Content-Type', 'application/xml')
-        .send(testData.forms.simpleEntity)
-        .expect(200);
+        // Set ownerOnly on the dataset
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ ownerOnly: true })
+          .expect(200);
 
-      await asAlice.patch('/v1/projects/1/datasets/people')
-        .send({ ownerOnly: true })
-        .expect(200);
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'App User' }).expect(200);
 
-      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
-        .send({ displayName: 'App User' }).expect(200);
+        // Create an entity as Alice (not the app user)
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'alice entity' })
+          .expect(200);
 
-      // Two entities created by Alice
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'alice entity 1' }).expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'alice entity 2' }).expect(200);
+        // Create one entity as the app user via submission
+        await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
+          .expect(200);
+        await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
+          .send(testData.instances.simpleEntity.one.replace(''))
+          .send(testData.instances.simpleEntity.one.replace(
+            '<entities:label>Alice (88)</entities:label>',
+            '<entities:label>Made By App User</entities:label>'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await exhaust(container);
 
-      // One entity created by app user via submission
-      await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
-        .expect(200);
-      await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
-        .send(testData.instances.simpleEntity.one)
-        .set('Content-Type', 'application/xml')
-        .expect(200);
-      await exhaust(container);
+        // viewAs the app user — should only see the entity they created
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(1);
+            body.value[0].label.should.eql('Made By App User');
+          });
+      }));
 
-      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$count=true`)
-        .expect(200)
-        .then(({ body }) => {
-          body['@odata.count'].should.eql(1);
-          body.value.length.should.eql(1);
-        });
-    }));
+      it('should return correct $count when filtered by ownerOnly', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
 
-    it('should return 404 if viewAs actor does not exist', testService(async (service) => {
-      const asAlice = await service.login('alice');
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.simpleEntity)
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/datasets')
-        .send({ name: 'people' })
-        .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ ownerOnly: true })
+          .expect(200);
 
-      await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=99999')
-        .expect(404);
-    }));
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'App User' }).expect(200);
 
-    it('should return 400 if viewAs is not a numeric ID', testService(async (service) => {
-      const asAlice = await service.login('alice');
+        // Two entities created by Alice
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'alice entity 1' }).expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'alice entity 2' }).expect(200);
 
-      await asAlice.post('/v1/projects/1/datasets')
-        .send({ name: 'people' })
-        .expect(200);
+        // One entity created by app user via submission
+        await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
+          .expect(200);
+        await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
+          .send(testData.instances.simpleEntity.one)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await exhaust(container);
 
-      await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=notanumber')
-        .expect(400)
-        .then(({ body }) => {
-          body.code.should.eql(400.8);
-        });
-    }));
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$count=true`)
+          .expect(200)
+          .then(({ body }) => {
+            body['@odata.count'].should.eql(1);
+            body.value.length.should.eql(1);
+          });
+      }));
 
-    it('should filter entities based on actor property rules', testService(async (service) => {
-      const asAlice = await service.login('alice');
+      it('should apply ownerOnly filter even for a non-app-user actor', testService(async (service) => {
+        const asAlice = await service.login('alice');
+        const asBob = await service.login('bob');
 
-      // Dataset with a region property
-      await asAlice.post('/v1/projects/1/datasets')
-        .send({ name: 'people' })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/properties')
-        .send({ name: 'region' })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.simpleEntity)
+          .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ ownerOnly: true })
+          .expect(200);
 
-      // Set up actor property and filter rule: entity.region must match actor.region
-      await asAlice.post('/v1/projects/1/actor-properties')
-        .send({ name: 'region' })
-        .expect(200);
-      await asAlice.patch('/v1/projects/1/datasets/people')
-        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
-        .expect(200);
+        // Entity created by Alice
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'alice entity' })
+          .expect(200);
+        // Entity created by Bob
+        await asBob.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'bob entity' })
+          .expect(200);
 
-      // Two entities in 'north', one in 'south'
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'north person 1', data: { region: 'north' } })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'north person 2', data: { region: 'north' } })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'south person', data: { region: 'south' } })
-        .expect(200);
+        const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
 
-      // App user assigned to 'north'
-      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
-        .send({ displayName: 'North Worker' }).expect(200);
-      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
-        .send({ properties: { region: 'north' } })
-        .expect(200);
+        // viewAs Bob (a web user) on an ownerOnly dataset — only his entity
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(1);
+            body.value[0].label.should.eql('bob entity');
+          });
+      }));
+    });
 
-      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
-        .expect(200)
-        .then(({ body }) => {
-          body.value.length.should.eql(2);
-          body.value.map(e => e.label).should.containDeep(['north person 1', 'north person 2']);
-        });
-    }));
+    describe('viewAs with actor property filter rules', () => {
+      it('should filter entities based on actor property rules', testService(async (service) => {
+        const asAlice = await service.login('alice');
 
-    it('should return correct $count with actor property filter', testService(async (service) => {
-      const asAlice = await service.login('alice');
+        // Dataset with a region property
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'region' })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/datasets')
-        .send({ name: 'people' })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/properties')
-        .send({ name: 'region' })
-        .expect(200);
+        // Set up actor property and filter rule: entity.region must match actor.region
+        await asAlice.post('/v1/projects/1/actor-properties')
+          .send({ name: 'region' })
+          .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/actor-properties')
-        .send({ name: 'region' })
-        .expect(200);
-      await asAlice.patch('/v1/projects/1/datasets/people')
-        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
-        .expect(200);
+        // Two entities in 'north', one in 'south'
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'north person 1', data: { region: 'north' } })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'north person 2', data: { region: 'north' } })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'south person', data: { region: 'south' } })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'south person 1', data: { region: 'south' } })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'south person 2', data: { region: 'south' } })
-        .expect(200);
+        // App user assigned to 'north'
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'North Worker' }).expect(200);
+        await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+          .send({ properties: { region: 'north' } })
+          .expect(200);
 
-      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
-        .send({ displayName: 'South Worker' }).expect(200);
-      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
-        .send({ properties: { region: 'south' } })
-        .expect(200);
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(2);
+            body.value.map(e => e.label).should.containDeep(['north person 1', 'north person 2']);
+          });
+      }));
 
-      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$count=true`)
-        .expect(200)
-        .then(({ body }) => {
-          body['@odata.count'].should.eql(2);
-          body.value.length.should.eql(2);
-        });
-    }));
+      it('should return correct $count with actor property filter', testService(async (service) => {
+        const asAlice = await service.login('alice');
 
-    it('should apply ownerOnly filter even for a non-app-user actor', testService(async (service) => {
-      const asAlice = await service.login('alice');
-      const asBob = await service.login('bob');
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'region' })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/forms?publish=true')
-        .set('Content-Type', 'application/xml')
-        .send(testData.forms.simpleEntity)
-        .expect(200);
-      await asAlice.patch('/v1/projects/1/datasets/people')
-        .send({ ownerOnly: true })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/actor-properties')
+          .send({ name: 'region' })
+          .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+          .expect(200);
 
-      // Entity created by Alice
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'alice entity' })
-        .expect(200);
-      // Entity created by Bob
-      await asBob.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'bob entity' })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'south person 1', data: { region: 'south' } })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'south person 2', data: { region: 'south' } })
+          .expect(200);
 
-      const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'South Worker' }).expect(200);
+        await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+          .send({ properties: { region: 'south' } })
+          .expect(200);
 
-      // viewAs Bob (a web user) on an ownerOnly dataset — only his entity
-      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
-        .expect(200)
-        .then(({ body }) => {
-          body.value.length.should.eql(1);
-          body.value[0].label.should.eql('bob entity');
-        });
-    }));
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$count=true`)
+          .expect(200)
+          .then(({ body }) => {
+            body['@odata.count'].should.eql(2);
+            body.value.length.should.eql(2);
+          });
+      }));
 
-    it('should return no entities for actor with no matching property values', testService(async (service) => {
-      const asAlice = await service.login('alice');
+      it('should return no entities for actor with no matching property values', testService(async (service) => {
+        const asAlice = await service.login('alice');
 
-      await asAlice.post('/v1/projects/1/datasets')
-        .send({ name: 'people' })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/properties')
-        .send({ name: 'region' })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'region' })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/actor-properties')
-        .send({ name: 'region' })
-        .expect(200);
-      await asAlice.patch('/v1/projects/1/datasets/people')
-        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/actor-properties')
+          .send({ name: 'region' })
+          .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+          .expect(200);
 
-      // App user with no region property set
-      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
-        .send({ displayName: 'Unassigned Worker' }).expect(200);
+        // App user with no region property set
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'Unassigned Worker' }).expect(200);
 
-      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
-        .expect(200)
-        .then(({ body }) => {
-          body.value.length.should.eql(0);
-        });
-    }));
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(0);
+          });
+      }));
 
-    it('should apply property filter even for a web user actor (unlike the OpenRosa path)', testService(async (service) => {
-      // NOTE: The real OpenRosa CSV path skips access filtering for actors that can
-      // entity.list (managers, web users). viewAs does NOT replicate that check —
-      // it always applies the SQL filter. A web user with no actor property values
-      // set will get 0 entities, not all entities.
-      const asAlice = await service.login('alice');
-      const asBob = await service.login('bob');
+      it('should apply property filter even for a web user actor (unlike the OpenRosa path)', testService(async (service) => {
+        // NOTE: The real OpenRosa CSV path skips access filtering for actors that can
+        // entity.list (managers, web users). viewAs does NOT replicate that check —
+        // it always applies the SQL filter. A web user with no actor property values
+        // set will get 0 entities, not all entities.
+        const asAlice = await service.login('alice');
+        const asBob = await service.login('bob');
 
-      await asAlice.post('/v1/projects/1/datasets')
-        .send({ name: 'people' })
-        .expect(200);
-      await asAlice.post('/v1/projects/1/datasets/people/properties')
-        .send({ name: 'region' })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'region' })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/actor-properties')
-        .send({ name: 'region' })
-        .expect(200);
-      await asAlice.patch('/v1/projects/1/datasets/people')
-        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/actor-properties')
+          .send({ name: 'region' })
+          .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+          .expect(200);
 
-      await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
-        .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+          .expect(200);
 
-      // Bob is a web user (project manager) with no actor property values
-      const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
+        // Bob is a web user (project manager) with no actor property values
+        const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
 
-      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
-        .expect(200)
-        .then(({ body }) => {
-          body.value.length.should.eql(0);
-        });
-    }));
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(0);
+          });
+      }));
+    });
   });
 
   describe('GET service document', () => {

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -941,7 +941,7 @@ describe('api: /datasets/:name.svc', () => {
         await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=notanumber')
           .expect(400)
           .then(({ body }) => {
-            body.code.should.eql(400.8);
+            body.code.should.eql(400.11);
           });
       }));
     });
@@ -972,7 +972,6 @@ describe('api: /datasets/:name.svc', () => {
         await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
           .expect(200);
         await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
-          .send(testData.instances.simpleEntity.one.replace(''))
           .send(testData.instances.simpleEntity.one.replace(
             '<entities:label>Alice (88)</entities:label>',
             '<entities:label>Made By App User</entities:label>'))
@@ -1027,9 +1026,8 @@ describe('api: /datasets/:name.svc', () => {
           });
       }));
 
-      it('should apply ownerOnly filter even for a non-app-user actor', testService(async (service) => {
-        const asAlice = await service.login('alice');
-        const asBob = await service.login('bob');
+      it('should apply ownerOnly filter for a web data collector', testService(async (service, container) => {
+        const [asAlice, asChelsea] = await service.login(['alice', 'chelsea']);
 
         await asAlice.post('/v1/projects/1/forms?publish=true')
           .set('Content-Type', 'application/xml')
@@ -1039,23 +1037,31 @@ describe('api: /datasets/:name.svc', () => {
           .send({ ownerOnly: true })
           .expect(200);
 
+        // Assign Chelsea the Data Collector (formfill) role on the project.
+        const chelseaId = await asChelsea.get('/v1/users/current')
+          .then(({ body }) => body.id);
+        await asAlice.post(`/v1/projects/1/assignments/formfill/${chelseaId}`)
+          .expect(200);
+
         // Entity created by Alice
         await asAlice.post('/v1/projects/1/datasets/people/entities')
           .send({ uuid: uuid(), label: 'alice entity' })
           .expect(200);
-        // Entity created by Bob
-        await asBob.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'bob entity' })
+        // Entity created by Chelsea via submission
+        await asChelsea.post('/v1/projects/1/forms/simpleEntity/submissions')
+          .send(testData.instances.simpleEntity.one.replace(
+            '<entities:label>Alice (88)</entities:label>',
+            '<entities:label>chelsea entity</entities:label>'))
+          .set('Content-Type', 'application/xml')
           .expect(200);
+        await exhaust(container);
 
-        const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
-
-        // viewAs Bob (a web user) on an ownerOnly dataset — only his entity
-        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
+        // viewAs Chelsea (a web data collector) on an ownerOnly dataset — only her entity
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${chelseaId}`)
           .expect(200)
           .then(({ body }) => {
             body.value.length.should.eql(1);
-            body.value[0].label.should.eql('bob entity');
+            body.value[0].label.should.eql('chelsea entity');
           });
       }));
     });
@@ -1179,11 +1185,7 @@ describe('api: /datasets/:name.svc', () => {
           });
       }));
 
-      it('should apply property filter even for a web user actor (unlike the OpenRosa path)', testService(async (service) => {
-        // NOTE: The real OpenRosa CSV path skips access filtering for actors that can
-        // entity.list (managers, web users). viewAs does NOT replicate that check —
-        // it always applies the SQL filter. A web user with no actor property values
-        // set will get 0 entities, not all entities.
+      it('should reproduce filter behavior where actors with entity.list see all entities, unfiltered', testService(async (service) => {
         const asAlice = await service.login('alice');
         const asBob = await service.login('bob');
 
@@ -1211,7 +1213,7 @@ describe('api: /datasets/:name.svc', () => {
         await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
           .expect(200)
           .then(({ body }) => {
-            body.value.length.should.eql(0);
+            body.value.length.should.eql(1);
           });
       }));
     });

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -903,10 +903,10 @@ describe('api: /datasets/:name.svc', () => {
         .expect(200);
 
       await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'entity1' })
+        .send({ label: 'entity1' })
         .expect(200);
       await asAlice.post('/v1/projects/1/datasets/people/entities')
-        .send({ uuid: uuid(), label: 'entity2' })
+        .send({ label: 'entity2' })
         .expect(200);
 
       const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
@@ -965,7 +965,7 @@ describe('api: /datasets/:name.svc', () => {
 
         // Create an entity as Alice (not the app user)
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'alice entity' })
+          .send({ label: 'alice entity' })
           .expect(200);
 
         // Create one entity as the app user via submission
@@ -1005,9 +1005,9 @@ describe('api: /datasets/:name.svc', () => {
 
         // Two entities created by Alice
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'alice entity 1' }).expect(200);
+          .send({ label: 'alice entity 1' }).expect(200);
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'alice entity 2' }).expect(200);
+          .send({ label: 'alice entity 2' }).expect(200);
 
         // One entity created by app user via submission
         await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
@@ -1045,7 +1045,7 @@ describe('api: /datasets/:name.svc', () => {
 
         // Entity created by Alice
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'alice entity' })
+          .send({ label: 'alice entity' })
           .expect(200);
         // Entity created by Chelsea via submission
         await asChelsea.post('/v1/projects/1/forms/simpleEntity/submissions')
@@ -1088,13 +1088,13 @@ describe('api: /datasets/:name.svc', () => {
 
         // Two entities in 'north', one in 'south'
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'north person 1', data: { region: 'north' } })
+          .send({ label: 'north person 1', data: { region: 'north' } })
           .expect(200);
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'north person 2', data: { region: 'north' } })
+          .send({ label: 'north person 2', data: { region: 'north' } })
           .expect(200);
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'south person', data: { region: 'south' } })
+          .send({ label: 'south person', data: { region: 'south' } })
           .expect(200);
 
         // App user assigned to 'north'
@@ -1130,13 +1130,13 @@ describe('api: /datasets/:name.svc', () => {
           .expect(200);
 
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+          .send({ label: 'north person', data: { region: 'north' } })
           .expect(200);
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'south person 1', data: { region: 'south' } })
+          .send({ label: 'south person 1', data: { region: 'south' } })
           .expect(200);
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'south person 2', data: { region: 'south' } })
+          .send({ label: 'south person 2', data: { region: 'south' } })
           .expect(200);
 
         const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
@@ -1171,7 +1171,7 @@ describe('api: /datasets/:name.svc', () => {
           .expect(200);
 
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+          .send({ label: 'north person', data: { region: 'north' } })
           .expect(200);
 
         // App user with no region property set
@@ -1204,7 +1204,7 @@ describe('api: /datasets/:name.svc', () => {
           .expect(200);
 
         await asAlice.post('/v1/projects/1/datasets/people/entities')
-          .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+          .send({ label: 'north person', data: { region: 'north' } })
           .expect(200);
 
         // Bob is a web user (project manager) with no actor property values
@@ -1214,6 +1214,63 @@ describe('api: /datasets/:name.svc', () => {
           .expect(200)
           .then(({ body }) => {
             body.value.length.should.eql(1);
+          });
+      }));
+    });
+
+    describe('viewAs combined with other query params', () => {
+      // shared setup: dataset with region property filter, app user assigned to north
+      // north entity 1 created by Alice, north entity 2 by Bob, south entity by Alice
+      const setupPropertyFilter = async (service, asAlice) => {
+        const asBob = await service.login('bob');
+
+        await asAlice.post('/v1/projects/1/datasets').send({ name: 'people' }).expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/properties').send({ name: 'region' }).expect(200);
+        await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'north entity 1', data: { region: 'north' } }).expect(200);
+        await asBob.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'north entity 2', data: { region: 'north' } }).expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'south entity', data: { region: 'south' } }).expect(200);
+
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'North Worker' }).expect(200);
+        await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+          .send({ properties: { region: 'north' } }).expect(200);
+        return appUser;
+      };
+
+      it('should apply $filter alongside viewAs', testService(async (service) => {
+        const asAlice = await service.login('alice');
+        const appUser = await setupPropertyFilter(service, asAlice);
+
+        const aliceId = await asAlice.get('/v1/users/current').then(({ body }) => body.id);
+
+        // viewAs filters to 2 north entities; $filter by Alice's creatorId narrows to the 1 she created
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$filter=__system/creatorId eq ${aliceId}&$count=true`)
+          .expect(200)
+          .then(({ body }) => {
+            body['@odata.count'].should.eql(1);
+            body.value.length.should.eql(1);
+            body.value[0].label.should.eql('north entity 1');
+          });
+      }));
+
+      it('should apply $search alongside viewAs', testService(async (service) => {
+        const asAlice = await service.login('alice');
+        const appUser = await setupPropertyFilter(service, asAlice);
+
+        // viewAs filters to north entities; $search further narrows to only the matching label
+        await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$search=entity+1`)
+          .expect(200)
+          .then(({ body }) => {
+            body.value.length.should.eql(1);
+            body.value[0].label.should.eql('north entity 1');
           });
       }));
     });

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -1006,6 +1006,206 @@ describe('api: /datasets/:name.svc', () => {
       await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=99999')
         .expect(404);
     }));
+
+    it('should return 400 if viewAs is not a numeric ID', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=notanumber')
+        .expect(400)
+        .then(({ body }) => {
+          body.code.should.eql(400.8);
+        });
+    }));
+
+    it('should filter entities based on actor property rules', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      // Dataset with a region property
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      // Set up actor property and filter rule: entity.region must match actor.region
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      // Two entities in 'north', one in 'south'
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'north person 1', data: { region: 'north' } })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'north person 2', data: { region: 'north' } })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'south person', data: { region: 'south' } })
+        .expect(200);
+
+      // App user assigned to 'north'
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'North Worker' }).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'north' } })
+        .expect(200);
+
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.value.length.should.eql(2);
+          body.value.map(e => e.label).should.containDeep(['north person 1', 'north person 2']);
+        });
+    }));
+
+    it('should return correct $count with actor property filter', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'south person 1', data: { region: 'south' } })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'south person 2', data: { region: 'south' } })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'South Worker' }).expect(200);
+      await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+        .send({ properties: { region: 'south' } })
+        .expect(200);
+
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$count=true`)
+        .expect(200)
+        .then(({ body }) => {
+          body['@odata.count'].should.eql(2);
+          body.value.length.should.eql(2);
+        });
+    }));
+
+    it('should apply ownerOnly filter even for a non-app-user actor', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      const asBob = await service.login('bob');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.simpleEntity)
+        .expect(200);
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ ownerOnly: true })
+        .expect(200);
+
+      // Entity created by Alice
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'alice entity' })
+        .expect(200);
+      // Entity created by Bob
+      await asBob.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'bob entity' })
+        .expect(200);
+
+      const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
+
+      // viewAs Bob (a web user) on an ownerOnly dataset — only his entity
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.value.length.should.eql(1);
+          body.value[0].label.should.eql('bob entity');
+        });
+    }));
+
+    it('should return no entities for actor with no matching property values', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+        .expect(200);
+
+      // App user with no region property set
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'Unassigned Worker' }).expect(200);
+
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.value.length.should.eql(0);
+        });
+    }));
+
+    it('should apply property filter even for a web user actor (unlike the OpenRosa path)', testService(async (service) => {
+      // NOTE: The real OpenRosa CSV path skips access filtering for actors that can
+      // entity.list (managers, web users). viewAs does NOT replicate that check —
+      // it always applies the SQL filter. A web user with no actor property values
+      // set will get 0 entities, not all entities.
+      const asAlice = await service.login('alice');
+      const asBob = await service.login('bob');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'north person', data: { region: 'north' } })
+        .expect(200);
+
+      // Bob is a web user (project manager) with no actor property values
+      const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
+
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${bobId}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.value.length.should.eql(0);
+        });
+    }));
   });
 
   describe('GET service document', () => {

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -894,6 +894,120 @@ describe('api: /datasets/:name.svc', () => {
     }));
   });
 
+  describe('GET /Entities with viewAs', () => {
+    it('should return all entities if dataset has no access filter', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'entity1' })
+        .expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'entity2' })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'App User' }).expect(200);
+
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.value.length.should.eql(2);
+        });
+    }));
+
+    it('should filter entities for ownerOnly dataset', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.simpleEntity)
+        .expect(200);
+
+      // Set ownerOnly on the dataset
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ ownerOnly: true })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'App User' }).expect(200);
+
+      // Create two entities as Alice (not the app user)
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'alice entity' })
+        .expect(200);
+
+      // Create one entity as the app user via submission
+      await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
+        .expect(200);
+      await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
+        .send(testData.instances.simpleEntity.one)
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+      await exhaust(container);
+
+      // viewAs the app user — should only see the entity they created
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}`)
+        .expect(200)
+        .then(({ body }) => {
+          body.value.length.should.eql(1);
+          body.value[0].label.should.eql('Alice (88)');
+        });
+    }));
+
+    it('should return correct $count when filtered by ownerOnly', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/forms?publish=true')
+        .set('Content-Type', 'application/xml')
+        .send(testData.forms.simpleEntity)
+        .expect(200);
+
+      await asAlice.patch('/v1/projects/1/datasets/people')
+        .send({ ownerOnly: true })
+        .expect(200);
+
+      const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+        .send({ displayName: 'App User' }).expect(200);
+
+      // Two entities created by Alice
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'alice entity 1' }).expect(200);
+      await asAlice.post('/v1/projects/1/datasets/people/entities')
+        .send({ uuid: uuid(), label: 'alice entity 2' }).expect(200);
+
+      // One entity created by app user via submission
+      await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
+        .expect(200);
+      await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
+        .send(testData.instances.simpleEntity.one)
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+      await exhaust(container);
+
+      await asAlice.get(`/v1/projects/1/datasets/people.svc/Entities?viewAs=${appUser.id}&$count=true`)
+        .expect(200)
+        .then(({ body }) => {
+          body['@odata.count'].should.eql(1);
+          body.value.length.should.eql(1);
+        });
+    }));
+
+    it('should return 404 if viewAs actor does not exist', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1/datasets/people.svc/Entities?viewAs=99999')
+        .expect(404);
+    }));
+  });
+
   describe('GET service document', () => {
     it('should return service document', testService(async (service) => {
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1879

Add `?viewAs=<actorId>` query parameter to entities endpoints (both OData and REST) to filter the list to only what would be shown to that actor if the entities were fetched as a CSV form attachment. 

This will emulate
- `ownerOnly` filters (for app users, public links, _and_ web data collectors)
- actor property filters (app users and public links)

If the actor ID of a manager, viewer, or admin is provided (someone who can view all entities), this filter will return all entities.

This filter can be applied with other filters in the OData endpoint, e.g. `$filter` and `$search` to further filter the entities for a specific user.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

I have a few questions to discuss:
- is `viewAs` a good query parameter name?
- is it actually necessary for the REST endpoint to have this? it doesn't have any other filters. But since this one isn't odata, it seems ok to add it to the REST endpoint. 
- is it weird to have this non-OData query param alongside the OData parameters? 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Gives more options to users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

API docs are updated as part of the PR. 
