### PR TITLE
Add WF+Enketo sub counts to usage metrics for 2026.3

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
       "analytics": {
         "url": "https://data.getodk.cloud/v1/key/eOZ7S4bzyUW!g1PF6dIXsnSqktRuewzLTpmc6ipBtRq$LDfIMTUKswCexvE0UwJ9/projects/1/forms/odk-analytics/submissions",
         "formId": "odk-analytics",
-        "version": "v2026.2.0_1"
+        "version": "v2026.3.0_1"
       },
       "mailingListOptIn": {
         "url": "https://data.getodk.cloud/v1/key/Dd0XJq$!skdvUmMLUO1!srDmrxePJSIiGuj3ttbzlayelMxxXMQF3hmeJ24rcT8N/projects/8/forms/mailing_list_opt_in/submissions",

--- a/lib/data/analytics.js
+++ b/lib/data/analytics.js
@@ -60,6 +60,22 @@ const metricsTemplate = {
     },
     "num_datasets_with_geometry": 0,
     "num_multi_entity_errors": 0,
+    "num_wf_submissions": {
+      "recent": 0,
+      "total": 0
+    },
+    "num_enketo_submissions": {
+      "recent": 0,
+      "total": 0
+    },
+    "num_wf_submission_edits": {
+      "recent": 0,
+      "total": 0
+    },
+    "num_enketo_submission_edits": {
+      "recent": 0,
+      "total": 0
+    },
   },
   "projects": [
     {

--- a/lib/model/query/analytics.js
+++ b/lib/model/query/analytics.js
@@ -729,6 +729,18 @@ WHERE
   AND (details->'problem'->>'problemCode') = '400.43'
 `);
 
+const countSubmissionsByWebClient = () => ({ one }) => one(sql`
+select
+  count(*) filter (where root is true and "userAgent" like 'odk-web-forms/%') as wf_subs_total,
+  count(*) filter (where root is true and "userAgent" like 'odk-web-forms/%' and "createdAt" >= ${_cutoffDate}) as wf_subs_recent,
+  count(*) filter (where root is true and "userAgent" like 'Enketo/%') as enketo_subs_total,
+  count(*) filter (where root is true and "userAgent" like 'Enketo/%' and "createdAt" >= ${_cutoffDate}) as enketo_subs_recent,
+  count(*) filter (where root is not true and "userAgent" like 'odk-web-forms/%') as wf_edits_total,
+  count(*) filter (where root is not true and "userAgent" like 'odk-web-forms/%' and "createdAt" >= ${_cutoffDate}) as wf_edits_recent,
+  count(*) filter (where root is not true and "userAgent" like 'Enketo/%') as enketo_edits_total,
+  count(*) filter (where root is not true and "userAgent" like 'Enketo/%' and "createdAt" >= ${_cutoffDate}) as enketo_edits_recent
+from submission_defs`);
+
 const countEntityBulkDeletes = () => ({ one }) => one(sql`
 SELECT
   count(*) AS total,
@@ -1027,6 +1039,7 @@ const previewMetrics = () => (({ Analytics }) => runSequentially([
   Analytics.countDatasetsWithGeometry,
   Analytics.countEntityBulkDeletes,
   Analytics.countMultiEntityErrors,
+  Analytics.countSubmissionsByWebClient,
   Analytics.checkLoginCustomization,
   Analytics.projectMetrics
 ]).then(([db, encrypt, bigForm, maxGeo, admins, audits,
@@ -1037,6 +1050,7 @@ const previewMetrics = () => (({ Analytics }) => runSequentially([
   datasetsWithGeometry,
   entityBulkDeletes,
   multiEntityErrors,
+  webClientSubs,
   loginCustomization,
   projMetrics]) => {
   const metrics = clone(metricsTemplate);
@@ -1105,6 +1119,12 @@ const previewMetrics = () => (({ Analytics }) => runSequentially([
   // 2026.1 login customizations
   for (const [key, value] of Object.entries(loginCustomization))
     metrics.system[key] = value;
+
+  // 2026.3 web forms vs enketo adoption
+  metrics.system.num_wf_submissions = { total: webClientSubs.wf_subs_total, recent: webClientSubs.wf_subs_recent };
+  metrics.system.num_enketo_submissions = { total: webClientSubs.enketo_subs_total, recent: webClientSubs.enketo_subs_recent };
+  metrics.system.num_wf_submission_edits = { total: webClientSubs.wf_edits_total, recent: webClientSubs.wf_edits_recent };
+  metrics.system.num_enketo_submission_edits = { total: webClientSubs.enketo_edits_total, recent: webClientSubs.enketo_edits_recent };
 
   return metrics;
 }));
@@ -1175,6 +1195,7 @@ module.exports = {
   countDatasetsWithGeometry,
   countEntitiesWithGeometry,
   countMultiEntityErrors,
+  countSubmissionsByWebClient,
   countEntityBulkDeletes,
   checkLoginCustomization,
   countDeletedDatasetAndPropertiesByProject,

--- a/test/data/odk-analytics.xml
+++ b/test/data/odk-analytics.xml
@@ -4,7 +4,7 @@
     <h:title>ODK Analytics</h:title>
     <model odk:xforms-version="1.0.0">
       <instance>
-        <data id="odk-analytics" version="v2026.2.0_1">
+        <data id="odk-analytics" version="v2026.3.0_1">
           <config>
             <email/>
             <organization/>
@@ -60,6 +60,22 @@
             </num_entity_bulk_deletes>
             <num_datasets_with_geometry/>
             <num_multi_entity_errors/>
+            <num_wf_submissions>
+              <recent/>
+              <total/>
+            </num_wf_submissions>
+            <num_enketo_submissions>
+              <recent/>
+              <total/>
+            </num_enketo_submissions>
+            <num_wf_submission_edits>
+              <recent/>
+              <total/>
+            </num_wf_submission_edits>
+            <num_enketo_submission_edits>
+              <recent/>
+              <total/>
+            </num_enketo_submission_edits>
           </system>
           <projects jr:template="">
             <id/>
@@ -456,6 +472,14 @@
       <bind nodeset="/data/system/num_entity_bulk_deletes/total" type="int"/>
       <bind nodeset="/data/system/num_datasets_with_geometry" type="int"/>
       <bind nodeset="/data/system/num_multi_entity_errors" type="int"/>
+      <bind nodeset="/data/system/num_wf_submissions/recent" type="int"/>
+      <bind nodeset="/data/system/num_wf_submissions/total" type="int"/>
+      <bind nodeset="/data/system/num_enketo_submissions/recent" type="int"/>
+      <bind nodeset="/data/system/num_enketo_submissions/total" type="int"/>
+      <bind nodeset="/data/system/num_wf_submission_edits/recent" type="int"/>
+      <bind nodeset="/data/system/num_wf_submission_edits/total" type="int"/>
+      <bind nodeset="/data/system/num_enketo_submission_edits/recent" type="int"/>
+      <bind nodeset="/data/system/num_enketo_submission_edits/total" type="int"/>
       <bind nodeset="/data/projects/id" type="string"/>
       <bind nodeset="/data/projects/users/num_managers/recent" type="int"/>
       <bind nodeset="/data/projects/users/num_managers/total" type="int"/>
@@ -700,6 +724,42 @@
       <input ref="/data/system/num_multi_entity_errors">
         <label>Number of errors from repeat Entities</label>
       </input>
+      <group ref="/data/system/num_wf_submissions">
+        <label>Number of Submissions with Web Forms</label>
+        <input ref="/data/system/num_wf_submissions/recent">
+          <label>in the past 45 days</label>
+        </input>
+        <input ref="/data/system/num_wf_submissions/total">
+          <label>Total</label>
+        </input>
+      </group>
+      <group ref="/data/system/num_enketo_submissions">
+        <label>Number of Submissions with Enketo</label>
+        <input ref="/data/system/num_enketo_submissions/recent">
+          <label>in the past 45 days</label>
+        </input>
+        <input ref="/data/system/num_enketo_submissions/total">
+          <label>Total</label>
+        </input>
+      </group>
+      <group ref="/data/system/num_wf_submission_edits">
+        <label>Number of Submission edits with Web Forms</label>
+        <input ref="/data/system/num_wf_submission_edits/recent">
+          <label>in the past 45 days</label>
+        </input>
+        <input ref="/data/system/num_wf_submission_edits/total">
+          <label>Total</label>
+        </input>
+      </group>
+      <group ref="/data/system/num_enketo_submission_edits">
+        <label>Number of Submission edits with Enketo</label>
+        <input ref="/data/system/num_enketo_submission_edits/recent">
+          <label>in the past 45 days</label>
+        </input>
+        <input ref="/data/system/num_enketo_submission_edits/total">
+          <label>Total</label>
+        </input>
+      </group>
     </group>
     <group ref="/data/projects">
       <label>Project Details</label>

--- a/test/integration/other/analytics-queries.js
+++ b/test/integration/other/analytics-queries.js
@@ -825,6 +825,61 @@ describe('analytics task queries @slow', function () {
       counts.total.should.equal(2); // 2 bulk delete operations total
       counts.recent.should.equal(1); // 1 recent bulk delete operation
     }));
+
+    it('should count submissions and edits by web client', testService(async (service, container) => {
+      const asAlice = await service.login('alice');
+
+      // 1 wf submission with 2 edits
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'odk-web-forms/1.0')
+        .attach('xml_submission_file', Buffer.from(simpleInstance('wf')), { filename: 'data.xml' });
+
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'odk-web-forms/1.0')
+        .attach('xml_submission_file', Buffer.from(withSimpleIds('wf', 'wf_updated').replace('Alice', 'Alyssa')), { filename: 'data.xml' });
+
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'odk-web-forms/1.0')
+        .attach('xml_submission_file', Buffer.from(withSimpleIds('wf_updated', 'wf_updated_again').replace('Alice', 'Alyssa')), { filename: 'data.xml' });
+
+      // 1 enketo submission with 1 edit
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'Enketo/1.0')
+        .attach('xml_submission_file', Buffer.from(simpleInstance('enk')), { filename: 'data.xml' });
+
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'Enketo/1.0')
+        .attach('xml_submission_file', Buffer.from(withSimpleIds('enk', 'enk_updated').replace('Alice', 'Alyssa')), { filename: 'data.xml' });
+
+      // Set these existing subs to be created in the past
+      await container.run(sql`UPDATE submission_defs SET "createdAt" = '1999-1-1T00:00:00Z' WHERE TRUE`);
+
+      // new wf submission and edit
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'odk-web-forms/1.0')
+        .attach('xml_submission_file', Buffer.from(simpleInstance('wf2')), { filename: 'data.xml' });
+
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'odk-web-forms/1.0')
+        .attach('xml_submission_file', Buffer.from(withSimpleIds('wf2', 'wf2_updated').replace('Alice', 'Alyssa')), { filename: 'data.xml' });
+
+      const counts = await container.Analytics.countSubmissionsByWebClient();
+      counts.wf_subs_total.should.equal(2);
+      counts.wf_subs_recent.should.equal(1);
+      counts.wf_edits_total.should.equal(3);
+      counts.wf_edits_recent.should.equal(1);
+      counts.enketo_subs_total.should.equal(1);
+      counts.enketo_subs_recent.should.equal(0);
+      counts.enketo_edits_total.should.equal(1);
+      counts.enketo_edits_recent.should.equal(0);
+    }));
   });
 
   describe('user metrics', () => {
@@ -2863,6 +2918,27 @@ describe('analytics task queries @slow', function () {
         .set('Content-Type', 'image/jpeg')
         .send('testimage')
         .expect(200);
+
+      // 2026.3 Web Forms and Enketo submission counts
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'odk-web-forms/1.0')
+        .attach('xml_submission_file', Buffer.from(simpleInstance('wf')), { filename: 'data.xml' });
+
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'odk-web-forms/1.0')
+        .attach('xml_submission_file', Buffer.from(withSimpleIds('wf', 'wf_updated').replace('Alice', 'Alyssa')), { filename: 'data.xml' });
+
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'Enketo/1.0')
+        .attach('xml_submission_file', Buffer.from(simpleInstance('enk')), { filename: 'data.xml' });
+
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .set('User-Agent', 'Enketo/1.0')
+        .attach('xml_submission_file', Buffer.from(withSimpleIds('enk', 'enk_updated').replace('Alice', 'Alyssa')), { filename: 'data.xml' });
 
       // ---- Add new behavior above ---
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2139

### New system metrics

- `num_wf_submissions` — total, recent
- `num_enketo_submissions` — total, recent
- `num_wf_submission_edits` — total, recent
- `num_enketo_submission_edits` — total, recent

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-backend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

These metrics give us a current snapshot at a high level and don't let us see project breakdown, but that's okay. We are primarily interested in whether people who need web submission right now are using WF, Enketo, or a mix of both. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

More analytics. 

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No. 