### PR TITLE
Remove request body properly

### DIFF
--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -102,10 +102,6 @@ const sanitizeEventRequest = (event) => {
     if (event.request.headers && event.request.headers['x-action-notes'])
       event.request.headers['x-action-notes'] = null;
 
-    // clear out request body data for all endpoints
-    if (event.request.data)
-      event.request.data = null;
-
     // remove sensitive info from URL via query string or path
     if (event.request.url) {
       // handle endpoints that might expose sensitive data through query params
@@ -192,6 +188,14 @@ const _init = (config) => { // eslint-disable-line no-shadow
     integrations: defaults => [
       ...defaults.filter(i => !disabledIntegrations.includes(i.name)),
       Sentry.dedupeIntegration(),
+
+      // Modified default integrations:
+      // See: https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/#modifying-default-integrations
+
+      // See: https://docs.sentry.io/platforms/javascript/guides/connect/configuration/integrations/http/
+      Sentry.httpIntegration({
+        ignoreIncomingRequestBody: 'none',
+      }),
     ],
     tracesSampleRate: Number(config.traceRate || 0),
     tunnel: config.__test_tunnel,

--- a/test/unit/external/sanitize-sentry.js
+++ b/test/unit/external/sanitize-sentry.js
@@ -24,7 +24,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{"email":"test-email","password":"test-pass"}',
       headers: {
         host: 'localhost:8383',
         'user-agent': 'HTTPie/2.4.0',
@@ -58,7 +58,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         host: 'localhost:8383',
         'user-agent': 'HTTPie/2.4.0',
@@ -106,7 +106,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         'x-forwarded-proto': 'https',
         host: 'localhost:8383',
@@ -151,7 +151,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         host: 'localhost:8383',
         'user-agent': 'HTTPie/2.4.0',
@@ -187,7 +187,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         host: 'localhost:8383',
         'user-agent': 'HTTPie/2.4.0',
@@ -237,7 +237,7 @@ const exampleRequests = [
     ,
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         'x-forwarded-proto': 'https',
         host: 'localhost:8383',
@@ -302,7 +302,7 @@ const exampleRequests = [
     ,
     {
       cookies: null,
-      data: null,
+      data: '{"__csrf":"td..wQ"}',
       headers: {
         'x-forwarded-proto': 'https',
         host: 'localhost:8383',
@@ -356,7 +356,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         'x-forwarded-proto': 'https',
         host: 'localhost:8383',
@@ -409,7 +409,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         'x-forwarded-proto': 'https',
         host: 'localhost:8383',
@@ -462,7 +462,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{}',
       headers: {
         'x-forwarded-proto': 'https',
         host: 'localhost:8383',
@@ -499,7 +499,7 @@ const exampleRequests = [
     },
     {
       cookies: null,
-      data: null,
+      data: '{"displayName":"Test Display Name"}',
       headers: {
         host: 'localhost:8383',
         'user-agent': 'HTTPie/2.4.0',

--- a/test/unit/external/sanitize-sentry.js
+++ b/test/unit/external/sanitize-sentry.js
@@ -3,7 +3,7 @@ const appRoot = require('app-root-path');
 const { sanitizeEventRequest, isSensitiveEndpoint, filterTokenFromUrl } = require(appRoot + '/lib/external/sentry');
 
 // These cases are based on real requests!
-const cases = [
+const exampleRequests = [
   // Request body with sensitive data
   [
     {
@@ -518,59 +518,69 @@ const cases = [
   ]
 ];
 
-// sensitive endpoints where querystrings need to be removed
-const sensitiveEndpoints = [
-  ['GET', '/v1/users?q=personal_name'],
-  ['GET', '/v1/projects/6/forms/formid/submissions.csv?keyid=pass'],
-  ['GET', '/v1/projects/6/forms/formid/submissions.csv.zip?keyid=pass'],
-  ['GET', '/v1/projects/6/forms/formid/draft/submissions.csv?keyid=pass'],
-  ['GET', '/v1/projects/6/forms/formid/draft/submissions.csv.zip?keyid=pass'],
-  ['HEAD', '/v1/projects/6/formList?formID=my_form_id&st=enketo_token'],
-  ['POST', '/v1/projects/6/submission?st=enketo_token']
-];
-
-// non-sensitive endpoints to send along useful querystrings
-const nonSensitiveEndpoints = [
-  ['GET', '/v1/users/reset/initiate?invalidate=true'],
-  ['POST', '/v1/projects/6/forms/formid/submissions.csv?attachments=false'],
-  ['POST', '/v1/projects/6/forms/formid/submissions.csv.zip?attachments=false'],
-  ['POST', '/v1/projects/6/forms/formid/draft/submissions.csv?attachments=false'],
-  ['POST', '/v1/projects/6/forms/formid/draft/submissions.csv.zip?attachments=false'],
-];
-
-const filteredTokenUrls = [
-  ['/v1/key/APP_USER_KEY/projects/3/formList', '/v1/key/[FILTERED]/projects/3/formList'],
-  ['/v1/test/DRAFT_TOKEN/projects/3/forms/draft/submission', '/v1/test/[FILTERED]/projects/3/forms/draft/submission'],
-  ['/v1/projects/2/forms/test/attachments', '/v1/projects/2/forms/test/attachments'], // the form ID is 'test' but doesn't get filtered
-  ['/v1/key/PUBLIC_ACCESS_KEY/projects/5/formList?formID=form_id&st=PUBLIC_ACCESS_KEY', '/v1/key/[FILTERED]/projects/5/formList?formID=form_id&st=PUBLIC_ACCESS_KEY'] // query string removal is not in the filtering step
-];
-
 describe('external: sanitize-sentry', () => {
-  it('removes sensitive data from request objects ', () => {
-
-    for (const [input, expectedOutput] of cases) {
-      sanitizeEventRequest({ request: input }).should.eql({ request: expectedOutput });
-    }
+  describe('sanitizeEventRequest()', () => {
+    exampleRequests.forEach(([ input, expectedOutput ], idx) => {
+      it(`should remove sensitive data from request object #${idx+1}`, () => {
+        sanitizeEventRequest({ request: input }).should.eql({ request: expectedOutput });
+      });
+    });
   });
 
-  it('identifies sensitive URLs ', () => {
-    for (const [method, url] of sensitiveEndpoints) {
-      // eslint-disable-next-line object-curly-spacing
-      isSensitiveEndpoint({url, method}).should.equal(true);
-    }
+  describe('isSensitiveEndpoint()', () => {
+    [
+      ['GET', '/v1/users?q=personal_name'],
+      ['GET', '/v1/projects/6/forms/formid/submissions.csv?keyid=pass'],
+      ['GET', '/v1/projects/6/forms/formid/submissions.csv.zip?keyid=pass'],
+      ['GET', '/v1/projects/6/forms/formid/draft/submissions.csv?keyid=pass'],
+      ['GET', '/v1/projects/6/forms/formid/draft/submissions.csv.zip?keyid=pass'],
+      ['HEAD', '/v1/projects/6/formList?formID=my_form_id&st=enketo_token'],
+      ['POST', '/v1/projects/6/submission?st=enketo_token'],
+    ].forEach(([ method, url ]) => {
+      it(`should correctly identify ${method} ${url} as sensitive`, () => {
+        isSensitiveEndpoint({ url, method }).should.equal(true);
+      });
+    });
+
+    it('identifies non-sensitive URLs ', () => {
+      [
+        ['GET', '/v1/users/reset/initiate?invalidate=true'],
+        ['POST', '/v1/projects/6/forms/formid/submissions.csv?attachments=false'],
+        ['POST', '/v1/projects/6/forms/formid/submissions.csv.zip?attachments=false'],
+        ['POST', '/v1/projects/6/forms/formid/draft/submissions.csv?attachments=false'],
+        ['POST', '/v1/projects/6/forms/formid/draft/submissions.csv.zip?attachments=false'],
+      ].forEach(([ method, url ]) => {
+        it(`should correctly identify ${method} ${url} as NOT sensitive`, () => {
+          isSensitiveEndpoint({ url, method }).should.equal(false);
+        });
+      });
+    });
   });
 
-  it('identifies non-sensitive URLs ', () => {
-    for (const [method, url] of nonSensitiveEndpoints) {
-      // eslint-disable-next-line object-curly-spacing
-      isSensitiveEndpoint({url, method}).should.equal(false);
-    }
-  });
-
-  it('filters app user and draft tokens from URLs', () => {
-    for (const [inputUrl, expectedUrl ] of filteredTokenUrls) {
-      filterTokenFromUrl(inputUrl).should.equal(expectedUrl);
-    }
+  describe('filterTokenFromUrl()', () => {
+    [
+      [
+        '/v1/key/APP_USER_KEY/projects/3/formList',
+        '/v1/key/[FILTERED]/projects/3/formList',
+      ],
+      [
+        '/v1/test/DRAFT_TOKEN/projects/3/forms/draft/submission',
+        '/v1/test/[FILTERED]/projects/3/forms/draft/submission',
+      ],
+      [
+        // the form ID is 'test' but doesn't get filtered
+        '/v1/projects/2/forms/test/attachments',
+        '/v1/projects/2/forms/test/attachments',
+      ],
+      [
+        // query string removal is not in the filtering step
+        '/v1/key/PUBLIC_ACCESS_KEY/projects/5/formList?formID=form_id&st=PUBLIC_ACCESS_KEY',
+        '/v1/key/[FILTERED]/projects/5/formList?formID=form_id&st=PUBLIC_ACCESS_KEY',
+      ],
+    ].forEach(([ inputUrl, expectedUrl ], idx) => {
+      it(`should correctly filter token(s) from example #${idx+1}`, () => {
+        filterTokenFromUrl(inputUrl).should.equal(expectedUrl);
+      });
+    });
   });
 });
-


### PR DESCRIPTION
Instead of removing request bodies in `sanitizeEventRequest()`, use the standard configuration of the Sentry HTTP integration to achieve the same result.

#### What has been done to verify that this works as intended?

- [ ] existing tests which still pass after change, but didn't when stripping was removed from `sanitizeEventRequest()` but not added to `HttpIntegration` config?
- [ ] new tests which failed when stripping was removed from `sanitizeEventRequest()` but not added to `HttpIntegration` config?

#### Why is this the best possible solution? Were any other approaches considered?

Uses the official approach, so should also apply to other event sources beyond errors.

See docs for `beforeSend()`: https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#beforeSend

Vs:

* ...TODO...

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No expected effect, except better privacy and perhaps occasional improved performance.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.