### PR TITLE
Fixes: added back deletedAt field for entity endpoints

### DIFF
--- a/lib/model/query/entities.js
+++ b/lib/model/query/entities.js
@@ -925,7 +925,7 @@ resolveConflict.audit = (entity, dataset) => (log) => log('entity.update.resolve
 // SERVING ENTITIES
 
 const _exportUnjoiner = unjoiner(
-  specificFields(Entity, 'id', 'uuid', 'creatorId', 'createdAt', 'updatedAt', 'conflict'),
+  specificFields(Entity, 'id', 'uuid', 'creatorId', 'createdAt', 'updatedAt', 'deletedAt', 'conflict'),
   specificFields(Entity.Def, 'label', 'data', 'version'),
   specificFields(Actor.alias('actors', 'creator'), 'displayName', 'id'),
 );

--- a/test/integration/api/odata-entities.js
+++ b/test/integration/api/odata-entities.js
@@ -345,6 +345,9 @@ describe('api: /datasets/:name.svc', () => {
           .then(({ body }) => {
             for (const [index, value] of body.value.entries()) {
               value.__id.should.be.eql(uuids[index*2 + idxOffset]);
+              if ([uuids[0], uuids[2], uuids[4]].includes(uuids[index*2 + idxOffset])) {
+                value.__system.deletedAt.should.be.an.isoDate();
+              }
             }
           });
       }));


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2142

regression of https://github.com/getodk/central-backend/pull/1896

#### What has been done to verify that this works as intended?

Updated tests

#### Why is this the best possible solution? Were any other approaches considered?

Was thinking to add `deletedAt` conditionally but that makes the code really complicated and also inconsistent with submissions odata.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No