### PR TITLE
Add logging with count to db migration to add blob size

### DIFF
--- a/lib/model/migrations/20260717-01-add-blob-size.js
+++ b/lib/model/migrations/20260717-01-add-blob-size.js
@@ -3,6 +3,11 @@ const up = async (db) => {
   // backfill size for blobs whose content is still stored locally. blobs whose
   // content has already been offloaded to S3 (content IS NULL) cannot be
   // backfilled and will have a null size.
+
+  // Note: rows shape is from the pg driver, not Knex, so it should survive a Knex replacement
+  const { rows: [{ count }] } = await db.raw('SELECT COUNT(*) FROM blobs WHERE content IS NOT NULL');
+  console.log(`Backfilling blob sizes for ${count} local blob(s). Blobs offloaded to S3 will not be backfilled.`); // eslint-disable-line no-console
+
   await db.raw('UPDATE blobs SET size = octet_length(content) WHERE content IS NOT NULL');
 };
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2135

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Running it.

#### Why is this the best possible solution? Were any other approaches considered?

This migration counts the number of blobs (with content) and console logs that. We discussed just logging that the migration was running, but thought the count info would be useful.

Very old db migrations using knex relied on the knex-specific output, but this migration just uses `db.raw`. The result from `raw` is direct from the database so it should still be usable even if we switch away from knex in the future. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Provides more information about potentially long-running migrations. 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.