### PR TITLE
log-upgrade: suppress output

### DIFF
--- a/lib/bin/log-upgrade.js
+++ b/lib/bin/log-upgrade.js
@@ -27,4 +27,4 @@ try {
   // and logUpgrade task wont run
 }
 
-if (version) run(logUpgrade({ version, server, client }));
+if (version) run(logUpgrade({ version, server, client }), { silent: true });

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -22,6 +22,7 @@ const config = require('config');
 const container = require('../model/container');
 const Problem = require('../util/problem');
 const Option = require('../util/option');
+const { noop } = require('../util/util');
 const { slonikPool } = require('../external/slonik');
 const jsonSerialize = require('../util/json-serialize');
 
@@ -139,9 +140,9 @@ const emailing = (messageId, t) => ((typeof t === 'function')
 
 // Executes a task and writes the result of that task to stdout. Takes
 // t: Task|(() => Task).
-const run = (t) => ((typeof t === 'function')
+const run = (t, opts={}) => ((typeof t === 'function')
   ? run(t())
-  : t.then(compose(writeTo(process.stdout), jsonSerialize), fault));
+  : t.then(opts.silent ? noop : compose(writeTo(process.stdout), jsonSerialize), fault));
 
 
 module.exports = { task, auditing, emailing, run };


### PR DESCRIPTION
Add option to `task.run()` to prevent default of printing JSON-serialised return value to stdout.

Closes getodk/central#2125

#### What has been done to verify that this works as intended?

- [x] ci

Also:

```
$ node lib/bin/log-upgrade.js 
```
(there was no output)

```
$ SENTRY_TAGS='{"version.central":"c1","version.client":"c2"}' node lib/bin/log-upgrade.js 
attempted to log Sentry transaction in development:
{ op: 'task', name: 'log-upgrade', duration: 54.322198000000014 }
```

#### Why is this the best possible solution? Were any other approaches considered?

Seems helpful anyway to have an option to suppress output from tasks.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Should decrease their alarm reported in getodk/central#2125.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.