### PR TITLE
Decode form version in submission XML

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -50,6 +50,10 @@ info:
     - [GET /audits](/central-api-system-endpoints/#getting-audit-log-entries) now uses less-than when filtering with the `end` parameter.
     - [Form Attachment](/central-api-form-management/#listing-form-attachments) objects now include a `size` field (in bytes) when a file has been uploaded. The field is absent for dataset-linked attachments and empty slots, and may be `null` for blobs uploaded before this version.
 
+    **Fixed**:
+
+    - Central now decodes the Form `version` string in Submission XML. This can prevent a 404 error when a Submission is sent.
+
     ## ODK Central v2026.2
 
     **Added**:

--- a/lib/model/frames/submission.js
+++ b/lib/model/frames/submission.js
@@ -7,6 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
+const { decodeXML } = require('entities');
 const { v4: uuid } = require('uuid');
 const { Frame, table, readable, writable, embedded, into } = require('../frame');
 const { consumeAndBuffer } = require('../../util/stream');
@@ -63,7 +64,7 @@ class Submission extends Frame.define(
         const foundInstanceId = Option.of(metaInstanceId.orElse(attrInstanceId));
         const instanceId = foundInstanceId.orElseGet(uuid);
         const instanceName = metaInstanceName.orNull();
-        const version = versionText.orElse('');
+        const version = versionText.map(decodeXML).orElse('');
 
         const localKey = localKeyText.orNull();
         const encDataAttachmentName = encDataAttachmentNameText.orNull();

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -289,7 +289,7 @@ describe('api: /submission', () => {
     it('should decode the form version', testService(async (service) => {
       const asAlice = await service.login('alice');
 
-      // Adds a version string of <&> to XML after encoding it
+      // Adds a version string of <&@> to XML after encoding it
       const addVersion = (xml) =>
         xml.replace(/(<data id="simple")>/, '$1 version="&lt;&amp;&#64;&gt;">');
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -286,10 +286,12 @@ describe('api: /submission', () => {
           .then(({ formDefId }) => one(sql`select * from form_defs where id=${formDefId}`))
           .then((formDef) => { formDef.version.should.equal('two'); }))));
 
+    // getodk/central#2219
     it('should decode the form version', testService(async (service) => {
       const asAlice = await service.login('alice');
 
-      // Adds a version string of <&@> to XML after encoding it
+      // Adds a version string of <&@> to XML after encoding it. @ doesn't
+      // strictly need to be encoded, but Collect currently does encode it.
       const addVersion = (xml) =>
         xml.replace(/(<data id="simple")>/, '$1 version="&lt;&amp;&#64;&gt;">');
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -291,7 +291,7 @@ describe('api: /submission', () => {
 
       // Adds a version string of <&> to XML after encoding it
       const addVersion = (xml) =>
-        xml.replace(/(<data id="simple")>/, '$1 version="&lt;&amp;&gt;">');
+        xml.replace(/(<data id="simple")>/, '$1 version="&lt;&amp;&#64;&gt;">');
 
       // Publish a new version of the form with an encoded version string.
       await asAlice.post('/v1/projects/1/forms/simple/draft')
@@ -303,7 +303,7 @@ describe('api: /submission', () => {
       await asAlice.get('/v1/projects/1/forms/simple')
         .expect(200)
         .then(({ body }) => {
-          body.version.should.equal('<&>');
+          body.version.should.equal('<&@>');
         });
 
       // Create a submission to the new version of the form.
@@ -320,7 +320,7 @@ describe('api: /submission', () => {
         .set('X-Extended-Metadata', 'true')
         .expect(200)
         .then(({ body }) => {
-          body.formVersion.should.equal('<&>');
+          body.formVersion.should.equal('<&@>');
         });
     }));
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -286,6 +286,44 @@ describe('api: /submission', () => {
           .then(({ formDefId }) => one(sql`select * from form_defs where id=${formDefId}`))
           .then((formDef) => { formDef.version.should.equal('two'); }))));
 
+    it('should decode the form version', testService(async (service) => {
+      const asAlice = await service.login('alice');
+
+      // Adds a version string of <&> to XML after encoding it
+      const addVersion = (xml) =>
+        xml.replace(/(<data id="simple")>/, '$1 version="&lt;&amp;&gt;">');
+
+      // Publish a new version of the form with an encoded version string.
+      await asAlice.post('/v1/projects/1/forms/simple/draft')
+        .send(addVersion(testData.forms.simple))
+        .set('Content-Type', 'application/xml')
+        .expect(200);
+      await asAlice.post('/v1/projects/1/forms/simple/draft/publish')
+        .expect(200);
+      await asAlice.get('/v1/projects/1/forms/simple')
+        .expect(200)
+        .then(({ body }) => {
+          body.version.should.equal('<&>');
+        });
+
+      // Create a submission to the new version of the form.
+      await asAlice.post('/v1/projects/1/submission')
+        .set('X-OpenRosa-Version', '1.0')
+        .attach(
+          'xml_submission_file',
+          Buffer.from(addVersion(testData.instances.simple.one)),
+          { filename: 'data.xml' }
+        )
+        .expect(201);
+
+      await asAlice.get('/v1/projects/1/forms/simple/submissions/one/versions/one')
+        .set('X-Extended-Metadata', 'true')
+        .expect(200)
+        .then(({ body }) => {
+          body.formVersion.should.equal('<&>');
+        });
+    }));
+
     it('should store the correct formdef and actor ids', testService((service, { all, oneFirst }) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/submission')

--- a/test/unit/model/frames/submission.js
+++ b/test/unit/model/frames/submission.js
@@ -62,6 +62,12 @@ describe('Submission', () => {
       });
     });
 
+    it('should decode version', async () => {
+      const xml = '<data id="mycoolform" version="&lt;&amp;&gt;"><orx:meta><orx:instanceID>myinstance</orx:instanceID></orx:meta><field/></data>';
+      const partial = await Submission.fromXml(xml);
+      partial.def.version.should.equal('<&>');
+    });
+
     it('should squash null version to empty-string', () => {
       const xml = '<data id="mycoolform"><orx:meta><orx:instanceID>myinstance</orx:instanceID></orx:meta><field/></data>';
       return Submission.fromXml(xml).then((partial) => {

--- a/test/unit/model/frames/submission.js
+++ b/test/unit/model/frames/submission.js
@@ -63,9 +63,9 @@ describe('Submission', () => {
     });
 
     it('should decode version', async () => {
-      const xml = '<data id="mycoolform" version="&lt;&amp;&gt;"><orx:meta><orx:instanceID>myinstance</orx:instanceID></orx:meta><field/></data>';
+      const xml = '<data id="mycoolform" version="&lt;&amp;&#64;&gt;"><orx:meta><orx:instanceID>myinstance</orx:instanceID></orx:meta><field/></data>';
       const partial = await Submission.fromXml(xml);
-      partial.def.version.should.equal('<&>');
+      partial.def.version.should.equal('<&@>');
     });
 
     it('should squash null version to empty-string', () => {


### PR DESCRIPTION
This PR closes getodk/central#2219. It updates `Submission.fromXml()` to decode the form `version` string found in the submission XML.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I tried to do something similar to what was done in #550.

At some point, we could consider decoding more systematically. However, the goal of this PR is just to decode `version`.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

I think it should be safe to merge this PR even though regression testing is in progress. It should only come up for users whose form `version` string contains encoded characters.