### PR TITLE
Check for case-insensitive uniqueness on actor props

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -2266,7 +2266,7 @@ paths:
       description: |-
         Registers a new actor property name for this project. Once registered, the property can be set on any App User or Public Link within the project via `PATCH`.
 
-        Property names follow the same rules as Entity property names: they must be non-empty, may contain letters, digits, hyphens, and underscores, and the name `displayName` (case-insensitive) is reserved.
+        Property names follow the same rules as Entity property names: they must be non-empty, may contain letters, digits, hyphens, and underscores, and the name `displayName` (case-insensitive) is reserved. Property names must be unique within a project and the uniqueness check is case-insensitive, so `region` and `Region` cannot coexist.
 
         Requires `actor_property.update` permission.
       operationId: createActorProperty

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -2,15 +2,25 @@ const { sql } = require('slonik');
 const { map } = require('ramda');
 const { ActorProperty } = require('../frames');
 const { construct } = require('../../util/util');
+const Problem = require('../../util/problem');
 
 
 // Creates a new actor property name for a project.
-const create = (project, name) => ({ one }) =>
-  one(sql`
+// Enforce case-insensitive uniqueness without a separate round-trip.
+const create = (project, name) => ({ maybeOne }) =>
+  maybeOne(sql`
 INSERT INTO actor_properties ("projectId", "name")
-VALUES (${project.id}, ${name})
+SELECT ${project.id}, ${name}
+WHERE NOT EXISTS (
+  SELECT 1 FROM actor_properties
+  WHERE lower(name) = lower(${name}) AND "projectId" = ${project.id}
+)
 RETURNING *`)
-    .then(construct(ActorProperty));
+    .then((result) => {
+      if (!result.isDefined())
+        throw Problem.user.uniquenessViolation({ table: 'actor_properties', fields: [ 'name', 'projectId' ], values: [ name, project.id ] });
+      return construct(ActorProperty)(result.get());
+    });
 
 create.audit = (project, name) => (log) => log('actor_property.create', project, { name });
 

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -19,7 +19,7 @@ const create = (project, name) => async ({ maybeOne, one }) => {
 
   // Returns a special problem if name conflicts with existing name on casing
   if (conflict.isDefined())
-    throw Problem.user.propertyNameConflict({ duplicateProperties: [{ current: conflict.get().name, provided: name }] });
+    throw Problem.user.uniquenessViolationCaseMismatch({ field: 'name', current: conflict.get().name, provided: name });
 
   // Could return a uniqueness violation if name matches exactly.
   return one(sql`

--- a/lib/model/query/actor-properties.js
+++ b/lib/model/query/actor-properties.js
@@ -6,21 +6,28 @@ const Problem = require('../../util/problem');
 
 
 // Creates a new actor property name for a project.
-// Enforce case-insensitive uniqueness without a separate round-trip.
-const create = (project, name) => ({ maybeOne }) =>
-  maybeOne(sql`
-INSERT INTO actor_properties ("projectId", "name")
-SELECT ${project.id}, ${name}
-WHERE NOT EXISTS (
-  SELECT 1 FROM actor_properties
-  WHERE lower(name) = lower(${name}) AND "projectId" = ${project.id}
-)
-RETURNING *`)
-    .then((result) => {
-      if (!result.isDefined())
-        throw Problem.user.uniquenessViolation({ table: 'actor_properties', fields: [ 'name', 'projectId' ], values: [ name, project.id ] });
-      return construct(ActorProperty)(result.get());
-    });
+// Check for case-insensitive conflict first; if a different-cased name exists,
+// throw propertyNameConflict. Otherwise insert and let the DB uniqueness
+// constraint handle any exact-duplicate race condition.
+const create = (project, name) => async ({ maybeOne, one }) => {
+  const conflict = await maybeOne(sql`
+    SELECT name FROM actor_properties
+    WHERE lower(name) = lower(${name})
+    AND name != ${name}
+    AND "projectId" = ${project.id}
+    LIMIT 1`);
+
+  // Returns a special problem if name conflicts with existing name on casing
+  if (conflict.isDefined())
+    throw Problem.user.propertyNameConflict({ duplicateProperties: [{ current: conflict.get().name, provided: name }] });
+
+  // Could return a uniqueness violation if name matches exactly.
+  return one(sql`
+    INSERT INTO actor_properties ("projectId", "name")
+    VALUES (${project.id}, ${name})
+    RETURNING *`)
+    .then(construct(ActorProperty));
+};
 
 create.audit = (project, name) => (log) => log('actor_property.create', project, { name });
 

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -197,32 +197,33 @@ createPublishedDataset.audit.withResult = true;
 const del = (dataset) => ({ run }) => run(markDeleted(dataset));
 del.audit = (dataset) => (log) => log('dataset.delete', dataset);
 
-// Insert a Dataset Property when there is no associated form and immediately publish
-const _createPublishedProperty = (property) => sql`
-INSERT INTO ds_properties ("name", "datasetId", "publishedAt")
-VALUES (${property.name}, ${property.datasetId}, clock_timestamp())
-ON CONFLICT ("datasetId", "name") WHERE "deletedAt" IS NULL
-DO UPDATE SET "publishedAt" = clock_timestamp()
-WHERE ds_properties."publishedAt" IS NULL
-RETURNING *`;
-
-const _getDuplicatePropertyName = (property) => sql`
-  SELECT name FROM ds_properties 
-  WHERE lower(name) = lower(${property.name})
-    AND "datasetId" = ${property.datasetId} 
-    AND "publishedAt" IS NOT NULL
-    AND "deletedAt" IS NULL
-`;
-
-// eslint-disable-next-line no-unused-vars
+// Used to create a dataset property via the API
+// Publishes this property instantly because it is outside of the form-publishing flow.
 const createPublishedProperty = (property, dataset) => async ({ all, maybeOne }) => {
 
-  const duplicateProperty = await maybeOne(_getDuplicatePropertyName(property));
-  if (duplicateProperty.isDefined()) {
-    throw Problem.user.uniquenessViolation({ table: 'ds_properties', fields: [ 'name', 'datasetId' ], values: [ duplicateProperty.get().name, dataset.id ] });
+  const _createPublishedProperty = () => sql`
+  INSERT INTO ds_properties ("name", "datasetId", "publishedAt")
+  VALUES (${property.name}, ${property.datasetId}, clock_timestamp())
+  ON CONFLICT ("datasetId", "name") WHERE "deletedAt" IS NULL
+  DO UPDATE SET "publishedAt" = clock_timestamp()
+  WHERE ds_properties."publishedAt" IS NULL
+  RETURNING *`;
+
+  const _getCaseMismatchProperty = () => sql`
+    SELECT name FROM ds_properties
+    WHERE lower(name) = lower(${property.name})
+      AND name != ${property.name}
+      AND "datasetId" = ${property.datasetId}
+      AND "publishedAt" IS NOT NULL
+      AND "deletedAt" IS NULL
+  `;
+
+  const caseMismatchProperty = await maybeOne(_getCaseMismatchProperty());
+  if (caseMismatchProperty.isDefined()) {
+    throw Problem.user.uniquenessViolationCaseMismatch({ field: 'name', current: caseMismatchProperty.get().name, provided: property.name });
   }
 
-  const result = await all(_createPublishedProperty(property));
+  const result = await all(_createPublishedProperty());
   if (result.length === 0)
     throw Problem.user.uniquenessViolation({ table: 'ds_properties', fields: [ 'name', 'datasetId' ], values: [ property.name, dataset.id ] });
   return result[0];

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -214,12 +214,13 @@ const _getDuplicatePropertyName = (property) => sql`
     AND "deletedAt" IS NULL
 `;
 
-// eslint-disable-next-line no-unused-vars
 const createPublishedProperty = (property, dataset) => async ({ all, maybeOne }) => {
 
   const duplicateProperty = await maybeOne(_getDuplicatePropertyName(property));
   if (duplicateProperty.isDefined()) {
-    throw Problem.user.uniquenessViolation({ table: 'ds_properties', fields: [ 'name', 'datasetId' ], values: [ duplicateProperty.get().name, dataset.id ] });
+    const currentPropertyName = duplicateProperty.get().name;
+    if (currentPropertyName !== property.name)
+      throw Problem.user.propertyNameConflict({ duplicateProperties: [{ current: currentPropertyName, provided: property.name }] });
   }
 
   const result = await all(_createPublishedProperty(property));

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -156,7 +156,7 @@ const createOrMerge = (parsedDataset, form, fields) => async ({ context, one, Ac
       }))
       .filter(property => property.current);
     if (duplicateProperties.length > 0) {
-      throw Problem.user.propertyNameConflict({ duplicateProperties });
+      throw Problem.user.propertyNameConflictInForm({ duplicateProperties });
     }
   }
 
@@ -317,7 +317,7 @@ const publishIfExists = (formDefId, publishedAt) => async ({ all, context, maybe
 
   const duplicateProperties = await all(_propertyNameConflict());
   if (duplicateProperties.length > 0) {
-    throw Problem.user.propertyNameConflict({ duplicateProperties });
+    throw Problem.user.propertyNameConflictInForm({ duplicateProperties });
   }
 
   const properties = await all(_publishIfExists());

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -214,13 +214,12 @@ const _getDuplicatePropertyName = (property) => sql`
     AND "deletedAt" IS NULL
 `;
 
+// eslint-disable-next-line no-unused-vars
 const createPublishedProperty = (property, dataset) => async ({ all, maybeOne }) => {
 
   const duplicateProperty = await maybeOne(_getDuplicatePropertyName(property));
   if (duplicateProperty.isDefined()) {
-    const currentPropertyName = duplicateProperty.get().name;
-    if (currentPropertyName !== property.name)
-      throw Problem.user.propertyNameConflict({ duplicateProperties: [{ current: currentPropertyName, provided: property.name }] });
+    throw Problem.user.uniquenessViolation({ table: 'ds_properties', fields: [ 'name', 'datasetId' ], values: [ duplicateProperty.get().name, dataset.id ] });
   }
 
   const result = await all(_createPublishedProperty(property));

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -250,7 +250,10 @@ const problems = {
 
     datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization.`),
 
-    propertyNameConflict: problem(409.17, () => 'This form attempts to create new Entity properties that match with existing ones except for capitalization.'),
+    propertyNameConflict: problem(409.17, ({ duplicateProperties }) => {
+      const pairs = duplicateProperties.map(({ current, provided }) => `'${provided}' conflicts with '${current}'`).join(', ');
+      return `A property name conflicts with an existing one due to capitalization: ${pairs}.`;
+    }),
 
     duplicateSubmission: problem(409.18, () => `This submission has been deleted. You may not resubmit it.`),
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -250,7 +250,7 @@ const problems = {
 
     datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization.`),
 
-    propertyNameConflict: problem(409.17, () => 'This form attempts to create new Entity properties that match with existing ones except for capitalization.'),
+    propertyNameConflictInForm: problem(409.17, () => 'This form attempts to create new Entity properties that match with existing ones except for capitalization.'),
 
     duplicateSubmission: problem(409.18, () => `This submission has been deleted. You may not resubmit it.`),
 
@@ -261,6 +261,8 @@ const problems = {
     deletePropPrereqViolation: problem(409.22, ({ propertyName }) => `Prerequisites for deleting the property "${propertyName}" are not met.`),
 
     datasetMissingForFormRestore: problem(409.23, () => `This Form cannot be restored because the related dataset(s) has been modified or deleted.`),
+
+    uniquenessViolationCaseMismatch: problem(409.24, ({ field, current, provided }) => `A resource already exists with ${field} '${current}' and you provided '${provided}' with different capitalization.`),
   },
   internal: {
     // no detail information, as this is only called when we don't know what happened.

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -250,10 +250,7 @@ const problems = {
 
     datasetNameConflict: problem(409.16, ({ current, provided }) => `A dataset named '${current}' exists and you provided '${provided}' with the same name but different capitalization.`),
 
-    propertyNameConflict: problem(409.17, ({ duplicateProperties }) => {
-      const pairs = duplicateProperties.map(({ current, provided }) => `'${provided}' conflicts with '${current}'`).join(', ');
-      return `A property name conflicts with an existing one due to capitalization: ${pairs}.`;
-    }),
+    propertyNameConflict: problem(409.17, () => 'This form attempts to create new Entity properties that match with existing ones except for capitalization.'),
 
     duplicateSubmission: problem(409.18, () => `This submission has been deleted. You may not resubmit it.`),
 

--- a/test/integration/api/actor-properties.js
+++ b/test/integration/api/actor-properties.js
@@ -9,24 +9,6 @@ describe('api: /projects/:id/actor-properties', () => {
         .expect(403);
     }));
 
-    it('should reject if name is not allowed (using same name rules as dataset properties)', testService(async (service) => {
-      const asAlice = await service.login('alice');
-      await asAlice.post('/v1/projects/1/actor-properties')
-        .send({ name: '__notallowed' })
-        .expect(400);
-    }));
-
-    it('should reject if name matches an existing name with with different case', testService(async (service) => {
-      const asAlice = await service.login('alice');
-      await asAlice.post('/v1/projects/1/actor-properties')
-        .send({ name: 'region' })
-        .expect(200);
-
-      await asAlice.post('/v1/projects/1/actor-properties')
-        .send({ name: 'REGION' })
-        .expect(409);
-    }));
-
     it('should create a actor property and return success', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/actor-properties')
@@ -69,16 +51,31 @@ describe('api: /projects/:id/actor-properties', () => {
         .expect(400);
     }));
 
-    it('should reject if existing name is sent again', testService(async (service) => {
+    it('should reject with uniquenessViolation if exact same name is sent again', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/actor-properties')
         .send({ name: 'region' })
         .expect(200);
 
-      await asAlice.post('/v1/projects/1/actor-properties')
+      const { body } = await asAlice.post('/v1/projects/1/actor-properties')
         .send({ name: 'region' })
         .expect(409);
+      body.code.should.equal(409.3);
     }));
+
+    it('should reject with propertyNameConflict if name matches an existing name with different case', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      const { body } = await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'REGION' })
+        .expect(409);
+      body.code.should.equal(409.17);
+      body.message.should.containEql("'REGION' conflicts with 'region'");
+    }));
+
   });
 
   describe('GET /projects/:id/actor-properties', () => {

--- a/test/integration/api/actor-properties.js
+++ b/test/integration/api/actor-properties.js
@@ -63,7 +63,7 @@ describe('api: /projects/:id/actor-properties', () => {
       body.code.should.equal(409.3);
     }));
 
-    it('should reject with propertyNameConflict if name matches an existing name with different case', testService(async (service) => {
+    it('should reject with problem if name matches an existing name with different case', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/actor-properties')
         .send({ name: 'region' })
@@ -72,9 +72,8 @@ describe('api: /projects/:id/actor-properties', () => {
       const { body } = await asAlice.post('/v1/projects/1/actor-properties')
         .send({ name: 'REGION' })
         .expect(409);
-      // TODO: will update this to use a different problem soon.
-      body.code.should.equal(409.17);
-      body.message.should.containEql('This form attempts to create new Entity properties that match with existing ones except for capitalization.');
+      body.code.should.equal(409.24);
+      body.message.should.eql("A resource already exists with name 'region' and you provided 'REGION' with different capitalization.");
     }));
 
   });

--- a/test/integration/api/actor-properties.js
+++ b/test/integration/api/actor-properties.js
@@ -72,8 +72,9 @@ describe('api: /projects/:id/actor-properties', () => {
       const { body } = await asAlice.post('/v1/projects/1/actor-properties')
         .send({ name: 'REGION' })
         .expect(409);
+      // TODO: will update this to use a different problem soon.
       body.code.should.equal(409.17);
-      body.message.should.containEql("'REGION' conflicts with 'region'");
+      body.message.should.containEql('This form attempts to create new Entity properties that match with existing ones except for capitalization.');
     }));
 
   });

--- a/test/integration/api/actor-properties.js
+++ b/test/integration/api/actor-properties.js
@@ -9,6 +9,24 @@ describe('api: /projects/:id/actor-properties', () => {
         .expect(403);
     }));
 
+    it('should reject if name is not allowed (using same name rules as dataset properties)', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: '__notallowed' })
+        .expect(400);
+    }));
+
+    it('should reject if name matches an existing name with with different case', testService(async (service) => {
+      const asAlice = await service.login('alice');
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'region' })
+        .expect(200);
+
+      await asAlice.post('/v1/projects/1/actor-properties')
+        .send({ name: 'REGION' })
+        .expect(409);
+    }));
+
     it('should create a actor property and return success', testService(async (service) => {
       const asAlice = await service.login('alice');
       await asAlice.post('/v1/projects/1/actor-properties')

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -529,8 +529,8 @@ describe('datasets and entities', () => {
           })
           .expect(409)
           .then(({ body }) => {
-            body.code.should.equal(409.3);
-            body.message.should.match(/A resource already exists with name,datasetId/);
+            body.code.should.equal(409.17);
+            body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'HEIGHT' conflicts with 'height'\./);
           });
       }));
 
@@ -4428,7 +4428,7 @@ describe('datasets and entities', () => {
             .set('Content-Type', 'application/xml')
             .expect(409)
             .then(({ body }) => {
-              body.message.should.match(/This form attempts to create new Entity properties that match with existing ones except for capitalization/);
+              body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'FIRST_NAME' conflicts with 'first_name'\./);
             });
         }));
 
@@ -4452,7 +4452,8 @@ describe('datasets and entities', () => {
           await alice.post('/v1/projects/1/forms/simpleEntity/draft/publish')
             .expect(409)
             .then(({ body }) => {
-              body.message.should.match(/This form attempts to create new Entity properties that match with existing ones except for capitalization/);
+              // This is the opposite conflict as above because the second form was published first
+              body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'first_name' conflicts with 'FIRST_NAME'\./);
             });
         }));
 
@@ -4473,7 +4474,7 @@ describe('datasets and entities', () => {
             .set('Content-Type', 'application/xml')
             .expect(409)
             .then(({ body }) => {
-              body.message.should.match(/This form attempts to create new Entity properties that match with existing ones except for capitalization/);
+              body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'FIRST_NAME' conflicts with 'first_name'\./);
             });
         }));
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -529,8 +529,8 @@ describe('datasets and entities', () => {
           })
           .expect(409)
           .then(({ body }) => {
-            body.code.should.equal(409.17);
-            body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'HEIGHT' conflicts with 'height'\./);
+            body.code.should.equal(409.3);
+            body.message.should.match(/A resource already exists with name,datasetId/);
           });
       }));
 
@@ -4428,7 +4428,7 @@ describe('datasets and entities', () => {
             .set('Content-Type', 'application/xml')
             .expect(409)
             .then(({ body }) => {
-              body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'FIRST_NAME' conflicts with 'first_name'\./);
+              body.message.should.match(/This form attempts to create new Entity properties that match with existing ones except for capitalization/);
             });
         }));
 
@@ -4452,8 +4452,7 @@ describe('datasets and entities', () => {
           await alice.post('/v1/projects/1/forms/simpleEntity/draft/publish')
             .expect(409)
             .then(({ body }) => {
-              // This is the opposite conflict as above because the second form was published first
-              body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'first_name' conflicts with 'FIRST_NAME'\./);
+              body.message.should.match(/This form attempts to create new Entity properties that match with existing ones except for capitalization/);
             });
         }));
 
@@ -4474,7 +4473,7 @@ describe('datasets and entities', () => {
             .set('Content-Type', 'application/xml')
             .expect(409)
             .then(({ body }) => {
-              body.message.should.match(/A property name conflicts with an existing one due to capitalization: 'FIRST_NAME' conflicts with 'first_name'\./);
+              body.message.should.match(/This form attempts to create new Entity properties that match with existing ones except for capitalization/);
             });
         }));
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -529,8 +529,104 @@ describe('datasets and entities', () => {
           })
           .expect(409)
           .then(({ body }) => {
+            body.code.should.equal(409.24);
+            body.message.should.match(/A resource already exists with name 'height' and you provided 'HEIGHT' with different capitalization./);
+          });
+      }));
+
+      it('should allow properties that conflict with draft form properties', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        // set up dataset "people" first so it is already published
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+
+        // uses people dataset with first_name
+        await asAlice.post('/v1/projects/1/forms')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        // should allow this to be published because existing "first_name" is a draft
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'FIRST_NAME' })
+          .expect(200);
+
+        // Direct conflict with previous name
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'FIRST_NAME' })
+          .expect(409)
+          .then(({ body }) => {
             body.code.should.equal(409.3);
-            body.message.should.match(/A resource already exists with name,datasetId/);
+            body.message.should.startWith('A resource already exists with name,datasetId value(s) of FIRST_NAME');
+          });
+
+        // Case mistmatch with published property but matching draft property
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'first_name' })
+          .expect(409)
+          .then(({ body }) => {
+            body.code.should.equal(409.24);
+            body.message.should.eql("A resource already exists with name 'FIRST_NAME' and you provided 'first_name' with different capitalization.");
+          });
+
+        // Case mistmatch with published property and draft property
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'FiRsT_NaMe' })
+          .expect(409)
+          .then(({ body }) => {
+            body.code.should.equal(409.24);
+            body.message.should.eql("A resource already exists with name 'FIRST_NAME' and you provided 'FiRsT_NaMe' with different capitalization.");
+          });
+      }));
+
+      it('should allow properties that conflict with deleted properties but conflict with the current name if case differs', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'trees' })
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/datasets/trees/properties')
+          .send({ name: 'height' })
+          .expect(200);
+
+        // delete the property
+        await asAlice.delete('/v1/projects/1/datasets/trees/properties/height')
+          .expect(200);
+
+        // remake with different case
+        await asAlice.post('/v1/projects/1/datasets/trees/properties')
+          .send({ name: 'HEIGHT' })
+          .expect(200);
+
+        // reject in different ways
+        // 1. Exact match with current version
+        await asAlice.post('/v1/projects/1/datasets/trees/properties')
+          .send({ name: 'HEIGHT' })
+          .expect(409)
+          .then(({ body }) => {
+            body.code.should.equal(409.3);
+            body.message.should.startWith('A resource already exists with name,datasetId value(s) of HEIGHT');
+          });
+
+        // 2. Match deleted property
+        await asAlice.post('/v1/projects/1/datasets/trees/properties')
+          .send({ name: 'height' })
+          .expect(409)
+          .then(({ body }) => {
+            body.code.should.equal(409.24);
+            body.message.should.eql("A resource already exists with name 'HEIGHT' and you provided 'height' with different capitalization.");
+          });
+
+        // 3. Don't match case of any past properties
+        await asAlice.post('/v1/projects/1/datasets/trees/properties')
+          .send({ name: 'hEiGhT' })
+          .expect(409)
+          .then(({ body }) => {
+            body.code.should.equal(409.24);
+            body.message.should.eql("A resource already exists with name 'HEIGHT' and you provided 'hEiGhT' with different capitalization.");
           });
       }));
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2161 

* Renames problem `409.17` from `propertyNameConflict` to `propertyNameConflictInForm` in the code to make it specific to property name conflicts within the form upload/publish flow.
* Introduces a new problem `409.24` called `uniquenessViolationCaseMismatch`
* Updates `ActorProperties.create` function and SQL to be able to check for case-insensitive duplicates and return either the existing `409.3` (exact match) problem or the new `409.24` problem.
* Updates the code for creating Dataset properties via the API to be a little more self-contained, use a pattern from the actor-properties query, and to use the new `409.24` problem when in the case-mismatch duplicate situation.
* Updates dataset property API tests to distinguish between `409.3` and `409.24`
* Adds more dataset property API tests that use draft properties and deleted properties and ensure the right problem is returned. 


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed a lot in code review! When tying to reuse the 409.17 problem (also about properties that match but not on case) we realized how much that is tied into the form+dataset flow. Decided to introduce a special problem for the case-mismatch situation that can be used for actor properties and dataset properties and isn't too tied to properties. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Prevents users from naming properties `FOO` and `Foo` to avoid future confusion. Will use the casing of the first property entry. 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Small docs change made. 