### PR TITLE
Add "viewAs" query param to entities CSV download and geojson endpoints

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -44,7 +44,7 @@ info:
     ## ODK Central v2026.3
 
     **Added**:
-    - [Entities OData](/central-api-odata-endpoints/#odata-dataset-service) and [GET Entities Metadata](/central-api-entity-management/#entities-metadata) now support a `viewAs` query parameter to preview the filtered Entity list for a specific Actor.
+    - [Entities OData](/central-api-odata-endpoints/#odata-dataset-service), [GET Entities Metadata](/central-api-entity-management/#entities-metadata), [Download Dataset](/central-api-dataset-management/#download-dataset), and [Entities Geodata](/central-api-entity-management/#entities-geodata) now support a `viewAs` query parameter to preview the filtered Entity list for a specific Actor.
 
     **Changed**:
     - [GET /audits](/central-api-system-endpoints/#getting-audit-log-entries) now uses less-than when filtering with the `end` parameter.
@@ -9007,6 +9007,15 @@ paths:
         schema:
           type: string
         example: john
+      - name: viewAs
+        in: query
+        description: |-
+          If provided, filters the response to only the Entities that the specified Actor would be able to see, based on the Dataset's access filter (`ownerOnly` or property rules). The value must be a numeric Actor ID.
+
+          This is intended for previewing what a particular App User or Public Link would receive when downloading the Dataset via a linked Form Attachment.
+        schema:
+          type: number
+        example: 42
       responses:
         "200":
           description: OK
@@ -9317,6 +9326,15 @@ paths:
         description: The `$search` querystring parameter can be used to search entity data (user-defined properties) and the `label` field, using the same search behavior as the [OData Dataset Service](/central-api-odata-endpoints/#odata-dataset-service).
         schema:
           type: string
+      - name: viewAs
+        in: query
+        description: |-
+          If provided, filters the response to only the Entities that the specified Actor would be able to see, based on the Dataset's access filter (`ownerOnly` or property rules). The value must be a numeric Actor ID.
+
+          This is intended for previewing what a particular App User or Public Link would receive when downloading the Dataset via a linked Form Attachment.
+        schema:
+          type: number
+        example: 42
       responses:
         "200":
           description: OK

--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -1183,6 +1183,7 @@ restoreByIds.audit = (restoredUuids, _, dataset) => (log) => {
 restoreByIds.audit.withResult = true;
 
 module.exports = {
+  _actorHasAccess,
   createNew, _processSubmissionEvent, _processEntityData,
   createOrUpdateSource, updateSourceDetails,
   createMany,

--- a/lib/model/query/geo-extracts.js
+++ b/lib/model/query/geo-extracts.js
@@ -9,7 +9,7 @@
 
 const { sql } = require('slonik');
 const { arrayHasElements } = require('../../util/util');
-const { searchClause } = require('./entities');
+const { searchClause, _actorHasAccess } = require('./entities');
 const { odataFilter, odataExcludeDeleted } = require('../../data/odata-filter');
 const { DEFAULT_ORDER_BY } = require('./submissions');
 const submissionData = require('../../data/submission');
@@ -168,10 +168,10 @@ const getSubmissionFeatureCollectionGeoJson = (formPK, odataQuery, fieldPaths, l
 };
 
 
-const getEntityFeatureCollectionGeoJson = (datasetPK, odataQuery, limit=null, search=null) => ({ db }) => {
+const getEntityFeatureCollectionGeoJson = (datasetPK, odataQuery, limit=null, search=null, filterActorId=null) => ({ db }) => {
 
   const searchFilter = searchClause(search);
-
+  const actorFilter = filterActorId != null ? sql`AND ${_actorHasAccess(filterActorId)}` : sql``;
 
   return db.oneFirst(sql`
       WITH extracted AS (
@@ -205,6 +205,7 @@ const getEntityFeatureCollectionGeoJson = (datasetPK, odataQuery, limit=null, se
             ${odataFilter(odataQuery, odataToColumnMapEntities)}
             AND
             ${odataExcludeDeleted(odataQuery, odataToColumnMapEntities)}
+            ${actorFilter}
           LIMIT ${limit}
           ),
           featuregeojsoned AS (

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -181,7 +181,7 @@ module.exports = (service, endpoint) => {
     return success;
   }));
 
-  service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(async ({ Datasets, Entities, Projects }, { params, auth, query }, request, response) => {
+  service.get('/projects/:projectId/datasets/:name/entities.csv', endpoint(async ({ Auth, Actors, Datasets, Entities, Projects }, { params, auth, query }, request, response) => {
     const project = await Projects.getById(params.projectId).then(getOrNotFound);
     await auth.canOrReject('entity.list', project);
 
@@ -190,8 +190,15 @@ module.exports = (service, endpoint) => {
     const dataset = await Datasets.get(params.projectId, params.name, true, true).then(getOrNotFound);
     const properties = await Datasets.getProperties(dataset.id);
 
+    let filterActorId = null;
+    if (query.viewAs != null) {
+      const actor = await Actors.getById(parseInt(query.viewAs, 10)).then(getOrNotFound);
+      const targetCanList = await Auth.can(actor, 'entity.list', project);
+      filterActorId = targetCanList ? null : actor.id;
+    }
+
     const csv = async () => {
-      const entities = await Entities.streamForExport(dataset.id, options);
+      const entities = await Entities.streamForExport(dataset.id, options, filterActorId);
       const filename = sanitize(dataset.name);
       const extension = 'csv';
       response.set('Content-Disposition', contentDisposition(`${filename}.${extension}`));
@@ -199,7 +206,7 @@ module.exports = (service, endpoint) => {
       return streamEntityCsv(entities, properties);
     };
 
-    if (options.filter) return csv();
+    if (options.filter || query.viewAs != null) return csv();
 
     const datasetHashMetadata = await Datasets.computeHashes([dataset.id]).then(res => res.get(dataset.id));
     const serverEtag = datasetHashMetadata.openRosaHash;

--- a/lib/resources/geo-extracts.js
+++ b/lib/resources/geo-extracts.js
@@ -70,17 +70,25 @@ module.exports = (service, endpoint) => {
     return withEtag(submissionsEtag, generateBody, true);
   }));
 
-  service.get('/projects/:projectId/datasets/:datasetName/entities.geojson', endpoint.plain(async ({ Datasets, GeoExtracts }, { auth, query, params }) => {
+  service.get('/projects/:projectId/datasets/:datasetName/entities.geojson', endpoint.plain(async ({ Auth, Actors, Datasets, GeoExtracts }, { auth, query, params }) => {
 
     const foundDataset = await Datasets.get(params.projectId, params.datasetName, true)
       .then(getOrNotFound)
       .then((dataset) => auth.canOrReject('entity.list', dataset));
+
+    let filterActorId = null;
+    if (query.viewAs != null) {
+      const actor = await Actors.getById(parseInt(query.viewAs, 10)).then(getOrNotFound);
+      const targetCanList = await Auth.can(actor, 'entity.list', foundDataset);
+      filterActorId = targetCanList ? null : actor.id;
+    }
 
     return GeoExtracts.getEntityFeatureCollectionGeoJson(
       foundDataset.id,
       queryParamToArray(query.$filter)[0],
       Number.parseInt(query.limit, 10) || null,
       queryParamToArray(query.$search)[0],
+      filterActorId,
     ).then(json);
   }));
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -1438,6 +1438,151 @@ describe('datasets and entities', () => {
     });
 
 
+    describe('viewAs on entities.csv', () => {
+      it('should return 404 if viewAs actor does not exist', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities.csv?viewAs=99999')
+          .expect(404);
+      }));
+
+      it('should return 400 if viewAs is not a numeric ID', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+
+        await asAlice.get('/v1/projects/1/datasets/people/entities.csv?viewAs=notanumber')
+          .expect(400)
+          .then(({ body }) => {
+            body.code.should.eql(400.11);
+          });
+      }));
+
+      it('should return all entities if dataset has no access filter', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'entity 1' })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'entity 2' })
+          .expect(200);
+
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'App User' }).expect(200);
+
+        await asAlice.get(`/v1/projects/1/datasets/people/entities.csv?viewAs=${appUser.id}`)
+          .expect(200)
+          .then(({ text }) => {
+            text.split('\n').length.should.eql(4); // header + 2 entities + trailing newline
+          });
+      }));
+
+      it('should filter entities by ownerOnly for viewAs actor', testService(async (service, container) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/forms?publish=true')
+          .send(testData.forms.simpleEntity)
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ ownerOnly: true })
+          .expect(200);
+
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'App User' }).expect(200);
+
+        // Alice creates one entity
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'alice entity', data: { first_name: 'Alice' } })
+          .expect(200);
+
+        // App user creates one entity via submission
+        await asAlice.post(`/v1/projects/1/forms/simpleEntity/assignments/app-user/${appUser.id}`)
+          .expect(200);
+        await service.post(`/v1/key/${appUser.token}/projects/1/forms/simpleEntity/submissions`)
+          .send(testData.instances.simpleEntity.one
+            .replace('<entities:label>Alice (88)</entities:label>', '<entities:label>App User Entity</entities:label>'))
+          .set('Content-Type', 'application/xml')
+          .expect(200);
+        await exhaust(container);
+
+        await asAlice.get(`/v1/projects/1/datasets/people/entities.csv?viewAs=${appUser.id}`)
+          .expect(200)
+          .then(({ text }) => {
+            text.split('\n').length.should.eql(3); // header + 1 entity + trailing newline
+            text.should.containEql('App User Entity');
+            text.should.not.containEql('alice entity');
+          });
+      }));
+
+      it('should filter entities by property rules for viewAs actor', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/properties')
+          .send({ name: 'region' })
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/actor-properties')
+          .send({ name: 'region' })
+          .expect(200);
+        await asAlice.patch('/v1/projects/1/datasets/people')
+          .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+          .expect(200);
+
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'north person', data: { region: 'north' } })
+          .expect(200);
+        await asAlice.post('/v1/projects/1/datasets/people/entities')
+          .send({ label: 'south person', data: { region: 'south' } })
+          .expect(200);
+
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'North Worker' }).expect(200);
+        await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+          .send({ properties: { region: 'north' } })
+          .expect(200);
+
+        await asAlice.get(`/v1/projects/1/datasets/people/entities.csv?viewAs=${appUser.id}`)
+          .expect(200)
+          .then(({ text }) => {
+            text.split('\n').length.should.eql(3); // header + 1 entity + trailing newline
+            text.should.containEql('north person');
+            text.should.not.containEql('south person');
+          });
+      }));
+
+      it('should skip ETag caching when viewAs is present', testService(async (service) => {
+        const asAlice = await service.login('alice');
+
+        await asAlice.post('/v1/projects/1/datasets')
+          .send({ name: 'people' })
+          .expect(200);
+
+        const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+          .send({ displayName: 'App User' }).expect(200);
+
+        const result = await asAlice.get(`/v1/projects/1/datasets/people/entities.csv?viewAs=${appUser.id}`)
+          .expect(200);
+
+        should.not.exist(result.get('ETag'));
+      }));
+    });
+
     describe('projects/:id/trash/datasets/:datasetId/entities.csv GET', () => {
       it('should reject if the user cannot access the deleted dataset', testEntities(async (service) => {
         const asAlice = await service.login('alice');

--- a/test/integration/api/geodata.js
+++ b/test/integration/api/geodata.js
@@ -1010,3 +1010,99 @@ describe('api: entities-geodata', () => {
   }));
 
 });
+
+
+describe('api: entities-geodata viewAs', () => {
+
+  it('should return 404 if viewAs actor does not exist', testService(async (service, { db }) => {
+    const { asAlice } = await setupGeoEntities(service, db);
+
+    await asAlice.get('/v1/projects/1/datasets/geofun/entities.geojson?viewAs=99999')
+      .expect(404);
+  }));
+
+  it('should return 400 if viewAs is not a numeric ID', testService(async (service, { db }) => {
+    const { asAlice } = await setupGeoEntities(service, db);
+
+    await asAlice.get('/v1/projects/1/datasets/geofun/entities.geojson?viewAs=notanumber')
+      .expect(400)
+      .then(({ body }) => {
+        body.code.should.eql(400.11);
+      });
+  }));
+
+  it('should return all entities if dataset has no access filter', testService(async (service, { db }) => {
+    const { asAlice } = await setupGeoEntities(service, db);
+
+    const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+      .send({ displayName: 'App User' }).expect(200);
+
+    await asAlice.get(`/v1/projects/1/datasets/geofun/entities.geojson?viewAs=${appUser.id}`)
+      .expect(200)
+      .then(({ body }) => {
+        body.features.length.should.equal(3); // 5 entities, 2 with invalid geodata
+      });
+  }));
+
+  it('should filter entities by ownerOnly for viewAs actor', testService(async (service, { db }) => {
+    const { asAlice, asBob } = await setupGeoEntities(service, db);
+
+    // asBob created entity 'c'; demote Bob to formfill so he lacks entity.list
+    const bobId = await asBob.get('/v1/users/current').then(({ body }) => body.id);
+    await asAlice.delete(`/v1/projects/1/assignments/manager/${bobId}`).expect(200);
+    await asAlice.post(`/v1/projects/1/assignments/formfill/${bobId}`).expect(200);
+
+    await asAlice.patch('/v1/projects/1/datasets/geofun')
+      .send({ ownerOnly: true })
+      .expect(200);
+
+    await asAlice.get(`/v1/projects/1/datasets/geofun/entities.geojson?viewAs=${bobId}`)
+      .expect(200)
+      .then(({ body }) => {
+        body.features.length.should.equal(1);
+        body.features[0].id.should.equal('12345678-1234-4123-8234-123456789aac');
+      });
+  }));
+
+  it('should filter entities by property rules for viewAs actor', testService(async (service) => {
+    const asAlice = await service.login('alice');
+
+    await asAlice.post('/v1/projects/1/datasets')
+      .send({ name: 'geofun' })
+      .expect(200);
+    await asAlice.post('/v1/projects/1/datasets/geofun/properties')
+      .send({ name: 'geometry' })
+      .expect(200);
+    await asAlice.post('/v1/projects/1/datasets/geofun/properties')
+      .send({ name: 'region' })
+      .expect(200);
+
+    await asAlice.post('/v1/projects/1/actor-properties')
+      .send({ name: 'region' })
+      .expect(200);
+    await asAlice.patch('/v1/projects/1/datasets/geofun')
+      .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'region' }] } })
+      .expect(200);
+
+    await asAlice.post('/v1/projects/1/datasets/geofun/entities')
+      .send({ uuid: '12345678-1234-4123-8234-123456789aaa', label: 'north point', data: { geometry: '1 2 3 0', region: 'north' } })
+      .expect(200);
+    await asAlice.post('/v1/projects/1/datasets/geofun/entities')
+      .send({ uuid: '12345678-1234-4123-8234-123456789aab', label: 'south point', data: { geometry: '1 2 3 0', region: 'south' } })
+      .expect(200);
+
+    const { body: appUser } = await asAlice.post('/v1/projects/1/app-users')
+      .send({ displayName: 'North Worker' }).expect(200);
+    await asAlice.patch(`/v1/projects/1/app-users/${appUser.id}`)
+      .send({ properties: { region: 'north' } })
+      .expect(200);
+
+    await asAlice.get(`/v1/projects/1/datasets/geofun/entities.geojson?viewAs=${appUser.id}`)
+      .expect(200)
+      .then(({ body }) => {
+        body.features.length.should.equal(1);
+        body.features[0].id.should.equal('12345678-1234-4123-8234-123456789aaa');
+      });
+  }));
+
+});


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2162

Adds `viewAs` query parameter to entities csv download and entities geojson endpoint. These let Frontend use this viewAs filter when showing entities on map or preparing a segmented CSV download. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests. Will be testing it with a frontend branch making use of it, too.

#### Why is this the best possible solution? Were any other approaches considered?

I think this approach is what's needed.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Frontend filters work better! 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

Should probably come back and add docs.