### PR TITLE
Fix entity submission parsing to allow fields named label to be saved

### DIFF
--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -161,11 +161,10 @@ const submissionXmlToEntityData = (structurals, entityFields, xml) => {
 
         const entity = last(entities[datasetId]);
 
-        if (name === 'label')
-          entity.system.label = textBuffer;
-        else
+        if (propertyName != null)
           entity.data[propertyName] = textBuffer;
-
+        else if (name === 'label')
+          entity.system.label = textBuffer;
       }
     }
   }, { xmlMode: true, decodeEntities: true });

--- a/lib/data/entity.js
+++ b/lib/data/entity.js
@@ -152,7 +152,7 @@ const submissionXmlToEntityData = (structurals, entityFields, xml) => {
 
       if (structural == null && entityField != null) {
 
-        const { name, propertyName, datasetId } = entityField;
+        const { propertyName, datasetId } = entityField;
 
         if (!entities[datasetId]) {
           // It's possible to see entity properties before the entity block
@@ -163,7 +163,7 @@ const submissionXmlToEntityData = (structurals, entityFields, xml) => {
 
         if (propertyName != null)
           entity.data[propertyName] = textBuffer;
-        else if (name === 'label')
+        else // entityField with name === 'label' is the only other possibility
           entity.system.label = textBuffer;
       }
     }

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -310,43 +310,30 @@ describe('extracting and validating entities', () => {
 
     it('should save a form field with name label to an entity property (issue c#1970)', async () => {
       const form = `<?xml version="1.0"?>
-        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:entities="http://www.opendatakit.org/xforms/entities">
-            <h:head>
-                <h:title>label_to_property</h:title>
-                <model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
-                    <instance>
-                        <data id="label_to_property" version="5">
-                            <grp>
-                                <label/>
-                            </grp>
-                            <thing/>
-                            <thing_note/>
-                            <meta>
-                                <entity dataset="things" create="1" id="">
-                                    <label/>
-                                </entity>
-                                <instanceID/>
-                            </meta>
-                        </data>
-                    </instance>
-                    <instance id="things" src="jr://file-csv/things.csv"/>
-                    <bind nodeset="/data/grp/label" type="string" entities:saveto="denomination"/>
-                    <bind nodeset="/data/thing" type="string"/>
-                    <bind nodeset="/data/thing_note" readonly="true()" type="string"/>
-                    <bind nodeset="/data/meta/entity/@id" readonly="true()" type="string"/>
-                    <setvalue ref="/data/meta/entity/@id" event="odk-instance-first-load" value="uuid()"/>
-                    <bind nodeset="/data/meta/entity/label" calculate=" /data/grp/label " readonly="true()" type="string"/>
-                    <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
-                </model>
-            </h:head>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:entities="http://www.opendatakit.org/xforms/entities">
+          <h:head>
+            <model entities:entities-version="2024.1.0">
+              <instance>
+                <data id="label_to_property" version="1">
+                  <grp>
+                    <label/>
+                  </grp>
+                  <meta>
+                    <entity dataset="people" id="" create="1">
+                      <label/>
+                    </entity>
+                  </meta>
+                </data>
+              </instance>
+              <bind nodeset="/data/grp/label" type="string" entities:saveto="denomination"/>
+            </model>
+          </h:head>
         </h:html>`;
 
-      const sub = `<data id="label_to_property" version="5">
+      const sub = `<data id="label_to_property" version="1">
         <grp>
           <label>property value</label>
         </grp>
-        <thing/>
-        <thing_note/>
         <meta>
           <entity dataset="things" create="1" id="e9027bee-d4de-42d6-afde-4c6effcc16cb">
             <label>entity label</label>

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -307,6 +307,59 @@ describe('extracting and validating entities', () => {
         });
       });
     });
+
+    it('should save a form field with name label to an entity property (issue c#1970)', async () => {
+      const form = `<?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:entities="http://www.opendatakit.org/xforms/entities">
+            <h:head>
+                <h:title>label_to_property</h:title>
+                <model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
+                    <instance>
+                        <data id="label_to_property" version="5">
+                            <grp>
+                                <label/>
+                            </grp>
+                            <thing/>
+                            <thing_note/>
+                            <meta>
+                                <entity dataset="things" create="1" id="">
+                                    <label/>
+                                </entity>
+                                <instanceID/>
+                            </meta>
+                        </data>
+                    </instance>
+                    <instance id="things" src="jr://file-csv/things.csv"/>
+                    <bind nodeset="/data/grp/label" type="string" entities:saveto="denomination"/>
+                    <bind nodeset="/data/thing" type="string"/>
+                    <bind nodeset="/data/thing_note" readonly="true()" type="string"/>
+                    <bind nodeset="/data/meta/entity/@id" readonly="true()" type="string"/>
+                    <setvalue ref="/data/meta/entity/@id" event="odk-instance-first-load" value="uuid()"/>
+                    <bind nodeset="/data/meta/entity/label" calculate=" /data/grp/label " readonly="true()" type="string"/>
+                    <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+                </model>
+            </h:head>
+        </h:html>`;
+
+      const sub = `<data id="label_to_property" version="5">
+        <grp>
+          <label>property value</label>
+        </grp>
+        <thing/>
+        <thing_note/>
+        <meta>
+          <entity dataset="things" create="1" id="e9027bee-d4de-42d6-afde-4c6effcc16cb">
+            <label>entity label</label>
+          </entity>
+          <instanceID>uuid:a3eca9e7-d627-4d47-a399-2ab2cac80718</instanceID>
+        </meta>
+      </data>`;
+
+      const { entityFields, structuralFields } = await entityRepeatFieldsFor(form);
+      const result = await submissionXmlToEntityData(structuralFields, entityFields, sub);
+      should(result[0].data).eql({'denomination': 'property value'})
+      result[0].system.label.should.equal('entity label');
+    });
   });
 
   describe('extract multiple entities from submission with repeats', () => {

--- a/test/unit/data/entity.js
+++ b/test/unit/data/entity.js
@@ -357,7 +357,7 @@ describe('extracting and validating entities', () => {
 
       const { entityFields, structuralFields } = await entityRepeatFieldsFor(form);
       const result = await submissionXmlToEntityData(structuralFields, entityFields, sub);
-      should(result[0].data).eql({'denomination': 'property value'})
+      should(result[0].data).eql({ denomination: 'property value' });
       result[0].system.label.should.equal('entity label');
     });
   });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1970

Found the bug where any form field named `"label"` (because it was expecting things like`/meta/entity/label`) was written to the entity label, even if it was associated with a dataset property. 


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Reproducing the bug with a test and then fixing it. 

#### Why is this the best possible solution? Were any other approaches considered?

I think flipping the if statement like that is fine. It will write the any valid property now and not get confused by properties from a field named "label".

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Fixes a bug for users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.