### PR TITLE
Check that dataset and actor properties exist for access filter

### DIFF
--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -1079,23 +1079,19 @@ const getListWithProperties = (projectId, ids) => async ({ all }) => {
 
 // Adds or updates a single access filter rule for a dataset.
 // datasetPropertyName and userPropertyName are names (strings).
-const setAccessFilter = (datasetId, datasetPropertyName, userPropertyName) => ({ maybeOne }) =>
-  maybeOne(sql`
-WITH ds_prop AS (
-  SELECT id FROM ds_properties
-  WHERE "datasetId" = ${datasetId} AND "name" = ${datasetPropertyName} AND "publishedAt" IS NOT NULL
-), actor_prop AS (
-  SELECT ap.id FROM actor_properties ap
-  JOIN datasets d ON d."projectId" = ap."projectId"
-  WHERE d.id = ${datasetId} AND ap."name" = ${userPropertyName}
-), inserted AS (
-  INSERT INTO dataset_access_filters ("datasetId", "datasetPropertyId", "actorPropertyId")
-  SELECT ${datasetId}, ds_prop.id, actor_prop.id FROM ds_prop, actor_prop
-  ON CONFLICT ("datasetPropertyId", "actorPropertyId") DO NOTHING
-  RETURNING *
-)
-SELECT * FROM inserted`)
-    .then((rows) => rows.map((row) => new Dataset.AccessFilter(row)));
+// If a non-existent actor or dataset property is passed in, this will silently do nothing.
+// This function is called from setAccessFilters, which pre-checks that properties exist.
+const _setAccessFilter = (datasetId, datasetPropertyName, userPropertyName) => ({ run }) =>
+  run(sql`
+INSERT INTO dataset_access_filters ("datasetId", "datasetPropertyId", "actorPropertyId")
+SELECT ${datasetId}, dp.id, ap.id
+FROM ds_properties dp
+JOIN actor_properties ap ON ap."projectId" = (SELECT "projectId" FROM datasets WHERE id = ${datasetId})
+WHERE dp."datasetId" = ${datasetId}
+  AND dp."name" = ${datasetPropertyName}
+  AND dp."publishedAt" IS NOT NULL
+  AND ap."name" = ${userPropertyName}
+ON CONFLICT ("datasetPropertyId", "actorPropertyId") DO NOTHING`);
 
 // Returns all access filter rules for a dataset as DatasetAccessFilter instances.
 const getAccessFilter = (datasetId) => ({ all }) =>
@@ -1117,18 +1113,24 @@ const deleteAllAccessFilters = (datasetId) => ({ run }) =>
 // rules is an array of { datasetProperty, actorProperty } objects.
 // Passing an empty array deletes all rules.
 const setAccessFilters = (dataset, rules) => async ({ ActorProperties, Datasets }) => {
-  const datasetPropertyNames = new Set((await Datasets.getProperties(dataset.id)).map(({ name }) => name));
-  const actorPropertyNames = new Set((await ActorProperties.getAllForProject(dataset.projectId)).map(({ name }) => name));
+  const [datasetProperties, actorProperties] = await Promise.all([
+    Datasets.getProperties(dataset.id),
+    ActorProperties.getAllForProject(dataset.projectId),
+  ]);
+  const datasetPropertyNames = new Set(datasetProperties.map(({ name }) => name));
+  const actorPropertyNames = new Set(actorProperties.map(({ name }) => name));
 
   for (const { datasetProperty, actorProperty } of rules) {
-    if (!datasetPropertyNames.has(datasetProperty) || !actorPropertyNames.has(actorProperty))
-      throw Problem.user.accessFilterError({ reason: 'Access filter references a property that does not exist.' });
+    if (!datasetPropertyNames.has(datasetProperty))
+      throw Problem.user.accessFilterError({ reason: `Dataset property '${datasetProperty}' does not exist.` });
+    if (!actorPropertyNames.has(actorProperty))
+      throw Problem.user.accessFilterError({ reason: `Actor property '${actorProperty}' does not exist.` });
   }
 
   await Datasets.deleteAllAccessFilters(dataset.id);
   for (const { datasetProperty, actorProperty } of rules) {
     // eslint-disable-next-line no-await-in-loop
-    await Datasets.setAccessFilter(dataset.id, datasetProperty, actorProperty);
+    await Datasets._setAccessFilter(dataset.id, datasetProperty, actorProperty);
   }
 };
 
@@ -1145,5 +1147,5 @@ module.exports = {
   del, purge, deleteProperty,
   getTargetDatasetsAndProperties, getLinkedDatasets, getRelatedDatasetsOfForm,
   getListWithProperties,
-  setAccessFilter, getAccessFilter, deleteAllAccessFilters, setAccessFilters
+  _setAccessFilter, getAccessFilter, deleteAllAccessFilters, setAccessFilters
 };

--- a/lib/model/query/datasets.js
+++ b/lib/model/query/datasets.js
@@ -1116,11 +1116,19 @@ const deleteAllAccessFilters = (datasetId) => ({ run }) =>
 // Atomically replaces all access filter rules for a dataset.
 // rules is an array of { datasetProperty, actorProperty } objects.
 // Passing an empty array deletes all rules.
-const setAccessFilters = (datasetId, rules) => async ({ Datasets }) => {
-  await Datasets.deleteAllAccessFilters(datasetId);
+const setAccessFilters = (dataset, rules) => async ({ ActorProperties, Datasets }) => {
+  const datasetPropertyNames = new Set((await Datasets.getProperties(dataset.id)).map(({ name }) => name));
+  const actorPropertyNames = new Set((await ActorProperties.getAllForProject(dataset.projectId)).map(({ name }) => name));
+
+  for (const { datasetProperty, actorProperty } of rules) {
+    if (!datasetPropertyNames.has(datasetProperty) || !actorPropertyNames.has(actorProperty))
+      throw Problem.user.accessFilterError({ reason: 'Access filter references a property that does not exist.' });
+  }
+
+  await Datasets.deleteAllAccessFilters(dataset.id);
   for (const { datasetProperty, actorProperty } of rules) {
     // eslint-disable-next-line no-await-in-loop
-    await Datasets.setAccessFilter(datasetId, datasetProperty, actorProperty);
+    await Datasets.setAccessFilter(dataset.id, datasetProperty, actorProperty);
   }
 };
 

--- a/lib/resources/datasets.js
+++ b/lib/resources/datasets.js
@@ -85,7 +85,7 @@ module.exports = (service, endpoint) => {
         }
         // Disable ownerOnly if set, then replace all property rules
         updates.ownerOnly = false;
-        await Datasets.setAccessFilters(dataset.id, rules);
+        await Datasets.setAccessFilters(dataset, rules);
 
       } else {
         throw Problem.user.unexpectedValue({ field: 'accessFilter.type', value: accessFilter.type, reason: 'type must be ownerOnly or property.' });

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -161,6 +161,8 @@ const problems = {
       return `${baseMessage}: ${externalMessage[0].toLowerCase()}${externalMessage.substring(1)}`;
     }),
 
+    accessFilterError: problem(400.45, ({ reason }) => `There was a problem with the dataset access filter. ${reason}`),
+
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),
 

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -6808,6 +6808,28 @@ describe('datasets and entities', () => {
             });
         }));
 
+        it('should reject if property does not exist', testService(async (service) => {
+          const asAlice = await service.login('alice');
+          await createDataset(asAlice, 1, 'trees', ['region']);
+          await asAlice.post('/v1/projects/1/actor-properties').send({ name: 'region' }).expect(200);
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'region', actorProperty: 'doesNotExist' }] } })
+            .expect(400)
+            .then(({ body }) => {
+              body.code.should.be.eql(400.45);
+              body.message.should.be.eql('There was a problem with the dataset access filter. Access filter references a property that does not exist.');
+            });
+
+          await asAlice.patch('/v1/projects/1/datasets/trees')
+            .send({ accessFilter: { type: 'property', rules: [{ datasetProperty: 'doesNotExist', actorProperty: 'region' }] } })
+            .expect(400)
+            .then(({ body }) => {
+              body.code.should.be.eql(400.45);
+              body.message.should.be.eql('There was a problem with the dataset access filter. Access filter references a property that does not exist.');
+            });
+        }));
+
         it('should log when a filter rule is added to a dataset', testService(async (service, { Audits }) => {
           const asAlice = await service.login('alice');
           await createDataset(asAlice, 1, 'trees', ['region']);

--- a/test/integration/api/datasets.js
+++ b/test/integration/api/datasets.js
@@ -6818,7 +6818,7 @@ describe('datasets and entities', () => {
             .expect(400)
             .then(({ body }) => {
               body.code.should.be.eql(400.45);
-              body.message.should.be.eql('There was a problem with the dataset access filter. Access filter references a property that does not exist.');
+              body.message.should.be.eql('There was a problem with the dataset access filter. Actor property \'doesNotExist\' does not exist.');
             });
 
           await asAlice.patch('/v1/projects/1/datasets/trees')
@@ -6826,7 +6826,7 @@ describe('datasets and entities', () => {
             .expect(400)
             .then(({ body }) => {
               body.code.should.be.eql(400.45);
-              body.message.should.be.eql('There was a problem with the dataset access filter. Access filter references a property that does not exist.');
+              body.message.should.be.eql('There was a problem with the dataset access filter. Dataset property \'doesNotExist\' does not exist.');
             });
         }));
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1972

Checks the provided dataset and actor properties (from the access filter rules) against actual dataset properties and actor properties without just skipping over them. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Test.

#### Why is this the best possible solution? Were any other approaches considered?

Adds an extra check of property existence within the Dataset.setAccessFilters query. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Will give a better error if a user provides (via api) a property that doesn't exist instead of silently accepting and ignoring it. 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

We don't document these failure/problem cases that much in the API docs so I don't think it's necessary to add.