### PR TITLE
GET projects/:id: add option to include verbs only

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -2642,7 +2642,7 @@ paths:
         example: "16"
       - name: verbs
         in: query
-        description: If set to `true`, will return allowed verbs for the current user on this project.  When extended metadata is requested, this parameter is ignored, and verbs are always included.
+        description: If set to `true`, will return allowed verbs for the current actor on this project.  When extended metadata is requested, this parameter is ignored, and verbs are always included.
         schema:
           type: boolean
         example: "true"

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -2640,6 +2640,12 @@ paths:
         schema:
           type: number
         example: "16"
+      - name: verbs
+        in: query
+        description: If set to `true`, will return allowed verbs for the current user on this project.  When extended metadata is requested, this parameter is ignored, and verbs are always included.
+        schema:
+          type: boolean
+        example: "true"
       responses:
         "200":
           description: 'This is the Extended Metadata response, if requested via the

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -40,7 +40,7 @@ module.exports = (service, endpoint) => {
     Projects.getById(params.id, queryOptions)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.read', project))
-      .then((project) => ((queryOptions.extended === true)
+      .then((project) => ((queryOptions.extended === true || queryOptions.argData.includeVerbs === 'true')
         ? auth.verbsOn(project).then((verbs) => Object.assign({ verbs }, project.forApi()))
         : project))));
 

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -40,7 +40,7 @@ module.exports = (service, endpoint) => {
     Projects.getById(params.id, queryOptions)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.read', project))
-      .then((project) => ((queryOptions.extended === true || query.includeVerbs === 'true')
+      .then((project) => ((queryOptions.extended === true || query.verbs === 'true')
         ? auth.verbsOn(project).then((verbs) => Object.assign({ verbs }, project.forApi()))
         : project))));
 

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -36,11 +36,11 @@ module.exports = (service, endpoint) => {
     auth.canOrReject('project.create', Project.species)
       .then(() => Projects.create(Project.fromApi(body)))));
 
-  service.get('/projects/:id', endpoint(({ Projects }, { auth, params, queryOptions }) =>
+  service.get('/projects/:id', endpoint(({ Projects }, { auth, params, query, queryOptions }) =>
     Projects.getById(params.id, queryOptions)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('project.read', project))
-      .then((project) => ((queryOptions.extended === true || queryOptions.argData.includeVerbs === 'true')
+      .then((project) => ((queryOptions.extended === true || query.includeVerbs === 'true')
         ? auth.verbsOn(project).then((verbs) => Object.assign({ verbs }, project.forApi()))
         : project))));
 

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -504,7 +504,7 @@ describe('api: /projects', () => {
                 ]);
               }))))));
 
-    describe('query param: includeVerbs=true', () => {
+    describe('query param: verbs=true', () => {
       it('should return verb information', testService(async (service) => {
         const asAlice = await service.login('alice');
 
@@ -512,7 +512,7 @@ describe('api: /projects', () => {
         const { body: { verbs: allAdminVerbs } } = await asAlice.get('/v1/roles/admin').expect(200);
 
 
-        await asAlice.get('/v1/projects/1?includeVerbs=true')
+        await asAlice.get('/v1/projects/1?verbs=true')
           .expect(200)
           .then(({ body }) => {
             body.verbs.should.be.an.Array();
@@ -520,7 +520,7 @@ describe('api: /projects', () => {
             body.verbs.should.containDeep(minimalExpectedVerbs);
           });
 
-        await asAlice.get('/v1/projects/1?includeVerbs=true')
+        await asAlice.get('/v1/projects/1?verbs=true')
           .set('X-Extended-Metadata', 'true')
           .expect(200)
           .then(({ body }) => {
@@ -542,7 +542,7 @@ describe('api: /projects', () => {
           .set('Content-Type', 'application/xml')
           .expect(200);
 
-        await asAlice.get('/v1/projects/1?includeVerbs=true')
+        await asAlice.get('/v1/projects/1?verbs=true')
           .expect(200)
           .then(({ body }) => {
             should.not.exist(body.forms);
@@ -550,7 +550,7 @@ describe('api: /projects', () => {
             should.not.exist(body.lastSubmission);
           });
 
-        await asAlice.get('/v1/projects/1?includeVerbs=true')
+        await asAlice.get('/v1/projects/1?verbs=true')
           .set('X-Extended-Metadata', 'true')
           .expect(200)
           .then(({ body }) => {

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -482,6 +482,39 @@ describe('api: /projects', () => {
                   'actor_property.list'
                 ]);
               }))))));
+
+    describe('query param: includeVerbs=true', () => {
+      it('should return verb information', testService(async (service) => {
+        const asAlice = await service.login('alice');
+        const { body: project } = await asAlice.get('/v1/projects/1?includeVerbs=true')
+          .expect(200);
+        project.verbs.should.be.an.Array();
+        const { body: admin } = await asAlice.get('/v1/roles/admin').expect(200);
+        project.verbs.should.eqlInAnyOrder(admin.verbs);
+        project.verbs.should.containDeep([ 'user.password.invalidate', 'project.delete' ]);
+      }));
+
+      it('should not return datasets unless metadata is requested', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1?includeVerbs=true')
+          .expect(200)
+          .then(({ body }) => {
+            should.not.exist(body.datasets);
+          });
+
+        await asAlice.get('/v1/projects/1?includeVerbs=true')
+          .set('X-Extended-Metadata', 'true')
+          .expect(200)
+          .then(({ body }) => {
+            body.datasets.should.equal(1);
+          });
+      }));
+    });
   });
 
   describe('/:id PATCH', () => {

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -519,7 +519,7 @@ describe('api: /projects', () => {
         await asAlice.post('/v1/projects/1/forms/simple/submissions')
           .send(testData.instances.simple.one)
           .set('Content-Type', 'application/xml')
-          .expect(200),
+          .expect(200);
 
         await asAlice.get('/v1/projects/1?includeVerbs=true')
           .expect(200)

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -486,32 +486,57 @@ describe('api: /projects', () => {
     describe('query param: includeVerbs=true', () => {
       it('should return verb information', testService(async (service) => {
         const asAlice = await service.login('alice');
-        const { body: project } = await asAlice.get('/v1/projects/1?includeVerbs=true')
-          .expect(200);
-        project.verbs.should.be.an.Array();
-        const { body: admin } = await asAlice.get('/v1/roles/admin').expect(200);
-        project.verbs.should.eqlInAnyOrder(admin.verbs);
-        project.verbs.should.containDeep([ 'user.password.invalidate', 'project.delete' ]);
-      }));
 
-      it('should not return datasets unless metadata is requested', testService(async (service) => {
-        const asAlice = await service.login('alice');
+        const minimalExpectedVerbs = [ 'user.password.invalidate', 'project.delete' ];
+        const { body: { verbs: allAdminVerbs } } = await asAlice.get('/v1/roles/admin').expect(200);
 
-        await asAlice.post('/v1/projects/1/datasets')
-          .send({ name: 'people' })
-          .expect(200);
 
         await asAlice.get('/v1/projects/1?includeVerbs=true')
           .expect(200)
           .then(({ body }) => {
-            should.not.exist(body.datasets);
+            body.verbs.should.be.an.Array();
+            body.verbs.should.eqlInAnyOrder(allAdminVerbs);
+            body.verbs.should.containDeep(minimalExpectedVerbs);
           });
 
         await asAlice.get('/v1/projects/1?includeVerbs=true')
           .set('X-Extended-Metadata', 'true')
           .expect(200)
           .then(({ body }) => {
+            body.verbs.should.be.an.Array();
+            body.verbs.should.eqlInAnyOrder(allAdminVerbs);
+            body.verbs.should.containDeep(minimalExpectedVerbs);
+          });
+      }));
+
+      it('should not return other extended metadata unless requested', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1?includeVerbs=true')
+          .expect(200)
+          .then(({ body }) => {
+            should.not.exist(body.forms);
+            should.not.exist(body.datasets);
+            should.not.exist(body.lastSubmission);
+          });
+
+        await asAlice.get('/v1/projects/1?includeVerbs=true')
+          .set('X-Extended-Metadata', 'true')
+          .expect(200)
+          .then(({ body }) => {
+            body.should.be.an.ExtendedProject();
+            body.forms.should.equal(3);
             body.datasets.should.equal(1);
+            body.lastSubmission.should.be.a.recentIsoDate();
           });
       }));
     });

--- a/test/integration/api/projects.js
+++ b/test/integration/api/projects.js
@@ -516,10 +516,10 @@ describe('api: /projects', () => {
           .send({ name: 'people' })
           .expect(200);
 
-        await asAlice.post('/v1/projects/1/forms')
-          .send(testData.forms.simpleEntity)
+        await asAlice.post('/v1/projects/1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
           .set('Content-Type', 'application/xml')
-          .expect(200);
+          .expect(200),
 
         await asAlice.get('/v1/projects/1?includeVerbs=true')
           .expect(200)
@@ -534,7 +534,7 @@ describe('api: /projects', () => {
           .expect(200)
           .then(({ body }) => {
             body.should.be.an.ExtendedProject();
-            body.forms.should.equal(3);
+            body.forms.should.equal(2);
             body.datasets.should.equal(1);
             body.lastSubmission.should.be.a.recentIsoDate();
           });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2032

#### What has been done to verify that this works as intended?

- [x] existing tests
- [x] new tests

#### Why is this the best possible solution? Were any other approaches considered?

- [x] confirm if using query parameters is idiomatic
- [x] confirm if chosen query parameter is acceptable

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Adds an extra way to query the API, but shouldn't affect existing endpoints or users.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Yes, probably.

- [x] update docs