### PR TITLE
sentry: exclude request bodies from breadcrumbs

### DIFF
--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -191,7 +191,7 @@ const _init = (config) => { // eslint-disable-line no-shadow
     environment: process.env.SENTRY_ENVIRONMENT || 'production',
     integrations: defaults => [
       ...defaults.filter(i => !disabledIntegrations.includes(i.name)),
-      
+
       // Modified default integrations
       Sentry.httpIntegration({
         maxIncomingRequestBodySize: 'none',

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -192,6 +192,8 @@ const _init = (config) => { // eslint-disable-line no-shadow
     integrations: defaults => [
       ...defaults.filter(i => !disabledIntegrations.includes(i.name)),
 
+      Sentry.dedupeIntegration(),
+
       // Modified default integrations
       Sentry.httpIntegration({
         maxIncomingRequestBodySize: 'none',

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -192,6 +192,14 @@ const _init = (config) => { // eslint-disable-line no-shadow
     integrations: defaults => [
       ...defaults.filter(i => !disabledIntegrations.includes(i.name)),
       Sentry.dedupeIntegration(),
+
+      // Modified default integrations:
+      // See: https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/#modifying-default-integrations
+
+      // See: https://docs.sentry.io/platforms/javascript/guides/connect/configuration/integrations/http/
+      Sentry.httpIntegration({
+        ignoreIncomingRequestBody: 'none',
+      }),
     ],
     tracesSampleRate: Number(config.traceRate || 0),
     tunnel: config.__test_tunnel,

--- a/lib/external/sentry.js
+++ b/lib/external/sentry.js
@@ -191,14 +191,10 @@ const _init = (config) => { // eslint-disable-line no-shadow
     environment: process.env.SENTRY_ENVIRONMENT || 'production',
     integrations: defaults => [
       ...defaults.filter(i => !disabledIntegrations.includes(i.name)),
-      Sentry.dedupeIntegration(),
-
-      // Modified default integrations:
-      // See: https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/#modifying-default-integrations
-
-      // See: https://docs.sentry.io/platforms/javascript/guides/connect/configuration/integrations/http/
+      
+      // Modified default integrations
       Sentry.httpIntegration({
-        ignoreIncomingRequestBody: 'none',
+        maxIncomingRequestBodySize: 'none',
       }),
     ],
     tracesSampleRate: Number(config.traceRate || 0),


### PR DESCRIPTION
See:

* https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/#modifying-default-integrations
* https://docs.sentry.io/platforms/javascript/guides/connect/configuration/integrations/http/#maxincomingrequestbodysize

Related:

* https://github.com/getodk/central-backend/pull/1928
* https://github.com/getodk/central-backend/pull/1929

#### What has been done to verify that this works as intended?

Nothing - just read the docs #YOLO 🤘

#### Why is this the best possible solution? Were any other approaches considered?

Considered adding tests, but there are currently no tests in this repo for real Sentry output:

* integration tests run with a mocked/faked Sentry implementation.
* e2e tests do not make any assertions about Sentry calls

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Hopefully no bad effect, but improved privacy and performance.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.