### PR TITLE
ci: output postgres logs

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -42,3 +42,6 @@ jobs:
       env:
         PG_VERSION: ${{ matrix.postgres-version }}
     - run: make test-db-migrations
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -28,7 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         postgres-version:
-          - "19"
+          - "14.23"
+          - "18"
     steps:
     - uses: actions/checkout@v6
     - name: Set node version

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -43,4 +43,4 @@ jobs:
     - run: make test-db-migrations
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres
+      run: docker logs odk-central-backend-dev-postgres || true

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -28,8 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         postgres-version:
-          - "14.23"
-          - "18"
+          - "19"
     steps:
     - uses: actions/checkout@v6
     - name: Set node version

--- a/.github/workflows/db-ssl.yml
+++ b/.github/workflows/db-ssl.yml
@@ -28,3 +28,6 @@ jobs:
     - run: PGSSLROOTCERT=./.pg-certs/ca.crt PGSSLMODE=verify-full make migrations
     - run: make test-db-ssl
     - run: ./test/db-ssl/test-restore
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres-ssl

--- a/.github/workflows/db-ssl.yml
+++ b/.github/workflows/db-ssl.yml
@@ -30,4 +30,4 @@ jobs:
     - run: ./test/db-ssl/test-restore
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres-ssl
+      run: docker logs odk-central-backend-dev-postgres-ssl || true

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -43,3 +43,6 @@ jobs:
       with:
         name: Playwright Test Report
         path: test/e2e/oidc/playwright-tests/results/html-report/
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -45,4 +45,4 @@ jobs:
         path: test/e2e/oidc/playwright-tests/results/html-report/
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres
+      run: docker logs odk-central-backend-dev-postgres || true

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -30,3 +30,6 @@ jobs:
     - name: Fake OIDC Server Logs
       if: always()
       run: "! [[ -f ./fake-oidc-server.log ]] || cat ./fake-oidc-server.log"
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -32,4 +32,4 @@ jobs:
       run: "! [[ -f ./fake-oidc-server.log ]] || cat ./fake-oidc-server.log"
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres
+      run: docker logs odk-central-backend-dev-postgres || true

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -33,3 +33,6 @@ jobs:
     - name: Backend Logs
       if: always()
       run: "! [[ -f ./server.log ]] || cat ./server.log"
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -35,4 +35,4 @@ jobs:
       run: "! [[ -f ./server.log ]] || cat ./server.log"
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres
+      run: docker logs odk-central-backend-dev-postgres || true

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -32,3 +32,6 @@ jobs:
     - name: Backend Logs
       if: always()
       run: "! [[ -f ./backend.log ]] || cat ./backend.log"
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -34,4 +34,4 @@ jobs:
       run: "! [[ -f ./backend.log ]] || cat ./backend.log"
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres
+      run: docker logs odk-central-backend-dev-postgres || true

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -54,3 +54,6 @@ jobs:
     - name: Backend Logs
       if: always()
       run: "! [[ -f ./server.log ]] || cat ./server.log"
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -56,4 +56,4 @@ jobs:
       run: "! [[ -f ./server.log ]] || cat ./server.log"
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres
+      run: docker logs odk-central-backend-dev-postgres || true

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -28,3 +28,6 @@ jobs:
       env:
         PG_VERSION: ${{ matrix.postgres-version }}
     - run: make test
+    - name: PostgreSQL logs
+      if: always()
+      run: docker logs odk-central-backend-dev-postgres

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -30,4 +30,4 @@ jobs:
     - run: make test
     - name: PostgreSQL logs
       if: always()
-      run: docker logs odk-central-backend-dev-postgres
+      run: docker logs odk-central-backend-dev-postgres || true


### PR DESCRIPTION
Helpful for debugging workflow failures.

#### What has been done to verify that this works as intended?

Used in https://github.com/getodk/central-backend/pull/1924 to help debug intermittent postgres startup issues.

#### Why is this the best possible solution? Were any other approaches considered?

Not including these logs until they are needed?  But in the case of https://github.com/getodk/central-backend/pull/1924, there were occasional failures which could not be recreated easily on demand.  This meant significant added time caused by configuring logs later, and then waiting for a failure to recur.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect - just CI.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.