### PR TITLE
ci: skip npm audit

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: make run-docker-postgres
       env:
         PG_VERSION: ${{ matrix.postgres-version }}

--- a/.github/workflows/db-ssl.yml
+++ b/.github/workflows/db-ssl.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: make run-docker-postgres-ssl
       env:
         PG_VERSION: ${{ matrix.postgres-version }}

--- a/.github/workflows/oidc-e2e.yml
+++ b/.github/workflows/oidc-e2e.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: make run-docker-postgres
       env:
         PG_VERSION: ${{ matrix.postgres-version }}

--- a/.github/workflows/oidc-integration.yml
+++ b/.github/workflows/oidc-integration.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: FAKE_OIDC_ROOT_URL=http://localhost:9898 make fake-oidc-server-ci > fake-oidc-server.log &
     - run: make run-docker-postgres
       env:

--- a/.github/workflows/s3-e2e.yml
+++ b/.github/workflows/s3-e2e.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: make run-docker-postgres
       env:
         PG_VERSION: ${{ matrix.postgres-version }}

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: make run-docker-postgres
       env:
         PG_VERSION: ${{ matrix.postgres-version }}

--- a/.github/workflows/standard-e2e.yml
+++ b/.github/workflows/standard-e2e.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: make run-docker-postgres
       env:
         PG_VERSION: ${{ matrix.postgres-version.full }}

--- a/.github/workflows/standard-suite.yml
+++ b/.github/workflows/standard-suite.yml
@@ -22,7 +22,7 @@ jobs:
         node-version-file: package.json
         cache: 'npm'
     - run: make check-for-large-files
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: make api-docs-lint
     - run: make run-docker-postgres
       env:


### PR DESCRIPTION
* avoid extra network calls
* slightly faster normally; much faster when npm audit is struggling
* audit output is informational only

Ref https://github.com/getodk/central-frontend/pull/1879

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

* avoid extra network calls
* slightly faster normally; much faster when npm audit is struggling
* audit output is informational only

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect - just test code.

#### Does this change require updates to the API documentation? If so, please update docs/api.yaml as part of this PR.

No.