### PR TITLE
test/api/projects: test dataset/extended metadata relationship

### DIFF
--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -378,6 +378,27 @@ describe('api: /projects', () => {
               body.appUsers.should.equal(1);
             })))));
 
+    it('should return datasets iff extended metadata is requested', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      await asAlice.post('/v1/projects/1/datasets')
+        .send({ name: 'people' })
+        .expect(200);
+
+      await asAlice.get('/v1/projects/1')
+        .expect(200)
+        .then(({ body }) => {
+          should.not.exist(body.datasets);
+        });
+
+      await asAlice.get('/v1/projects/1')
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.datasets.should.equal(1);
+        });
+    }));
+
     it('should not return deleted datasets', testService(async (service) => {
       const asAlice = await service.login('alice');
 


### PR DESCRIPTION
Add explicit test linking datasets to extended metadata.

Ref getodk/central#2032

#### What has been done to verify that this works as intended?

Looking into getodk/central#2032, there didn't seem to be any explicit link in the tests between the `X-Extended-Metadata` header and inclusion of dataset information.

#### Why is this the best possible solution? Were any other approaches considered?

Could continue to not test it.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect - just a new test.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.