### PR TITLE
docker-postgres: extract make targets as script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ SHELL := /usr/bin/env bash
 NODE_CONFIG_ENV ?= test
 export PGAPPNAME ?= odkcentral
 
-PG_IMG = odk-central-backend-dev-postgres
-PG_VERSION ?= 14
-
 node_modules: package.json
 	npm install
 	touch node_modules
@@ -145,64 +142,27 @@ lint: node_version
 
 .PHONY: run-docker-postgres
 run-docker-postgres: stop-docker-postgres
-	docker start $(PG_IMG) || (\
-		docker run -d \
-			--name $(PG_IMG) \
-			--publish 127.0.0.1:5432:5432 \
-			--env POSTGRES_PASSWORD=odktest \
-			postgres:$(PG_VERSION) \
-				--shared_preload_libraries=pg_stat_statements \
-		&& sleep 2 \
-		&& docker exec $(PG_IMG) pg_isready --username=postgres --timeout=10 \
-		&& node lib/bin/create-docker-databases.js $(if $(CI),,--log) \
-	)
+	test/bin/docker-postgres.sh start
 
 .PHONY: run-docker-postgres-ssl
 run-docker-postgres-ssl: stop-docker-postgres-ssl
-	mkdir -p .pg-certs && \
-	(cd .pg-certs && [[ -s ca.key     ]] || openssl genrsa -out     ca.key 2048) && \
-	(cd .pg-certs && [[ -s not-ca.key ]] || openssl genrsa -out not-ca.key 2048) && \
-	(cd .pg-certs && [[ -s ca.crt     ]] || openssl req -x509 -new -nodes -key     ca.key -sha256 -days 1 -out     ca.crt -subj "/CN=TestCA") && \
-	(cd .pg-certs && [[ -s not-ca.crt ]] || openssl req -x509 -new -nodes -key not-ca.key -sha256 -days 1 -out not-ca.crt -subj "/CN=NotTestCA") && \
-	(cd .pg-certs && [[ -s server.key ]] || openssl genrsa -out server.key 2048) && \
-	(cd .pg-certs && [[ -s server.csr ]] || openssl req -new -key server.key -out server.csr -subj "/CN=localhost") && \
-	(cd .pg-certs && [[ -s server.crt ]] || openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 1 -sha256 -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")) && \
-	sudo chown -R 999:999 .pg-certs && \
-	sudo -k && \
-	docker start $(PG_IMG)-ssl || (\
-		docker run -d \
-			--name $(PG_IMG)-ssl \
-			--publish 127.0.0.1:5432:5432 \
-			--env POSTGRES_PASSWORD=odktest \
-			--volume $(PWD)/.pg-certs:/postgres-certs \
-			postgres:$(PG_VERSION) \
-				--shared_preload_libraries=pg_stat_statements \
-				--ssl=on \
-				--ssl_cert_file=/postgres-certs/server.crt \
-				--ssl_key_file=/postgres-certs/server.key \
-		&& sleep 2 \
-		&& docker exec $(PG_IMG)-ssl pg_isready --username=postgres --timeout=10 \
-		&& node lib/bin/create-docker-databases.js $(if $(CI),,--log) \
-		&& docker exec $(PG_IMG)-ssl bash -c "sed -i 's/^host\b/hostssl/' \$$PGDATA/pg_hba.conf" \
-		&& docker exec $(PG_IMG)-ssl psql -U postgres -c "SELECT pg_reload_conf();" \
-		&& docker exec $(PG_IMG)-ssl pg_isready --username=postgres --timeout=10 \
-	)
+	test/bin/docker-postgres.sh --ssl start
 
 .PHONY: stop-docker-postgres
 stop-docker-postgres:
-	docker stop $(PG_IMG) || true
+	test/bin/docker-postgres.sh stop
 
 .PHONY: stop-docker-postgres-ssl
 stop-docker-postgres-ssl:
-	docker stop $(PG_IMG)-ssl || true
+	test/bin/docker-postgres.sh --ssl stop
 
 .PHONY: rm-docker-postgres
 rm-docker-postgres: stop-docker-postgres
-	docker rm $(PG_IMG) || true
+	test/bin/docker-postgres.sh remove
 
 .PHONY: rm-docker-postgres-ssl
 rm-docker-postgres-ssl: stop-docker-postgres-ssl
-	docker rm $(PG_IMG)-ssl || true
+	test/bin/docker-postgres.sh --ssl remove
 
 
 ################################################################################

--- a/test/bin/docker-postgres.sh
+++ b/test/bin/docker-postgres.sh
@@ -3,7 +3,7 @@ set -e
 set -u
 set -o pipefail
 
-log() { echo >&2 "[start-postgres] $*"; }
+log() { echo >&2 "[docker-postgres] $*"; }
 
 imageName=odk-central-backend-dev-postgres
 PG_VERSION="${PG_VERSION-14}"
@@ -82,7 +82,7 @@ docker run \
 sleep 2
 docker exec "$imageName" pg_isready --username=postgres --timeout=10
 
-node lib/bin/create-docker-databases.js "${CI:+--log}"
+node lib/bin/create-docker-databases.js ${CI:+--log}
 
 if [[ "$enableSsl" = true ]]; then
   docker exec "$imageName" bash -c 'sed -i "s/^host\b/hostssl/" "$PGDATA/pg_hba.conf"'

--- a/test/bin/docker-postgres.sh
+++ b/test/bin/docker-postgres.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -o pipefail
+
+log() { echo >&2 "[start-postgres] $*"; }
+
+imageName=odk-central-backend-dev-postgres
+PG_VERSION="${PG_VERSION-14}"
+
+enableSsl=
+if [[ "${1-}" = --ssl ]]; then
+  imageName="$imageName-ssl"
+  enableSsl=true
+  shift
+fi
+
+usage() {
+  exitCode="${1-1}"
+  cat <<EOF
+    $0 [--ssl] [--help|start|stop|remove]
+EOF
+  exit "$exitCode"
+}
+
+if [[ $# -lt 1 ]]; then
+  usage 1
+fi
+
+case "$1" in
+  remove) docker rm   "$imageName" || true; exit ;;
+  stop)   docker stop "$imageName" || true; exit ;;
+  start)  ;; # continue script
+  *)      usage 1 ;;
+esac
+
+if [[ "$enableSsl" = true ]]; then
+  log "Setting up any missing SSL certs..."
+
+  mkdir -p .pg-certs
+  (
+    cd .pg-certs
+
+    [[ -s ca.key     ]] || openssl genrsa -out     ca.key 2048
+    [[ -s not-ca.key ]] || openssl genrsa -out not-ca.key 2048
+    [[ -s ca.crt     ]] || openssl req -x509 -new -nodes -key     ca.key -sha256 -days 1 -out     ca.crt -subj "/CN=TestCA"
+    [[ -s not-ca.crt ]] || openssl req -x509 -new -nodes -key not-ca.key -sha256 -days 1 -out not-ca.crt -subj "/CN=NotTestCA"
+    [[ -s server.key ]] || openssl genrsa -out server.key 2048
+    [[ -s server.csr ]] || openssl req -new -key server.key -out server.csr -subj "/CN=localhost"
+    [[ -s server.crt ]] || openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+                                        -out server.crt -days 1 -sha256 -extfile \
+                           <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+  )
+
+  log "Changing cert ownership; this may require sudo password..."
+  sudo chown -R 999:999 .pg-certs
+  sudo -k
+
+  log "SSL certs setup completed OK."
+fi
+
+log "Attempting to start existing container..."
+if docker start "$imageName"; then
+  log "(Re)started OK."
+  exit
+fi
+log "Failed to start existing container."
+
+log "Starting fresh container..."
+docker run \
+    --detach \
+    --name "$imageName" \
+    --publish 127.0.0.1:5432:5432 \
+    --env POSTGRES_PASSWORD=odktest \
+    ${enableSsl:+"--volume" "$PWD"/.pg-certs:/postgres-certs} \
+    postgres:"$PG_VERSION" \
+        --shared_preload_libraries=pg_stat_statements \
+        ${enableSsl:+--ssl=on} \
+        ${enableSsl:+--ssl_cert_file=/postgres-certs/server.crt} \
+        ${enableSsl:+--ssl_key_file=/postgres-certs/server.key}
+
+sleep 2
+docker exec "$imageName" pg_isready --username=postgres --timeout=10
+
+node lib/bin/create-docker-databases.js "${CI:+--log}"
+
+if [[ "$enableSsl" = true ]]; then
+  docker exec "$imageName" bash -c 'sed -i "s/^host\b/hostssl/" "$PGDATA/pg_hba.conf"'
+  docker exec "$imageName" psql -U postgres -c 'SELECT pg_reload_conf();'
+  docker exec "$imageName" pg_isready --username=postgres --timeout=10
+fi
+
+log "Fresh container started OK."

--- a/test/bin/docker-postgres.sh
+++ b/test/bin/docker-postgres.sh
@@ -31,6 +31,7 @@ case "$1" in
   remove) docker rm   "$imageName" || true; exit ;;
   stop)   docker stop "$imageName" || true; exit ;;
   start)  ;; # continue script
+  --help) usage 0 ;;
   *)      usage 1 ;;
 esac
 


### PR DESCRIPTION
* simplifies and unifies massive make targets
* prepares for fixing bug with waiting (https://github.com/getodk/central/issues/2141)

#### What has been done to verify that this works as intended?

- [x] tested locally
- [x] tested locally with ssl
- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

* make syntax is even more arcane than bash
* the ssl vs. non-ssl scripts were similar, but hard to share implementations in make

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just dev/test code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.