### PR TITLE
Recompute blob file size on hash conflict

### DIFF
--- a/lib/model/query/blobs.js
+++ b/lib/model/query/blobs.js
@@ -22,7 +22,7 @@ const ensure = (blob) => ({ oneFirst }) => oneFirst(sql`
     INSERT INTO blobs (sha, md5, content, "contentType", size) VALUES (
       ${blob.sha}, ${blob.md5}, ${sql.binary(blob.content)}, ${blob.contentType || sql`DEFAULT`}, ${blob.content.length}
     )
-    ON CONFLICT (sha, "contentType") DO NOTHING
+    ON CONFLICT (sha, "contentType") DO UPDATE SET size = EXCLUDED.size WHERE blobs.size IS NULL
     RETURNING id
   )
   SELECT coalesce((SELECT id FROM ensured), (SELECT id FROM extant)) as id

--- a/test/integration/other/blobs.js
+++ b/test/integration/other/blobs.js
@@ -171,7 +171,7 @@ describe('blob query module', () => {
       });
   }));
 
-  it('should not recompute size when blob with same hash comes in', testService(async (service, container) => {
+  it('should recompute size when blob with same hash comes in if size was empty', testService(async (service, container) => {
     const asAlice = await service.login('alice');
     const bufferContent = Buffer.from('some,csv,data');
 
@@ -210,14 +210,14 @@ describe('blob query module', () => {
       .send(bufferContent)
       .expect(200)
       .then(({ body }) => {
-        should.not.exist(body.size);
+        body.size.should.equal(13);
       });
 
     await asAlice.get('/v1/projects/1/forms/consumeDatasets/draft/attachments')
       .expect(200)
       .then(({ body }) => {
         body[0].name.should.equal('people.csv');
-        should.not.exist(body[0].size);
+        body[0].size.should.equal(13);
       });
   }));
 });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2126

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Updating the relevant test.

#### Why is this the best possible solution? Were any other approaches considered?

The file contents size was there, it just needed to be saved. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Makes things a bit clearer for users instead of mysteriously never seeing a size for a file even if it gets reuploaded (or if the same file gets uploaded in a different context). 

There's still a chance for confusing behavior, but at least its easier to explain, e.g. "if the file was on S3, we didn't bother computing its size".

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

I don't think so.